### PR TITLE
runner: Django backend + Channels consumer for Apple Pi Dash runner

### DIFF
--- a/.ai_design/implement_runner/github-runner-architecture.md
+++ b/.ai_design/implement_runner/github-runner-architecture.md
@@ -1,0 +1,543 @@
+# GitHub Actions Self-Hosted Runner — Architecture Reference
+
+Purpose: this document explains how GitHub Actions self-hosted runners work end to end, so Apple Pi Dash can adopt the same pattern for connecting cloud-side orchestration to a local coding agent (Codex) running on a user's dev machine.
+
+Source-of-truth references:
+
+- Runner source: https://github.com/actions/runner (C#/.NET)
+- Runner docs: https://docs.github.com/en/actions/hosting-your-own-runners
+- Actions Runner Controller (K8s): https://github.com/actions/actions-runner-controller
+
+This doc is a technical summary, not a verbatim spec. Where GHA's internals are undocumented, the behavior is described from observation of the open-source runner and public docs.
+
+Implementation notes for this document:
+
+- Statements about GitHub internals that are not documented should be read as "observed behavior", not as a stable public contract.
+- Apple Pi Dash sections below are normative for implementation unless marked as an open question.
+
+---
+
+## 1. The two-role split
+
+Any system that ships work from a cloud service to a user-owned machine has two roles:
+
+| Role                        | Owns                                       | Does                                                                                  |
+| --------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------- |
+| **Orchestrator** (cloud)    | The source of truth — jobs, state, routing | Decides _what_ runs and _when_, matches jobs to runners, tracks state, exposes UI/API |
+| **Runner / worker** (local) | The execution environment                  | Executes _one_ job at a time, streams results back, holds local credentials           |
+
+In GHA:
+
+- **Orchestrator** = GitHub's Actions service (cloud).
+- **Runner** = the `actions/runner` binary a user installs on their own machine.
+
+In Apple Pi Dash's target architecture:
+
+- **Orchestrator** = Django/Celery in `apps/api` (+ a WS service modeled on `apps/live`).
+- **Runner** = a new daemon installed on the user's dev PC that drives `codex app-server`.
+
+The rest of this document is how GHA implements the runner side and the cloud ↔ runner contract between them.
+
+---
+
+## 2. The networking trick: outbound-initiated, bidirectional
+
+A runner sits behind NAT / corporate firewall / home router. Cloud → laptop inbound connections are blocked. The runner solves this by **initiating outbound** to the cloud and holding the connection open. Once TCP+TLS is established, the channel is full-duplex; the _server_ can push frames down it at any time.
+
+```
+Dev PC (runner)                               GitHub cloud
+      │                                             │
+      │  TCP+TLS on :443 (outbound, allowed) ─────► │
+      │ ◄───────────────────────────  handshake     │
+      │                                             │
+      │ ═════════ persistent bidirectional ═══════ │
+      │                                             │
+      │  heartbeat ──►                              │
+      │              ◄── "here's job #42"           │   server push, unsolicited
+      │  ack ──►                                    │
+      │  log line ──►                               │
+      │              ◄── "cancel job #42"           │   server push again
+```
+
+Transports GHA has used over time:
+
+1. **HTTP long-poll (classic).** Runner sends `GET /message` with a long timeout; server holds it open until a message exists. Simple, firewall-friendly, slightly laggy.
+2. **Brokered WebSocket / HTTP2 streams (modern).** Full-duplex, instant push, lower latency. Same NAT-traversal property because the runner initiates.
+
+The exact broker/session internals on GitHub's side are not a public API. The transport summary above is the mental model to copy, not a protocol contract to depend on.
+
+Both look identical to any firewall: one outbound HTTPS connection on 443.
+
+Takeaway: you do not need ngrok, Tailscale, port forwarding, UDP hole-punching, or an A2A push endpoint. An outbound-initiated persistent connection solves reachability.
+
+---
+
+## 3. Registration lifecycle
+
+Runner install is a two-step credential exchange: a **short-lived registration token** is traded for **long-lived runner credentials** that the runner keeps on disk.
+
+### 3.1. Registration token (short-lived)
+
+- Issued by the GitHub UI or API at a scope (repo / org / enterprise). TTL ~1 hour.
+- Single-use. Can be revoked.
+- Carries the authorization "this token's holder is allowed to register a runner in scope X".
+
+### 3.2. `config.sh` handshake
+
+The user runs:
+
+```bash
+./config.sh \
+  --url https://github.com/ORG/REPO \
+  --token <REG_TOKEN> \
+  --labels gpu,staging,arm64 \
+  --name my-laptop
+```
+
+What the runner does during config:
+
+1. POSTs the registration token to GitHub's API.
+2. GitHub validates scope + TTL, assigns the runner a stable **numeric ID**, records labels and name.
+3. GitHub returns **long-lived credentials**: an RSA keypair + a token.
+4. Runner writes three files to its install dir:
+   - `.runner` — JSON config (id, url, labels, poolId, agentName).
+   - `.credentials` — credential descriptor (scheme, auth URL).
+   - `.credentials_rsaparams` — RSA private key material.
+5. Registration token is discarded. From now on the runner authenticates itself with the stored credentials.
+
+### 3.3. Labels
+
+Every runner advertises a label set. Defaults assigned automatically:
+
+- `self-hosted`
+- OS: `Linux` | `Windows` | `macOS`
+- Arch: `X64` | `ARM64` | `ARM`
+
+Custom labels are user-provided (`--labels`): `gpu`, `staging`, `mac-studio`, `has-docker`, etc. Labels are how jobs target the right runner.
+
+### 3.4. Runner groups (multi-tenant scoping)
+
+Org/enterprise-scoped runners are organized into **runner groups**. A group has a policy:
+
+- Which repos (or orgs/workflows) may use runners in this group.
+- Whether public repos are allowed.
+
+At dispatch time, a job is filtered to the groups its repo is authorized for, _then_ label matching happens within that set. This stops Team A's workflows from picking up Team B's GPUs.
+
+### 3.5. Ephemeral vs persistent runners
+
+- **Persistent (default):** stays alive, takes one job, returns to idle, takes the next.
+- **Ephemeral (`--ephemeral`):** takes one job then self-deregisters and exits. Used heavily for K8s/Actions Runner Controller autoscaling — each pod is single-use, so no dirty state leaks between jobs.
+
+### 3.6. De-registration
+
+- `./config.sh remove --token <REMOVAL_TOKEN>` with a removal token from the UI.
+- A runner that stops heartbeating goes to **offline** state; stays registered (but unusable) for ~14 days, then may be auto-cleaned.
+
+---
+
+## 4. The runtime: waiting for work
+
+Once configured, `./run.sh` (or the systemd / launchd / Windows service wrapper) starts the main loop:
+
+1. **Authenticate.** Exchange the stored credentials for a short-lived session token against GitHub's auth endpoint.
+2. **Open session.** Register a "message session" with the Actions service, advertising runner id + current state (`online`, `idle`).
+3. **Hold connection.** Long-poll (or brokered WS) on the session, waiting for messages.
+4. **Heartbeat.** Send application-level pings every ~30s so dead connections are detected quickly (TCP keepalive alone is too slow and middleboxes often kill it).
+5. **Receive a message.** Two kinds:
+   - **Job assignment** — full job spec arrives; runner ACKs, locks to busy, begins executing.
+   - **Control message** — cancel, settings update, force-upgrade trigger, etc.
+6. **Report status.** During job execution, stream logs and step results back up the same session. On completion, post the final job result.
+7. **Release.** Return to idle, loop.
+
+If the connection drops:
+
+- Runner reconnects with **jittered exponential backoff** (important — without jitter a deploy on the cloud side causes a thundering-herd reconnect).
+- On reconnect, runner presents its id and any in-flight job context. If a job was mid-run, the cloud decides whether to resume or mark failed.
+
+---
+
+## 5. Job dispatch and matching
+
+When a workflow triggers (push, PR, schedule, manual dispatch), the Actions service has to pick a runner. Algorithm in outline:
+
+```
+1. Parse `runs-on` in the job definition.
+   Example:  runs-on: [self-hosted, linux, gpu]
+
+2. Scope filter:
+   - Determine which runner groups this repo/workflow is authorized to use.
+   - Candidate set = runners in those groups.
+
+3. Label filter:
+   - Keep only candidates whose advertised labels are a SUPERSET of the
+     labels in `runs-on`. (All job labels must be present on the runner.)
+
+4. State filter:
+   - Keep only runners currently online AND idle (not executing a job).
+
+5. Pick:
+   - First-available wins (with internal load-balancing heuristics).
+   - If set is empty, job sits in the queue. It will be re-evaluated as
+     runners free up or new ones come online.
+
+6. Dispatch:
+   - Push the job message down that runner's open session.
+   - Include a per-job short-lived credential (GITHUB_TOKEN) scoped to
+     this job's permissions.
+
+7. Lock:
+   - Mark runner busy in the scheduler. No other job goes to it until it
+     reports completion.
+```
+
+Label matching is **superset, not equality**. A runner advertising `[self-hosted, linux, X64, gpu, staging]` satisfies a job wanting `[self-hosted, linux, gpu]`.
+
+Operational details from GitHub's documented behavior that matter when copying this model:
+
+- If an assigned runner does not accept/pick up a job within about **60 seconds**, GitHub re-queues the job.
+- If no matching runner becomes available, a queued self-hosted runner job can remain queued for up to **24 hours** before timing out.
+
+---
+
+## 6. Per-job lifecycle on the runner
+
+Once a job message arrives:
+
+1. **Job envelope arrives** — workflow + job id, commit sha, repo, secrets, per-job `GITHUB_TOKEN`, steps, container/service specs.
+2. **Workspace setup** — fresh checkout (or clean of previous), set `GITHUB_WORKSPACE`.
+3. **Services up** — any `services:` containers started.
+4. **Steps execute** sequentially:
+   - Each step is a process the runner spawns (bash/pwsh/node) with env vars and secret masking.
+   - stdout/stderr captured line-by-line, timestamped, and streamed back to the service.
+   - Commands like `::set-output::` / `$GITHUB_OUTPUT` are parsed from the stream and reflected into job state.
+5. **Post-step cleanup** — tear down containers, clean caches per config, optionally delete the workspace.
+6. **Report final status** — `completed` + conclusion (`success` | `failure` | `cancelled` | `skipped`).
+7. **Return to idle** (persistent) or **exit** (ephemeral).
+
+Cancellation: if a cancel message arrives mid-step, the runner sends SIGINT / SIGTERM (then SIGKILL after a grace period) to the step process, aborts remaining steps, runs post-step cleanups, reports `cancelled`.
+
+---
+
+## 7. Security model
+
+Layers:
+
+1. **Registration token.** Short TTL, single-use, scoped. Cannot do anything but register once.
+2. **Runner credentials.** Long-lived but per-runner; can be revoked from the UI at any time. Stored on disk with file-mode 0600; compromise = that runner is compromised, not the org.
+3. **Per-job `GITHUB_TOKEN`.** Minted by the service at dispatch time, TTL ≈ job duration + a grace window, scope = just this job's repo with permissions declared in the workflow. This is what actually authenticates the job's git operations and API calls. It is **never** the runner's own credentials.
+4. **Secrets.** Sent in the job envelope, masked in log output, never persisted on the runner beyond the job's lifetime (unless a step writes them to disk itself, which is a workflow author error).
+5. **Network.** All runner ↔ service traffic is TLS on 443. The runner never accepts inbound connections.
+6. **Trust boundary.** The service trusts the runner to execute code faithfully. The runner trusts the service to send well-formed jobs. Neither trusts the _workflow author_ past the permissions granted by `GITHUB_TOKEN` + supplied secrets.
+
+---
+
+## 8. Reconnection, offline handling, and reliability
+
+Operational realities of long-lived connections:
+
+- **Middlebox idle timeouts.** Corporate proxies drop idle TCP at 60s. Runner sends application pings every ~20–30s.
+- **Reconnect storms.** If the service redeploys, thousands of runners disconnect at once. Without jitter, they all reconnect simultaneously and melt the new instance. Runner uses exponential backoff with randomized jitter (sleep random 1–10s, double on repeat, cap at a minute).
+- **In-flight job on disconnect.** Runner continues executing the job locally. On reconnect, it presents in-flight status. Service decides: resume streaming logs if within a resume window, or mark the job as failed if the runner was gone too long.
+- **Crash recovery.** If the runner process crashes mid-job, the job is marked failed on next reconnect; no partial-state merge. Workspace may be left dirty — cleaned on next job start.
+- **Offline detection.** No heartbeat for N seconds → runner marked `offline` in the UI. Job queue will skip it during matching.
+
+---
+
+## 9. Scalability
+
+Per-connection cost is dominated by memory for socket buffers + session state. Typical orders of magnitude:
+
+| Stack                  | Memory/connection | Practical max per server |
+| ---------------------- | ----------------- | ------------------------ |
+| Python/Django Channels | ~10–20 KB         | 10K–50K                  |
+| Node.js (`ws`)         | ~6–10 KB          | 100K–500K                |
+| Go                     | ~4–8 KB           | 100K–500K                |
+| Elixir/Phoenix         | ~3 KB             | 1M+                      |
+| Rust (tokio)           | ~1–2 KB           | 1M+                      |
+
+Idle CPU is effectively zero (just heartbeats). Real cost comes from **message volume during active jobs**, not from idle connection count.
+
+Horizontal scaling pattern:
+
+- WS servers are **stateless** — session state (which runner is connected where, which job is running) lives in a shared store (Redis / DB).
+- Each WS server subscribes to a pub/sub channel keyed by the runner-ids currently connected to it.
+- When the orchestrator wants to push to runner R, it publishes to channel `runner:R`; the WS server holding R's connection receives and forwards down the socket.
+- Reconnects can land on any WS server (behind an L4 LB); the pub/sub mapping updates automatically.
+
+---
+
+## 10. Mapping to Apple Pi Dash
+
+What transfers directly:
+
+| GitHub concept                     | Apple Pi Dash equivalent                                                    | Notes                                                                     |
+| ---------------------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| Actions service (orchestrator)     | Django (`apps/api`) + a WS service (new, modeled on `apps/live`)            | Django owns state; WS service owns the socket                             |
+| Self-hosted runner binary          | `apple-pi-dash-runner` daemon (new, to build)                               | Single binary: Go or Rust recommended                                     |
+| Registration token                 | One-time code generated in Apple Pi Dash settings UI                        | Short TTL, single-use                                                     |
+| `.credentials` on disk             | Runner token + machine id, stored under `~/.config/apple-pi-dash-runner/`   | File mode 0600                                                            |
+| Labels (`linux`, `gpu`, `staging`) | Capabilities: `codex`, `macos`, `arm64`, `docker`, `git`                    | Same matching rules; do not encode an exact local checkout path in labels |
+| Runner groups                      | Per-user / per-workspace pools                                              | "Only this user's machines pick up this user's tasks"                     |
+| `runs-on: [self-hosted, gpu]`      | Apple Pi Dash work item metadata declaring required capabilities            | Triage step sets these                                                    |
+| Job envelope                       | `AgentRun` payload: work item id, repo path, prompt, run config             | Matches Codex `thread/start` + `turn/start` params                        |
+| Per-job `GITHUB_TOKEN`             | Per-run short-lived credential scoped to the AgentRun's allowed API surface | E.g. scoped webhook back                                                  |
+| Step execution (bash)              | Drive `codex app-server` via JSON-RPC on stdio or local WS                  | `turn/start` → stream `item/*` deltas → `turn/completed`                  |
+| Log streaming                      | Stream Codex `item/*` events up the WS                                      | 1:1 shape, just wrapped                                                   |
+| Cancel message                     | `turn/interrupt` on Codex + runner cleanup                                  | Server → runner → app-server                                              |
+| Ephemeral runner                   | Probably not — dev PCs are persistent                                       | But consider ephemeral "workspace runs" inside containers                 |
+
+Features GHA has that Apple Pi Dash specifically needs _beyond_ the GHA model:
+
+- **Mid-run approvals.** Codex pauses and asks "can I run `rm`?" → runner forwards an approval request up the WS → Django persists it and pushes to the user's browser → user clicks in Apple Pi Dash UI → answer flows back. GHA has no analog; this is unique to interactive agent work and is the reason you can't repurpose the GHA runner binary directly.
+- **Thread resume.** Codex's `thread/resume` lets a run reattach after reconnect. GHA jobs are stateless shell runs and have no equivalent. Apple Pi Dash must persist `thread_id` per `AgentRun` and pass it through on reconnect.
+- **Local credentials stay local.** Codex login (`account/login/start`) happens on the laptop. Apple Pi Dash never sees the user's OpenAI/ChatGPT credentials. The runner mediates everything.
+
+---
+
+## 11. Apple Pi Dash implementation constraints
+
+These are the extra rules Apple Pi Dash needs so this explainer is implementable rather than just informative.
+
+### 11.1. Runner auth is a separate protocol from `apps/live`
+
+The new runner WS service may reuse the deployment/runtime pattern of `apps/live`, but **must not** reuse its auth model.
+
+- `apps/live` authenticates browser/editor traffic with cookies and shared secrets.
+- The runner service must use:
+  - short-lived registration tokens for initial pairing
+  - long-lived per-runner credentials stored locally
+  - short-lived session auth for each active connection
+  - explicit revocation and credential rotation
+
+Do not authenticate a machine runner with browser cookies or a static shared header secret.
+
+### 11.2. Capabilities are for eligibility, not for exact repo selection
+
+Scheduler matching and local execution binding are separate concerns.
+
+- **Capabilities** answer: "is this machine eligible?"
+  - Examples: `codex`, `git`, `docker`, `macos`, `arm64`
+- **Execution binding** answers: "where exactly should this run happen on disk?"
+  - Examples: `/Users/alice/src/acme/foo`, worktree `feature/runner`, checkout strategy `clone_if_missing`
+
+The orchestrator must not assume that a capability like `repo:acme/foo` is enough to identify a unique local workspace. One machine may have:
+
+- multiple clones of the same repo
+- multiple worktrees
+- no checkout yet
+- a stale checkout on the wrong branch
+
+`AgentRun.run_config` therefore needs an explicit workspace binding policy, not just labels.
+
+### 11.3. Approval states require leases and timeouts
+
+`awaiting_approval` is not just a UI state; it is a resource lock on a real machine. The system must define:
+
+- approval request timeout
+- what happens if the web UI disconnects
+- whether the runner keeps the Codex process warm while waiting
+- when a run is auto-cancelled vs resumed
+- whether timed-out approvals release the runner immediately
+
+Default implementation rule:
+
+- while a run is in `assigned`, `running`, or `awaiting_approval`, that runner slot is reserved
+- `awaiting_approval` expires after a server-defined timeout
+- on expiry, the server sends cancel to the runner and marks the run `cancelled` unless a future resume protocol is explicitly implemented
+
+### 11.4. Event retention must be bounded
+
+Persisting every raw Codex delta forever in Postgres will become expensive quickly.
+
+Default implementation rule:
+
+- persist all events needed for live UI replay during the active run
+- persist a durable final transcript or compacted event stream at completion
+- allow raw high-volume deltas to be compacted or moved to object storage later
+
+---
+
+## 12. Django-side data model (proposed)
+
+Minimum tables to support this architecture:
+
+- **`Runner`**
+  - `id`, `user_id` (owner), `workspace_id`
+  - `name` (user-chosen, e.g. "my-laptop")
+  - `labels` / `capabilities` (JSON or m2m)
+  - `status` (`online` | `offline` | `busy`)
+  - `last_heartbeat_at`
+  - `credential_fingerprint`
+  - `protocol_version`
+  - `os`, `arch`, `runner_version`
+  - `created_at`, `revoked_at`
+
+- **`RunnerRegistrationToken`**
+  - `id`, `workspace_id`, `created_by_user_id`
+  - `token_hash` (store hash, not plaintext)
+  - `expires_at` (≤ 1h)
+  - `consumed_at` (nullable; single-use)
+
+- **`AgentRun`**
+  - `id`, `work_item_id`, `runner_id` (nullable until assigned)
+  - `status` (`queued` | `assigned` | `running` | `awaiting_approval` | `completed` | `failed` | `cancelled`)
+  - `thread_id` (Codex thread, for resume)
+  - `prompt`, `run_config` (model, repo binding, branch, checkout strategy)
+  - `required_capabilities` (JSON)
+  - `lease_expires_at`
+  - `created_at`, `assigned_at`, `started_at`, `ended_at`
+  - `error` (nullable)
+
+- **`AgentRunEvent`** (append-only log of `item/*` events for UI replay + audit)
+  - `id`, `agent_run_id`, `seq`, `type`, `payload`, `created_at`
+
+- **`ApprovalRequest`**
+  - `id`, `agent_run_id`, `kind` (`commandExecution` | `fileChange`), `payload`
+  - `status` (`pending` | `accepted` | `declined`)
+  - `decision_payload`
+  - `expires_at`
+  - `requested_at`, `decided_at`, `decided_by_user_id`
+
+Matching query (pseudo-SQL):
+
+```sql
+SELECT r.*
+FROM runner r
+WHERE r.workspace_id = :ws
+  AND r.status = 'online'
+  AND r.labels @> :required_capabilities  -- superset
+  AND NOT EXISTS (
+    SELECT 1 FROM agent_run ar
+    WHERE ar.runner_id = r.id AND ar.status IN ('assigned','running','awaiting_approval')
+  )
+ORDER BY r.last_heartbeat_at DESC
+LIMIT 1;
+```
+
+---
+
+## 13. Protocol and lifecycle defaults
+
+The following defaults close the main implementation gaps.
+
+### 13.1. Runner connection protocol
+
+Minimum message families:
+
+- `hello`
+  - sent by runner on connect
+  - includes `runner_id`, `credential`, `protocol_version`, `runner_version`, `os`, `arch`, advertised `capabilities`
+- `hello_ack`
+  - sent by server
+  - includes accepted protocol version, heartbeat interval, reconnect backoff policy
+- `heartbeat`
+  - sent by runner on interval
+  - includes current run state and optional in-flight `agent_run_id`
+- `assign_run`
+  - sent by server
+  - includes `agent_run_id`, `run_config`, prompt payload, approval policy, scoped per-run credential
+- `run_event`
+  - sent by runner
+  - includes `agent_run_id`, `seq`, `type`, `payload`
+- `approval_requested`
+  - sent by runner
+  - includes `approval_request_id`, `agent_run_id`, `kind`, `payload`, `expires_at`
+- `approval_decision`
+  - sent by server
+  - includes `approval_request_id`, decision, actor, decision payload
+- `cancel_run`
+  - sent by server
+  - includes `agent_run_id`, reason
+- `run_completed`
+  - sent by runner
+  - includes `agent_run_id`, final status, summary payload
+
+Protocol rules:
+
+- all messages carry a stable message id for dedupe
+- `run_event.seq` is monotonic per `agent_run_id`
+- server operations must be idempotent on retries
+- runner reconnect always starts with `hello`, never with an implicit resume
+
+### 13.2. Execution binding defaults
+
+Default local workspace rule:
+
+- one runner per machine
+- one active run per runner in v1
+- `run_config` must contain either:
+  - an explicit absolute local path chosen earlier, or
+  - a repo URL plus a checkout policy (`require_existing` or `clone_if_missing`)
+
+Recommended v1 default:
+
+- support `require_existing` first
+- do not implement automatic clone/worktree creation until the runner protocol is stable
+
+### 13.3. Cancellation and reconnect defaults
+
+Default behavior:
+
+- if runner disconnects during a run, local execution may continue
+- server marks runner `offline` after heartbeat expiry
+- run enters a reconnect grace window
+- if the same runner reconnects within the grace window and presents the in-flight `agent_run_id`, the server resumes streaming
+- otherwise the server cancels the run and marks it `failed` or `cancelled` based on cause
+
+Suggested starting values:
+
+- heartbeat every 20 seconds
+- runner offline after 60 seconds without heartbeat
+- reconnect grace window 5 minutes
+- approval timeout 10 minutes
+
+### 13.4. Recommended defaults to keep
+
+1. **Runner language.** Go or Rust give the best binary-distribution story. Rust is a good fit for the local daemon.
+2. **Runner scope.** One runner per machine.
+3. **Approval defaults.** Auto-approve reads; require approval for writes, destructive shell commands, and network access.
+4. **WS service stack.** Dedicated Node service from day one; reuse `apps/live` deployment patterns, not its auth model.
+5. **Pub/sub store.** Valkey/Redis for runner-id to WS-server routing.
+6. **Protocol versioning.** Required in `hello`.
+7. **Upgrade mechanism.** Start manual or prompt-and-confirm; add auto-update later.
+8. **Telemetry.** Minimal by default: version, OS, arch, health counters.
+
+---
+
+## 14. What to build first (suggested phasing)
+
+The runner ships with a built-in **TUI** from v1 — see `tui-design.md` in this directory. TUI and daemon share a local Unix-socket JSON-RPC so the TUI is a thin client that can attach/detach without restarting the daemon.
+
+**Phase 0 — proof of concept, one user, happy path.**
+
+- Django model for `Runner`, `RunnerRegistrationToken`, `AgentRun`.
+- A tiny Node WS service that accepts runner connections and forwards messages to/from Django via Redis.
+- Minimal runner daemon: config via token, WS connect, execute a hard-coded shell command, stream stdout back. No Codex yet.
+- Minimal TUI: Status view only, read-only, attaches over local socket. Proves the daemon/client split.
+
+**Phase 1 — Codex integration + TUI MVP.**
+
+- Runner spawns `codex app-server` and bridges its JSON-RPC to the cloud WS.
+- Django UI shows live `item/*` events per `AgentRun`.
+- TUI adds: Config view (read/write, hot-apply), Approvals view, first-run onboarding wizard.
+
+**Phase 2 — approvals end-to-end.**
+
+- `ApprovalRequest` model, web UI round-trip, TUI round-trip, Codex `requestApproval` integration.
+- Either surface can answer; daemon records decision source.
+
+**Phase 3 — multi-runner, label matching, runner groups, thread resume.**
+
+- TUI adds: Runs history view with detail, doctor subcommand, search/filter.
+
+**Phase 4 — production hardening.**
+
+- Jittered reconnect, upgrade flow, capability advertisement, telemetry, admin UI for runner management.
+- TUI adds: diff preview, log follower, help overlay.
+
+**Post-v1 — optional native tray icon.**
+
+- Reuses the same local-socket IPC as the TUI. Tray is an alternate client, not a rewrite.
+
+Each phase is independently demonstrable and testable.

--- a/.ai_design/implement_runner/implementation-tasks.md
+++ b/.ai_design/implement_runner/implementation-tasks.md
@@ -1,0 +1,369 @@
+# Apple Pi Dash Runner — Implementation Tasks
+
+Purpose: track the implementation of the Apple Pi Dash local runner, cloud integration, and built-in TUI.
+
+Companion docs in this directory:
+
+- `runner-design.md`
+- `github-runner-architecture.md`
+- `tui-design.md`
+
+How to use this file:
+
+- Keep task status in-place with checkboxes.
+- Add PR links or issue ids inline after the task text.
+- Do not delete completed tasks; strike or annotate only if scope changes.
+- If a task expands materially, split it into a separate subtask block in this file.
+
+## Milestones
+
+- [ ] Phase 0: one-user happy-path proof of concept
+- [ ] Phase 1: Codex bridge and local persistence
+- [ ] Phase 2: approvals end to end
+- [ ] Phase 3: production-grade runner lifecycle
+- [ ] Phase 4: TUI MVP complete
+- [ ] Phase 5: hardening and rollout
+
+## 0. Project setup
+
+- [ ] Decide the implementation repo layout
+      Notes: confirm whether the runner lives in this monorepo as a Rust workspace member, a sibling directory under `apps/`, or a top-level `runner/` directory.
+- [ ] Create the runner project scaffold
+      Notes: include build, test, fmt, lint, and release targets.
+- [ ] Choose the Rust crate baseline
+      Notes: likely `tokio`, `reqwest`, `tokio-tungstenite` or equivalent, `serde`, `toml`, `tracing`, `ratatui`, `crossterm`, `clap`, `directories`.
+- [ ] Define versioning strategy
+      Notes: semver for runner binary and explicit protocol version for runner-cloud messages.
+- [ ] Add local developer commands to repo docs or AGENTS-facing docs
+      Notes: build runner, run daemon, run TUI, run tests.
+
+## 1. Cloud contract
+
+### 1.1. Registration and auth
+
+- [ ] Define registration endpoint request/response schema
+      Notes: input token, runner name, OS, arch, version; output runner id, runner secret, heartbeat interval, protocol version.
+- [ ] Define runner credential storage format
+      Notes: separate config from secret-bearing credentials.
+- [ ] Define reconnect authentication flow
+      Notes: runner reconnects with long-lived credential and receives short-lived session acceptance.
+- [ ] Define credential revocation behavior
+      Notes: what happens when the server revokes a runner while it is connected.
+- [ ] Define credential rotation behavior
+      Notes: whether rotation is push-driven, pull-driven, or manual in v1.
+
+### 1.2. WebSocket protocol
+
+- [ ] Write message schema for `hello`
+- [ ] Write message schema for `hello_ack`
+- [ ] Write message schema for `heartbeat`
+- [ ] Write message schema for `assign_run`
+- [ ] Write message schema for `run_event`
+- [ ] Write message schema for `approval_requested`
+- [ ] Write message schema for `approval_decision`
+- [ ] Write message schema for `cancel_run`
+- [ ] Write message schema for `run_completed`
+- [ ] Define message idempotency rules
+      Notes: retries must not create duplicate runs, duplicate approvals, or duplicate completion processing.
+- [ ] Define event ordering rules
+      Notes: monotonic `seq` per run, reconnect replay expectations, server handling for gaps.
+
+### 1.3. Lifecycle defaults
+
+- [ ] Finalize heartbeat interval
+- [ ] Finalize offline timeout
+- [ ] Finalize reconnect grace window
+- [ ] Finalize approval timeout
+- [ ] Finalize server behavior when runner disconnects mid-run
+- [ ] Finalize server behavior when approval times out
+
+## 2. Django data model and APIs
+
+### 2.1. Models
+
+- [ ] Add `Runner` model
+      Notes: owner, workspace, name, status, capabilities, credential fingerprint, version, OS, arch, last heartbeat.
+- [ ] Add `RunnerRegistrationToken` model
+      Notes: store token hash only, expiration, consumed state.
+- [ ] Add `AgentRun` model
+      Notes: run config, required capabilities, lease expiry, thread id, lifecycle timestamps, error field.
+- [ ] Add `AgentRunEvent` model or equivalent transcript storage
+      Notes: confirm bounded retention approach before shipping full event persistence.
+- [ ] Add `ApprovalRequest` model
+      Notes: pending/accepted/declined, payload, expiry, decision source.
+- [ ] Add migrations and model tests
+
+### 2.2. Runner APIs
+
+- [ ] Implement runner registration API
+- [ ] Implement runner deregistration API
+- [ ] Implement runner reconnect/session-auth API
+- [ ] Implement runner heartbeat update API or WS-backed equivalent
+- [ ] Implement runner revocation path
+- [ ] Implement admin/user API to mint registration tokens
+
+### 2.3. Run APIs
+
+- [ ] Implement API to create `AgentRun` from a work item
+- [ ] Implement API to cancel an `AgentRun`
+- [ ] Implement API to inspect run status and transcript summary
+- [ ] Implement API to fetch recent runs for a runner
+- [ ] Implement API to fetch pending approvals
+- [ ] Implement API to answer approvals from web UI
+
+## 3. Realtime service
+
+### 3.1. Service scaffold
+
+- [ ] Create a dedicated runner WS service
+      Notes: reuse `apps/live` deployment patterns, not its auth model.
+- [ ] Add service configuration for Redis, ports, secrets, and base URL
+- [ ] Add health endpoint
+- [ ] Add structured logging
+- [ ] Add graceful shutdown behavior
+
+### 3.2. Runner connection handling
+
+- [ ] Implement `hello` handshake validation
+- [ ] Track connected runner sessions in memory
+- [ ] Persist runner presence to shared state
+- [ ] Implement heartbeat handling
+- [ ] Mark runner offline on timeout
+- [ ] Reject protocol-version mismatches cleanly
+
+### 3.3. Pub/sub and routing
+
+- [ ] Implement Redis pub/sub for runner-targeted messages
+- [ ] Implement routing from Django/orchestrator to connected runner socket
+- [ ] Implement reconnect-safe session remapping
+- [ ] Implement dedupe for duplicate inbound runner messages
+
+### 3.4. Run control
+
+- [ ] Implement `assign_run` delivery to runner
+- [ ] Implement `cancel_run` delivery to runner
+- [ ] Implement `approval_decision` delivery to runner
+- [ ] Implement `run_completed` ingestion from runner
+- [ ] Implement `approval_requested` ingestion from runner
+
+## 4. Scheduling and orchestration
+
+- [ ] Define how a work item becomes an `AgentRun`
+- [ ] Implement runner selection query for v1
+      Notes: one user-owned online idle runner; no label matching in MVP if following `runner-design.md`.
+- [ ] Implement run lease acquisition
+- [ ] Prevent concurrent assignment to one runner
+- [ ] Requeue or fail runs that are not accepted within the acceptance window
+- [ ] Implement cancellation propagation from cloud to runner
+- [ ] Implement reconnect resume logic for in-flight runs
+
+## 5. Runner daemon
+
+### 5.1. CLI and process model
+
+- [ ] Implement CLI entrypoints
+      Notes: `configure`, `start`, `service install`, `service start`, `service stop`, `status`, `doctor`, `tui`.
+- [ ] Implement daemon main loop
+- [ ] Implement config and credential file loading
+- [ ] Enforce file permissions for secrets and local IPC
+- [ ] Implement structured logging and log rotation policy
+
+### 5.2. Service integration
+
+- [ ] Implement macOS `launchd` install/start/stop
+- [ ] Implement Linux `systemd --user` install/start/stop
+- [ ] Add service status diagnostics
+
+### 5.3. Cloud connection
+
+- [ ] Implement registration flow
+- [ ] Implement WS connect and `hello`
+- [ ] Implement heartbeat loop
+- [ ] Implement jittered exponential reconnect
+- [ ] Implement reconnect-state reporting for in-flight run
+- [ ] Handle revocation and forced disconnect
+
+### 5.4. Workspace management
+
+- [ ] Implement working-dir config
+- [ ] Detect existing git repo in working dir
+- [ ] Handle empty-dir clone path
+- [ ] Refuse non-empty non-repo working dir
+- [ ] Capture and report clone/auth/network failures clearly
+- [ ] Persist workspace resolution details in local run history
+
+### 5.5. Local state machine
+
+- [ ] Implement runner states
+      Notes: idle, assigned, running, awaiting approval, reconnecting, awaiting reauth.
+- [ ] Enforce one active run at a time
+- [ ] Implement run lease expiry handling
+- [ ] Implement graceful shutdown during active run
+
+## 6. Codex bridge
+
+### 6.1. Subprocess management
+
+- [ ] Spawn `codex app-server` with configured working directory
+- [ ] Capture stdout/stderr and parse JSON-RPC messages
+- [ ] Implement clean startup timeout handling
+- [ ] Implement clean shutdown and forced kill fallback
+- [ ] Handle Codex crash and one-time resume attempt
+
+### 6.2. Run execution
+
+- [ ] Translate `assign_run` into Codex thread/turn start calls
+- [ ] Persist `thread_id` for resume
+- [ ] Handle Codex completion message
+- [ ] Handle Codex failure message
+- [ ] Forward only lifecycle events to cloud per MVP privacy rules
+- [ ] Keep `item/*` deltas local only
+
+### 6.3. Reauth path
+
+- [ ] Detect Codex auth failure / reauth-needed signal
+- [ ] Move runner/run into `awaiting_reauth`
+- [ ] Notify TUI and web surfaces
+- [ ] Resume run after successful reauth if supported
+- [ ] Fail run cleanly if reauth does not happen within timeout
+
+## 7. Approval flow
+
+### 7.1. Policy engine
+
+- [ ] Implement read-only auto-approve allowlist
+- [ ] Implement always-deny destructive action list
+- [ ] Implement config-driven approval policy
+- [ ] Add tests for policy classification
+
+### 7.2. Approval routing
+
+- [ ] Persist approval request locally and in cloud
+- [ ] Notify local TUI subscribers
+- [ ] Notify web UI via cloud
+- [ ] Accept decision from either surface
+- [ ] Deduplicate first-writer-wins decision handling
+- [ ] Return decision to Codex
+- [ ] Expire stale approvals and cancel run by default
+
+## 8. Local persistence and privacy
+
+- [ ] Define local run-history directory layout
+- [ ] Write JSONL or equivalent append-only local event log
+- [ ] Persist final transcript summary per run
+- [ ] Bound retention by age or size
+- [ ] Ensure cloud only receives allowed lifecycle data in MVP
+- [ ] Add redaction rules for logs if needed
+
+## 9. TUI client
+
+### 9.1. Local IPC
+
+- [ ] Implement Unix-socket IPC on macOS/Linux
+- [ ] Define JSON-RPC methods for TUI attachment
+- [ ] Implement `status.get`
+- [ ] Implement `status.subscribe`
+- [ ] Implement `config.get`
+- [ ] Implement `config.update`
+- [ ] Implement `runs.list`
+- [ ] Implement `runs.get`
+- [ ] Implement `approvals.list`
+- [ ] Implement `approvals.decide`
+- [ ] Implement `doctor.run`
+
+### 9.2. Views
+
+- [ ] Build Status view
+- [ ] Build Runs list view
+- [ ] Build Run detail view
+- [ ] Build Config view
+- [ ] Build Approvals view
+- [ ] Build Help overlay
+
+### 9.3. UX flows
+
+- [ ] Implement first-run onboarding wizard
+- [ ] Implement approval focus-jump and bell behavior
+- [ ] Implement quit vs stop-daemon confirmation
+- [ ] Implement refresh and search interactions
+
+## 10. Web UI
+
+- [ ] Add runner registration-token creation UI
+- [ ] Add runner status UI
+- [ ] Add current run detail UI
+- [ ] Add recent runs UI
+- [ ] Add approval inbox UI
+- [ ] Add approval decision actions
+- [ ] Add runner revoke/disconnect controls
+
+## 11. Observability and ops
+
+- [ ] Define runner logs schema
+- [ ] Define WS service logs schema
+- [ ] Add metrics for connected runners, heartbeats, active runs, approval latency
+- [ ] Add alerts for offline runners and repeated reconnect failures
+- [ ] Add basic admin troubleshooting guide
+
+## 12. Security review
+
+- [ ] Verify secret files are written with correct permissions
+- [ ] Verify local IPC is user-only
+- [ ] Verify runner auth is not cookie-based and does not reuse `apps/live` shared-secret model
+- [ ] Verify approval requests cannot be forged or replayed easily
+- [ ] Verify cloud-scoped credentials are least-privilege
+- [ ] Verify local event logs do not leak unnecessary secrets
+
+## 13. Testing
+
+### 13.1. Unit tests
+
+- [ ] Runner config parsing
+- [ ] Credential storage and permissions
+- [ ] WS message encoding/decoding
+- [ ] Reconnect backoff behavior
+- [ ] Workspace resolution logic
+- [ ] Approval policy classification
+- [ ] Local state-machine transitions
+
+### 13.2. Integration tests
+
+- [ ] Registration end to end
+- [ ] Runner connect and heartbeat end to end
+- [ ] Assign-run happy path end to end
+- [ ] Approval round-trip from Codex to TUI/web and back
+- [ ] Cancellation path end to end
+- [ ] Disconnect and reconnect resume path
+- [ ] Codex reauth path
+
+### 13.3. Manual validation matrix
+
+- [ ] macOS arm64 install to first successful run
+- [ ] macOS x64 install to first successful run
+- [ ] Linux x64 install to first successful run
+- [ ] Existing repo working-dir flow
+- [ ] Empty-dir clone flow
+- [ ] Clone-auth failure flow
+- [ ] Laptop sleep/wake during active run
+- [ ] TUI attach/detach during active run
+
+## 14. Release readiness
+
+- [ ] Build signed release artifacts for supported platforms
+- [ ] Publish install instructions
+- [ ] Publish operator/admin guide
+- [ ] Publish end-user setup guide
+- [ ] Roll out to internal users first
+- [ ] Collect feedback and bug list
+- [ ] Decide go/no-go for broader rollout
+
+## 15. Deferred work
+
+- [ ] Windows support
+- [ ] Automatic clone/worktree management beyond `require_existing`
+- [ ] Multi-runner or multi-slot concurrency per machine
+- [ ] Rich transcript sync to cloud
+- [ ] Diff preview in TUI
+- [ ] Native tray icon
+- [ ] Auto-update flow
+- [ ] Containerized per-run isolation

--- a/.ai_design/implement_runner/observability.md
+++ b/.ai_design/implement_runner/observability.md
@@ -1,0 +1,75 @@
+# Runner Observability
+
+## Metrics (Prometheus)
+
+`GET /api/v1/runner/metrics/` exposes point-in-time gauges in the Prometheus
+text exposition format (v0.0.4). Scrape every 15–60s.
+
+| Metric                            | Type  | Meaning                                                                        |
+| --------------------------------- | ----- | ------------------------------------------------------------------------------ |
+| `apple_pi_dash_runner_online`     | gauge | Runners currently `online` in the DB.                                          |
+| `apple_pi_dash_runner_busy`       | gauge | Runners currently executing a run.                                             |
+| `apple_pi_dash_runner_offline`    | gauge | Runners whose heartbeat has lapsed. Excludes revoked.                          |
+| `apple_pi_dash_runs_active`       | gauge | AgentRuns in `assigned` / `running` / `awaiting_approval` / `awaiting_reauth`. |
+| `apple_pi_dash_approvals_pending` | gauge | ApprovalRequests with `status=pending`.                                        |
+
+### Alert rules (starter)
+
+```yaml
+- alert: RunnerOfflineBurst
+  expr: delta(apple_pi_dash_runner_offline[5m]) > 5
+  for: 5m
+  annotations:
+    summary: "More than 5 runners went offline in 5 minutes — check WS service."
+
+- alert: ApprovalBacklog
+  expr: apple_pi_dash_approvals_pending > 20
+  for: 15m
+  annotations:
+    summary: "Approval backlog >20 for 15 minutes — user workflow is blocked."
+```
+
+## Log schema
+
+Every runner subsystem emits structured records via `tracing` (runner) and
+Python `logging` (Django). Use these fields consistently so log search works.
+
+### Runner daemon (`apple_pi_dash_runner`, Rust `tracing`)
+
+| Field              | Type   | Emitted on                             |
+| ------------------ | ------ | -------------------------------------- |
+| `runner_id`        | uuid   | always when available                  |
+| `run_id`           | uuid   | any frame scoped to an AgentRun        |
+| `approval_id`      | string | approval flow events                   |
+| `protocol_version` | int    | on handshake                           |
+| `cloud_url`        | string | on connection open/close               |
+| `thread_id`        | string | Codex bridge events                    |
+| `codex.stderr`     | target | drained stderr from `codex app-server` |
+
+### Django consumer (`apple_pi_dash.runner.consumers`)
+
+| Event                      | Level | Fields                                            |
+| -------------------------- | ----- | ------------------------------------------------- |
+| Protocol mismatch at hello | WARN  | `runner_id`, `client_protocol`, `server_protocol` |
+| Duplicate `mid` dropped    | DEBUG | `runner_id`, `mid`                                |
+| Seq replay dropped         | INFO  | `runner_id`, `run_id`, `seq`, `last`              |
+| Seq gap                    | INFO  | `runner_id`, `run_id`, `seq`, `last`              |
+| Unknown message type       | DEBUG | `runner_id`, `type`                               |
+| Exception in handler       | ERROR | `runner_id`, `type`, traceback                    |
+
+### Celery tasks
+
+| Task                            | Log on                     | Fields  |
+| ------------------------------- | -------------------------- | ------- |
+| `runner.expire_stale_approvals` | Count of expired approvals | `count` |
+| `runner.mark_offline_runners`   | Count of runners demoted   | `count` |
+
+## Runbook pointers
+
+- Runner stuck `online` but no activity → scrape `/api/v1/runner/metrics/`;
+  if `apple_pi_dash_runs_active > 0` but specific runs are stale, check the
+  Celery `mark_offline_runners` cadence and `last_heartbeat_at` on the row.
+- Repeated reconnect storms → look for `protocol mismatch` lines at WARN and
+  the Rust daemon's `cloud WS connect failed` at WARN. Jittered backoff caps
+  at 60s per daemon; if the server side is flapping, the clients will
+  exponentially back off.

--- a/.ai_design/implement_runner/operator-guide.md
+++ b/.ai_design/implement_runner/operator-guide.md
@@ -1,0 +1,100 @@
+# Runner — Operator / Admin Guide
+
+This covers the cloud-side operation of the runner subsystem: deployment, capacity, monitoring, and incident response. For user-facing onboarding see `user-guide.md`.
+
+## What runs where
+
+| Component                            | Owner       | Host                       | Resources                                            |
+| ------------------------------------ | ----------- | -------------------------- | ---------------------------------------------------- |
+| Django ASGI (includes `/ws/runner/`) | `apps/api`  | existing `api` service     | +1 worker recommended per 1k concurrent runners      |
+| `runner.expire_stale_approvals`      | Celery beat | existing `beat` + `worker` | 1 invocation/min                                     |
+| `runner.mark_offline_runners`        | Celery beat | existing `beat` + `worker` | 1 invocation/min                                     |
+| Redis / Valkey                       | existing    | existing                   | Channels needs pub/sub; re-uses existing `REDIS_URL` |
+| Postgres                             | existing    | existing                   | +4 small tables (see below)                          |
+
+No new deploy target, no new secret. If `REDIS_URL` is set (production), Channels uses `channels_redis.core.RedisChannelLayer`; otherwise (dev/test) `channels.layers.InMemoryChannelLayer` (single-process only).
+
+## Database impact
+
+Four new tables, all prefixed with `runner_` or `agent_run_`:
+
+| Table                       | Growth pattern                         | Retention                         |
+| --------------------------- | -------------------------------------- | --------------------------------- |
+| `runner`                    | O(users × 5)                           | Keep revoked rows for audit       |
+| `runner_registration_token` | Short-lived; consumed or expires in 1h | Safe to GC after 30 days          |
+| `agent_run`                 | One per user-triggered run             | Keep forever by default           |
+| `agent_run_event`           | N per run, up to 100s                  | Consider S3 archive after 30 days |
+| `agent_run_approval`        | ≤1 per approval request                | Keep forever (audit)              |
+
+Nothing here is bounded by the existing Postgres tuning. The largest table by row count will be `agent_run_event`; plan a rollup if you expect >1M runs/month.
+
+## Configuration
+
+| Env var     | Default          | Meaning                                         |
+| ----------- | ---------------- | ----------------------------------------------- |
+| `REDIS_URL` | required in prod | Used by cache, channel layer, existing services |
+| `AMQP_URL`  | required in prod | Celery broker                                   |
+
+No new env vars. Runner caps are code constants:
+
+- `Runner.MAX_PER_USER = 5` (`models.py`) — per-user runner cap
+- `HEARTBEAT_INTERVAL_SECS = 25` (`consumers.py`) — advertised to the daemon in `welcome`
+- `HEARTBEAT_OFFLINE_GRACE = 90s` (`tasks.py`) — how long before a stale-heartbeat runner is demoted to offline
+- approval expiry = 10 minutes (`supervisor.rs` sets it; `expire_stale_approvals` enforces it)
+
+Bump these in a deploy if the defaults turn out wrong for your workload. Log first (see `observability.md`), then raise.
+
+## Reverse-proxy
+
+The Caddy configs (`apps/proxy/Caddyfile.ce`, `Caddyfile.aio.ce`) already route `/ws/runner/*` to `api:8000`. If you run your own proxy, the WS upgrade needs:
+
+- `Connection: upgrade` and `Upgrade: websocket` passed through (Caddy does this by default on `reverse_proxy`)
+- no body-size limit on the upgrade hop
+- the `Authorization: Bearer ...` header preserved
+
+## Monitoring
+
+Scrape `GET /api/v1/runner/metrics/` — see `observability.md` for the full schema. Suggested dashboard:
+
+1. Current online / busy / offline runner counts
+2. Active runs (should oscillate around your workspace's typical concurrency)
+3. Pending approvals (should near zero; sustained growth = user workflow blocker)
+4. Offline burst (delta of `offline` over 5m) — indicator of a deploy or network incident
+
+The runner consumer logs structured events under the `apple_pi_dash.runner.consumers` logger. Surface `WARN`/`ERROR` from that logger in your aggregation tool.
+
+## Incident response
+
+### Symptom: no runners ever come online
+
+1. `GET /api/v1/runner/health/` — returns `{"ok": true}`? If not, the Django/ASGI process is unhealthy.
+2. `GET /api/v1/runner/metrics/` — returns counts at all? If the response is empty or 5xx, the DB is unreachable.
+3. On the runner side, `apple-pi-dash-runner status --json` — does the daemon see the WS as connected?
+4. Check Caddy / your proxy access logs for `/ws/runner/` upgrade requests. 426 or 400 indicates the upgrade headers are being stripped.
+
+### Symptom: approvals pile up and never get decided
+
+1. Check `apple_pi_dash_approvals_pending` — is it climbing or stable?
+2. Is `runner.expire_stale_approvals` running? `celery -A apple_pi_dash.celery beat-status`. It should fire once per minute.
+3. If the scheduler is off, an approval older than 10 minutes should have been auto-cancelled on the next task tick.
+
+### Symptom: thundering-herd reconnect after a deploy
+
+Runners use jittered exponential backoff capped at 60s, but if many runners disconnect at once you'll see a reconnect window of ~1–60s on rolling restart. This is expected. If a flap persists, check:
+
+- Caddy / LB is not enforcing idle timeouts shorter than 30s (would kick all heartbeating runners)
+- Django ASGI worker count is sufficient for the connection load
+
+### Symptom: a user hits the 5-runner cap
+
+Rare by design. If legitimate (e.g. a user has 5 dev machines plus a build box), bump `Runner.MAX_PER_USER` — but see whether they're leaking revoked rows first. Revoked runners do NOT count against the cap, but stale "online" rows from machines that never cleanly disconnected do until the `mark_offline_runners` Celery task runs.
+
+## Backup / disaster recovery
+
+The runner sub-schema is covered by whatever Postgres backup regime you run for the rest of Apple Pi Dash. Redis state is not restored from backup — runners will reconnect and repopulate their `runner.<id>` Channels groups automatically.
+
+Per-runner transcripts (`history/runs/*.jsonl`) live on the user's laptop only. If a user loses their machine, those are gone. This is a design choice (local-only events).
+
+## Upgrades
+
+Bump `PROTOCOL_VERSION` in `apple_pi_dash/runner/consumers.py` **and** `runner/src/lib.rs` together. Runner daemons on an older protocol will log a warning but continue; the server can be stricter by rejecting mismatched versions at `hello` (commented path in `on_hello`).

--- a/.ai_design/implement_runner/runner-design.md
+++ b/.ai_design/implement_runner/runner-design.md
@@ -1,0 +1,746 @@
+# Apple Pi Dash Runner — MVP Design
+
+This document specifies the MVP runner for Apple Pi Dash: a **thin local connector** that accepts tasks assigned by the Apple Pi Dash cloud and invokes Codex locally to execute them. The runner performs **no orchestration** — scheduling, retries, matching, prompt composition, and "done" interpretation all live in the cloud.
+
+Companion docs in this directory:
+
+- `github-runner-architecture.md` — reference for how GHA's runner works (blueprint).
+- `tui-design.md` — runner's built-in TUI.
+
+---
+
+## 1. Scope
+
+### In scope
+
+- Register with Apple Pi Dash cloud using a one-time token → obtain long-lived runner credentials.
+- Maintain a persistent outbound WebSocket to the cloud; send heartbeats; reconnect with backoff.
+- Accept one task at a time; bridge the cloud's task message to `codex app-server`.
+- Relay approval requests from Codex up to the cloud (and to the local TUI); accept decisions from either surface.
+- Report lifecycle events to the cloud (`run_started`, `approval_request`, `run_completed` with Codex's structured "done" payload, `run_failed`, `run_cancelled`, `run_awaiting_reauth`).
+- Keep Codex event stream **local only** (not streamed to cloud). Persist per-run history on disk.
+- Built-in TUI (Ratatui) that attaches to the daemon over a local socket.
+- First-run validation: Codex installed + logged in, git configured with working credentials.
+
+### Out of scope for MVP
+
+- Orchestration logic (scheduling, retry, matching) — cloud owns this.
+- Prompt composition from work-item fields — cloud owns this.
+- Opening PRs, running tests, interpreting "done" — Codex emits a structured signal per the cloud's prompt, runner passes it up, cloud decides.
+- Multiple runners per machine — one runner per machine in MVP.
+- Label/capability matching — each runner has a globally-unique ID; cloud assigns to an online idle runner owned by the user.
+- Codex sandbox mode enforcement beyond defaults — deferred.
+- Streaming Codex event deltas to cloud — local only in MVP; cloud can fetch history later.
+- Cross-task workspace isolation — single shared working directory.
+- Windows support — v2.
+- Native tray icon — post-v1.
+
+---
+
+## 2. Committed decisions (from scoping)
+
+| #   | Topic                        | Decision                                                                                                                                                                                                                                                                       |
+| --- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1   | Working directory            | Runner config specifies working dir. Default `$TMPDIR/.apple_pi/`. If dir has a git repo → use it. If not → request repo URL from cloud, `git clone` into dir. Clone-auth failure is reported. Every task runs Codex against this dir.                                         |
+| 2   | Concurrency                  | One task at a time per runner.                                                                                                                                                                                                                                                 |
+| 3   | Assignment                   | One runner instance per dev machine. Globally unique runner ID. Cloud assigns to an online idle runner owned by the user. No label matching.                                                                                                                                   |
+| 4   | Prompt construction          | Cloud renders; runner receives a ready-to-use prompt string. Runner never composes prompts.                                                                                                                                                                                    |
+| 5   | "Done" criteria              | Cloud's prompt instructs Codex to emit structured data as a done signal. Runner forwards that data verbatim. Cloud decides what happens next.                                                                                                                                  |
+| 6   | Approval policy              | Auto-approve read-only allowlist; ask for everything else; never auto-approve destructive ops / writes outside workspace / git push / non-allowlisted network. Editable per-runner in TUI.                                                                                     |
+| 7   | Platforms v1                 | macOS arm64, macOS x64, Linux x64. Linux arm64 in v1.1. Windows v2.                                                                                                                                                                                                            |
+| 8   | Failure recovery             | WS drop → reconnect + report state. Runner crash → Codex dies, mark failed on restart. Codex crash → attempt `thread/resume` once, else failed. Laptop sleep → reconnect + `thread/resume` on wake. Codex 401 → `awaiting_reauth`, prompt user via TUI/web, resume on success. |
+| A   | Git credentials              | Runner uses user's existing git config. First-run onboarding validates with a dry-run `git ls-remote` against the user's primary repo host.                                                                                                                                    |
+| C   | Cloud-initiated cancellation | Cloud sends `cancel` → runner sends `turn/interrupt` to Codex → wait for graceful stop (SIGKILL fallback after N seconds) → runner reports `run_cancelled`.                                                                                                                    |
+| D   | Event privacy                | Codex `item/*` deltas stay **local** (persisted to run history file). Only lifecycle + approval + final done signal go to cloud.                                                                                                                                               |
+| E   | Idle behavior                | Heartbeats only. No periodic doctor checks. No pre-warm of Codex.                                                                                                                                                                                                              |
+
+---
+
+## 3. Architecture
+
+```
+┌─────────────────────── dev laptop ─────────────────────────────────┐
+│                                                                     │
+│   apple-pi-dash-runner  (daemon, long-lived)                        │
+│   ┌─────────────────────────────────────────────────────────────┐  │
+│   │  Cloud WS client  ◄─── outbound WSS on 443 ────►            │  │
+│   │                                                             │  │
+│   │  State machine (one active run at a time)                  │  │
+│   │                                                             │  │
+│   │  Codex bridge  ◄── stdio ──►  codex app-server (subprocess)│  │
+│   │                                                             │  │
+│   │  Working dir manager         Approval router               │  │
+│   │                                                             │  │
+│   │  Local IPC server (Unix socket)                             │  │
+│   │  History writer (JSONL)      Config file (TOML)             │  │
+│   └─────────────────────────────────────────────────────────────┘  │
+│            ▲                                                        │
+│            │ Unix socket                                            │
+│   apple-pi-dash-runner tui  (Ratatui, ad-hoc client)                │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+                        │  WSS  │
+                        ▼       ▼
+                 ┌──────────────────────┐
+                 │  Apple Pi Dash cloud  │
+                 │  (Django + Node WS)   │
+                 └──────────────────────┘
+```
+
+Key properties:
+
+- Single long-lived outbound WebSocket — NAT-friendly, the one and only public surface.
+- No inbound listeners on the laptop except a local Unix socket (0600, user-only).
+- Codex is spawned on demand per task; killed and cleaned up per task.
+- TUI is a separate process; it starts and stops freely without affecting the daemon.
+
+---
+
+## 4. Runner lifecycle
+
+### 4.1. Install
+
+Distribution: one static binary per target triple. Users install via:
+
+- Homebrew tap: `brew install apple-pi-dash/tap/runner`
+- Direct download: `curl -fsSL https://... | sh`
+- Linux: `.deb` / `.rpm`
+- Future: Windows MSI (v2)
+
+Install does not require root; binary lives in `$HOME/.local/bin/apple-pi-dash-runner` by default.
+
+### 4.2. First-run configure
+
+```
+apple-pi-dash-runner configure \
+  --url https://cloud.apple-pi-dash.so \
+  --token <ONE_TIME_CODE> \
+  [--name my-laptop]
+```
+
+Sequence:
+
+1. POST `{runner_name, os, arch, version}` + token to cloud registration endpoint.
+2. Cloud returns long-lived `runner_id` (global UUID) + `runner_secret` (bearer token).
+3. Write `config.toml` and `credentials.toml` with file mode 0600.
+4. **Validate environment** (on-install doctor):
+   - Codex binary: which `codex` resolves; run `codex --version`.
+   - Codex auth: run `codex whoami` (or equivalent). Refuse to complete setup if unauthenticated.
+   - Git config: verify `user.name` and `user.email` set, run `git ls-remote <any configured repo>` dry-run. Warn if git creds look missing.
+5. Print a success line with the runner's global ID and instruction to run `service install` or `start`.
+
+If TUI is used instead, the first-run wizard in `tui-design.md` performs steps 1–5 interactively.
+
+### 4.3. Service install
+
+```
+apple-pi-dash-runner service install   # systemd user unit / launchd plist
+apple-pi-dash-runner service start
+apple-pi-dash-runner service status
+apple-pi-dash-runner service stop
+```
+
+- **Linux**: generate a `~/.config/systemd/user/apple-pi-dash-runner.service`, `systemctl --user daemon-reload`, enable with `linger` optional.
+- **macOS**: generate a `~/Library/LaunchAgents/so.apple-pi-dash.runner.plist`, load with `launchctl bootstrap gui/$UID`.
+
+### 4.4. Run loop (simplified)
+
+```
+connect_to_cloud():
+    open WSS
+    send Hello { runner_id, version, os, arch, status: Idle }
+    expect Welcome
+
+main_loop():
+    spawn heartbeat_task    # sends Heartbeat every 25s
+    spawn ipc_server_task   # local Unix socket for TUI
+    while true:
+        msg = read_ws()
+        match msg:
+            Assign(task)   -> handle_assign(task)
+            Cancel(run_id) -> handle_cancel(run_id)
+            Decide(dec)    -> handle_decision(dec)
+            ReauthHint     -> notify_user()
+
+on_ws_drop():
+    jittered_backoff()
+    reconnect()
+    on success: resend current run state if a run is in-flight
+```
+
+### 4.5. Handling one task (happy path)
+
+```
+handle_assign(task):
+    send Accept { run_id: task.run_id }
+    resolve_workspace()
+        ├─ if config.working_dir is a valid git repo: use it
+        └─ else:
+            request RepoInfo from cloud (already carried in Assign)
+            run `git clone <url> <working_dir>` using user's git creds
+            on failure (auth or network): send RunFailed{reason: workspace_setup}
+    spawn codex app-server (--cwd = working_dir)
+    codex: initialize -> thread/start (no resume) -> turn/start { prompt: task.prompt }
+    send RunStarted { run_id, thread_id, started_at }
+    loop on codex events:
+        item/commandExecution/requestApproval -> approval_flow()
+        item/fileChange/requestApproval        -> approval_flow()
+        (every other item/* event)             -> write to local history; do NOT send to cloud
+        turn/completed { conclusion: success, done_payload } -> send RunCompleted; break
+        turn/completed { conclusion: failed }  -> send RunFailed; break
+    cleanup:
+        close thread, terminate app-server
+        persist final history record
+        set state = Idle
+```
+
+### 4.6. Approval flow
+
+```
+approval_flow(req):
+    check policy:
+        if req matches auto-approve allowlist: respond Accept; return
+        if req matches auto-decline list:      respond Decline; return
+    persist ApprovalRequest { pending }
+    notify TUI (via IPC) and cloud (via WS)
+    wait for Decide { approval_id, decision } from either:
+        - TUI subscriber (local Unix socket)
+        - Cloud WS
+    deduplicate: first responder wins; record source
+    send decision back to Codex via app-server
+    persist ApprovalRequest { resolved }
+```
+
+### 4.7. Shutdown
+
+- `SIGTERM` → stop accepting new assignments; if a run is active, attempt graceful Codex `turn/interrupt`, wait up to N seconds, then SIGKILL; close WS; flush history; exit.
+- `runner remove --token <REMOVAL_TOKEN>` → call cloud `deregister`, delete credentials and config, exit.
+
+---
+
+## 5. Working directory & git setup
+
+This is the one piece of business logic the runner owns. Detailed behavior:
+
+### 5.1. Configuration
+
+```toml
+# ~/.config/apple-pi-dash-runner/config.toml
+[workspace]
+working_dir = "/var/folders/.../T/.apple_pi"   # default: $TMPDIR/.apple_pi
+```
+
+Override via CLI: `apple-pi-dash-runner configure --working-dir /path/to/repo`.
+
+### 5.2. On assignment
+
+```
+resolve_workspace(task):
+    dir = config.workspace.working_dir
+    ensure dir exists (mkdir -p)
+    if is_git_repo(dir):                          # dir/.git exists
+        log("using existing repo at {dir}")
+        return dir
+    if dir_is_empty(dir):
+        git_clone(task.repo_url, dir)              # uses user's git creds
+        return dir
+    return Err(NonEmptyNonRepo)                   # refuse to operate
+```
+
+### 5.3. Clone failures
+
+`git clone` can fail for:
+
+- Network unreachable → `run_failed { reason: network }`.
+- Auth rejected (SSH key, HTTPS creds) → `run_failed { reason: git_auth, detail: <stderr> }`.
+- URL invalid → `run_failed { reason: invalid_repo_url }`.
+
+All stderr is captured verbatim in the failure report. Cloud surfaces this to the user in the work item UI.
+
+### 5.4. Reused state between tasks
+
+Runner does **not** reset the working directory between tasks. Dirty trees, stray branches, cached build artifacts all persist. This is intentional:
+
+- MVP concurrency is 1, so there's no in-flight overlap.
+- Reusing the dir makes large repos fast (no re-clone, no re-install of deps).
+- Hygiene is the **prompt's** responsibility. The cloud instructs Codex (via the rendered prompt) to reset/stash/checkout as appropriate before starting work.
+
+The runner surfaces current git state (branch, dirty?) in a pre-run `workspace_state` field included in `Accept` so the cloud can decide to inject prompt preamble about cleanup if it cares.
+
+### 5.5. Caveat to document in onboarding
+
+If `working_dir` is inside `$TMPDIR` on Linux (often `/tmp`, which may be `tmpfs`), the clone is lost on reboot and re-cloning happens on the next task. For large repos, users should override `working_dir` to a durable path.
+
+---
+
+## 6. Data model
+
+### 6.1. On-disk layout
+
+```
+~/.config/apple-pi-dash-runner/
+├── config.toml          # user-editable config
+└── credentials.toml     # runner_id + runner_secret (0600)
+
+~/.local/share/apple-pi-dash-runner/
+├── history/
+│   ├── runs/
+│   │   └── <run_id>.jsonl      # one JSONL per run; all Codex events + lifecycle
+│   └── runs_index.json         # small index: run_id, work_item_id, status, timestamps
+├── logs/
+│   └── YYYY-MM-DD.log
+└── pid                         # daemon PID file
+```
+
+### 6.2. Config schema
+
+```toml
+version = 1
+
+[runner]
+name = "my-laptop"
+cloud_url = "https://cloud.apple-pi-dash.so"
+# runner_id + secret are in credentials.toml
+
+[workspace]
+working_dir = "/var/folders/.../T/.apple_pi"
+
+[codex]
+binary = "/usr/local/bin/codex"      # auto-detected; overridable
+model_default = "gpt-5-codex"
+
+[approval_policy]
+auto_approve_readonly_shell = true
+auto_approve_workspace_writes = false
+auto_approve_network = false
+allowlist_commands = ["ls", "cat", "pwd", "git status", "git diff", "git log", "git branch"]
+
+[logging]
+level = "info"
+retention_days = 14
+```
+
+### 6.3. Credentials
+
+```toml
+runner_id = "r_01HY..."        # server-assigned UUID, global
+runner_secret = "rns_..."      # bearer, used in WS Authorization header
+issued_at = "2026-04-18T12:34:56Z"
+```
+
+### 6.4. Run history record (JSONL)
+
+Each run is one file: `history/runs/<run_id>.jsonl`. Line-delimited JSON. Lines are:
+
+- `header` (first line) — task metadata, start time.
+- `codex_event` — every `item/*` and `turn/*` notification from app-server, verbatim.
+- `approval` — approval requested + resolved.
+- `lifecycle` — state transitions (started, awaiting_approval, awaiting_reauth, cancelled, failed, completed).
+- `footer` (last line) — final status + done payload (if any) + end time.
+
+Rationale for JSONL over SQLite in v1: simpler, zero schema migrations, `tail -f` works for debugging. Migrate to SQLite in v2 if query needs grow.
+
+---
+
+## 7. Cloud ↔ runner protocol
+
+Transport: WebSocket Secure (WSS) on 443. Messages are JSON frames. Every message has `{ "type": "...", "v": 1, ... }`.
+
+Authorization: `Authorization: Bearer <runner_secret>` on the initial HTTP upgrade. `runner_id` is derived from the token server-side and echoed in the welcome.
+
+### 7.1. Lifecycle messages
+
+**Runner → Cloud:**
+
+| Type                  | Shape                                                        | Meaning                                                                                    |
+| --------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| `hello`               | `{ runner_id, version, os, arch, status: "idle" \| "busy" }` | First frame after connect                                                                  |
+| `heartbeat`           | `{ ts }`                                                     | Every 25s                                                                                  |
+| `accept`              | `{ run_id, workspace_state: { branch, dirty } }`             | Accepting an assignment                                                                    |
+| `run_started`         | `{ run_id, thread_id, started_at }`                          | Codex thread established                                                                   |
+| `approval_request`    | `{ run_id, approval_id, kind, payload, reason }`             | Forwarded from Codex, needs human                                                          |
+| `run_awaiting_reauth` | `{ run_id }`                                                 | Codex returned 401                                                                         |
+| `run_completed`       | `{ run_id, done_payload, ended_at }`                         | Codex reported success; `done_payload` is the structured object Codex was prompted to emit |
+| `run_failed`          | `{ run_id, reason, detail }`                                 | `reason ∈ { workspace_setup, git_auth, network, codex_crash, internal }`                   |
+| `run_cancelled`       | `{ run_id, cancelled_at }`                                   | Acknowledges a cancel                                                                      |
+| `bye`                 | `{ reason }`                                                 | Graceful disconnect (service stopping)                                                     |
+
+**Cloud → Runner:**
+
+| Type          | Shape                                                                                                      | Meaning                                                |
+| ------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| `welcome`     | `{ server_time, protocol_version }`                                                                        | Initial reply                                          |
+| `assign`      | `{ run_id, work_item_id, prompt, repo_url, repo_ref?, expected_codex_model?, approval_policy_overrides? }` | New task                                               |
+| `cancel`      | `{ run_id, reason }`                                                                                       | Abort the active run                                   |
+| `decide`      | `{ run_id, approval_id, decision: "accept" \| "decline" \| "accept_for_session", decided_by }`             | Answer to an approval                                  |
+| `config_push` | `{ approval_policy }`                                                                                      | Optional cloud-side policy updates (deferred past MVP) |
+| `ping`        | `{ ts }`                                                                                                   | Optional; runner echoes with heartbeat                 |
+
+### 7.2. Flow diagrams
+
+**Happy-path task:**
+
+```
+runner                                     cloud
+  │                                          │
+  │ ──────── hello ─────────────────────────► │
+  │ ◄──────── welcome ─────────────────────── │
+  │                                          │
+  │ ◄──────── assign { run_id, prompt,… } ─── │
+  │ ─────── accept { workspace_state } ─────► │
+  │ ─── (git clone if needed, spawn codex) ─  │
+  │ ─────── run_started ──────────────────── ► │
+  │                                          │
+  │ ─────── approval_request ──────────────► │   (if Codex asks)
+  │ ◄──────── decide { accept } ──────────── │
+  │                                          │
+  │ ─────── run_completed { done_payload } ► │
+```
+
+**Cancel:**
+
+```
+  │ ◄──────── cancel { run_id } ──────────── │
+  │ (runner.turn_interrupt → codex)         │
+  │ (grace 10s, then SIGKILL app-server)    │
+  │ ─────── run_cancelled ────────────────► │
+```
+
+**Disconnect during run:**
+
+```
+  × WS drops
+  (codex keeps running locally)
+  (jittered backoff: 1–10s → 2–20s → … cap 60s)
+  │ ──────── hello { status: "busy" } ─────► │
+  │ ──────── run_resumed { run_id, thread_id, elapsed } ─► │   (extend of hello)
+  │ ◄──────── welcome ─────────────────────── │
+  (continue streaming approvals/completion)
+```
+
+### 7.3. Backoff
+
+Reconnect on disconnect: `sleep = min(60, 2^n + rand(0, n))` seconds where `n` is the consecutive-failure count, capped at 60s, reset on success.
+
+---
+
+## 8. Codex bridge
+
+Runner talks to `codex app-server` over stdio (default). WebSocket mode (`codex app-server --listen ws://127.0.0.1:<port>`) is a v1.1 option if stdio proves limiting.
+
+### 8.1. Subprocess lifecycle
+
+```
+per-task:
+    binary = config.codex.binary
+    args   = ["app-server"]
+    env    = current + any CODEX_* overrides
+    cwd    = config.workspace.working_dir
+
+    spawn with tokio::process::Command
+    wire:
+        child.stdin  ← JSON-RPC requests
+        child.stdout → JSON-RPC responses + notifications (line-delimited)
+        child.stderr → drained to runner log file
+```
+
+### 8.2. JSON-RPC methods invoked
+
+Phase ordering within one task:
+
+1. `initialize { clientInfo: { name: "apple-pi-dash-runner", version } }` → wait for `initialize` response.
+2. Send `initialized` notification.
+3. `account/read` — confirm auth state. If unauthenticated → `run_awaiting_reauth`.
+4. `thread/start { cwd, model?, sandboxPolicy: "workspace-write", approvalPolicy: "on-request" }` → capture `thread_id`.
+5. `turn/start { input: [{ role: "user", content: task.prompt }], model?, effort? }`.
+6. Listen for notifications:
+   - `item/agentMessage/delta`, `item/reasoning/textDelta`, `item/commandExecution/outputDelta`, `item/fileChange/outputDelta`, `turn/diff/updated`, `turn/plan/updated`, `thread/tokenUsage/updated` → write to **local history only**.
+   - `item/commandExecution/requestApproval`, `item/fileChange/requestApproval` → run through approval flow (section 9).
+   - `item/completed`, `item/started` → local history only.
+   - `turn/completed` → parse conclusion + extract done_payload from the final `item/agentMessage/completed` content (per the cloud's prompt contract).
+7. Close the thread, terminate the app-server subprocess.
+
+### 8.3. Resume on reconnect
+
+If the WS drops mid-run but Codex is still alive:
+
+- On reconnect, runner sends `hello { status: "busy" }` + `run_resumed { run_id, thread_id }`.
+- Cloud marks the run as `reconnected`, trusts the runner's state.
+- Any approvals/events that occurred during disconnect are replayed up if they're still pending (runner buffers them).
+
+If Codex died too:
+
+- Runner attempts `thread/resume { threadId }` **once** on a fresh app-server.
+- If resume fails (Codex returns `thread_not_found` or similar), runner reports `run_failed { reason: codex_crash }`.
+
+---
+
+## 9. Approval flow
+
+### 9.1. Policy evaluation
+
+On `requestApproval`:
+
+```
+evaluate(req):
+    if is_destructive(req):                    # rm -rf, writes outside workspace, sudo
+        return Ask                             # never auto-approve
+    if matches allowlist_commands(req.command):
+        return AutoAccept
+    if req.kind == commandExecution and req.command is read-only shell:
+        if config.auto_approve_readonly_shell:
+            return AutoAccept
+    if req.kind == fileChange and req.path inside working_dir:
+        if config.auto_approve_workspace_writes:
+            return AutoAccept
+    return Ask
+```
+
+### 9.2. Ask path
+
+1. Persist a pending `ApprovalRequest` locally (JSONL + in-memory index).
+2. Publish to IPC subscribers (TUI) and WS (cloud). Both surfaces can answer.
+3. Wait for the **first** `decide` to arrive (from either).
+4. Send the decision back to Codex (`item/commandExecution/requestApproval` response with `decision`).
+5. Record which surface answered and who (`decided_by`).
+6. A late second `decide` is ignored with a log line.
+
+### 9.3. Decision semantics
+
+- `accept` — Codex proceeds with this one action.
+- `accept_for_session` — runner remembers for the rest of this thread and auto-answers subsequent matching requests.
+- `decline` — Codex sees it as denied; usually continues with an alternative or stops.
+- Cancel of the run happens via the separate `cancel` message, not through an approval response.
+
+---
+
+## 10. Failure recovery (summary table)
+
+| Scenario                       | Runner action                                                                                                     | Reported state             |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| WS drops, Codex alive          | Jittered backoff, reconnect, `hello` with `busy`, `run_resumed` with state                                        | `reconnected` (cloud-side) |
+| WS drops, Codex dies           | On reconnect report `run_failed { codex_crash }`, cleanup                                                         | `failed`                   |
+| Runner process crash           | On next start: scan history, mark any "running" rows as `failed { runner_crashed }`, cleanup subprocess if leaked | `failed`                   |
+| Codex subprocess crash mid-run | Try `thread/resume` once on fresh app-server; else `run_failed { codex_crash }`                                   | `failed` or `running`      |
+| Laptop sleep                   | TCP hangs → WS ping fails → treat as drop → reconnect + `thread/resume` on wake                                   | `reconnected`              |
+| Codex 401                      | Suspend run; emit `run_awaiting_reauth`; TUI + web UI prompt for re-auth; resume on user fix                      | `awaiting_reauth`          |
+| Workspace clone failure        | `run_failed { workspace_setup, detail }`                                                                          | `failed`                   |
+| `cancel` received              | `turn/interrupt`, wait 10s, SIGKILL app-server, cleanup, `run_cancelled`                                          | `cancelled`                |
+| Cloud marks runner offline     | No local effect; runner keeps trying to reconnect                                                                 | —                          |
+
+---
+
+## 11. Code structure (Rust crate)
+
+Single binary, multiple modules. Organized by concern:
+
+```
+apple-pi-dash-runner/
+├── Cargo.toml
+├── src/
+│   ├── main.rs                     # CLI dispatch (clap)
+│   ├── cli/
+│   │   ├── mod.rs
+│   │   ├── configure.rs            # `runner configure`
+│   │   ├── service.rs              # `runner service [install|start|stop|status]`
+│   │   ├── start.rs                # `runner start` (foreground)
+│   │   ├── status.rs               # `runner status` (prints summary via IPC)
+│   │   ├── tui.rs                  # `runner tui` (spawns Ratatui app)
+│   │   ├── doctor.rs               # `runner doctor`
+│   │   └── remove.rs               # `runner remove`
+│   ├── daemon/
+│   │   ├── mod.rs                  # main async orchestrator, state machine
+│   │   ├── state.rs                # Idle / Busy / Reconnecting; current run
+│   │   └── supervisor.rs           # task spawning + join handles
+│   ├── cloud/
+│   │   ├── mod.rs
+│   │   ├── ws.rs                   # tokio-tungstenite client w/ reconnect + heartbeat
+│   │   ├── protocol.rs             # serde enums: ClientMsg, ServerMsg
+│   │   └── register.rs             # one-time token → credentials exchange (reqwest)
+│   ├── codex/
+│   │   ├── mod.rs
+│   │   ├── app_server.rs           # spawn, stdio split, line framing
+│   │   ├── jsonrpc.rs              # Request/Response/Notification types
+│   │   ├── schema.rs               # enums for item/*, turn/*, account/*
+│   │   └── bridge.rs               # cloud msg ↔ codex jsonrpc translation
+│   ├── workspace/
+│   │   ├── mod.rs
+│   │   ├── resolve.rs              # working_dir logic (section 5)
+│   │   └── git.rs                  # thin wrapper around system `git` command
+│   ├── config/
+│   │   ├── mod.rs
+│   │   ├── file.rs                 # TOML read/write, 0600 perms
+│   │   └── schema.rs               # Config, Credentials, ApprovalPolicy structs
+│   ├── ipc/
+│   │   ├── mod.rs                  # Unix socket server (daemon) + client (TUI/CLI)
+│   │   ├── protocol.rs             # local JSON-RPC methods (see tui-design.md §"Local IPC")
+│   │   └── server.rs
+│   ├── history/
+│   │   ├── mod.rs
+│   │   ├── jsonl.rs                # append-only writer + reader
+│   │   └── index.rs                # lightweight runs_index.json
+│   ├── approval/
+│   │   ├── mod.rs
+│   │   ├── policy.rs               # evaluate() per section 9.1
+│   │   └── router.rs               # fan-out to TUI + cloud; first-wins
+│   ├── service/
+│   │   ├── mod.rs
+│   │   ├── systemd.rs              # generate user unit
+│   │   └── launchd.rs              # generate plist
+│   ├── tui/
+│   │   ├── mod.rs                  # Ratatui app entry
+│   │   ├── app.rs                  # model/update/view (Elm-ish)
+│   │   ├── ipc_client.rs           # subscribes to daemon over Unix socket
+│   │   └── views/
+│   │       ├── status.rs
+│   │       ├── config.rs
+│   │       ├── approvals.rs
+│   │       └── runs.rs
+│   └── util/
+│       ├── mod.rs
+│       ├── paths.rs                # directories crate wrappers
+│       ├── backoff.rs              # jittered exponential
+│       └── signal.rs               # ctrl-c, sigterm handling
+├── tests/
+│   ├── cloud_protocol.rs           # round-trip serde tests
+│   ├── codex_bridge.rs             # fake app-server → bridge → fake cloud
+│   ├── workspace_resolve.rs
+│   └── approval_policy.rs
+└── dist/
+    ├── Cargo.dist.toml             # cargo-dist config
+    └── Formula/runner.rb           # generated Homebrew tap
+```
+
+### 11.1. Dependencies (MVP)
+
+- `tokio` (full) — async runtime
+- `tokio-tungstenite` + `rustls` — WS client
+- `tokio-util` — codec utilities
+- `serde` + `serde_json` + `toml` — data
+- `ratatui` + `crossterm` — TUI
+- `clap` (derive) — CLI
+- `tracing` + `tracing-subscriber` + `tracing-appender` — logs
+- `directories` — XDG + macOS paths
+- `reqwest` (rustls, no cookies) — registration HTTP
+- `thiserror` + `anyhow` — errors
+- `uuid` — run IDs
+- `self_replace` — self-update (post-v1)
+- `rustls-pemfile` — TLS trust store loading
+- `nix` (unix only) — file mode, signals
+
+No C dependencies in MVP (rustls everywhere, no OpenSSL). Makes cross-compilation clean.
+
+### 11.2. Expected LOC
+
+~2,500–3,500 LOC at MVP maturity. Daemon/cloud + codex bridge are the largest modules (~1,000 each); TUI is ~600–800; everything else is small.
+
+---
+
+## 12. Distribution & releases
+
+Tooling: **cargo-dist**.
+
+- `cargo dist init` → `dist/Cargo.dist.toml` describing the targets: `aarch64-apple-darwin`, `x86_64-apple-darwin`, `x86_64-unknown-linux-gnu`.
+- Each tagged release: GitHub Actions matrix builds binaries + generates Homebrew formula, `.deb`, `.tar.gz`, SHA256SUMS.
+- Homebrew tap hosted at `github.com/apple-pi-dash/homebrew-tap`.
+- `curl | sh` installer script resolves to the right target triple and drops binary in `$HOME/.local/bin`.
+
+Binary signing:
+
+- macOS: Developer ID codesign + notarize in CI. Without this, Gatekeeper will block first run.
+- Linux: no signing required; users trust the GitHub release + checksum.
+
+Self-update (v1.1+):
+
+- Runner checks `/runner/version` on cloud once per day.
+- If newer version advertised, download, verify checksum, replace binary with `self_replace`, re-exec.
+- Respect a `config.auto_update = false` override.
+
+---
+
+## 13. Testing strategy
+
+### 13.1. Unit tests
+
+- `cloud::protocol` — round-trip serde for every message variant.
+- `codex::schema` — deserialize real Codex event samples (checked in under `tests/fixtures/codex/`).
+- `approval::policy::evaluate` — table-driven: each rule with positive and negative cases.
+- `workspace::resolve` — tmpdir-based tests for empty/dir/repo/nonempty-nonrepo paths.
+
+### 13.2. Integration tests
+
+- **Fake cloud**: a small `tokio`-based WS server that drives the runner through assign → cancel / assign → approval → complete / WS-drop-resume scripts.
+- **Fake Codex app-server**: a binary (compiled in `tests/bin/`) that reads stdin JSON-RPC and replays canned event streams. Runner's bridge talks to it exactly like real Codex.
+- Combine: fake cloud + runner + fake codex → assert full scenarios end-to-end with no real network or real Codex.
+
+### 13.3. TUI tests
+
+- `ratatui`'s test backend captures rendered buffer; snapshot comparisons for each view in each state.
+
+### 13.4. Manual QA matrix per release
+
+- macOS arm64 (Sonoma+), macOS x64, Linux x64 (Ubuntu LTS + Fedora latest).
+- Scenarios: first-run configure, service install/start/stop, TUI connect + each view, approval from TUI + approval from web, WS drop + reconnect, Codex auth expiry simulation.
+
+---
+
+## 14. Phasing
+
+Aligns with the runner-side phases in `github-runner-architecture.md` §13.
+
+### v1.0 — MVP
+
+- [ ] CLI skeleton: `configure`, `start`, `service install/start/stop/status`, `status`, `doctor`, `remove`.
+- [ ] Config + credentials file handling with proper perms.
+- [ ] Cloud WS client with reconnect + heartbeat.
+- [ ] Codex app-server stdio bridge.
+- [ ] Workspace resolve + `git clone` on first task.
+- [ ] Approval policy + routing (auto-approve allowlist + ask).
+- [ ] Local JSONL history.
+- [ ] TUI v1.0 views (Status, Config, Approvals, onboarding wizard) — see `tui-design.md`.
+- [ ] Cargo-dist release pipeline for macOS arm64/x64 + Linux x64.
+- [ ] Homebrew tap.
+
+### v1.1
+
+- [ ] Runs history view in TUI; doctor subcommand; search/filter.
+- [ ] Linux arm64 build target.
+- [ ] Self-update.
+
+### v1.2
+
+- [ ] Diff preview + log follower in TUI.
+- [ ] Optional WebSocket transport to Codex app-server (vs stdio).
+
+### v2
+
+- [ ] Windows support (named pipe IPC, Windows Service, PowerShell integration).
+- [ ] Optional event streaming to cloud (behind user opt-in).
+- [ ] Native tray client reusing the local IPC.
+
+---
+
+## 15. Open questions / deferred
+
+- **Multi-runner per machine.** Explicitly deferred. Global runner ID makes this a forward-compatible change (just add a "discriminator" label later).
+- **Codex sandbox mode.** Deferred. MVP uses Codex's default `workspace-write` at `thread/start` time; no further enforcement.
+- **Streaming Codex events to cloud.** Deferred. History is local-only; cloud can later pull history via a signed API if the user opts in.
+- **Workflow templates + prompt composition.** Fully cloud-side; this doc deliberately ignores it beyond "prompt arrives in the assign message."
+- **Observability/telemetry.** Minimal in MVP: only the WS heartbeat + local logs. No analytics, no crash reporting service. Revisit when paid users exist.
+
+---
+
+## 16. What Symphony-shaped logic _does not_ live here
+
+For the reviewer's mental model, the runner **does not**:
+
+- Poll any tracker.
+- Maintain a scheduler or work queue.
+- Compose prompts from templates.
+- Decide retries.
+- Interpret "done" semantics.
+- Match tasks to runners.
+- Store global run state (only its own local history).
+- Open pull requests or run tests.
+
+All of that lives in Apple Pi Dash cloud. The runner is a mouthpiece for Codex with a persistent outbound connection and good manners about approvals and cleanup.

--- a/.ai_design/implement_runner/tui-design.md
+++ b/.ai_design/implement_runner/tui-design.md
@@ -1,0 +1,300 @@
+# Runner TUI — Design
+
+The MVP runner ships with a built-in TUI so users can configure the runner, watch it work, and answer approval requests from a terminal. This complements (not replaces) the Apple Pi Dash web UI.
+
+## Why a TUI for v1
+
+| Option               | Effort | UX for laptop users                                     | Verdict           |
+| -------------------- | ------ | ------------------------------------------------------- | ----------------- |
+| CLI only (GHA shape) | Small  | Poor — invisible daemon, users don't know if it's alive | Wrong for v1      |
+| TUI                  | Medium | Good — standard dev-tool shape (k9s, lazygit, gh-dash)  | **Right for MVP** |
+| Native tray icon     | Large  | Best — glanceable                                       | Defer to v2       |
+| Full desktop app     | Huge   | Overkill                                                | Skip              |
+
+A TUI also gives the developer-user immediate feedback during first-time setup ("is it connected? does it see Codex?"), which prevents the single biggest support issue: "I installed it and nothing happened."
+
+## Architecture: daemon + TUI client over local IPC
+
+The TUI is a **client**, not the runner itself. The runner daemon keeps running in the background (as a service) regardless of whether the TUI is open. The TUI attaches, reads state, sends commands, and detaches.
+
+```
+┌────────────────────── laptop ──────────────────────┐
+│                                                     │
+│   apple-pi-dash-runner  (service, always-on)        │
+│        │                                            │
+│        │  local Unix socket                         │
+│        │  (Windows: named pipe)                     │
+│        │                                            │
+│   apple-pi-dash-runner tui  (user launches adhoc)   │
+│        │                                            │
+│        │  ─────► outbound WS to cloud               │
+│        │  ─────► spawn codex app-server             │
+│                                                     │
+└─────────────────────────────────────────────────────┘
+```
+
+Why this shape:
+
+1. **TUI launches and exits cheaply.** Open it with `runner tui`, close with `q`, runner keeps working. No restart involved.
+2. **Multiple concurrent TUIs are safe.** User can tail status from two terminal tabs.
+3. **Same local-IPC surface will power the future tray icon.** The tray is just another client of the same socket.
+4. **Config changes apply live.** TUI POSTs to the daemon via the socket; daemon writes to disk and hot-applies. No process restart for most edits.
+5. **Decouples rendering from the work loop.** The daemon's core logic never blocks on TUI rendering.
+
+### Local IPC protocol
+
+Use JSON-RPC 2.0 over the Unix socket / named pipe. Same protocol style the runner uses toward Codex and toward the cloud — consistent across the codebase.
+
+Minimum methods (daemon-side):
+
+- `status.get` → current state snapshot (connection, current run, Codex health, config summary)
+- `status.subscribe` → stream of state deltas for the live view
+- `config.get` / `config.update` → read/write config (labels, approval policy, etc.)
+- `runs.list` → recent runs with pagination
+- `runs.get(id)` → detail + event stream
+- `approvals.list` → pending approvals
+- `approvals.decide(id, decision)` → answer an approval request
+- `runner.reregister` / `runner.disconnect` → lifecycle control
+- `doctor.run` → verify Codex installed + logged in, git config, network reachable
+
+Socket path:
+
+- Linux/macOS: `$XDG_RUNTIME_DIR/apple-pi-dash-runner.sock` (or `~/.local/share/apple-pi-dash-runner/sock`)
+- Windows: `\\.\pipe\apple-pi-dash-runner`
+
+Permissions: 0600 — only the owning user can connect.
+
+## Library choice
+
+**Go path (recommended stack):**
+
+- [Bubble Tea](https://github.com/charmbracelet/bubbletea) — Elm-architecture TUI framework from Charm.
+- [Bubbles](https://github.com/charmbracelet/bubbles) — ready-made components (list, viewport, text input, table, spinner).
+- [Lip Gloss](https://github.com/charmbracelet/lipgloss) — declarative styling/layout.
+
+Rationale: the Charm ecosystem is the de-facto standard for new Go TUIs in 2026. `k9s`, `gh dash`, `glow`, `soft-serve`, and others all use it. Low risk, high ergonomics, large community.
+
+**Rust path (if runner is in Rust):**
+
+- [Ratatui](https://github.com/ratatui/ratatui) — the standard modern Rust TUI (formerly `tui-rs`).
+- [Crossterm](https://github.com/crossterm-rs/crossterm) — terminal backend.
+
+Equally mature. Slightly more verbose than Bubble Tea but equally capable.
+
+## Views for MVP (v1 scope)
+
+Four primary views. Switch with number keys or tab. Vim-style `j/k/h/l` + arrow keys for navigation. `?` for help overlay everywhere.
+
+### 1. Status (default landing view)
+
+```
+╭─ Apple Pi Dash Runner ─────────────────────────────────────╮
+│ ● Connected        my-laptop                               │
+│ Workspace: acme    Labels: codex, macos, arm64             │
+│ Uptime 4h 23m      Last heartbeat 2s ago                   │
+├────────────────────────────────────────────────────────────┤
+│ Preconditions                                              │
+│   ✓ Codex binary     /usr/local/bin/codex  (v0.45.0)       │
+│   ✓ Codex auth       mrc2048@gmail.com (ChatGPT Plus)      │
+│   ✓ Git              2.43.0                                 │
+│   ✓ Network          cloud reachable                       │
+├────────────────────────────────────────────────────────────┤
+│ Current run                                                 │
+│   PROJ-123 — Refactor auth module                          │
+│   Status: running   Thread: th_01HX…                       │
+│   Started 12:34:56  Events 127                             │
+│                                                             │
+│   Recent events                                             │
+│     12:35:03  tool_call   shell: git status                │
+│     12:35:09  item/delta  "Reading src/auth/…"             │
+│     12:35:12  tool_call   write: src/auth/session.py       │
+├────────────────────────────────────────────────────────────┤
+│ [1]Status [2]Runs [3]Config [4]Approvals  [?]Help  [q]Quit │
+╰────────────────────────────────────────────────────────────╯
+```
+
+Glanceable summary: Am I connected? Is Codex healthy? What am I doing right now?
+
+### 2. Runs
+
+A scrollable table of recent `AgentRun`s (pulled from the daemon's cache; daemon keeps last N=100).
+
+```
+╭─ Runs ─────────────────────────────────────────────────────╮
+│ ID        Work Item               Status      Started       │
+├────────────────────────────────────────────────────────────┤
+│ r_0xA3   PROJ-123 Refactor auth   ▶ running   12:34         │
+│ r_0xA2   PROJ-119 Fix flaky test  ✓ done      11:02         │
+│ r_0xA1   PROJ-118 Docs typo       ✓ done      10:55         │
+│ r_0xA0   PROJ-115 Upgrade deps    ✗ failed    10:12         │
+│ …                                                          │
+╰────────────────────────────────────────────────────────────╯
+
+↵ Open detail   f Filter   / Search   [esc] Back
+```
+
+Detail view (`↵` on a row): shows the event stream + final diff + any approvals.
+
+### 3. Config
+
+Form-style editor. Edits are POSTed to the daemon and applied live.
+
+```
+╭─ Configuration ────────────────────────────────────────────╮
+│ Identity                                                   │
+│   Runner name     my-laptop                                │
+│   Workspace       acme                                     │
+│   Cloud URL       https://cloud.apple-pi-dash.so           │
+│                                                             │
+│ Capabilities (labels)                           [e] edit   │
+│   codex, macos, arm64                                      │
+│                                                             │
+│ Codex                                                       │
+│   Binary path     /usr/local/bin/codex           ✓ found   │
+│   Model default   gpt-5-codex                              │
+│                                                             │
+│ Approval policy                                             │
+│   [x] Auto-approve read-only shell                         │
+│   [ ] Auto-approve writes inside workspace                 │
+│   [ ] Auto-approve network calls                           │
+│                                                             │
+│ Logging                                                     │
+│   Level           info  ▾                                  │
+│   Retention       7 days                                   │
+│                                                             │
+│ [s] Save   [r] Re-register   [d] Disconnect   [esc] Back   │
+╰────────────────────────────────────────────────────────────╯
+```
+
+Behaviors:
+
+- `s` persists and hot-applies what can be, flags what needs a restart.
+- `r` (re-register) prompts for a new registration token, tears down the current identity, and reconnects.
+- `d` (disconnect) de-registers from cloud and stops the daemon.
+
+### 4. Approvals
+
+The most interactive view. Shows pending approval requests from Codex. Answering one pushes the decision back through the daemon → WS → cloud → runner → `codex app-server`.
+
+```
+╭─ Pending approvals (1) ────────────────────────────────────╮
+│ PROJ-123 — Refactor auth module                            │
+│                                                             │
+│ Codex wants to run shell command:                          │
+│                                                             │
+│   $ rm -rf /Users/rich/workspace/acme/.cache               │
+│                                                             │
+│ Working dir: /Users/rich/workspace/acme                    │
+│ Reason: "Clearing stale build cache before next step"      │
+│                                                             │
+│ Exposure: filesystem write (destructive)                   │
+├────────────────────────────────────────────────────────────┤
+│ [a] Approve once                                           │
+│ [A] Approve for this session                               │
+│ [d] Decline                                                │
+│ [c] Cancel run                                             │
+│ [esc] Back                                                 │
+╰────────────────────────────────────────────────────────────╯
+```
+
+Notes:
+
+- Daemon can also auto-answer based on the configured approval policy; TUI shows only what needs a human.
+- When a new approval arrives and the TUI is open, focus jumps to this view and the terminal bell rings (unless user disabled).
+- Same `ApprovalRequest` object is also exposed to the Apple Pi Dash web UI; whichever answers first wins. Daemon records the decision source for audit.
+
+## Key bindings summary
+
+| Key            | Action                                |
+| -------------- | ------------------------------------- |
+| `1`–`4`        | Jump to view                          |
+| `j/k` or `↑/↓` | Move selection                        |
+| `↵`            | Open / activate                       |
+| `esc`          | Back                                  |
+| `/`            | Search in current view                |
+| `?`            | Help overlay                          |
+| `r`            | Refresh                               |
+| `q`            | Quit TUI (daemon keeps running)       |
+| `Q`            | Quit and stop daemon (confirm prompt) |
+
+`Q` requires a confirmation step ("Stop the runner daemon? [y/N]") because stopping a live run is destructive.
+
+## First-run onboarding flow
+
+When the user runs `apple-pi-dash-runner tui` and no config exists on disk, the TUI walks them through setup instead of showing the dashboard:
+
+```
+Step 1 of 4: Paste registration code
+  Get a one-time code from Apple Pi Dash → Settings → Runners → New runner.
+  Code:  __________
+
+Step 2 of 4: Verify Codex
+  Checking Codex installation...
+    ✓ codex v0.45.0 found at /usr/local/bin/codex
+    ✓ logged in as mrc2048@gmail.com
+
+Step 3 of 4: Choose labels
+  Default labels:  self-hosted, macos, arm64
+  Add custom:      codex, acme-repo
+  [x] acme-repo    [ ] personal-repo
+
+Step 4 of 4: Install as service
+  [x] Start on login (launchd)
+
+  [Finish]
+```
+
+Steps that detect problems (Codex missing, auth expired) become interactive remedies rather than errors.
+
+## Accessibility and terminal compatibility
+
+- Target: modern emulators that support truecolor + mouse — iTerm2, Alacritty, Wezterm, Windows Terminal, GNOME Terminal, Konsole, Kitty.
+- Gracefully degrade to 256-color mode. Detect with `$COLORTERM`.
+- Respect `$NO_COLOR`. Provide a `--no-color` flag.
+- Every action reachable by keyboard; mouse is nice-to-have.
+- Do not rely on Unicode-specific box-drawing for critical affordances; glyphs degrade on plain ASCII terminals but content is still readable.
+- Respect `$TERM` variations. Refuse to start and print a clear message on `dumb`/`xterm-mono`.
+
+## Out of scope for v1
+
+Defer these to v2+:
+
+- Multi-pane layout configurable by user.
+- Theme support beyond a default + a light variant.
+- Remote TUI (attaching to another machine's runner over the network). GHA doesn't do this either; unnecessary complication.
+- Rich text-editor-style config inputs. Keep it form-based.
+- Full run replay (ability to scroll back through an entire historical thread's events). Show recent-N only; point users to the web UI for full history.
+
+## Testing strategy
+
+- **Golden-frame tests.** Use `teatest` (Bubble Tea's testing harness) to drive the TUI state and assert rendered output against golden files.
+- **IPC contract tests.** Spin up the daemon with an in-memory cloud + in-memory Codex mock; drive it through the JSON-RPC socket and assert state transitions.
+- **Real-terminal smoke test.** A single CI job that boots the TUI in a `tmux` session and checks it renders the Status view without crashing on each supported OS.
+- **Manual QA matrix per release.** macOS Terminal, iTerm2, Linux GNOME Terminal, Windows Terminal — render the four main views, resize the window, trigger an approval.
+
+## Phasing within the TUI itself
+
+**v1.0 (MVP):**
+
+- Status view (read-only) with live event stream for the current run.
+- Config view with read + write.
+- Approvals view with approve/decline.
+- First-run onboarding wizard.
+
+**v1.1:**
+
+- Runs view with history table + detail.
+- Doctor subcommand surfacing health checks.
+- Search / filter in Runs view.
+
+**v1.2:**
+
+- Per-run diff preview (the unified diff Codex is about to propose).
+- Log viewer with follow mode.
+- Help overlay with searchable keybinding list.
+
+**v2 and beyond (may unlock the tray icon):**
+
+- Expose the daemon's IPC socket to a native tray client (same contract, different presenter).
+- Optional themes.
+- Plugin hooks for custom status panels.

--- a/.ai_design/implement_runner/user-guide.md
+++ b/.ai_design/implement_runner/user-guide.md
@@ -1,0 +1,153 @@
+# Runner — End-User Setup Guide
+
+This guide walks you through connecting your dev machine to Apple Pi Dash so the cloud can assign coding tasks to Codex running locally.
+
+**Who this is for:** developers who want their Apple Pi Dash issues to become live Codex runs on their own hardware.
+
+**What you need before you start:**
+
+- Apple Pi Dash account with access to your workspace
+- Codex installed and logged in (`codex --version` works, `codex account status` shows your account)
+- Git installed with working credentials for the repos you'll work on
+- macOS (arm64/x64) or Linux (x64). Windows is not yet supported.
+
+## 1. Install the runner
+
+Pick one:
+
+```bash
+# Homebrew (macOS + Linux)
+brew install apple-pi-dash/tap/runner
+
+# Shell installer
+curl -fsSL https://cloud.apple-pi-dash.so/install.sh | sh
+```
+
+Both drop `apple-pi-dash-runner` into `$HOME/.local/bin`. Make sure that directory is in your `PATH`.
+
+## 2. Get a registration code
+
+1. Sign in to `https://cloud.apple-pi-dash.so` (or your self-hosted URL).
+2. Open your workspace → **Runners** tab.
+3. Click **Mint registration code**.
+4. Copy the code. It's single-use and expires in 1 hour.
+
+You can register up to 5 runners per account per workspace.
+
+## 3. Configure the runner
+
+### Option A — interactive TUI (recommended for first-time setup)
+
+```bash
+apple-pi-dash-runner tui
+```
+
+The TUI detects that no config exists and walks you through 4 steps:
+
+1. **Cloud URL** — prefilled with the default; change if you're self-hosting.
+2. **Registration code + runner name** — paste the code you copied; the name defaults to your hostname.
+3. **Preflight** — the wizard runs `codex --version`, `codex account status`, and `git --version`. Any red ✗ means fix that before continuing (usually `codex login` or installing git).
+4. **Install as service** — tick the box to start the daemon at login.
+
+### Option B — command-line (scripts / CI)
+
+```bash
+apple-pi-dash-runner configure \
+  --url https://cloud.apple-pi-dash.so \
+  --token <PASTE_REGISTRATION_CODE> \
+  --name my-laptop
+
+apple-pi-dash-runner service install
+apple-pi-dash-runner service start
+```
+
+The daemon now runs as a `launchd` agent (macOS) or `systemd --user` unit (Linux) and will auto-start on login.
+
+## 4. Verify it's connected
+
+```bash
+apple-pi-dash-runner status
+```
+
+You should see `connected` and your cloud URL. Equivalently, open the web UI → **Runners** tab; the new runner appears with a green **online** badge within a few seconds.
+
+## 5. Attach the TUI dashboard
+
+```bash
+apple-pi-dash-runner tui
+```
+
+Four tabs:
+
+- **Status** — connection state, current run, Codex/git health
+- **Runs** — recent runs on this machine (last 100)
+- **Config** — live config view (edit with `e` on supported fields)
+- **Approvals** — pending approval requests
+
+Press `?` anywhere for help. `q` closes the TUI (daemon keeps running). `Q` stops the daemon entirely.
+
+## 6. Respond to approval requests
+
+When Codex tries to do something risky (write outside the workspace, run `git push`, network access, etc.) it pauses and asks for approval. You'll see it in **two** places:
+
+- The runner's **Approvals** TUI tab — the terminal bell rings and the view auto-focuses.
+- The web UI's **Runners → Approvals** tab — shows every pending approval across all your runners.
+
+Pick either surface; whichever answers first wins. The other surface will clear automatically.
+
+Actions:
+
+- **Accept once** — Codex proceeds with this one action.
+- **Accept for session** — remembered for the rest of the current thread, so similar requests auto-pass.
+- **Decline** — Codex sees denial and usually continues with an alternative.
+- **Cancel run** — kill the whole run.
+
+Pending approvals expire after 10 minutes; the server then cancels the run automatically.
+
+## 7. Day-to-day
+
+- **Your working directory** lives at `$TMPDIR/.apple_pi` by default. Change with `apple-pi-dash-runner configure --working-dir /path/to/repo` or the Config tab. Runs reuse this directory; Codex is expected to reset/stash/checkout at the start of each task.
+- **Logs** are in `~/.local/share/apple-pi-dash-runner/logs/`.
+- **Per-run transcripts** are stored as JSONL in `~/.local/share/apple-pi-dash-runner/history/runs/`.
+
+## 8. Upgrading
+
+```bash
+brew upgrade apple-pi-dash-runner
+apple-pi-dash-runner service stop
+apple-pi-dash-runner service start
+```
+
+A protocol version bump will be announced in the release notes. The daemon logs a warning if the server expects a newer version; in that case, upgrade.
+
+## 9. Rotating your runner credential
+
+If you suspect your runner secret has leaked:
+
+```bash
+apple-pi-dash-runner rotate
+apple-pi-dash-runner service stop
+apple-pi-dash-runner service start
+```
+
+The old secret is invalidated immediately. No downtime on the runner record in the cloud — just a forced WS reconnect with the new secret.
+
+## 10. Removing
+
+```bash
+apple-pi-dash-runner service stop
+apple-pi-dash-runner service uninstall
+apple-pi-dash-runner remove
+```
+
+This deregisters the runner in the cloud, deletes local credentials and config, and stops the agent. Your transcripts under `~/.local/share/apple-pi-dash-runner/history/` are NOT deleted automatically — remove them manually if you want.
+
+## Troubleshooting
+
+**`status` shows disconnected** → daemon isn't running. Check `apple-pi-dash-runner service status`. If the unit is loaded but not active, `service start` it. If systemd says "failed", check `journalctl --user -u apple-pi-dash-runner`.
+
+**`doctor` says `codex-auth: unable to confirm`** → run `codex login`. Re-run `doctor` to confirm.
+
+**`workspace_setup` failure on a new run** → check that your working directory either contains a git repo or is empty. The daemon refuses to operate on a non-empty non-repo directory to avoid clobbering anything.
+
+**Approvals TUI beeps but no popup** → the wizard only auto-focuses when the TUI is on a tab other than Approvals. Press `4` to go to it.

--- a/apps/api/apple_pi_dash/asgi.py
+++ b/apps/api/apple_pi_dash/asgi.py
@@ -4,15 +4,21 @@
 
 import os
 
-from channels.routing import ProtocolTypeRouter
+from channels.routing import ProtocolTypeRouter, URLRouter
 from django.core.asgi import get_asgi_application
-
-django_asgi_app = get_asgi_application()
-
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "apple_pi_dash.settings.production")
 # Initialize Django ASGI application early to ensure the AppRegistry
 # is populated before importing code that may import ORM models.
+django_asgi_app = get_asgi_application()
 
+from apple_pi_dash.runner.routing import (  # noqa: E402
+    websocket_urlpatterns as runner_ws_urls,
+)
 
-application = ProtocolTypeRouter({"http": get_asgi_application()})
+application = ProtocolTypeRouter(
+    {
+        "http": django_asgi_app,
+        "websocket": URLRouter(runner_ws_urls),
+    }
+)

--- a/apps/api/apple_pi_dash/celery.py
+++ b/apps/api/apple_pi_dash/celery.py
@@ -77,6 +77,15 @@ app.conf.beat_schedule = {
         "task": "apple_pi_dash.bgtasks.exporter_expired_task.delete_old_s3_link",
         "schedule": crontab(hour=3, minute=45),  # UTC 03:45
     },
+    # Runner lifecycle
+    "runner-expire-stale-approvals": {
+        "task": "runner.expire_stale_approvals",
+        "schedule": crontab(minute="*/1"),
+    },
+    "runner-mark-offline-runners": {
+        "task": "runner.mark_offline_runners",
+        "schedule": crontab(minute="*/1"),
+    },
 }
 
 

--- a/apps/api/apple_pi_dash/runner/__init__.py
+++ b/apps/api/apple_pi_dash/runner/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2023-present Apple Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+default_app_config = "apple_pi_dash.runner.apps.RunnerConfig"

--- a/apps/api/apple_pi_dash/runner/admin.py
+++ b/apps/api/apple_pi_dash/runner/admin.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2023-present Apple Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+from django.contrib import admin
+
+from apple_pi_dash.runner.models import (
+    AgentRun,
+    AgentRunEvent,
+    ApprovalRequest,
+    Runner,
+    RunnerRegistrationToken,
+)
+
+
+@admin.register(Runner)
+class RunnerAdmin(admin.ModelAdmin):
+    list_display = ("name", "owner", "workspace", "status", "last_heartbeat_at")
+    list_filter = ("status", "workspace")
+    search_fields = ("name", "owner__email")
+
+
+@admin.register(RunnerRegistrationToken)
+class RegistrationTokenAdmin(admin.ModelAdmin):
+    list_display = ("id", "workspace", "created_by", "expires_at", "consumed_at")
+    list_filter = ("workspace",)
+
+
+@admin.register(AgentRun)
+class AgentRunAdmin(admin.ModelAdmin):
+    list_display = ("id", "status", "runner", "owner", "started_at", "ended_at")
+    list_filter = ("status",)
+    search_fields = ("id", "runner__name")
+
+
+@admin.register(AgentRunEvent)
+class AgentRunEventAdmin(admin.ModelAdmin):
+    list_display = ("id", "agent_run", "seq", "kind", "created_at")
+    list_filter = ("kind",)
+
+
+@admin.register(ApprovalRequest)
+class ApprovalRequestAdmin(admin.ModelAdmin):
+    list_display = ("id", "agent_run", "kind", "status", "requested_at", "decided_at")
+    list_filter = ("status", "kind")

--- a/apps/api/apple_pi_dash/runner/apps.py
+++ b/apps/api/apple_pi_dash/runner/apps.py
@@ -1,0 +1,12 @@
+# Copyright (c) 2023-present Apple Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+from django.apps import AppConfig
+
+
+class RunnerConfig(AppConfig):
+    name = "apple_pi_dash.runner"
+    label = "runner"
+    verbose_name = "Apple Pi Dash Runner"
+    default_auto_field = "django.db.models.BigAutoField"

--- a/apps/api/apple_pi_dash/runner/authentication.py
+++ b/apps/api/apple_pi_dash/runner/authentication.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2023-present Apple Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""DRF authentication for runner daemons using a bearer credential.
+
+Runner daemons call ``/api/v1/runner/...`` with ``Authorization: Bearer <runner_secret>``.
+The secret is stored hashed in :class:`Runner.credential_hash`.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+from rest_framework import authentication, exceptions
+
+from apple_pi_dash.runner.models import Runner, RunnerStatus
+from apple_pi_dash.runner.services.tokens import hash_token
+
+
+class RunnerBearerAuthentication(authentication.BaseAuthentication):
+    keyword = "Bearer"
+
+    def authenticate(self, request) -> Optional[Tuple[Runner, None]]:
+        header = authentication.get_authorization_header(request)
+        if not header:
+            return None
+        parts = header.split()
+        if len(parts) != 2 or parts[0].decode().lower() != self.keyword.lower():
+            return None
+        raw = parts[1].decode()
+        hashed = hash_token(raw)
+        try:
+            runner = Runner.objects.get(credential_hash=hashed)
+        except Runner.DoesNotExist:
+            raise exceptions.AuthenticationFailed("invalid runner credential")
+        if runner.status == RunnerStatus.REVOKED:
+            raise exceptions.AuthenticationFailed("runner is revoked")
+        # Present the runner as the DRF-authenticated entity. Views that need
+        # the owning user should use `request.auth_runner.owner`.
+        request.auth_runner = runner
+        return (runner, None)
+
+    def authenticate_header(self, request) -> str:
+        return self.keyword

--- a/apps/api/apple_pi_dash/runner/consumers.py
+++ b/apps/api/apple_pi_dash/runner/consumers.py
@@ -1,0 +1,425 @@
+# Copyright (c) 2023-present Apple Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Channels consumer that owns one runner's WebSocket connection.
+
+Runners authenticate with an ``Authorization: Bearer <runner_secret>`` header
+on the HTTP upgrade request. The consumer joins a ``runner.<id>`` group so
+other processes can push work via
+:func:`apple_pi_dash.runner.services.pubsub.send_to_runner`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections import OrderedDict
+from datetime import timedelta
+from typing import Any, Dict, Optional
+from uuid import UUID
+
+from asgiref.sync import sync_to_async
+from channels.generic.websocket import AsyncJsonWebsocketConsumer
+from django.utils import timezone
+
+from apple_pi_dash.runner.models import (
+    AgentRun,
+    AgentRunEvent,
+    AgentRunStatus,
+    ApprovalKind,
+    ApprovalRequest,
+    ApprovalStatus,
+    Runner,
+    RunnerStatus,
+)
+from apple_pi_dash.runner.services.pubsub import runner_group
+from apple_pi_dash.runner.services.tokens import hash_token
+
+logger = logging.getLogger(__name__)
+
+PROTOCOL_VERSION = 1
+HEARTBEAT_INTERVAL_SECS = 25
+OFFLINE_GRACE_SECS = 60
+
+
+SEEN_MESSAGE_CACHE_SIZE = 512
+MAX_SEQ_LOOKBACK = 128
+
+
+class RunnerConsumer(AsyncJsonWebsocketConsumer):
+    runner: Optional[Runner] = None
+    group_name: Optional[str] = None
+    # Per-connection dedupe cache of message_ids we've already applied.
+    # LRU-bounded so a misbehaving runner can't grow us unboundedly.
+    seen_messages: "OrderedDict[str, None]"
+    # Per-run last-seen seq; used to drop duplicates and log gaps.
+    last_seq_per_run: Dict[str, int]
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.seen_messages = OrderedDict()
+        self.last_seq_per_run = {}
+
+    async def connect(self) -> None:
+        auth = self._header("authorization")
+        if not auth or not auth.lower().startswith("bearer "):
+            await self.close(code=4401)
+            return
+        raw = auth.split(" ", 1)[1].strip()
+        runner = await self._find_runner(raw)
+        if runner is None:
+            await self.close(code=4401)
+            return
+        if runner.status == RunnerStatus.REVOKED:
+            await self.close(code=4403)
+            return
+        # Protocol check.
+        proto = self._header("x-runner-protocol")
+        if proto and proto.strip() and int(proto.strip()) != PROTOCOL_VERSION:
+            logger.warning(
+                "runner %s protocol mismatch (server=%s, client=%s)",
+                runner.id,
+                PROTOCOL_VERSION,
+                proto,
+            )
+        self.runner = runner
+        self.group_name = runner_group(runner.id)
+        await self.channel_layer.group_add(self.group_name, self.channel_name)
+        await self.accept()
+        await self._mark_online(runner.id)
+        await self.send_json({
+            "v": 1,
+            "type": "welcome",
+            "server_time": timezone.now().isoformat(),
+            "heartbeat_interval_secs": HEARTBEAT_INTERVAL_SECS,
+            "protocol_version": PROTOCOL_VERSION,
+        })
+
+    async def disconnect(self, code: int) -> None:
+        if self.group_name is not None:
+            await self.channel_layer.group_discard(self.group_name, self.channel_name)
+        if self.runner is not None:
+            await self._mark_offline(self.runner.id)
+
+    async def receive_json(self, content: Dict[str, Any], **_: Any) -> None:
+        mtype = content.get("type")
+        runner = self.runner
+        if runner is None:
+            return
+        if self._is_duplicate(content):
+            logger.debug(
+                "runner %s sent duplicate message %s; dropping",
+                runner.id,
+                content.get("mid"),
+            )
+            return
+        if not self._seq_ok(runner, content):
+            return
+        handler = getattr(self, f"on_{mtype}", None)
+        if handler is None:
+            logger.debug("runner %s sent unknown type %s", runner.id, mtype)
+            return
+        try:
+            await handler(runner, content)
+        except Exception:
+            logger.exception("error handling %s from runner %s", mtype, runner.id)
+
+    def _is_duplicate(self, content: Dict[str, Any]) -> bool:
+        """LRU-bounded check on the wire ``mid`` so retries are idempotent."""
+        mid = content.get("mid")
+        if not mid:
+            return False
+        mid = str(mid)
+        if mid in self.seen_messages:
+            self.seen_messages.move_to_end(mid)
+            return True
+        self.seen_messages[mid] = None
+        if len(self.seen_messages) > SEEN_MESSAGE_CACHE_SIZE:
+            self.seen_messages.popitem(last=False)
+        return False
+
+    def _seq_ok(self, runner: Runner, content: Dict[str, Any]) -> bool:
+        """Enforce monotonic ``seq`` for ``run_event`` frames.
+
+        Frames without a ``seq`` or a ``run_id`` pass through. A seq that is
+        not strictly greater than the last-seen value is dropped and logged
+        (duplicate or out-of-order); a gap (skip > 1) is logged but
+        accepted — the transcript will simply be missing those events.
+        """
+        if content.get("type") != "run_event":
+            return True
+        run_id = str(content.get("run_id") or "")
+        seq = content.get("seq")
+        if not run_id or seq is None:
+            return True
+        try:
+            seq = int(seq)
+        except (TypeError, ValueError):
+            return True
+        last = self.last_seq_per_run.get(run_id)
+        if last is not None and seq <= last:
+            logger.info(
+                "runner %s sent seq=%s <= last=%s for run %s; dropping",
+                runner.id,
+                seq,
+                last,
+                run_id,
+            )
+            return False
+        if last is not None and seq > last + 1:
+            logger.info(
+                "runner %s sent seq=%s with gap after %s for run %s",
+                runner.id,
+                seq,
+                last,
+                run_id,
+            )
+        self.last_seq_per_run[run_id] = seq
+        # Keep the map bounded per-connection.
+        if len(self.last_seq_per_run) > MAX_SEQ_LOOKBACK:
+            # Drop the oldest entry (dict preserves insertion order in 3.7+).
+            self.last_seq_per_run.pop(next(iter(self.last_seq_per_run)))
+        return True
+
+    # ---- Inbound handlers ----
+
+    async def on_hello(self, runner: Runner, msg: Dict[str, Any]) -> None:
+        await sync_to_async(self._apply_hello)(runner, msg)
+        in_flight = msg.get("in_flight_run")
+        if in_flight:
+            await self._resume_run(runner, str(in_flight))
+
+    async def on_heartbeat(self, runner: Runner, msg: Dict[str, Any]) -> None:
+        await sync_to_async(self._apply_heartbeat)(runner, msg)
+
+    async def on_accept(self, runner: Runner, msg: Dict[str, Any]) -> None:
+        await sync_to_async(self._apply_lifecycle)(
+            runner, msg, AgentRunStatus.RUNNING
+        )
+
+    async def on_run_started(self, runner: Runner, msg: Dict[str, Any]) -> None:
+        await sync_to_async(self._apply_run_started)(runner, msg)
+
+    async def on_run_event(self, runner: Runner, msg: Dict[str, Any]) -> None:
+        await sync_to_async(self._persist_event)(runner, msg)
+
+    async def on_approval_request(self, runner: Runner, msg: Dict[str, Any]) -> None:
+        await sync_to_async(self._persist_approval)(runner, msg)
+
+    async def on_run_completed(self, runner: Runner, msg: Dict[str, Any]) -> None:
+        await sync_to_async(self._finalize_run)(runner, msg, AgentRunStatus.COMPLETED)
+
+    async def on_run_failed(self, runner: Runner, msg: Dict[str, Any]) -> None:
+        await sync_to_async(self._finalize_run)(runner, msg, AgentRunStatus.FAILED)
+
+    async def on_run_cancelled(self, runner: Runner, msg: Dict[str, Any]) -> None:
+        await sync_to_async(self._finalize_run)(runner, msg, AgentRunStatus.CANCELLED)
+
+    async def on_run_awaiting_reauth(
+        self, runner: Runner, msg: Dict[str, Any]
+    ) -> None:
+        await sync_to_async(self._apply_lifecycle)(
+            runner, msg, AgentRunStatus.AWAITING_REAUTH
+        )
+
+    async def on_run_resumed(self, runner: Runner, msg: Dict[str, Any]) -> None:
+        await sync_to_async(self._apply_lifecycle)(runner, msg, AgentRunStatus.RUNNING)
+        run_id = msg.get("run_id")
+        if run_id:
+            await self._resume_run(runner, str(run_id))
+
+    async def _resume_run(self, runner: Runner, run_id: str) -> None:
+        """Acknowledge an in-flight run on reconnect.
+
+        Loads the run, confirms it still belongs to this runner, and sends a
+        ``resume_ack`` with the last seq we persisted so the daemon can avoid
+        re-sending already-stored events. If the run was finalized during the
+        disconnect window we send a ``cancel`` instead so the daemon tears
+        down its local bridge cleanly.
+        """
+        run = await sync_to_async(
+            lambda: AgentRun.objects.filter(id=run_id, runner=runner).first()
+        )()
+        if run is None:
+            await self.send_json({
+                "v": 1,
+                "type": "cancel",
+                "run_id": run_id,
+                "reason": "unknown_run_on_reconnect",
+            })
+            return
+        if run.is_terminal:
+            await self.send_json({
+                "v": 1,
+                "type": "cancel",
+                "run_id": run_id,
+                "reason": f"run_already_{run.status}",
+            })
+            return
+        last_seq = await sync_to_async(self._last_seq_for_run)(run_id)
+        await self.send_json({
+            "v": 1,
+            "type": "resume_ack",
+            "run_id": run_id,
+            "last_seq": last_seq,
+            "status": run.status,
+            "thread_id": run.thread_id,
+        })
+        if last_seq is not None:
+            # Prime the local seq map so dupes of already-persisted events drop.
+            self.last_seq_per_run[run_id] = last_seq
+
+    @staticmethod
+    def _last_seq_for_run(run_id: str) -> Optional[int]:
+        return (
+            AgentRunEvent.objects.filter(agent_run_id=run_id)
+            .order_by("-seq")
+            .values_list("seq", flat=True)
+            .first()
+        )
+
+    async def on_bye(self, runner: Runner, msg: Dict[str, Any]) -> None:
+        await self.close()
+
+    # ---- Outbound — delivered via channels group_send ----
+
+    async def runner_send(self, event: Dict[str, Any]) -> None:
+        payload = event.get("payload") or {}
+        try:
+            await self.send_json(payload)
+        except Exception:
+            logger.exception("runner %s send failed", self.runner.id if self.runner else "?")
+
+    # ---- Sync helpers (DB-bound) ----
+
+    @staticmethod
+    async def _find_runner(raw: str) -> Optional[Runner]:
+        hashed = hash_token(raw)
+        return await sync_to_async(
+            lambda: Runner.objects.filter(credential_hash=hashed).first()
+        )()
+
+    @staticmethod
+    async def _mark_online(runner_id: UUID) -> None:
+        await sync_to_async(
+            lambda: Runner.objects.filter(pk=runner_id).update(
+                status=RunnerStatus.ONLINE,
+                last_heartbeat_at=timezone.now(),
+            )
+        )()
+
+    @staticmethod
+    async def _mark_offline(runner_id: UUID) -> None:
+        await sync_to_async(
+            lambda: Runner.objects.filter(pk=runner_id)
+            .exclude(status=RunnerStatus.REVOKED)
+            .update(status=RunnerStatus.OFFLINE)
+        )()
+
+    def _apply_hello(self, runner: Runner, msg: Dict[str, Any]) -> None:
+        updates = ["os", "arch", "runner_version", "last_heartbeat_at"]
+        runner.os = msg.get("os", "") or runner.os
+        runner.arch = msg.get("arch", "") or runner.arch
+        runner.runner_version = msg.get("version", "") or runner.runner_version
+        runner.last_heartbeat_at = timezone.now()
+        runner.save(update_fields=updates)
+
+    def _apply_heartbeat(self, runner: Runner, msg: Dict[str, Any]) -> None:
+        runner.mark_heartbeat()
+
+    def _apply_lifecycle(
+        self,
+        runner: Runner,
+        msg: Dict[str, Any],
+        new_status: AgentRunStatus,
+    ) -> None:
+        run_id = msg.get("run_id")
+        if not run_id:
+            return
+        updates = {"status": new_status}
+        if new_status == AgentRunStatus.RUNNING and "workspace_state" in msg:
+            # Accept frame carries workspace_state; squirrel it in run_config.
+            pass
+        AgentRun.objects.filter(id=run_id, runner=runner).update(**updates)
+
+    def _apply_run_started(self, runner: Runner, msg: Dict[str, Any]) -> None:
+        run_id = msg.get("run_id")
+        thread_id = msg.get("thread_id") or ""
+        if not run_id:
+            return
+        AgentRun.objects.filter(id=run_id, runner=runner).update(
+            status=AgentRunStatus.RUNNING,
+            thread_id=thread_id,
+            started_at=timezone.now(),
+        )
+
+    def _persist_event(self, runner: Runner, msg: Dict[str, Any]) -> None:
+        run_id = msg.get("run_id")
+        seq = int(msg.get("seq") or 0)
+        kind = (msg.get("kind") or "")[:64]
+        payload = msg.get("payload") or {}
+        if not run_id or not kind:
+            return
+        AgentRunEvent.objects.update_or_create(
+            agent_run_id=run_id,
+            seq=seq,
+            defaults={"kind": kind, "payload": payload},
+        )
+
+    def _persist_approval(self, runner: Runner, msg: Dict[str, Any]) -> None:
+        run_id = msg.get("run_id")
+        approval_id = msg.get("approval_id")
+        kind = (msg.get("kind") or ApprovalKind.OTHER).lower()
+        kind_mapped = {
+            "command_execution": ApprovalKind.COMMAND_EXECUTION,
+            "file_change": ApprovalKind.FILE_CHANGE,
+            "network_access": ApprovalKind.NETWORK_ACCESS,
+        }.get(kind, ApprovalKind.OTHER)
+        expires = msg.get("expires_at")
+        ApprovalRequest.objects.update_or_create(
+            id=approval_id,
+            defaults={
+                "agent_run_id": run_id,
+                "kind": kind_mapped,
+                "payload": msg.get("payload") or {},
+                "reason": msg.get("reason") or "",
+                "status": ApprovalStatus.PENDING,
+                "expires_at": expires,
+            },
+        )
+        AgentRun.objects.filter(id=run_id, runner=runner).update(
+            status=AgentRunStatus.AWAITING_APPROVAL
+        )
+
+    def _finalize_run(
+        self,
+        runner: Runner,
+        msg: Dict[str, Any],
+        new_status: AgentRunStatus,
+    ) -> None:
+        run_id = msg.get("run_id")
+        if not run_id:
+            return
+        updates: Dict[str, Any] = {
+            "status": new_status,
+            "ended_at": timezone.now(),
+        }
+        if new_status == AgentRunStatus.COMPLETED:
+            updates["done_payload"] = msg.get("done_payload")
+        if new_status == AgentRunStatus.FAILED:
+            updates["error"] = (msg.get("detail") or "")[:16000]
+        AgentRun.objects.filter(id=run_id, runner=runner).update(**updates)
+
+    # ---- misc ----
+
+    def _header(self, name: str) -> Optional[str]:
+        """Extract a header from the scope, case-insensitive."""
+        headers = self.scope.get("headers") or []
+        for key, value in headers:
+            if key.decode().lower() == name:
+                return value.decode()
+        return None
+
+    async def encode_json(self, content: Any) -> str:
+        return json.dumps(content, default=str)

--- a/apps/api/apple_pi_dash/runner/consumers.py
+++ b/apps/api/apple_pi_dash/runner/consumers.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import json
 import logging
 from collections import OrderedDict
-from datetime import timedelta
 from typing import Any, Dict, Optional
 from uuid import UUID
 
@@ -45,21 +44,22 @@ OFFLINE_GRACE_SECS = 60
 
 SEEN_MESSAGE_CACHE_SIZE = 512
 MAX_SEQ_LOOKBACK = 128
+# Upper bound on per-event JSON payload size. A rogue daemon could otherwise
+# fill the DB with arbitrarily large blobs in AgentRunEvent.payload.
+MAX_EVENT_PAYLOAD_BYTES = 64 * 1024
+CLOSE_CODE_ROTATED = 4010
 
 
 class RunnerConsumer(AsyncJsonWebsocketConsumer):
-    runner: Optional[Runner] = None
-    group_name: Optional[str] = None
-    # Per-connection dedupe cache of message_ids we've already applied.
-    # LRU-bounded so a misbehaving runner can't grow us unboundedly.
-    seen_messages: "OrderedDict[str, None]"
-    # Per-run last-seen seq; used to drop duplicates and log gaps.
-    last_seq_per_run: Dict[str, int]
-
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self.seen_messages = OrderedDict()
-        self.last_seq_per_run = {}
+        self.runner: Optional[Runner] = None
+        self.group_name: Optional[str] = None
+        # Per-connection dedupe cache of message_ids we've already applied.
+        # LRU-bounded so a misbehaving runner can't grow us unboundedly.
+        self.seen_messages: "OrderedDict[str, None]" = OrderedDict()
+        # Per-run last-seen seq; used to drop duplicates and log gaps.
+        self.last_seq_per_run: Dict[str, int] = {}
 
     async def connect(self) -> None:
         auth = self._header("authorization")
@@ -74,15 +74,26 @@ class RunnerConsumer(AsyncJsonWebsocketConsumer):
         if runner.status == RunnerStatus.REVOKED:
             await self.close(code=4403)
             return
-        # Protocol check.
-        proto = self._header("x-runner-protocol")
-        if proto and proto.strip() and int(proto.strip()) != PROTOCOL_VERSION:
-            logger.warning(
-                "runner %s protocol mismatch (server=%s, client=%s)",
-                runner.id,
-                PROTOCOL_VERSION,
-                proto,
-            )
+        # Protocol check — log on mismatch, but tolerate garbage headers so a
+        # malformed ``X-Runner-Protocol`` doesn't kill the connection.
+        proto_raw = (self._header("x-runner-protocol") or "").strip()
+        if proto_raw:
+            try:
+                proto_int = int(proto_raw)
+            except ValueError:
+                logger.warning(
+                    "runner %s sent non-numeric protocol header %r",
+                    runner.id,
+                    proto_raw,
+                )
+            else:
+                if proto_int != PROTOCOL_VERSION:
+                    logger.warning(
+                        "runner %s protocol mismatch (server=%s, client=%s)",
+                        runner.id,
+                        PROTOCOL_VERSION,
+                        proto_int,
+                    )
         self.runner = runner
         self.group_name = runner_group(runner.id)
         await self.channel_layer.group_add(self.group_name, self.channel_name)
@@ -291,6 +302,13 @@ class RunnerConsumer(AsyncJsonWebsocketConsumer):
         except Exception:
             logger.exception("runner %s send failed", self.runner.id if self.runner else "?")
 
+    async def runner_close(self, event: Dict[str, Any]) -> None:
+        """Force-close this WS (e.g. after credential rotation).
+
+        The daemon is expected to reconnect with the new secret.
+        """
+        await self.close(code=int(event.get("code") or CLOSE_CODE_ROTATED))
+
     # ---- Sync helpers (DB-bound) ----
 
     @staticmethod
@@ -337,11 +355,7 @@ class RunnerConsumer(AsyncJsonWebsocketConsumer):
         run_id = msg.get("run_id")
         if not run_id:
             return
-        updates = {"status": new_status}
-        if new_status == AgentRunStatus.RUNNING and "workspace_state" in msg:
-            # Accept frame carries workspace_state; squirrel it in run_config.
-            pass
-        AgentRun.objects.filter(id=run_id, runner=runner).update(**updates)
+        AgentRun.objects.filter(id=run_id, runner=runner).update(status=new_status)
 
     def _apply_run_started(self, runner: Runner, msg: Dict[str, Any]) -> None:
         run_id = msg.get("run_id")
@@ -361,6 +375,21 @@ class RunnerConsumer(AsyncJsonWebsocketConsumer):
         payload = msg.get("payload") or {}
         if not run_id or not kind:
             return
+        try:
+            encoded = json.dumps(payload, default=str)
+        except (TypeError, ValueError):
+            encoded = ""
+        if len(encoded.encode("utf-8")) > MAX_EVENT_PAYLOAD_BYTES:
+            logger.info(
+                "runner %s sent oversized event payload (run=%s seq=%s); truncating",
+                runner.id,
+                run_id,
+                seq,
+            )
+            payload = {
+                "_truncated": True,
+                "original_size_bytes": len(encoded.encode("utf-8")),
+            }
         AgentRunEvent.objects.update_or_create(
             agent_run_id=run_id,
             seq=seq,

--- a/apps/api/apple_pi_dash/runner/migrations/0001_initial.py
+++ b/apps/api/apple_pi_dash/runner/migrations/0001_initial.py
@@ -1,0 +1,355 @@
+# Copyright (c) 2023-present Apple Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+import uuid
+
+
+class Migration(migrations.Migration):
+    initial = True
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("db", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="Runner",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        db_index=True,
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("name", models.CharField(max_length=128)),
+                ("credential_hash", models.CharField(db_index=True, max_length=128)),
+                ("credential_fingerprint", models.CharField(max_length=16)),
+                ("capabilities", models.JSONField(blank=True, default=list)),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("online", "Online"),
+                            ("offline", "Offline"),
+                            ("busy", "Busy"),
+                            ("revoked", "Revoked"),
+                        ],
+                        db_index=True,
+                        default="offline",
+                        max_length=16,
+                    ),
+                ),
+                ("os", models.CharField(blank=True, default="", max_length=32)),
+                ("arch", models.CharField(blank=True, default="", max_length=32)),
+                (
+                    "runner_version",
+                    models.CharField(blank=True, default="", max_length=32),
+                ),
+                ("protocol_version", models.PositiveIntegerField(default=1)),
+                ("last_heartbeat_at", models.DateTimeField(blank=True, null=True)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("revoked_at", models.DateTimeField(blank=True, null=True)),
+                (
+                    "owner",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="runners",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "workspace",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="runners",
+                        to="db.workspace",
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "runner",
+                "ordering": ("-last_heartbeat_at", "-created_at"),
+            },
+        ),
+        migrations.AddIndex(
+            model_name="runner",
+            index=models.Index(
+                fields=["owner", "status"], name="runner_owner_status_idx"
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="runner",
+            index=models.Index(
+                fields=["workspace", "status"], name="runner_ws_status_idx"
+            ),
+        ),
+        migrations.CreateModel(
+            name="RunnerRegistrationToken",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        db_index=True,
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("token_hash", models.CharField(max_length=128, unique=True)),
+                ("label", models.CharField(blank=True, default="", max_length=128)),
+                ("expires_at", models.DateTimeField()),
+                ("consumed_at", models.DateTimeField(blank=True, null=True)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="runner_registration_tokens",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "workspace",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="runner_registration_tokens",
+                        to="db.workspace",
+                    ),
+                ),
+                (
+                    "consumed_by_runner",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="consumed_registration_tokens",
+                        to="runner.runner",
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "runner_registration_token",
+                "ordering": ("-created_at",),
+            },
+        ),
+        migrations.AddIndex(
+            model_name="runnerregistrationtoken",
+            index=models.Index(
+                fields=["workspace", "consumed_at"], name="runnreg_ws_consumed_idx"
+            ),
+        ),
+        migrations.CreateModel(
+            name="AgentRun",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        db_index=True,
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("queued", "Queued"),
+                            ("assigned", "Assigned"),
+                            ("running", "Running"),
+                            ("awaiting_approval", "Awaiting Approval"),
+                            ("awaiting_reauth", "Awaiting Reauth"),
+                            ("completed", "Completed"),
+                            ("failed", "Failed"),
+                            ("cancelled", "Cancelled"),
+                        ],
+                        db_index=True,
+                        default="queued",
+                        max_length=24,
+                    ),
+                ),
+                ("prompt", models.TextField(blank=True, default="")),
+                ("run_config", models.JSONField(blank=True, default=dict)),
+                ("required_capabilities", models.JSONField(blank=True, default=list)),
+                ("thread_id", models.CharField(blank=True, default="", max_length=128)),
+                ("lease_expires_at", models.DateTimeField(blank=True, null=True)),
+                ("done_payload", models.JSONField(blank=True, null=True)),
+                ("error", models.TextField(blank=True, default="")),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("assigned_at", models.DateTimeField(blank=True, null=True)),
+                ("started_at", models.DateTimeField(blank=True, null=True)),
+                ("ended_at", models.DateTimeField(blank=True, null=True)),
+                (
+                    "owner",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="agent_runs",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "workspace",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="agent_runs",
+                        to="db.workspace",
+                    ),
+                ),
+                (
+                    "runner",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="agent_runs",
+                        to="runner.runner",
+                    ),
+                ),
+                (
+                    "work_item",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="agent_runs",
+                        to="db.issue",
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "agent_run",
+                "ordering": ("-created_at",),
+            },
+        ),
+        migrations.AddIndex(
+            model_name="agentrun",
+            index=models.Index(
+                fields=["runner", "status"], name="agentrun_runner_status_idx"
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="agentrun",
+            index=models.Index(
+                fields=["owner", "status"], name="agentrun_owner_status_idx"
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="agentrun",
+            index=models.Index(
+                fields=["workspace", "status"], name="agentrun_ws_status_idx"
+            ),
+        ),
+        migrations.CreateModel(
+            name="AgentRunEvent",
+            fields=[
+                ("id", models.BigAutoField(primary_key=True, serialize=False)),
+                ("seq", models.PositiveIntegerField()),
+                ("kind", models.CharField(max_length=64)),
+                ("payload", models.JSONField(blank=True, default=dict)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "agent_run",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="events",
+                        to="runner.agentrun",
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "agent_run_event",
+                "ordering": ("agent_run", "seq"),
+                "unique_together": {("agent_run", "seq")},
+            },
+        ),
+        migrations.CreateModel(
+            name="ApprovalRequest",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        db_index=True,
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                (
+                    "kind",
+                    models.CharField(
+                        choices=[
+                            ("command_execution", "Command Execution"),
+                            ("file_change", "File Change"),
+                            ("network_access", "Network Access"),
+                            ("other", "Other"),
+                        ],
+                        max_length=24,
+                    ),
+                ),
+                ("payload", models.JSONField(blank=True, default=dict)),
+                ("reason", models.TextField(blank=True, default="")),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("pending", "Pending"),
+                            ("accepted", "Accepted"),
+                            ("declined", "Declined"),
+                            ("expired", "Expired"),
+                        ],
+                        db_index=True,
+                        default="pending",
+                        max_length=16,
+                    ),
+                ),
+                (
+                    "decision_source",
+                    models.CharField(blank=True, default="", max_length=16),
+                ),
+                ("requested_at", models.DateTimeField(auto_now_add=True)),
+                ("expires_at", models.DateTimeField(blank=True, null=True)),
+                ("decided_at", models.DateTimeField(blank=True, null=True)),
+                (
+                    "agent_run",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="approvals",
+                        to="runner.agentrun",
+                    ),
+                ),
+                (
+                    "decided_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="runner_approvals_decided",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "agent_run_approval",
+                "ordering": ("-requested_at",),
+            },
+        ),
+        migrations.AddIndex(
+            model_name="approvalrequest",
+            index=models.Index(
+                fields=["agent_run", "status"], name="approval_run_status_idx"
+            ),
+        ),
+    ]

--- a/apps/api/apple_pi_dash/runner/models.py
+++ b/apps/api/apple_pi_dash/runner/models.py
@@ -1,0 +1,254 @@
+# Copyright (c) 2023-present Apple Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+import uuid
+
+from django.conf import settings
+from django.db import models
+from django.utils import timezone
+
+
+class RunnerStatus(models.TextChoices):
+    ONLINE = "online", "Online"
+    OFFLINE = "offline", "Offline"
+    BUSY = "busy", "Busy"
+    REVOKED = "revoked", "Revoked"
+
+
+class AgentRunStatus(models.TextChoices):
+    QUEUED = "queued", "Queued"
+    ASSIGNED = "assigned", "Assigned"
+    RUNNING = "running", "Running"
+    AWAITING_APPROVAL = "awaiting_approval", "Awaiting Approval"
+    AWAITING_REAUTH = "awaiting_reauth", "Awaiting Reauth"
+    COMPLETED = "completed", "Completed"
+    FAILED = "failed", "Failed"
+    CANCELLED = "cancelled", "Cancelled"
+
+
+class ApprovalStatus(models.TextChoices):
+    PENDING = "pending", "Pending"
+    ACCEPTED = "accepted", "Accepted"
+    DECLINED = "declined", "Declined"
+    EXPIRED = "expired", "Expired"
+
+
+class ApprovalKind(models.TextChoices):
+    COMMAND_EXECUTION = "command_execution", "Command Execution"
+    FILE_CHANGE = "file_change", "File Change"
+    NETWORK_ACCESS = "network_access", "Network Access"
+    OTHER = "other", "Other"
+
+
+class Runner(models.Model):
+    """A physical dev machine that can execute AgentRuns."""
+
+    MAX_PER_USER = 5
+
+    id = models.UUIDField(
+        primary_key=True, default=uuid.uuid4, editable=False, db_index=True
+    )
+    owner = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name="runners",
+    )
+    workspace = models.ForeignKey(
+        "db.Workspace",
+        on_delete=models.CASCADE,
+        related_name="runners",
+    )
+    name = models.CharField(max_length=128)
+    # Runner authenticates over WS with a bearer token; we store only its hash.
+    credential_hash = models.CharField(max_length=128, db_index=True)
+    credential_fingerprint = models.CharField(max_length=16)
+    capabilities = models.JSONField(default=list, blank=True)
+    status = models.CharField(
+        max_length=16,
+        choices=RunnerStatus.choices,
+        default=RunnerStatus.OFFLINE,
+        db_index=True,
+    )
+    os = models.CharField(max_length=32, blank=True, default="")
+    arch = models.CharField(max_length=32, blank=True, default="")
+    runner_version = models.CharField(max_length=32, blank=True, default="")
+    protocol_version = models.PositiveIntegerField(default=1)
+    last_heartbeat_at = models.DateTimeField(null=True, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+    revoked_at = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        db_table = "runner"
+        ordering = ("-last_heartbeat_at", "-created_at")
+        indexes = [
+            models.Index(fields=["owner", "status"]),
+            models.Index(fields=["workspace", "status"]),
+        ]
+
+    def __str__(self) -> str:
+        return f"{self.name} ({self.owner_id})"
+
+    def mark_heartbeat(self) -> None:
+        self.last_heartbeat_at = timezone.now()
+        self.save(update_fields=["last_heartbeat_at"])
+
+    def revoke(self) -> None:
+        self.status = RunnerStatus.REVOKED
+        self.revoked_at = timezone.now()
+        self.save(update_fields=["status", "revoked_at"])
+
+
+class RunnerRegistrationToken(models.Model):
+    """Short-lived, single-use token used to pair a new runner with the cloud."""
+
+    id = models.UUIDField(
+        primary_key=True, default=uuid.uuid4, editable=False, db_index=True
+    )
+    workspace = models.ForeignKey(
+        "db.Workspace",
+        on_delete=models.CASCADE,
+        related_name="runner_registration_tokens",
+    )
+    created_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name="runner_registration_tokens",
+    )
+    token_hash = models.CharField(max_length=128, unique=True)
+    label = models.CharField(max_length=128, blank=True, default="")
+    expires_at = models.DateTimeField()
+    consumed_at = models.DateTimeField(null=True, blank=True)
+    consumed_by_runner = models.ForeignKey(
+        Runner,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="consumed_registration_tokens",
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        db_table = "runner_registration_token"
+        ordering = ("-created_at",)
+        indexes = [models.Index(fields=["workspace", "consumed_at"])]
+
+    def is_valid(self) -> bool:
+        return self.consumed_at is None and self.expires_at > timezone.now()
+
+
+class AgentRun(models.Model):
+    id = models.UUIDField(
+        primary_key=True, default=uuid.uuid4, editable=False, db_index=True
+    )
+    workspace = models.ForeignKey(
+        "db.Workspace",
+        on_delete=models.CASCADE,
+        related_name="agent_runs",
+    )
+    owner = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name="agent_runs",
+    )
+    runner = models.ForeignKey(
+        Runner,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="agent_runs",
+    )
+    work_item = models.ForeignKey(
+        "db.Issue",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="agent_runs",
+    )
+    status = models.CharField(
+        max_length=24,
+        choices=AgentRunStatus.choices,
+        default=AgentRunStatus.QUEUED,
+        db_index=True,
+    )
+    prompt = models.TextField(blank=True, default="")
+    run_config = models.JSONField(default=dict, blank=True)
+    required_capabilities = models.JSONField(default=list, blank=True)
+    thread_id = models.CharField(max_length=128, blank=True, default="")
+    lease_expires_at = models.DateTimeField(null=True, blank=True)
+    done_payload = models.JSONField(null=True, blank=True)
+    error = models.TextField(blank=True, default="")
+    created_at = models.DateTimeField(auto_now_add=True)
+    assigned_at = models.DateTimeField(null=True, blank=True)
+    started_at = models.DateTimeField(null=True, blank=True)
+    ended_at = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        db_table = "agent_run"
+        ordering = ("-created_at",)
+        indexes = [
+            models.Index(fields=["runner", "status"]),
+            models.Index(fields=["owner", "status"]),
+            models.Index(fields=["workspace", "status"]),
+        ]
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.status in {
+            AgentRunStatus.COMPLETED,
+            AgentRunStatus.FAILED,
+            AgentRunStatus.CANCELLED,
+        }
+
+
+class AgentRunEvent(models.Model):
+    """Append-only transcript of events streamed from the runner."""
+
+    id = models.BigAutoField(primary_key=True)
+    agent_run = models.ForeignKey(
+        AgentRun, on_delete=models.CASCADE, related_name="events"
+    )
+    seq = models.PositiveIntegerField()
+    kind = models.CharField(max_length=64)
+    payload = models.JSONField(default=dict, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        db_table = "agent_run_event"
+        unique_together = [("agent_run", "seq")]
+        ordering = ("agent_run", "seq")
+
+
+class ApprovalRequest(models.Model):
+    id = models.UUIDField(
+        primary_key=True, default=uuid.uuid4, editable=False, db_index=True
+    )
+    agent_run = models.ForeignKey(
+        AgentRun, on_delete=models.CASCADE, related_name="approvals"
+    )
+    kind = models.CharField(max_length=24, choices=ApprovalKind.choices)
+    payload = models.JSONField(default=dict, blank=True)
+    reason = models.TextField(blank=True, default="")
+    status = models.CharField(
+        max_length=16,
+        choices=ApprovalStatus.choices,
+        default=ApprovalStatus.PENDING,
+        db_index=True,
+    )
+    decision_source = models.CharField(max_length=16, blank=True, default="")
+    decided_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="runner_approvals_decided",
+    )
+    requested_at = models.DateTimeField(auto_now_add=True)
+    expires_at = models.DateTimeField(null=True, blank=True)
+    decided_at = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        db_table = "agent_run_approval"
+        ordering = ("-requested_at",)
+        indexes = [models.Index(fields=["agent_run", "status"])]

--- a/apps/api/apple_pi_dash/runner/routing.py
+++ b/apps/api/apple_pi_dash/runner/routing.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2023-present Apple Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+from django.urls import path
+
+from apple_pi_dash.runner.consumers import RunnerConsumer
+
+websocket_urlpatterns = [
+    path("ws/runner/", RunnerConsumer.as_asgi()),
+]

--- a/apps/api/apple_pi_dash/runner/serializers.py
+++ b/apps/api/apple_pi_dash/runner/serializers.py
@@ -42,7 +42,9 @@ class RegistrationTokenSerializer(serializers.ModelSerializer):
 
 
 class RegistrationRequestSerializer(serializers.Serializer):
-    token = serializers.CharField(min_length=8, max_length=128)
+    # Minted tokens are ``apd_reg_`` (8) + ~32 chars of entropy. Reject
+    # obvious garbage before we spend a DB round-trip on it.
+    token = serializers.CharField(min_length=16, max_length=128)
     runner_name = serializers.CharField(min_length=1, max_length=128)
     os = serializers.CharField(max_length=32)
     arch = serializers.CharField(max_length=32)
@@ -103,4 +105,4 @@ class ApprovalRequestSerializer(serializers.ModelSerializer):
 
 
 class ApprovalDecisionSerializer(serializers.Serializer):
-    decision = serializers.ChoiceField(choices=["accept", "decline", "accept_for_session"])
+    decision = serializers.ChoiceField(choices=["accept", "decline"])

--- a/apps/api/apple_pi_dash/runner/serializers.py
+++ b/apps/api/apple_pi_dash/runner/serializers.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2023-present Apple Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+from rest_framework import serializers
+
+from apple_pi_dash.runner.models import (
+    AgentRun,
+    AgentRunEvent,
+    ApprovalKind,
+    ApprovalRequest,
+    ApprovalStatus,
+    Runner,
+    RunnerRegistrationToken,
+)
+
+
+class RunnerSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Runner
+        fields = [
+            "id",
+            "name",
+            "status",
+            "os",
+            "arch",
+            "runner_version",
+            "protocol_version",
+            "capabilities",
+            "last_heartbeat_at",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = fields
+
+
+class RegistrationTokenSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = RunnerRegistrationToken
+        fields = ["id", "label", "expires_at", "consumed_at", "created_at"]
+        read_only_fields = fields
+
+
+class RegistrationRequestSerializer(serializers.Serializer):
+    token = serializers.CharField(min_length=8, max_length=128)
+    runner_name = serializers.CharField(min_length=1, max_length=128)
+    os = serializers.CharField(max_length=32)
+    arch = serializers.CharField(max_length=32)
+    version = serializers.CharField(max_length=32)
+    protocol_version = serializers.IntegerField(min_value=1, max_value=999)
+
+
+class RegistrationResponseSerializer(serializers.Serializer):
+    runner_id = serializers.UUIDField()
+    runner_secret = serializers.CharField()
+    heartbeat_interval_secs = serializers.IntegerField()
+    protocol_version = serializers.IntegerField()
+
+
+class AgentRunSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = AgentRun
+        fields = [
+            "id",
+            "status",
+            "prompt",
+            "thread_id",
+            "runner",
+            "work_item",
+            "created_at",
+            "assigned_at",
+            "started_at",
+            "ended_at",
+            "done_payload",
+            "error",
+        ]
+        read_only_fields = fields
+
+
+class AgentRunEventSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = AgentRunEvent
+        fields = ["id", "seq", "kind", "payload", "created_at"]
+        read_only_fields = fields
+
+
+class ApprovalRequestSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ApprovalRequest
+        fields = [
+            "id",
+            "agent_run",
+            "kind",
+            "payload",
+            "reason",
+            "status",
+            "decision_source",
+            "requested_at",
+            "decided_at",
+            "expires_at",
+        ]
+        read_only_fields = fields
+
+
+class ApprovalDecisionSerializer(serializers.Serializer):
+    decision = serializers.ChoiceField(choices=["accept", "decline", "accept_for_session"])

--- a/apps/api/apple_pi_dash/runner/services/__init__.py
+++ b/apps/api/apple_pi_dash/runner/services/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2023-present Apple Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.

--- a/apps/api/apple_pi_dash/runner/services/matcher.py
+++ b/apps/api/apple_pi_dash/runner/services/matcher.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2023-present Apple Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Runner selection for an AgentRun.
+
+MVP rule (per ``.ai_design/implement_runner/runner-design.md``): pick one
+online idle runner owned by the user. No label matching. Users may register
+up to ``Runner.MAX_PER_USER`` runners; the matcher still needs to pick only
+one per run.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Optional
+
+from django.db.models import Q
+from django.utils import timezone
+
+from apple_pi_dash.runner.models import AgentRun, AgentRunStatus, Runner, RunnerStatus
+
+# A runner is considered stale (no longer eligible) if it has not heartbeated
+# within this window. Defensive in case a runner crashed without calling Bye.
+HEARTBEAT_GRACE = timedelta(seconds=90)
+
+
+def select_runner_for_run(run: AgentRun) -> Optional[Runner]:
+    """Return a suitable Runner or ``None`` if no machine is currently eligible."""
+    alive_threshold = timezone.now() - HEARTBEAT_GRACE
+    busy_states = (
+        AgentRunStatus.ASSIGNED,
+        AgentRunStatus.RUNNING,
+        AgentRunStatus.AWAITING_APPROVAL,
+        AgentRunStatus.AWAITING_REAUTH,
+    )
+    return (
+        Runner.objects.filter(
+            owner=run.owner,
+            workspace=run.workspace,
+            status=RunnerStatus.ONLINE,
+            last_heartbeat_at__gte=alive_threshold,
+        )
+        .exclude(agent_runs__status__in=busy_states)
+        .order_by("-last_heartbeat_at")
+        .first()
+    )
+
+
+def can_register_another(user_id, workspace_id) -> bool:
+    """Enforce the per-user runner cap."""
+    active = Runner.objects.filter(
+        owner_id=user_id,
+        workspace_id=workspace_id,
+    ).exclude(status=RunnerStatus.REVOKED)
+    return active.count() < Runner.MAX_PER_USER
+
+
+def count_active(user_id, workspace_id) -> int:
+    return (
+        Runner.objects.filter(owner_id=user_id, workspace_id=workspace_id)
+        .exclude(status=RunnerStatus.REVOKED)
+        .count()
+    )
+
+
+def eligible_for_assignment(runner: Runner) -> Q:
+    """Convenience predicate for assertions/tests."""
+    return Q(pk=runner.pk, status=RunnerStatus.ONLINE)

--- a/apps/api/apple_pi_dash/runner/services/matcher.py
+++ b/apps/api/apple_pi_dash/runner/services/matcher.py
@@ -26,7 +26,12 @@ HEARTBEAT_GRACE = timedelta(seconds=90)
 
 
 def select_runner_for_run(run: AgentRun) -> Optional[Runner]:
-    """Return a suitable Runner or ``None`` if no machine is currently eligible."""
+    """Return a suitable Runner or ``None`` if no machine is currently eligible.
+
+    Caller must be inside a ``transaction.atomic()`` block — the query takes a
+    row-level lock (``SELECT … FOR UPDATE SKIP LOCKED``) so two concurrent
+    assignments can't pick the same runner.
+    """
     alive_threshold = timezone.now() - HEARTBEAT_GRACE
     busy_states = (
         AgentRunStatus.ASSIGNED,
@@ -35,7 +40,8 @@ def select_runner_for_run(run: AgentRun) -> Optional[Runner]:
         AgentRunStatus.AWAITING_REAUTH,
     )
     return (
-        Runner.objects.filter(
+        Runner.objects.select_for_update(skip_locked=True)
+        .filter(
             owner=run.owner,
             workspace=run.workspace,
             status=RunnerStatus.ONLINE,

--- a/apps/api/apple_pi_dash/runner/services/pubsub.py
+++ b/apps/api/apple_pi_dash/runner/services/pubsub.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2023-present Apple Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Channels group-send helpers used by orchestrator code (Celery tasks, views)
+to push messages onto a connected runner's WebSocket.
+
+Usage:
+
+    from apple_pi_dash.runner.services.pubsub import send_to_runner
+    send_to_runner(runner_id, {"type": "assign", ...})
+
+The corresponding group is created in :class:`RunnerConsumer` as
+``runner.<runner_id>``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+from uuid import UUID
+
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
+
+logger = logging.getLogger(__name__)
+
+
+def runner_group(runner_id: UUID | str) -> str:
+    return f"runner.{runner_id}"
+
+
+def send_to_runner(runner_id: UUID | str, message: Dict[str, Any]) -> None:
+    """Best-effort fire-and-forget send to a runner's current WS process."""
+    layer = get_channel_layer()
+    if layer is None:
+        logger.warning("channel layer not configured; cannot route to %s", runner_id)
+        return
+    async_to_sync(layer.group_send)(runner_group(runner_id), {
+        "type": "runner.send",
+        "payload": message,
+    })
+
+
+async def asend_to_runner(runner_id: UUID | str, message: Dict[str, Any]) -> None:
+    layer = get_channel_layer()
+    if layer is None:
+        logger.warning("channel layer not configured; cannot route to %s", runner_id)
+        return
+    await layer.group_send(runner_group(runner_id), {
+        "type": "runner.send",
+        "payload": message,
+    })

--- a/apps/api/apple_pi_dash/runner/services/pubsub.py
+++ b/apps/api/apple_pi_dash/runner/services/pubsub.py
@@ -51,3 +51,19 @@ async def asend_to_runner(runner_id: UUID | str, message: Dict[str, Any]) -> Non
         "type": "runner.send",
         "payload": message,
     })
+
+
+def close_runner_session(runner_id: UUID | str, code: int = 4010) -> None:
+    """Tell any connected consumer for this runner to close its WebSocket.
+
+    Used after credential rotation / revocation to drop sessions still bound
+    to an old secret.
+    """
+    layer = get_channel_layer()
+    if layer is None:
+        logger.warning("channel layer not configured; cannot close %s", runner_id)
+        return
+    async_to_sync(layer.group_send)(runner_group(runner_id), {
+        "type": "runner.close",
+        "code": code,
+    })

--- a/apps/api/apple_pi_dash/runner/services/tokens.py
+++ b/apps/api/apple_pi_dash/runner/services/tokens.py
@@ -16,7 +16,6 @@ import hmac
 import secrets
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Iterable, Optional
 
 from django.conf import settings
 from django.utils import timezone
@@ -72,12 +71,3 @@ def mint_runner_secret() -> MintedRunnerSecret:
         hashed=hash_token(raw),
         fingerprint=fingerprint(raw),
     )
-
-
-def verify_runner_secret(raw: str, candidates: Iterable[str]) -> Optional[str]:
-    """Return the matching hashed credential or ``None``."""
-    provided = hash_token(raw)
-    for stored in candidates:
-        if hmac.compare_digest(provided, stored):
-            return stored
-    return None

--- a/apps/api/apple_pi_dash/runner/services/tokens.py
+++ b/apps/api/apple_pi_dash/runner/services/tokens.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2023-present Apple Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Token minting, hashing, and verification for runner auth.
+
+A "registration token" is handed to a user one time and expires in one hour.
+The runner presents it once to obtain a "runner_secret": a long-lived bearer
+credential the daemon stores on disk and sends on every WS connect.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import secrets
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Iterable, Optional
+
+from django.conf import settings
+from django.utils import timezone
+
+REGISTRATION_TTL = timedelta(hours=1)
+# Display prefixes so users can visually distinguish token kinds.
+REGISTRATION_PREFIX = "apd_reg_"
+RUNNER_SECRET_PREFIX = "apd_rs_"
+
+
+def _pepper() -> bytes:
+    # Derived from SECRET_KEY so rotating it invalidates all registration tokens.
+    return hashlib.sha256(("runner/pepper/" + settings.SECRET_KEY).encode()).digest()
+
+
+def hash_token(raw: str) -> str:
+    """HMAC-SHA256(pepper, raw) hex — stored alongside runner rows."""
+    return hmac.new(_pepper(), raw.encode(), hashlib.sha256).hexdigest()
+
+
+def fingerprint(raw: str) -> str:
+    """Short non-secret identifier (for logs / admin UI)."""
+    return hashlib.sha256(raw.encode()).hexdigest()[:12]
+
+
+@dataclass(frozen=True)
+class MintedRegistration:
+    raw: str
+    hashed: str
+    expires_at: object
+
+
+def mint_registration_token() -> MintedRegistration:
+    raw = REGISTRATION_PREFIX + secrets.token_urlsafe(24)
+    return MintedRegistration(
+        raw=raw,
+        hashed=hash_token(raw),
+        expires_at=timezone.now() + REGISTRATION_TTL,
+    )
+
+
+@dataclass(frozen=True)
+class MintedRunnerSecret:
+    raw: str
+    hashed: str
+    fingerprint: str
+
+
+def mint_runner_secret() -> MintedRunnerSecret:
+    raw = RUNNER_SECRET_PREFIX + secrets.token_urlsafe(32)
+    return MintedRunnerSecret(
+        raw=raw,
+        hashed=hash_token(raw),
+        fingerprint=fingerprint(raw),
+    )
+
+
+def verify_runner_secret(raw: str, candidates: Iterable[str]) -> Optional[str]:
+    """Return the matching hashed credential or ``None``."""
+    provided = hash_token(raw)
+    for stored in candidates:
+        if hmac.compare_digest(provided, stored):
+            return stored
+    return None

--- a/apps/api/apple_pi_dash/runner/tasks.py
+++ b/apps/api/apple_pi_dash/runner/tasks.py
@@ -40,12 +40,25 @@ def expire_stale_approvals() -> int:
     """
     now = timezone.now()
     expired = 0
-    qs = ApprovalRequest.objects.select_related("agent_run__runner").filter(
-        status=ApprovalStatus.PENDING,
-        expires_at__lt=now,
+    pending_ids = list(
+        ApprovalRequest.objects.filter(
+            status=ApprovalStatus.PENDING, expires_at__lt=now
+        ).values_list("pk", flat=True)
     )
-    for approval in qs.iterator():
+    for approval_id in pending_ids:
+        runner_id = None
+        run_id = None
         with transaction.atomic():
+            # Re-fetch under row lock so a concurrent decide view can't move
+            # this approval to ACCEPTED/DECLINED while we expire it.
+            approval = (
+                ApprovalRequest.objects.select_for_update()
+                .select_related("agent_run")
+                .filter(pk=approval_id, status=ApprovalStatus.PENDING)
+                .first()
+            )
+            if approval is None:
+                continue
             ApprovalRequest.objects.filter(pk=approval.pk).update(
                 status=ApprovalStatus.EXPIRED,
                 decided_at=now,
@@ -59,16 +72,18 @@ def expire_stale_approvals() -> int:
                     status=AgentRunStatus.CANCELLED,
                     ended_at=now,
                 )
-                if run.runner_id:
-                    send_to_runner(
-                        run.runner_id,
-                        {
-                            "v": 1,
-                            "type": "cancel",
-                            "run_id": str(run.id),
-                            "reason": "approval_timeout",
-                        },
-                    )
+                runner_id = run.runner_id
+                run_id = run.id
+        if runner_id:
+            send_to_runner(
+                runner_id,
+                {
+                    "v": 1,
+                    "type": "cancel",
+                    "run_id": str(run_id),
+                    "reason": "approval_timeout",
+                },
+            )
         expired += 1
     if expired:
         logger.info("expired %s stale approval(s)", expired)

--- a/apps/api/apple_pi_dash/runner/tasks.py
+++ b/apps/api/apple_pi_dash/runner/tasks.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2023-present Apple Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Celery tasks for runner lifecycle maintenance.
+
+Registered via ``apps/api/apple_pi_dash/celery.py`` and the existing
+``INSTALLED_APPS`` celery beat schedule. These tasks are idempotent.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+
+from celery import shared_task
+from django.db import transaction
+from django.utils import timezone
+
+from apple_pi_dash.runner.models import (
+    AgentRun,
+    AgentRunStatus,
+    ApprovalRequest,
+    ApprovalStatus,
+    Runner,
+    RunnerStatus,
+)
+from apple_pi_dash.runner.services.pubsub import send_to_runner
+
+logger = logging.getLogger(__name__)
+
+HEARTBEAT_OFFLINE_GRACE = timedelta(seconds=90)
+
+
+@shared_task(name="runner.expire_stale_approvals")
+def expire_stale_approvals() -> int:
+    """Move expired ApprovalRequests to EXPIRED and cancel their runs.
+
+    Returns the number of approvals expired.
+    """
+    now = timezone.now()
+    expired = 0
+    qs = ApprovalRequest.objects.select_related("agent_run__runner").filter(
+        status=ApprovalStatus.PENDING,
+        expires_at__lt=now,
+    )
+    for approval in qs.iterator():
+        with transaction.atomic():
+            ApprovalRequest.objects.filter(pk=approval.pk).update(
+                status=ApprovalStatus.EXPIRED,
+                decided_at=now,
+            )
+            run = approval.agent_run
+            if run.status in {
+                AgentRunStatus.AWAITING_APPROVAL,
+                AgentRunStatus.RUNNING,
+            }:
+                AgentRun.objects.filter(pk=run.pk).update(
+                    status=AgentRunStatus.CANCELLED,
+                    ended_at=now,
+                )
+                if run.runner_id:
+                    send_to_runner(
+                        run.runner_id,
+                        {
+                            "v": 1,
+                            "type": "cancel",
+                            "run_id": str(run.id),
+                            "reason": "approval_timeout",
+                        },
+                    )
+        expired += 1
+    if expired:
+        logger.info("expired %s stale approval(s)", expired)
+    return expired
+
+
+@shared_task(name="runner.mark_offline_runners")
+def mark_offline_runners() -> int:
+    """Mark ONLINE runners as OFFLINE when their heartbeat is stale.
+
+    This complements the channels consumer's ``disconnect`` path for the case
+    where a process dies without a clean teardown.
+    """
+    threshold = timezone.now() - HEARTBEAT_OFFLINE_GRACE
+    affected = (
+        Runner.objects.filter(
+            status=RunnerStatus.ONLINE,
+        )
+        .exclude(last_heartbeat_at__gte=threshold)
+        .update(status=RunnerStatus.OFFLINE)
+    )
+    if affected:
+        logger.info("marked %s runner(s) offline via heartbeat timeout", affected)
+    return affected

--- a/apps/api/apple_pi_dash/runner/urls.py
+++ b/apps/api/apple_pi_dash/runner/urls.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2023-present Apple Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""External runner-facing API (daemon traffic) — mounted at ``/api/v1/runner/``.
+
+All routes here use the runner's bearer credential for auth except
+``register/`` and ``health/`` which are public (they bootstrap the credential
+itself).
+"""
+
+from django.urls import path
+
+from apple_pi_dash.runner.views import (
+    HealthEndpoint,
+    MetricsEndpoint,
+    RegisterEndpoint,
+    RunnerDeregisterEndpoint,
+    RunnerRotateEndpoint,
+)
+
+app_name = "runner"
+
+urlpatterns = [
+    path("health/", HealthEndpoint.as_view(), name="health"),
+    path("metrics/", MetricsEndpoint.as_view(), name="metrics"),
+    path("register/", RegisterEndpoint.as_view(), name="register"),
+    path(
+        "<uuid:runner_id>/deregister/",
+        RunnerDeregisterEndpoint.as_view(),
+        name="deregister",
+    ),
+    path(
+        "<uuid:runner_id>/rotate/",
+        RunnerRotateEndpoint.as_view(),
+        name="rotate",
+    ),
+]

--- a/apps/api/apple_pi_dash/runner/views/__init__.py
+++ b/apps/api/apple_pi_dash/runner/views/__init__.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2023-present Apple Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+from .approvals import ApprovalDecideEndpoint, ApprovalListEndpoint
+from .metrics import MetricsEndpoint
+from .register import (
+    HealthEndpoint,
+    RegisterEndpoint,
+    RegistrationTokenCreateEndpoint,
+    RunnerDeregisterEndpoint,
+    RunnerRotateEndpoint,
+)
+from .runners import RunnerDetailEndpoint, RunnerListEndpoint, RunnerRevokeEndpoint
+from .runs import AgentRunCancelEndpoint, AgentRunDetailEndpoint, AgentRunListEndpoint
+
+__all__ = [
+    "ApprovalDecideEndpoint",
+    "ApprovalListEndpoint",
+    "HealthEndpoint",
+    "MetricsEndpoint",
+    "RegisterEndpoint",
+    "RegistrationTokenCreateEndpoint",
+    "RunnerDeregisterEndpoint",
+    "RunnerRotateEndpoint",
+    "RunnerDetailEndpoint",
+    "RunnerListEndpoint",
+    "RunnerRevokeEndpoint",
+    "AgentRunCancelEndpoint",
+    "AgentRunDetailEndpoint",
+    "AgentRunListEndpoint",
+]

--- a/apps/api/apple_pi_dash/runner/views/approvals.py
+++ b/apps/api/apple_pi_dash/runner/views/approvals.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2023-present Apple Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apple_pi_dash.runner.models import (
+    AgentRunStatus,
+    ApprovalRequest,
+    ApprovalStatus,
+)
+from apple_pi_dash.runner.serializers import (
+    ApprovalDecisionSerializer,
+    ApprovalRequestSerializer,
+)
+from apple_pi_dash.runner.services.pubsub import send_to_runner
+
+
+class ApprovalListEndpoint(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        qs = (
+            ApprovalRequest.objects.filter(agent_run__owner=request.user)
+            .filter(status=ApprovalStatus.PENDING)
+            .order_by("-requested_at")[:200]
+        )
+        return Response(ApprovalRequestSerializer(qs, many=True).data)
+
+
+class ApprovalDecideEndpoint(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, approval_id):
+        serializer = ApprovalDecisionSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        try:
+            approval = ApprovalRequest.objects.select_related(
+                "agent_run", "agent_run__runner"
+            ).get(id=approval_id, agent_run__owner=request.user)
+        except ApprovalRequest.DoesNotExist:
+            return Response({"error": "not found"}, status=status.HTTP_404_NOT_FOUND)
+        if approval.status != ApprovalStatus.PENDING:
+            return Response(
+                {"error": "already decided"},
+                status=status.HTTP_409_CONFLICT,
+            )
+        decision = serializer.validated_data["decision"]
+        approval.status = (
+            ApprovalStatus.ACCEPTED
+            if decision != "decline"
+            else ApprovalStatus.DECLINED
+        )
+        approval.decision_source = "web"
+        approval.decided_by = request.user
+        approval.decided_at = timezone.now()
+        approval.save(
+            update_fields=["status", "decision_source", "decided_by", "decided_at"]
+        )
+        # Run stays in a "working" state after approval decision.
+        if approval.agent_run.status == AgentRunStatus.AWAITING_APPROVAL:
+            approval.agent_run.status = AgentRunStatus.RUNNING
+            approval.agent_run.save(update_fields=["status"])
+        runner = approval.agent_run.runner
+        if runner is not None:
+            send_to_runner(
+                runner.id,
+                {
+                    "v": 1,
+                    "type": "decide",
+                    "run_id": str(approval.agent_run_id),
+                    "approval_id": str(approval.id),
+                    "decision": decision,
+                    "decided_by": str(request.user.id),
+                },
+            )
+        return Response(ApprovalRequestSerializer(approval).data)

--- a/apps/api/apple_pi_dash/runner/views/approvals.py
+++ b/apps/api/apple_pi_dash/runner/views/approvals.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # See the LICENSE file for details.
 
+from django.db import transaction
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
@@ -38,37 +39,51 @@ class ApprovalDecideEndpoint(APIView):
     def post(self, request, approval_id):
         serializer = ApprovalDecisionSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        try:
-            approval = ApprovalRequest.objects.select_related(
-                "agent_run", "agent_run__runner"
-            ).get(id=approval_id, agent_run__owner=request.user)
-        except ApprovalRequest.DoesNotExist:
-            return Response({"error": "not found"}, status=status.HTTP_404_NOT_FOUND)
-        if approval.status != ApprovalStatus.PENDING:
-            return Response(
-                {"error": "already decided"},
-                status=status.HTTP_409_CONFLICT,
-            )
         decision = serializer.validated_data["decision"]
-        approval.status = (
-            ApprovalStatus.ACCEPTED
-            if decision != "decline"
-            else ApprovalStatus.DECLINED
-        )
-        approval.decision_source = "web"
-        approval.decided_by = request.user
-        approval.decided_at = timezone.now()
-        approval.save(
-            update_fields=["status", "decision_source", "decided_by", "decided_at"]
-        )
-        # Run stays in a "working" state after approval decision.
-        if approval.agent_run.status == AgentRunStatus.AWAITING_APPROVAL:
-            approval.agent_run.status = AgentRunStatus.RUNNING
-            approval.agent_run.save(update_fields=["status"])
-        runner = approval.agent_run.runner
-        if runner is not None:
+        runner_id = None
+        with transaction.atomic():
+            # select_for_update serializes with expire_stale_approvals so a
+            # user click can't race the beat task to an inconsistent state.
+            try:
+                approval = (
+                    ApprovalRequest.objects.select_for_update()
+                    .select_related("agent_run", "agent_run__runner")
+                    .get(id=approval_id, agent_run__owner=request.user)
+                )
+            except ApprovalRequest.DoesNotExist:
+                return Response(
+                    {"error": "not found"}, status=status.HTTP_404_NOT_FOUND
+                )
+            if approval.status != ApprovalStatus.PENDING:
+                return Response(
+                    {"error": "already decided"},
+                    status=status.HTTP_409_CONFLICT,
+                )
+            approval.status = (
+                ApprovalStatus.ACCEPTED
+                if decision == "accept"
+                else ApprovalStatus.DECLINED
+            )
+            approval.decision_source = "web"
+            approval.decided_by = request.user
+            approval.decided_at = timezone.now()
+            approval.save(
+                update_fields=[
+                    "status",
+                    "decision_source",
+                    "decided_by",
+                    "decided_at",
+                ]
+            )
+            # Run stays in a "working" state after approval decision.
+            if approval.agent_run.status == AgentRunStatus.AWAITING_APPROVAL:
+                approval.agent_run.status = AgentRunStatus.RUNNING
+                approval.agent_run.save(update_fields=["status"])
+            if approval.agent_run.runner_id is not None:
+                runner_id = approval.agent_run.runner_id
+        if runner_id is not None:
             send_to_runner(
-                runner.id,
+                runner_id,
                 {
                     "v": 1,
                     "type": "decide",

--- a/apps/api/apple_pi_dash/runner/views/metrics.py
+++ b/apps/api/apple_pi_dash/runner/views/metrics.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2023-present Apple Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Prometheus text-format metrics endpoint.
+
+Exposes point-in-time gauges derived from DB queries. Scrape with
+``GET /api/v1/runner/metrics/``. No new dependencies — we emit the format
+ourselves so the endpoint works with any Prometheus-compatible scraper.
+
+Schema (all gauges):
+- ``apple_pi_dash_runner_online``: count of runners in ``online`` state.
+- ``apple_pi_dash_runner_busy``: count of runners in ``busy`` state.
+- ``apple_pi_dash_runner_offline``: count of runners in ``offline`` state
+  (excludes revoked; revoked runners are retired, not a health signal).
+- ``apple_pi_dash_runs_active``: count of AgentRuns in an in-flight status
+  (assigned / running / awaiting_approval / awaiting_reauth).
+- ``apple_pi_dash_approvals_pending``: count of ApprovalRequests with
+  ``status=pending``.
+"""
+
+from __future__ import annotations
+
+from django.db.models import Count
+from django.http import HttpResponse
+from rest_framework.permissions import AllowAny
+from rest_framework.views import APIView
+
+from apple_pi_dash.runner.models import (
+    AgentRun,
+    AgentRunStatus,
+    ApprovalRequest,
+    ApprovalStatus,
+    Runner,
+    RunnerStatus,
+)
+
+
+ACTIVE_RUN_STATUSES = (
+    AgentRunStatus.ASSIGNED,
+    AgentRunStatus.RUNNING,
+    AgentRunStatus.AWAITING_APPROVAL,
+    AgentRunStatus.AWAITING_REAUTH,
+)
+
+
+def _gauge(name: str, help_text: str, value: int) -> str:
+    return (
+        f"# HELP {name} {help_text}\n"
+        f"# TYPE {name} gauge\n"
+        f"{name} {value}\n"
+    )
+
+
+class MetricsEndpoint(APIView):
+    authentication_classes: list = []
+    permission_classes = [AllowAny]
+    # Metrics scrapers expect ``text/plain``; DRF defaults to JSON. We bypass
+    # DRF rendering by returning ``HttpResponse`` directly.
+
+    def get(self, request):
+        status_counts = dict(
+            Runner.objects.values_list("status").annotate(c=Count("id"))
+        )
+        online = status_counts.get(RunnerStatus.ONLINE, 0)
+        busy = status_counts.get(RunnerStatus.BUSY, 0)
+        offline = status_counts.get(RunnerStatus.OFFLINE, 0)
+
+        active_runs = AgentRun.objects.filter(
+            status__in=ACTIVE_RUN_STATUSES
+        ).count()
+        pending_approvals = ApprovalRequest.objects.filter(
+            status=ApprovalStatus.PENDING
+        ).count()
+
+        body = "".join([
+            _gauge(
+                "apple_pi_dash_runner_online",
+                "Runners currently online.",
+                online,
+            ),
+            _gauge(
+                "apple_pi_dash_runner_busy",
+                "Runners currently executing a run.",
+                busy,
+            ),
+            _gauge(
+                "apple_pi_dash_runner_offline",
+                "Runners that have dropped their heartbeat (excludes revoked).",
+                offline,
+            ),
+            _gauge(
+                "apple_pi_dash_runs_active",
+                "AgentRuns in an in-flight status.",
+                active_runs,
+            ),
+            _gauge(
+                "apple_pi_dash_approvals_pending",
+                "ApprovalRequests waiting for a decision.",
+                pending_approvals,
+            ),
+        ])
+        return HttpResponse(body, content_type="text/plain; version=0.0.4")

--- a/apps/api/apple_pi_dash/runner/views/register.py
+++ b/apps/api/apple_pi_dash/runner/views/register.py
@@ -111,6 +111,9 @@ class RunnerDeregisterEndpoint(APIView):
 
     authentication_classes = [RunnerBearerAuthentication]
     permission_classes = []
+    # DRF's default throttles call ``request.user.is_authenticated``; our
+    # bearer auth puts a ``Runner`` instance there, so skip the throttle chain.
+    throttle_classes: list = []
 
     def post(self, request, runner_id):
         runner = getattr(request, "auth_runner", None)
@@ -131,6 +134,7 @@ class RunnerRotateEndpoint(APIView):
 
     authentication_classes = [RunnerBearerAuthentication]
     permission_classes = []
+    throttle_classes: list = []
 
     def post(self, request, runner_id):
         runner = getattr(request, "auth_runner", None)

--- a/apps/api/apple_pi_dash/runner/views/register.py
+++ b/apps/api/apple_pi_dash/runner/views/register.py
@@ -1,0 +1,193 @@
+# Copyright (c) 2023-present Apple Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+from django.db import transaction
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apple_pi_dash.runner.authentication import RunnerBearerAuthentication
+from apple_pi_dash.runner.models import (
+    Runner,
+    RunnerRegistrationToken,
+    RunnerStatus,
+)
+from apple_pi_dash.runner.serializers import (
+    RegistrationRequestSerializer,
+    RegistrationResponseSerializer,
+    RegistrationTokenSerializer,
+)
+from apple_pi_dash.runner.services import tokens
+from apple_pi_dash.runner.services.matcher import can_register_another
+
+
+HEARTBEAT_INTERVAL_SECS = 25
+PROTOCOL_VERSION = 1
+
+
+class HealthEndpoint(APIView):
+    authentication_classes: list = []
+    permission_classes = [AllowAny]
+
+    def get(self, request):
+        return Response({"ok": True, "protocol_version": PROTOCOL_VERSION})
+
+
+class RegisterEndpoint(APIView):
+    """POST /api/v1/runner/register/ — one-time-token to runner-secret exchange.
+
+    Called by the daemon during ``apple-pi-dash-runner configure``.
+    """
+
+    authentication_classes: list = []
+    permission_classes = [AllowAny]
+
+    @transaction.atomic
+    def post(self, request):
+        serializer = RegistrationRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        raw_token = data["token"]
+        hashed = tokens.hash_token(raw_token)
+        try:
+            reg = (
+                RunnerRegistrationToken.objects.select_for_update()
+                .get(token_hash=hashed)
+            )
+        except RunnerRegistrationToken.DoesNotExist:
+            return Response(
+                {"error": "invalid or expired registration token"},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+        if not reg.is_valid():
+            return Response(
+                {"error": "registration token already used or expired"},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+        if not can_register_another(reg.created_by_id, reg.workspace_id):
+            return Response(
+                {"error": f"runner cap reached ({Runner.MAX_PER_USER})"},
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        minted = tokens.mint_runner_secret()
+        runner = Runner.objects.create(
+            owner=reg.created_by,
+            workspace=reg.workspace,
+            name=data["runner_name"][:128],
+            credential_hash=minted.hashed,
+            credential_fingerprint=minted.fingerprint,
+            os=data["os"][:32],
+            arch=data["arch"][:32],
+            runner_version=data["version"][:32],
+            protocol_version=data["protocol_version"],
+        )
+        reg.consumed_at = timezone.now()
+        reg.consumed_by_runner = runner
+        reg.save(update_fields=["consumed_at", "consumed_by_runner"])
+
+        payload = RegistrationResponseSerializer(
+            {
+                "runner_id": runner.id,
+                "runner_secret": minted.raw,
+                "heartbeat_interval_secs": HEARTBEAT_INTERVAL_SECS,
+                "protocol_version": PROTOCOL_VERSION,
+            }
+        ).data
+        return Response(payload, status=status.HTTP_201_CREATED)
+
+
+class RunnerDeregisterEndpoint(APIView):
+    """POST /api/v1/runner/<uuid>/deregister/
+
+    Called by the daemon during ``apple-pi-dash-runner remove``. Authenticated
+    with the runner's own bearer secret; the server marks the runner revoked.
+    """
+
+    authentication_classes = [RunnerBearerAuthentication]
+    permission_classes = []
+
+    def post(self, request, runner_id):
+        runner = getattr(request, "auth_runner", None)
+        if runner is None or str(runner.id) != str(runner_id):
+            return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
+        runner.revoke()
+        return Response({"ok": True})
+
+
+class RunnerRotateEndpoint(APIView):
+    """POST /api/v1/runner/<uuid>/rotate/
+
+    Runner authenticates with its current bearer secret and receives a new
+    one. The old credential is immediately invalidated. The daemon writes the
+    new secret to ``credentials.toml`` and reconnects.
+    """
+
+    authentication_classes = [RunnerBearerAuthentication]
+    permission_classes = []
+
+    def post(self, request, runner_id):
+        runner = getattr(request, "auth_runner", None)
+        if runner is None or str(runner.id) != str(runner_id):
+            return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
+        minted = tokens.mint_runner_secret()
+        # Update in a single statement so no window has two valid credentials.
+        from apple_pi_dash.runner.models import Runner as RunnerModel
+
+        RunnerModel.objects.filter(pk=runner.pk).update(
+            credential_hash=minted.hashed,
+            credential_fingerprint=minted.fingerprint,
+        )
+        return Response(
+            {
+                "runner_id": str(runner.id),
+                "runner_secret": minted.raw,
+                "heartbeat_interval_secs": HEARTBEAT_INTERVAL_SECS,
+                "protocol_version": PROTOCOL_VERSION,
+            }
+        )
+
+
+class RegistrationTokenCreateEndpoint(APIView):
+    """POST /api/runners/tokens/  — web UI mints a one-time registration code."""
+
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request):
+        workspace_id = request.data.get("workspace")
+        label = request.data.get("label", "")[:128]
+        if not workspace_id:
+            return Response(
+                {"error": "workspace is required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if not can_register_another(request.user.id, workspace_id):
+            return Response(
+                {"error": f"runner cap reached ({Runner.MAX_PER_USER})"},
+                status=status.HTTP_409_CONFLICT,
+            )
+        minted = tokens.mint_registration_token()
+        record = RunnerRegistrationToken.objects.create(
+            workspace_id=workspace_id,
+            created_by=request.user,
+            token_hash=minted.hashed,
+            label=label,
+            expires_at=minted.expires_at,
+        )
+        return Response(
+            {
+                "registration": RegistrationTokenSerializer(record).data,
+                "token": minted.raw,
+            },
+            status=status.HTTP_201_CREATED,
+        )
+
+    def get(self, request):
+        qs = RunnerRegistrationToken.objects.filter(created_by=request.user).order_by(
+            "-created_at"
+        )
+        return Response(RegistrationTokenSerializer(qs, many=True).data)

--- a/apps/api/apple_pi_dash/runner/views/register.py
+++ b/apps/api/apple_pi_dash/runner/views/register.py
@@ -22,6 +22,7 @@ from apple_pi_dash.runner.serializers import (
 )
 from apple_pi_dash.runner.services import tokens
 from apple_pi_dash.runner.services.matcher import can_register_another
+from apple_pi_dash.runner.services.pubsub import close_runner_session
 
 
 HEARTBEAT_INTERVAL_SECS = 25
@@ -116,6 +117,7 @@ class RunnerDeregisterEndpoint(APIView):
         if runner is None or str(runner.id) != str(runner_id):
             return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
         runner.revoke()
+        close_runner_session(runner.pk)
         return Response({"ok": True})
 
 
@@ -136,12 +138,13 @@ class RunnerRotateEndpoint(APIView):
             return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
         minted = tokens.mint_runner_secret()
         # Update in a single statement so no window has two valid credentials.
-        from apple_pi_dash.runner.models import Runner as RunnerModel
-
-        RunnerModel.objects.filter(pk=runner.pk).update(
+        Runner.objects.filter(pk=runner.pk).update(
             credential_hash=minted.hashed,
             credential_fingerprint=minted.fingerprint,
         )
+        # Any WebSocket authenticated with the old secret is now orphaned —
+        # force-close it so the daemon reconnects with the new credential.
+        close_runner_session(runner.pk)
         return Response(
             {
                 "runner_id": str(runner.id),
@@ -159,7 +162,7 @@ class RegistrationTokenCreateEndpoint(APIView):
 
     def post(self, request):
         workspace_id = request.data.get("workspace")
-        label = request.data.get("label", "")[:128]
+        label = (request.data.get("label") or "")[:128]
         if not workspace_id:
             return Response(
                 {"error": "workspace is required"},

--- a/apps/api/apple_pi_dash/runner/views/runners.py
+++ b/apps/api/apple_pi_dash/runner/views/runners.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2023-present Apple Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apple_pi_dash.runner.models import Runner
+from apple_pi_dash.runner.serializers import RunnerSerializer
+
+
+class RunnerListEndpoint(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        qs = Runner.objects.filter(owner=request.user).order_by("-updated_at")
+        workspace_id = request.query_params.get("workspace")
+        if workspace_id:
+            qs = qs.filter(workspace_id=workspace_id)
+        return Response(RunnerSerializer(qs, many=True).data)
+
+
+class RunnerDetailEndpoint(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, runner_id):
+        try:
+            runner = Runner.objects.get(id=runner_id, owner=request.user)
+        except Runner.DoesNotExist:
+            return Response({"error": "not found"}, status=status.HTTP_404_NOT_FOUND)
+        return Response(RunnerSerializer(runner).data)
+
+
+class RunnerRevokeEndpoint(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, runner_id):
+        try:
+            runner = Runner.objects.get(id=runner_id, owner=request.user)
+        except Runner.DoesNotExist:
+            return Response({"error": "not found"}, status=status.HTTP_404_NOT_FOUND)
+        runner.revoke()
+        # Fan out a revoke WS message — best-effort; runner may already be offline.
+        from apple_pi_dash.runner.services.pubsub import send_to_runner
+
+        send_to_runner(
+            runner.id,
+            {"v": 1, "type": "revoke", "reason": "revoked by user"},
+        )
+        return Response(RunnerSerializer(runner).data)

--- a/apps/api/apple_pi_dash/runner/views/runners.py
+++ b/apps/api/apple_pi_dash/runner/views/runners.py
@@ -9,6 +9,7 @@ from rest_framework.views import APIView
 
 from apple_pi_dash.runner.models import Runner
 from apple_pi_dash.runner.serializers import RunnerSerializer
+from apple_pi_dash.runner.services.pubsub import close_runner_session, send_to_runner
 
 
 class RunnerListEndpoint(APIView):
@@ -43,10 +44,9 @@ class RunnerRevokeEndpoint(APIView):
             return Response({"error": "not found"}, status=status.HTTP_404_NOT_FOUND)
         runner.revoke()
         # Fan out a revoke WS message — best-effort; runner may already be offline.
-        from apple_pi_dash.runner.services.pubsub import send_to_runner
-
         send_to_runner(
             runner.id,
             {"v": 1, "type": "revoke", "reason": "revoked by user"},
         )
+        close_runner_session(runner.id)
         return Response(RunnerSerializer(runner).data)

--- a/apps/api/apple_pi_dash/runner/views/runs.py
+++ b/apps/api/apple_pi_dash/runner/views/runs.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # See the LICENSE file for details.
 
+from django.db import transaction
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
@@ -37,27 +38,30 @@ class AgentRunListEndpoint(APIView):
                 {"error": "prompt and workspace are required"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        run = AgentRun.objects.create(
-            owner=request.user,
-            workspace_id=workspace_id,
-            prompt=prompt,
-            run_config=request.data.get("run_config") or {},
-            required_capabilities=request.data.get("required_capabilities") or [],
-            work_item_id=request.data.get("work_item"),
-        )
-        chosen = matcher.select_runner_for_run(run)
-        if chosen is not None:
-            run.runner = chosen
-            run.status = AgentRunStatus.ASSIGNED
-            run.assigned_at = timezone.now()
-            run.save(update_fields=["runner", "status", "assigned_at"])
-            send_to_runner(
-                chosen.id,
-                {
+        chosen_id = None
+        with transaction.atomic():
+            run = AgentRun.objects.create(
+                owner=request.user,
+                workspace_id=workspace_id,
+                prompt=prompt,
+                run_config=request.data.get("run_config") or {},
+                required_capabilities=request.data.get("required_capabilities") or [],
+                work_item_id=request.data.get("work_item"),
+            )
+            chosen = matcher.select_runner_for_run(run)
+            if chosen is not None:
+                run.runner = chosen
+                run.status = AgentRunStatus.ASSIGNED
+                run.assigned_at = timezone.now()
+                run.save(update_fields=["runner", "status", "assigned_at"])
+                chosen_id = chosen.id
+                assign_msg = {
                     "v": 1,
                     "type": "assign",
                     "run_id": str(run.id),
-                    "work_item_id": str(run.work_item_id) if run.work_item_id else None,
+                    "work_item_id": (
+                        str(run.work_item_id) if run.work_item_id else None
+                    ),
                     "prompt": run.prompt,
                     "repo_url": run.run_config.get("repo_url"),
                     "repo_ref": run.run_config.get("repo_ref"),
@@ -66,8 +70,11 @@ class AgentRunListEndpoint(APIView):
                         "approval_policy_overrides"
                     ),
                     "deadline": None,
-                },
-            )
+                }
+        # Push over the WS only after the row is committed — otherwise the
+        # daemon could ack before the DB is visible to other processes.
+        if chosen_id is not None:
+            send_to_runner(chosen_id, assign_msg)
         return Response(
             AgentRunSerializer(run).data,
             status=status.HTTP_201_CREATED,

--- a/apps/api/apple_pi_dash/runner/views/runs.py
+++ b/apps/api/apple_pi_dash/runner/views/runs.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2023-present Apple Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apple_pi_dash.runner.models import AgentRun, AgentRunEvent, AgentRunStatus
+from apple_pi_dash.runner.serializers import (
+    AgentRunEventSerializer,
+    AgentRunSerializer,
+)
+from apple_pi_dash.runner.services import matcher
+from apple_pi_dash.runner.services.pubsub import send_to_runner
+
+
+class AgentRunListEndpoint(APIView):
+    """Create a new run from a work item, or list the authenticated user's runs."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        qs = AgentRun.objects.filter(owner=request.user).order_by("-created_at")
+        workspace_id = request.query_params.get("workspace")
+        if workspace_id:
+            qs = qs.filter(workspace_id=workspace_id)
+        return Response(AgentRunSerializer(qs[:200], many=True).data)
+
+    def post(self, request):
+        prompt = request.data.get("prompt")
+        workspace_id = request.data.get("workspace")
+        if not prompt or not workspace_id:
+            return Response(
+                {"error": "prompt and workspace are required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        run = AgentRun.objects.create(
+            owner=request.user,
+            workspace_id=workspace_id,
+            prompt=prompt,
+            run_config=request.data.get("run_config") or {},
+            required_capabilities=request.data.get("required_capabilities") or [],
+            work_item_id=request.data.get("work_item"),
+        )
+        chosen = matcher.select_runner_for_run(run)
+        if chosen is not None:
+            run.runner = chosen
+            run.status = AgentRunStatus.ASSIGNED
+            run.assigned_at = timezone.now()
+            run.save(update_fields=["runner", "status", "assigned_at"])
+            send_to_runner(
+                chosen.id,
+                {
+                    "v": 1,
+                    "type": "assign",
+                    "run_id": str(run.id),
+                    "work_item_id": str(run.work_item_id) if run.work_item_id else None,
+                    "prompt": run.prompt,
+                    "repo_url": run.run_config.get("repo_url"),
+                    "repo_ref": run.run_config.get("repo_ref"),
+                    "expected_codex_model": run.run_config.get("model"),
+                    "approval_policy_overrides": run.run_config.get(
+                        "approval_policy_overrides"
+                    ),
+                    "deadline": None,
+                },
+            )
+        return Response(
+            AgentRunSerializer(run).data,
+            status=status.HTTP_201_CREATED,
+        )
+
+
+class AgentRunDetailEndpoint(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, run_id):
+        try:
+            run = AgentRun.objects.get(id=run_id, owner=request.user)
+        except AgentRun.DoesNotExist:
+            return Response({"error": "not found"}, status=status.HTTP_404_NOT_FOUND)
+        include_events = request.query_params.get("include_events") == "1"
+        payload = AgentRunSerializer(run).data
+        if include_events:
+            events = AgentRunEvent.objects.filter(agent_run=run).order_by("seq")[:500]
+            payload["events"] = AgentRunEventSerializer(events, many=True).data
+        return Response(payload)
+
+
+class AgentRunCancelEndpoint(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, run_id):
+        try:
+            run = AgentRun.objects.get(id=run_id, owner=request.user)
+        except AgentRun.DoesNotExist:
+            return Response({"error": "not found"}, status=status.HTTP_404_NOT_FOUND)
+        if run.is_terminal:
+            return Response(
+                {"error": "run already terminal"},
+                status=status.HTTP_409_CONFLICT,
+            )
+        if run.runner_id:
+            send_to_runner(
+                run.runner_id,
+                {
+                    "v": 1,
+                    "type": "cancel",
+                    "run_id": str(run.id),
+                    "reason": request.data.get("reason", ""),
+                },
+            )
+        run.status = AgentRunStatus.CANCELLED
+        run.ended_at = timezone.now()
+        run.save(update_fields=["status", "ended_at"])
+        return Response(AgentRunSerializer(run).data)

--- a/apps/api/apple_pi_dash/runner/web_urls.py
+++ b/apps/api/apple_pi_dash/runner/web_urls.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2023-present Apple Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Web-app facing runner API (session auth) — mounted under ``/api/runners/``."""
+
+from django.urls import path
+
+from apple_pi_dash.runner.views import (
+    AgentRunCancelEndpoint,
+    AgentRunDetailEndpoint,
+    AgentRunListEndpoint,
+    ApprovalDecideEndpoint,
+    ApprovalListEndpoint,
+    RegistrationTokenCreateEndpoint,
+    RunnerDetailEndpoint,
+    RunnerListEndpoint,
+    RunnerRevokeEndpoint,
+)
+
+urlpatterns = [
+    path("", RunnerListEndpoint.as_view(), name="runner-list"),
+    path(
+        "tokens/",
+        RegistrationTokenCreateEndpoint.as_view(),
+        name="runner-tokens",
+    ),
+    path(
+        "<uuid:runner_id>/",
+        RunnerDetailEndpoint.as_view(),
+        name="runner-detail",
+    ),
+    path(
+        "<uuid:runner_id>/revoke/",
+        RunnerRevokeEndpoint.as_view(),
+        name="runner-revoke",
+    ),
+    path("runs/", AgentRunListEndpoint.as_view(), name="runner-runs"),
+    path(
+        "runs/<uuid:run_id>/",
+        AgentRunDetailEndpoint.as_view(),
+        name="runner-run-detail",
+    ),
+    path(
+        "runs/<uuid:run_id>/cancel/",
+        AgentRunCancelEndpoint.as_view(),
+        name="runner-run-cancel",
+    ),
+    path(
+        "approvals/",
+        ApprovalListEndpoint.as_view(),
+        name="runner-approvals",
+    ),
+    path(
+        "approvals/<uuid:approval_id>/decide/",
+        ApprovalDecideEndpoint.as_view(),
+        name="runner-approval-decide",
+    ),
+]

--- a/apps/api/apple_pi_dash/settings/common.py
+++ b/apps/api/apple_pi_dash/settings/common.py
@@ -53,7 +53,9 @@ INSTALLED_APPS = [
     "apple_pi_dash.license",
     "apple_pi_dash.api",
     "apple_pi_dash.authentication",
+    "apple_pi_dash.runner",
     # Third-party things
+    "channels",
     "rest_framework",
     "corsheaders",
     "django_celery_beat",
@@ -201,6 +203,21 @@ else:
         }
     }
 
+# Channels channel layer — used by apple_pi_dash.runner to fan messages to
+# connected runner WebSockets. Falls back to in-memory when Redis is not
+# available (dev/test); single-process only in that mode.
+if REDIS_URL:
+    CHANNEL_LAYERS = {
+        "default": {
+            "BACKEND": "channels_redis.core.RedisChannelLayer",
+            "CONFIG": {"hosts": [REDIS_URL]},
+        }
+    }
+else:
+    CHANNEL_LAYERS = {
+        "default": {"BACKEND": "channels.layers.InMemoryChannelLayer"},
+    }
+
 # Password validations
 AUTH_PASSWORD_VALIDATORS = [
     {"NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"},
@@ -288,6 +305,8 @@ CELERY_IMPORTS = (
     # issue version tasks
     "apple_pi_dash.bgtasks.issue_version_sync",
     "apple_pi_dash.bgtasks.issue_description_version_sync",
+    # runner lifecycle tasks
+    "apple_pi_dash.runner.tasks",
 )
 
 FILE_SIZE_LIMIT = int(os.environ.get("FILE_SIZE_LIMIT", 5242880))

--- a/apps/api/apple_pi_dash/tests/contract/runner/test_registration.py
+++ b/apps/api/apple_pi_dash/tests/contract/runner/test_registration.py
@@ -1,0 +1,160 @@
+# Copyright (c) 2023-present Apple Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+from datetime import timedelta
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+
+from apple_pi_dash.runner.models import (
+    AgentRunStatus,
+    Runner,
+    RunnerRegistrationToken,
+    RunnerStatus,
+)
+from apple_pi_dash.runner.services import tokens
+
+
+@pytest.fixture
+def registration(db, create_user, workspace):
+    minted = tokens.mint_registration_token()
+    record = RunnerRegistrationToken.objects.create(
+        workspace=workspace,
+        created_by=create_user,
+        token_hash=minted.hashed,
+        label="test",
+        expires_at=minted.expires_at,
+    )
+    return minted, record
+
+
+@pytest.mark.contract
+def test_register_exchanges_token_for_secret(api_client, registration):
+    minted, record = registration
+    url = reverse("runner:register")
+    payload = {
+        "token": minted.raw,
+        "runner_name": "laptop",
+        "os": "linux",
+        "arch": "x86_64",
+        "version": "0.1.0",
+        "protocol_version": 1,
+    }
+    resp = api_client.post(url, payload, format="json")
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["runner_secret"].startswith("apd_rs_")
+    assert body["protocol_version"] == 1
+    runner = Runner.objects.get(id=body["runner_id"])
+    assert runner.owner_id == record.created_by_id
+    record.refresh_from_db()
+    assert record.consumed_at is not None
+    assert record.consumed_by_runner_id == runner.id
+
+
+@pytest.mark.contract
+def test_register_rejects_expired_token(api_client, registration):
+    minted, record = registration
+    record.expires_at = timezone.now() - timedelta(minutes=1)
+    record.save(update_fields=["expires_at"])
+    url = reverse("runner:register")
+    resp = api_client.post(
+        url,
+        {
+            "token": minted.raw,
+            "runner_name": "laptop",
+            "os": "linux",
+            "arch": "x86_64",
+            "version": "0.1.0",
+            "protocol_version": 1,
+        },
+        format="json",
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.contract
+def test_register_rejects_reused_token(api_client, registration):
+    minted, _ = registration
+    url = reverse("runner:register")
+    payload = {
+        "token": minted.raw,
+        "runner_name": "laptop",
+        "os": "linux",
+        "arch": "x86_64",
+        "version": "0.1.0",
+        "protocol_version": 1,
+    }
+    first = api_client.post(url, payload, format="json")
+    second = api_client.post(url, payload, format="json")
+    assert first.status_code == 201
+    assert second.status_code == 401
+
+
+@pytest.mark.contract
+def test_register_enforces_runner_cap(api_client, db, create_user, workspace):
+    # Pre-create Runner.MAX_PER_USER runners to reach the cap.
+    for i in range(Runner.MAX_PER_USER):
+        Runner.objects.create(
+            owner=create_user,
+            workspace=workspace,
+            name=f"existing-{i}",
+            credential_hash=f"h{i}",
+            credential_fingerprint="f" * 12,
+            status=RunnerStatus.OFFLINE,
+        )
+    minted = tokens.mint_registration_token()
+    RunnerRegistrationToken.objects.create(
+        workspace=workspace,
+        created_by=create_user,
+        token_hash=minted.hashed,
+        expires_at=minted.expires_at,
+    )
+    url = reverse("runner:register")
+    resp = api_client.post(
+        url,
+        {
+            "token": minted.raw,
+            "runner_name": "another",
+            "os": "linux",
+            "arch": "x86_64",
+            "version": "0.1.0",
+            "protocol_version": 1,
+        },
+        format="json",
+    )
+    assert resp.status_code == 409
+
+
+@pytest.mark.contract
+def test_runner_deregister_revokes(api_client, db, registration):
+    minted, _record = registration
+    url = reverse("runner:register")
+    resp = api_client.post(
+        url,
+        {
+            "token": minted.raw,
+            "runner_name": "laptop",
+            "os": "linux",
+            "arch": "x86_64",
+            "version": "0.1.0",
+            "protocol_version": 1,
+        },
+        format="json",
+    )
+    body = resp.json()
+    deregister_url = reverse(
+        "runner:deregister", kwargs={"runner_id": body["runner_id"]}
+    )
+    resp = api_client.post(
+        deregister_url,
+        {},
+        HTTP_AUTHORIZATION=f"Bearer {body['runner_secret']}",
+        format="json",
+    )
+    assert resp.status_code == 200
+    runner = Runner.objects.get(id=body["runner_id"])
+    assert runner.status == RunnerStatus.REVOKED
+    assert runner.revoked_at is not None

--- a/apps/api/apple_pi_dash/tests/contract/runner/test_rotate.py
+++ b/apps/api/apple_pi_dash/tests/contract/runner/test_rotate.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2023-present Apple Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+import pytest
+from django.urls import reverse
+
+from apple_pi_dash.runner.models import Runner, RunnerStatus
+from apple_pi_dash.runner.services import tokens
+
+
+@pytest.fixture
+def provisioned_runner(db, create_user, workspace):
+    minted = tokens.mint_runner_secret()
+    runner = Runner.objects.create(
+        owner=create_user,
+        workspace=workspace,
+        name="rot",
+        credential_hash=minted.hashed,
+        credential_fingerprint=minted.fingerprint,
+        status=RunnerStatus.ONLINE,
+    )
+    return runner, minted.raw
+
+
+@pytest.mark.contract
+def test_rotate_returns_new_secret_and_invalidates_old(api_client, provisioned_runner):
+    runner, old_secret = provisioned_runner
+    url = reverse("runner:rotate", kwargs={"runner_id": runner.id})
+    resp = api_client.post(
+        url,
+        {},
+        HTTP_AUTHORIZATION=f"Bearer {old_secret}",
+        format="json",
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["runner_secret"] != old_secret
+    # Old secret no longer authenticates.
+    resp2 = api_client.post(
+        url,
+        {},
+        HTTP_AUTHORIZATION=f"Bearer {old_secret}",
+        format="json",
+    )
+    assert resp2.status_code in (401, 403)
+    # New secret does.
+    resp3 = api_client.post(
+        url,
+        {},
+        HTTP_AUTHORIZATION=f"Bearer {body['runner_secret']}",
+        format="json",
+    )
+    assert resp3.status_code == 200
+
+
+@pytest.mark.contract
+def test_rotate_rejects_cross_runner_credential(api_client, db, create_user, workspace):
+    minted_a = tokens.mint_runner_secret()
+    runner_a = Runner.objects.create(
+        owner=create_user,
+        workspace=workspace,
+        name="a",
+        credential_hash=minted_a.hashed,
+        credential_fingerprint=minted_a.fingerprint,
+        status=RunnerStatus.ONLINE,
+    )
+    minted_b = tokens.mint_runner_secret()
+    runner_b = Runner.objects.create(
+        owner=create_user,
+        workspace=workspace,
+        name="b",
+        credential_hash=minted_b.hashed,
+        credential_fingerprint=minted_b.fingerprint,
+        status=RunnerStatus.ONLINE,
+    )
+    url = reverse("runner:rotate", kwargs={"runner_id": runner_a.id})
+    resp = api_client.post(
+        url,
+        {},
+        HTTP_AUTHORIZATION=f"Bearer {minted_b.raw}",
+        format="json",
+    )
+    assert resp.status_code == 403

--- a/apps/api/apple_pi_dash/tests/unit/runner/test_dedupe.py
+++ b/apps/api/apple_pi_dash/tests/unit/runner/test_dedupe.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2023-present Apple Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+import pytest
+
+from apple_pi_dash.runner.consumers import RunnerConsumer
+
+
+class FakeRunner:
+    id = "runner-x"
+
+
+@pytest.mark.unit
+def test_message_id_dedupe_detects_repeat():
+    c = RunnerConsumer()
+    msg = {"mid": "m1", "type": "heartbeat"}
+    assert c._is_duplicate(msg) is False
+    assert c._is_duplicate(msg) is True
+
+
+@pytest.mark.unit
+def test_message_without_mid_never_duplicates():
+    c = RunnerConsumer()
+    msg = {"type": "heartbeat"}
+    assert c._is_duplicate(msg) is False
+    assert c._is_duplicate(msg) is False
+
+
+@pytest.mark.unit
+def test_seq_monotonic_enforced_for_run_events():
+    c = RunnerConsumer()
+    runner = FakeRunner()
+    base = {"type": "run_event", "run_id": "r1"}
+    assert c._seq_ok(runner, {**base, "seq": 1}) is True
+    assert c._seq_ok(runner, {**base, "seq": 2}) is True
+    # Replay or out-of-order: drop.
+    assert c._seq_ok(runner, {**base, "seq": 2}) is False
+    assert c._seq_ok(runner, {**base, "seq": 1}) is False
+    # Forward jump with a gap is accepted.
+    assert c._seq_ok(runner, {**base, "seq": 10}) is True
+
+
+@pytest.mark.unit
+def test_seq_check_ignored_for_non_run_events():
+    c = RunnerConsumer()
+    runner = FakeRunner()
+    assert c._seq_ok(runner, {"type": "heartbeat"}) is True

--- a/apps/api/apple_pi_dash/tests/unit/runner/test_matcher.py
+++ b/apps/api/apple_pi_dash/tests/unit/runner/test_matcher.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2023-present Apple Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+import pytest
+from django.utils import timezone
+
+from apple_pi_dash.runner.models import (
+    AgentRun,
+    AgentRunStatus,
+    Runner,
+    RunnerStatus,
+)
+from apple_pi_dash.runner.services import matcher
+
+
+@pytest.fixture
+def online_runner(db, create_user, workspace):
+    return Runner.objects.create(
+        owner=create_user,
+        workspace=workspace,
+        name="laptop",
+        credential_hash="h",
+        credential_fingerprint="f",
+        status=RunnerStatus.ONLINE,
+        last_heartbeat_at=timezone.now(),
+    )
+
+
+@pytest.fixture
+def queued_run(db, create_user, workspace):
+    return AgentRun.objects.create(
+        owner=create_user,
+        workspace=workspace,
+        prompt="do X",
+        status=AgentRunStatus.QUEUED,
+    )
+
+
+@pytest.mark.unit
+def test_matcher_picks_online_idle_runner(db, online_runner, queued_run):
+    assert matcher.select_runner_for_run(queued_run) == online_runner
+
+
+@pytest.mark.unit
+def test_matcher_ignores_offline(db, online_runner, queued_run):
+    online_runner.status = RunnerStatus.OFFLINE
+    online_runner.save(update_fields=["status"])
+    assert matcher.select_runner_for_run(queued_run) is None
+
+
+@pytest.mark.unit
+def test_matcher_ignores_busy_runner(db, online_runner, queued_run):
+    AgentRun.objects.create(
+        owner=queued_run.owner,
+        workspace=queued_run.workspace,
+        prompt="already in flight",
+        runner=online_runner,
+        status=AgentRunStatus.RUNNING,
+    )
+    assert matcher.select_runner_for_run(queued_run) is None
+
+
+@pytest.mark.unit
+def test_cap_enforced(db, create_user, workspace):
+    for i in range(Runner.MAX_PER_USER):
+        Runner.objects.create(
+            owner=create_user,
+            workspace=workspace,
+            name=f"r{i}",
+            credential_hash=f"h{i}",
+            credential_fingerprint="f" * 12,
+        )
+    assert matcher.can_register_another(create_user.id, workspace.id) is False
+    assert matcher.count_active(create_user.id, workspace.id) == Runner.MAX_PER_USER

--- a/apps/api/apple_pi_dash/tests/unit/runner/test_tokens.py
+++ b/apps/api/apple_pi_dash/tests/unit/runner/test_tokens.py
@@ -3,6 +3,7 @@
 # See the LICENSE file for details.
 
 import pytest
+from django.utils import timezone
 
 from apple_pi_dash.runner.services import tokens
 
@@ -22,7 +23,7 @@ def test_mint_registration_token_properties():
     minted = tokens.mint_registration_token()
     assert minted.raw.startswith("apd_reg_")
     assert minted.hashed == tokens.hash_token(minted.raw)
-    assert minted.expires_at > __import__("django").utils.timezone.now()
+    assert minted.expires_at > timezone.now()
 
 
 @pytest.mark.unit
@@ -31,18 +32,3 @@ def test_mint_runner_secret_properties():
     assert minted.raw.startswith("apd_rs_")
     assert minted.hashed == tokens.hash_token(minted.raw)
     assert len(minted.fingerprint) == 12
-
-
-@pytest.mark.unit
-def test_verify_runner_secret_matches():
-    minted = tokens.mint_runner_secret()
-    assert (
-        tokens.verify_runner_secret(minted.raw, [minted.hashed, "junk"])
-        == minted.hashed
-    )
-
-
-@pytest.mark.unit
-def test_verify_runner_secret_rejects_unknown():
-    minted = tokens.mint_runner_secret()
-    assert tokens.verify_runner_secret("nope", [minted.hashed]) is None

--- a/apps/api/apple_pi_dash/tests/unit/runner/test_tokens.py
+++ b/apps/api/apple_pi_dash/tests/unit/runner/test_tokens.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2023-present Apple Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+import pytest
+
+from apple_pi_dash.runner.services import tokens
+
+
+@pytest.mark.unit
+def test_hash_is_deterministic():
+    assert tokens.hash_token("abc") == tokens.hash_token("abc")
+
+
+@pytest.mark.unit
+def test_hash_distinguishes_inputs():
+    assert tokens.hash_token("a") != tokens.hash_token("b")
+
+
+@pytest.mark.unit
+def test_mint_registration_token_properties():
+    minted = tokens.mint_registration_token()
+    assert minted.raw.startswith("apd_reg_")
+    assert minted.hashed == tokens.hash_token(minted.raw)
+    assert minted.expires_at > __import__("django").utils.timezone.now()
+
+
+@pytest.mark.unit
+def test_mint_runner_secret_properties():
+    minted = tokens.mint_runner_secret()
+    assert minted.raw.startswith("apd_rs_")
+    assert minted.hashed == tokens.hash_token(minted.raw)
+    assert len(minted.fingerprint) == 12
+
+
+@pytest.mark.unit
+def test_verify_runner_secret_matches():
+    minted = tokens.mint_runner_secret()
+    assert (
+        tokens.verify_runner_secret(minted.raw, [minted.hashed, "junk"])
+        == minted.hashed
+    )
+
+
+@pytest.mark.unit
+def test_verify_runner_secret_rejects_unknown():
+    minted = tokens.mint_runner_secret()
+    assert tokens.verify_runner_secret("nope", [minted.hashed]) is None

--- a/apps/api/apple_pi_dash/urls.py
+++ b/apps/api/apple_pi_dash/urls.py
@@ -18,7 +18,9 @@ urlpatterns = [
     path("api/", include("apple_pi_dash.app.urls")),
     path("api/public/", include("apple_pi_dash.space.urls")),
     path("api/instances/", include("apple_pi_dash.license.urls")),
+    path("api/runners/", include("apple_pi_dash.runner.web_urls")),
     path("api/v1/", include("apple_pi_dash.api.urls")),
+    path("api/v1/runner/", include("apple_pi_dash.runner.urls")),
     path("auth/", include("apple_pi_dash.authentication.urls")),
     path("", include("apple_pi_dash.web.urls")),
 ]

--- a/apps/api/requirements/base.txt
+++ b/apps/api/requirements/base.txt
@@ -36,6 +36,7 @@ django-crum==0.7.9
 uvicorn==0.29.0
 # sockets
 channels==4.1.0
+channels-redis==4.2.0
 # ai
 openai==1.63.2
 # slack

--- a/apps/proxy/Caddyfile.aio.ce
+++ b/apps/proxy/Caddyfile.aio.ce
@@ -10,6 +10,9 @@
     handle /live/* {
         reverse_proxy localhost:3005
     }
+	handle /ws/runner/* {
+        reverse_proxy localhost:3004
+    }
 	handle /api/* {
         reverse_proxy localhost:3004
     }

--- a/apps/proxy/Caddyfile.ce
+++ b/apps/proxy/Caddyfile.ce
@@ -11,6 +11,9 @@
 	
 	reverse_proxy /live/* live:3000
 
+	# Runner WebSocket upgrade — served by Django ASGI (Channels).
+	reverse_proxy /ws/runner/* api:8000
+
 	reverse_proxy /api/* api:8000
 
 	reverse_proxy /auth/* api:8000


### PR DESCRIPTION
## Summary

First of three PRs that wire Apple Pi Dash to a local-machine runner daemon driving Codex.
This one adds only the **cloud side** — Django app + WebSocket consumer + infra/docs.
Companion PRs: \`runner-daemon\` (Rust binary) and \`runner-web\` (React UI).

- New \`apple_pi_dash.runner\` Django app — models (Runner, RunnerRegistrationToken, AgentRun, AgentRunEvent, ApprovalRequest), REST views, Channels consumer, Celery beat tasks, bearer auth, admin, services.
- Two API surfaces mounted: public-ish \`/api/v1/runner/{health,metrics,register,<id>/deregister,<id>/rotate}/\` for the daemon; session-auth \`/api/runners/…\` for the web UI.
- WebSocket at \`/ws/runner/\` with bearer credential, message-id dedupe, per-run seq enforcement, and \`resume_ack\` on reconnect.
- Celery tasks: \`runner.expire_stale_approvals\` + \`runner.mark_offline_runners\` (1/min each).
- Caddy CE + AIO configs route \`/ws/runner/*\` to the existing \`api\` service.
- Design + operator + user docs land in \`.ai_design/implement_runner/\`.

Design source-of-truth: \`.ai_design/implement_runner/runner-design.md\` and \`github-runner-architecture.md\`.

## Test plan

- [ ] \`pnpm --filter api check\` or equivalent Python lint passes
- [ ] \`python -m pytest apple_pi_dash/tests/unit/runner/ apple_pi_dash/tests/contract/runner/\` green (12 tests: tokens, matcher, dedupe, registration contract, rotation contract)
- [ ] Local: \`docker compose up\`; \`curl /api/v1/runner/health/\` returns \`{"ok": true, "protocol_version": 1}\`
- [ ] Local: \`curl /api/v1/runner/metrics/\` returns Prometheus text with 5 gauges
- [ ] Local: mint a registration token via admin, \`POST /api/v1/runner/register/\` returns \`runner_secret\`; \`POST …/rotate/\` with it returns a new secret and invalidates the old one
- [ ] Local: connect a raw WS client to \`/ws/runner/\` with \`Authorization: Bearer <secret>\` → receive \`welcome\` frame
- [ ] Local: CHANNEL_LAYERS falls back to \`InMemoryChannelLayer\` when \`REDIS_URL\` is unset (dev); uses \`channels_redis\` otherwise

🤖 Generated with [Claude Code](https://claude.com/claude-code)