### PR TITLE
runner: rename binary pi-dash-runner → pidash

### DIFF
--- a/.ai_design/implement_runner/github-runner-architecture.md
+++ b/.ai_design/implement_runner/github-runner-architecture.md
@@ -274,9 +274,9 @@ What transfers directly:
 | GitHub concept                     | Pi Dash equivalent                                                    | Notes                                                                     |
 | ---------------------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
 | Actions service (orchestrator)     | Django (`apps/api`) + a WS service (new, modeled on `apps/live`)            | Django owns state; WS service owns the socket                             |
-| Self-hosted runner binary          | `pi-dash-runner` daemon (new, to build)                               | Single binary: Go or Rust recommended                                     |
+| Self-hosted runner binary          | `pidash` daemon (new, to build)                               | Single binary: Go or Rust recommended                                     |
 | Registration token                 | One-time code generated in Pi Dash settings UI                        | Short TTL, single-use                                                     |
-| `.credentials` on disk             | Runner token + machine id, stored under `~/.config/pi-dash-runner/`   | File mode 0600                                                            |
+| `.credentials` on disk             | Runner token + machine id, stored under `~/.config/pidash/`   | File mode 0600                                                            |
 | Labels (`linux`, `gpu`, `staging`) | Capabilities: `codex`, `macos`, `arm64`, `docker`, `git`                    | Same matching rules; do not encode an exact local checkout path in labels |
 | Runner groups                      | Per-user / per-workspace pools                                              | "Only this user's machines pick up this user's tasks"                     |
 | `runs-on: [self-hosted, gpu]`      | Pi Dash work item metadata declaring required capabilities            | Triage step sets these                                                    |

--- a/.ai_design/implement_runner/observability.md
+++ b/.ai_design/implement_runner/observability.md
@@ -34,7 +34,7 @@ text exposition format (v0.0.4). Scrape every 15–60s.
 Every runner subsystem emits structured records via `tracing` (runner) and
 Python `logging` (Django). Use these fields consistently so log search works.
 
-### Runner daemon (`pi_dash_runner`, Rust `tracing`)
+### Runner daemon (`pidash`, Rust `tracing`)
 
 | Field              | Type   | Emitted on                             |
 | ------------------ | ------ | -------------------------------------- |

--- a/.ai_design/implement_runner/operator-guide.md
+++ b/.ai_design/implement_runner/operator-guide.md
@@ -69,7 +69,7 @@ The runner consumer logs structured events under the `pi_dash.runner.consumers` 
 
 1. `GET /api/v1/runner/health/` — returns `{"ok": true}`? If not, the Django/ASGI process is unhealthy.
 2. `GET /api/v1/runner/metrics/` — returns counts at all? If the response is empty or 5xx, the DB is unreachable.
-3. On the runner side, `pi-dash-runner status --json` — does the daemon see the WS as connected?
+3. On the runner side, `pidash status --json` — does the daemon see the WS as connected?
 4. Check Caddy / your proxy access logs for `/ws/runner/` upgrade requests. 426 or 400 indicates the upgrade headers are being stripped.
 
 ### Symptom: approvals pile up and never get decided

--- a/.ai_design/implement_runner/runner-design.md
+++ b/.ai_design/implement_runner/runner-design.md
@@ -41,7 +41,7 @@ Companion docs in this directory:
 
 | #   | Topic                        | Decision                                                                                                                                                                                                                                                                       |
 | --- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 1   | Working directory            | Runner config specifies working dir. Default `$TMPDIR/.pi_dash/`. If dir has a git repo → use it. If not → request repo URL from cloud, `git clone` into dir. Clone-auth failure is reported. Every task runs Codex against this dir.                                         |
+| 1   | Working directory            | Runner config specifies working dir. Default `$TMPDIR/.pidash/`. If dir has a git repo → use it. If not → request repo URL from cloud, `git clone` into dir. Clone-auth failure is reported. Every task runs Codex against this dir.                                         |
 | 2   | Concurrency                  | One task at a time per runner.                                                                                                                                                                                                                                                 |
 | 3   | Assignment                   | One runner instance per dev machine. Globally unique runner ID. Cloud assigns to an online idle runner owned by the user. No label matching.                                                                                                                                   |
 | 4   | Prompt construction          | Cloud renders; runner receives a ready-to-use prompt string. Runner never composes prompts.                                                                                                                                                                                    |
@@ -61,7 +61,7 @@ Companion docs in this directory:
 ```
 ┌─────────────────────── dev laptop ─────────────────────────────────┐
 │                                                                     │
-│   pi-dash-runner  (daemon, long-lived)                        │
+│   pidash  (daemon, long-lived)                        │
 │   ┌─────────────────────────────────────────────────────────────┐  │
 │   │  Cloud WS client  ◄─── outbound WSS on 443 ────►            │  │
 │   │                                                             │  │
@@ -76,7 +76,7 @@ Companion docs in this directory:
 │   └─────────────────────────────────────────────────────────────┘  │
 │            ▲                                                        │
 │            │ Unix socket                                            │
-│   pi-dash-runner tui  (Ratatui, ad-hoc client)                │
+│   pidash tui  (Ratatui, ad-hoc client)                │
 │                                                                     │
 └─────────────────────────────────────────────────────────────────────┘
                         │  WSS  │
@@ -107,13 +107,13 @@ Distribution: one static binary per target triple. Users install via:
 - Linux: `.deb` / `.rpm`
 - Future: Windows MSI (v2)
 
-Install does not require root; binary lives in `$HOME/.local/bin/pi-dash-runner` by default.
+Install does not require root; binary lives in `$HOME/.local/bin/pidash` by default.
 
 ### 4.2. First-run configure
 
 ```
-pi-dash-runner configure \
-  --url https://cloud.pi-dash.so \
+pidash configure \
+  --url https://cloud.pidash.so \
   --token <ONE_TIME_CODE> \
   [--name my-laptop]
 ```
@@ -134,14 +134,14 @@ If TUI is used instead, the first-run wizard in `tui-design.md` performs steps 1
 ### 4.3. Service install
 
 ```
-pi-dash-runner service install   # systemd user unit / launchd plist
-pi-dash-runner service start
-pi-dash-runner service status
-pi-dash-runner service stop
+pidash service install   # systemd user unit / launchd plist
+pidash service start
+pidash service status
+pidash service stop
 ```
 
-- **Linux**: generate a `~/.config/systemd/user/pi-dash-runner.service`, `systemctl --user daemon-reload`, enable with `linger` optional.
-- **macOS**: generate a `~/Library/LaunchAgents/so.pi-dash.runner.plist`, load with `launchctl bootstrap gui/$UID`.
+- **Linux**: generate a `~/.config/systemd/user/pidash.service`, `systemctl --user daemon-reload`, enable with `linger` optional.
+- **macOS**: generate a `~/Library/LaunchAgents/so.pidash.daemon.plist`, load with `launchctl bootstrap gui/$UID`.
 
 ### 4.4. Run loop (simplified)
 
@@ -225,12 +225,12 @@ This is the one piece of business logic the runner owns. Detailed behavior:
 ### 5.1. Configuration
 
 ```toml
-# ~/.config/pi-dash-runner/config.toml
+# ~/.config/pidash/config.toml
 [workspace]
-working_dir = "/var/folders/.../T/.pi_dash"   # default: $TMPDIR/.pi_dash
+working_dir = "/var/folders/.../T/.pidash"   # default: $TMPDIR/.pidash
 ```
 
-Override via CLI: `pi-dash-runner configure --working-dir /path/to/repo`.
+Override via CLI: `pidash configure --working-dir /path/to/repo`.
 
 ### 5.2. On assignment
 
@@ -278,11 +278,11 @@ If `working_dir` is inside `$TMPDIR` on Linux (often `/tmp`, which may be `tmpfs
 ### 6.1. On-disk layout
 
 ```
-~/.config/pi-dash-runner/
+~/.config/pidash/
 ├── config.toml          # user-editable config
 └── credentials.toml     # runner_id + runner_secret (0600)
 
-~/.local/share/pi-dash-runner/
+~/.local/share/pidash/
 ├── history/
 │   ├── runs/
 │   │   └── <run_id>.jsonl      # one JSONL per run; all Codex events + lifecycle
@@ -299,11 +299,11 @@ version = 1
 
 [runner]
 name = "my-laptop"
-cloud_url = "https://cloud.pi-dash.so"
+cloud_url = "https://cloud.pidash.so"
 # runner_id + secret are in credentials.toml
 
 [workspace]
-working_dir = "/var/folders/.../T/.pi_dash"
+working_dir = "/var/folders/.../T/.pidash"
 
 [codex]
 binary = "/usr/local/bin/codex"      # auto-detected; overridable
@@ -448,7 +448,7 @@ per-task:
 
 Phase ordering within one task:
 
-1. `initialize { clientInfo: { name: "pi-dash-runner", version } }` → wait for `initialize` response.
+1. `initialize { clientInfo: { name: "pidash", version } }` → wait for `initialize` response.
 2. Send `initialized` notification.
 3. `account/read` — confirm auth state. If unauthenticated → `run_awaiting_reauth`.
 4. `thread/start { cwd, model?, sandboxPolicy: "workspace-write", approvalPolicy: "on-request" }` → capture `thread_id`.
@@ -535,7 +535,7 @@ evaluate(req):
 Single binary, multiple modules. Organized by concern:
 
 ```
-pi-dash-runner/
+pidash/
 ├── Cargo.toml
 ├── src/
 │   ├── main.rs                     # CLI dispatch (clap)

--- a/.ai_design/implement_runner/tui-design.md
+++ b/.ai_design/implement_runner/tui-design.md
@@ -20,12 +20,12 @@ The TUI is a **client**, not the runner itself. The runner daemon keeps running 
 ```
 ┌────────────────────── laptop ──────────────────────┐
 │                                                     │
-│   pi-dash-runner  (service, always-on)        │
+│   pidash  (service, always-on)        │
 │        │                                            │
 │        │  local Unix socket                         │
 │        │  (Windows: named pipe)                     │
 │        │                                            │
-│   pi-dash-runner tui  (user launches adhoc)   │
+│   pidash tui  (user launches adhoc)   │
 │        │                                            │
 │        │  ─────► outbound WS to cloud               │
 │        │  ─────► spawn codex app-server             │
@@ -59,8 +59,8 @@ Minimum methods (daemon-side):
 
 Socket path:
 
-- Linux/macOS: `$XDG_RUNTIME_DIR/pi-dash-runner.sock` (or `~/.local/share/pi-dash-runner/sock`)
-- Windows: `\\.\pipe\pi-dash-runner`
+- Linux/macOS: `$XDG_RUNTIME_DIR/pidash.sock` (or `~/.local/share/pidash/sock`)
+- Windows: `\\.\pipe\pidash`
 
 Permissions: 0600 — only the owning user can connect.
 
@@ -144,7 +144,7 @@ Form-style editor. Edits are POSTed to the daemon and applied live.
 │ Identity                                                   │
 │   Runner name     my-laptop                                │
 │   Workspace       acme                                     │
-│   Cloud URL       https://cloud.pi-dash.so           │
+│   Cloud URL       https://cloud.pidash.so           │
 │                                                             │
 │ Capabilities (labels)                           [e] edit   │
 │   codex, macos, arm64                                      │
@@ -221,7 +221,7 @@ Notes:
 
 ## First-run onboarding flow
 
-When the user runs `pi-dash-runner tui` and no config exists on disk, the TUI walks them through setup instead of showing the dashboard:
+When the user runs `pidash tui` and no config exists on disk, the TUI walks them through setup instead of showing the dashboard:
 
 ```
 Step 1 of 4: Paste registration code

--- a/.ai_design/implement_runner/user-guide.md
+++ b/.ai_design/implement_runner/user-guide.md
@@ -17,17 +17,17 @@ Pick one:
 
 ```bash
 # Homebrew (macOS + Linux)
-brew install pi-dash/tap/runner
+brew install pidash/tap/pidash
 
 # Shell installer
-curl -fsSL https://cloud.pi-dash.so/install.sh | sh
+curl -fsSL https://cloud.pidash.so/install.sh | sh
 ```
 
-Both drop `pi-dash-runner` into `$HOME/.local/bin`. Make sure that directory is in your `PATH`.
+Both drop `pidash` into `$HOME/.local/bin`. Make sure that directory is in your `PATH`.
 
 ## 2. Get a registration code
 
-1. Sign in to `https://cloud.pi-dash.so` (or your self-hosted URL).
+1. Sign in to `https://cloud.pidash.so` (or your self-hosted URL).
 2. Open your workspace → **Runners** tab.
 3. Click **Mint registration code**.
 4. Copy the code. It's single-use and expires in 1 hour.
@@ -39,7 +39,7 @@ You can register up to 5 runners per account per workspace.
 ### Option A — interactive TUI (recommended for first-time setup)
 
 ```bash
-pi-dash-runner tui
+pidash tui
 ```
 
 The TUI detects that no config exists and walks you through 4 steps:
@@ -52,13 +52,13 @@ The TUI detects that no config exists and walks you through 4 steps:
 ### Option B — command-line (scripts / CI)
 
 ```bash
-pi-dash-runner configure \
-  --url https://cloud.pi-dash.so \
+pidash configure \
+  --url https://cloud.pidash.so \
   --token <PASTE_REGISTRATION_CODE> \
   --name my-laptop
 
-pi-dash-runner service install
-pi-dash-runner service start
+pidash service install
+pidash service start
 ```
 
 The daemon now runs as a `launchd` agent (macOS) or `systemd --user` unit (Linux) and will auto-start on login.
@@ -66,7 +66,7 @@ The daemon now runs as a `launchd` agent (macOS) or `systemd --user` unit (Linux
 ## 4. Verify it's connected
 
 ```bash
-pi-dash-runner status
+pidash status
 ```
 
 You should see `connected` and your cloud URL. Equivalently, open the web UI → **Runners** tab; the new runner appears with a green **online** badge within a few seconds.
@@ -74,7 +74,7 @@ You should see `connected` and your cloud URL. Equivalently, open the web UI →
 ## 5. Attach the TUI dashboard
 
 ```bash
-pi-dash-runner tui
+pidash tui
 ```
 
 Four tabs:
@@ -106,16 +106,16 @@ Pending approvals expire after 10 minutes; the server then cancels the run autom
 
 ## 7. Day-to-day
 
-- **Your working directory** lives at `$TMPDIR/.pi_dash` by default. Change with `pi-dash-runner configure --working-dir /path/to/repo` or the Config tab. Runs reuse this directory; Codex is expected to reset/stash/checkout at the start of each task.
-- **Logs** are in `~/.local/share/pi-dash-runner/logs/`.
-- **Per-run transcripts** are stored as JSONL in `~/.local/share/pi-dash-runner/history/runs/`.
+- **Your working directory** lives at `$TMPDIR/.pidash` by default. Change with `pidash configure --working-dir /path/to/repo` or the Config tab. Runs reuse this directory; Codex is expected to reset/stash/checkout at the start of each task.
+- **Logs** are in `~/.local/share/pidash/logs/`.
+- **Per-run transcripts** are stored as JSONL in `~/.local/share/pidash/history/runs/`.
 
 ## 8. Upgrading
 
 ```bash
-brew upgrade pi-dash-runner
-pi-dash-runner service stop
-pi-dash-runner service start
+brew upgrade pidash
+pidash service stop
+pidash service start
 ```
 
 A protocol version bump will be announced in the release notes. The daemon logs a warning if the server expects a newer version; in that case, upgrade.
@@ -125,9 +125,9 @@ A protocol version bump will be announced in the release notes. The daemon logs 
 If you suspect your runner secret has leaked:
 
 ```bash
-pi-dash-runner rotate
-pi-dash-runner service stop
-pi-dash-runner service start
+pidash rotate
+pidash service stop
+pidash service start
 ```
 
 The old secret is invalidated immediately. No downtime on the runner record in the cloud — just a forced WS reconnect with the new secret.
@@ -135,16 +135,16 @@ The old secret is invalidated immediately. No downtime on the runner record in t
 ## 10. Removing
 
 ```bash
-pi-dash-runner service stop
-pi-dash-runner service uninstall
-pi-dash-runner remove
+pidash service stop
+pidash service uninstall
+pidash remove
 ```
 
-This deregisters the runner in the cloud, deletes local credentials and config, and stops the agent. Your transcripts under `~/.local/share/pi-dash-runner/history/` are NOT deleted automatically — remove them manually if you want.
+This deregisters the runner in the cloud, deletes local credentials and config, and stops the agent. Your transcripts under `~/.local/share/pidash/history/` are NOT deleted automatically — remove them manually if you want.
 
 ## Troubleshooting
 
-**`status` shows disconnected** → daemon isn't running. Check `pi-dash-runner service status`. If the unit is loaded but not active, `service start` it. If systemd says "failed", check `journalctl --user -u pi-dash-runner`.
+**`status` shows disconnected** → daemon isn't running. Check `pidash service status`. If the unit is loaded but not active, `service start` it. If systemd says "failed", check `journalctl --user -u pidash`.
 
 **`doctor` says `codex-auth: unable to confirm`** → run `codex login`. Re-run `doctor` to confirm.
 

--- a/apps/api/pi_dash/runner/views/register.py
+++ b/apps/api/pi_dash/runner/views/register.py
@@ -40,7 +40,7 @@ class HealthEndpoint(APIView):
 class RegisterEndpoint(APIView):
     """POST /api/v1/runner/register/ — one-time-token to runner-secret exchange.
 
-    Called by the daemon during ``pi-dash-runner configure``.
+    Called by the daemon during ``pidash configure``.
     """
 
     authentication_classes: list = []
@@ -105,7 +105,7 @@ class RegisterEndpoint(APIView):
 class RunnerDeregisterEndpoint(APIView):
     """POST /api/v1/runner/<uuid>/deregister/
 
-    Called by the daemon during ``pi-dash-runner remove``. Authenticated
+    Called by the daemon during ``pidash remove``. Authenticated
     with the runner's own bearer secret; the server marks the runner revoked.
     """
 

--- a/apps/web/app/(all)/[workspaceSlug]/runners/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/page.tsx
@@ -124,7 +124,7 @@ const RunnersListPage = observer(function RunnersListPage() {
             <div className="mt-2 text-secondary">
               {t("runners.list.token_run_instructions")}
               <pre className="font-mono mt-1 text-11 whitespace-pre-wrap select-all">
-                pi-dash-runner configure --url {origin} --token {mintedToken}
+                pidash configure --url {origin} --token {mintedToken}
               </pre>
             </div>
             <div className="mt-3">

--- a/runner/Cargo.lock
+++ b/runner/Cargo.lock
@@ -1085,7 +1085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "pi-dash-runner"
+name = "pidash"
 version = "0.1.0"
 dependencies = [
  "anyhow",

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
-name = "pi-dash-runner"
+name = "pidash"
 version = "0.1.0"
 edition = "2024"
 rust-version = "1.93"
 description = "Pi Dash local runner: connects a dev machine to the Pi Dash cloud and drives Codex for assigned tasks."
 license = "AGPL-3.0-only"
-default-run = "pi-dash-runner"
+default-run = "pidash"
 
 [[bin]]
-name = "pi-dash-runner"
+name = "pidash"
 path = "src/main.rs"
 
 [lib]
-name = "pi_dash_runner"
+name = "pidash"
 path = "src/lib.rs"
 
 [dependencies]

--- a/runner/README.md
+++ b/runner/README.md
@@ -1,6 +1,6 @@
 # Pi Dash Runner
 
-Local daemon + TUI that connects a developer machine to the Pi Dash cloud and drives `codex app-server` for assigned tasks.
+Local daemon + TUI (`pidash` binary) that connects a developer machine to the Pi Dash cloud and drives `codex app-server` for assigned tasks.
 
 See `.ai_design/implement_runner/` for the design documents:
 
@@ -39,21 +39,21 @@ cargo test                                   # unit + integration tests
 cargo check                                  # quick type-check
 cargo clippy -- -D warnings                  # lint
 
-./target/debug/pi-dash-runner configure \
-  --url https://cloud.pi-dash.so \
+./target/debug/pidash configure \
+  --url https://cloud.pidash.so \
   --token <ONE_TIME_CODE> \
   --name my-laptop
 
-./target/debug/pi-dash-runner service install
-./target/debug/pi-dash-runner service start
-./target/debug/pi-dash-runner tui
+./target/debug/pidash service install
+./target/debug/pidash service start
+./target/debug/pidash tui
 ```
 
 ## Runtime paths (XDG)
 
-- Config: `~/.config/pi-dash-runner/`
-- Data / logs: `~/.local/share/pi-dash-runner/`
-- Runtime dir: `$XDG_RUNTIME_DIR/pi-dash-runner/` (Unix socket, PID file)
+- Config: `~/.config/pidash/`
+- Data / logs: `~/.local/share/pidash/`
+- Runtime dir: `$XDG_RUNTIME_DIR/pidash/` (Unix socket, PID file)
 
 All secrets on disk are written with `0600`. The Unix IPC socket is also `0600`.
 

--- a/runner/src/cli/configure.rs
+++ b/runner/src/cli/configure.rs
@@ -8,7 +8,7 @@ use crate::util::paths::Paths;
 
 #[derive(Debug, ClapArgs)]
 pub struct Args {
-    /// Pi Dash cloud base URL (https://cloud.pi-dash.so).
+    /// Pi Dash cloud base URL (https://cloud.pidash.so).
     #[arg(long)]
     pub url: String,
 
@@ -87,7 +87,7 @@ pub async fn run(args: Args, paths: &Paths) -> Result<()> {
     }
 
     println!(
-        "\nRegistered runner '{}' with id {}.\nNext: `pi-dash-runner service install && pi-dash-runner service start`\n",
+        "\nRegistered runner '{}' with id {}.\nNext: `pidash service install && pidash service start`\n",
         config.runner.name, creds.runner_id,
     );
     Ok(())

--- a/runner/src/cli/mod.rs
+++ b/runner/src/cli/mod.rs
@@ -11,24 +11,24 @@ mod status;
 mod tui;
 
 #[derive(Debug, Parser)]
-#[command(name = "pi-dash-runner", version, about, long_about = None)]
+#[command(name = "pidash", version, about, long_about = None)]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Command,
 
     /// Override config directory (XDG config by default).
-    #[arg(long, global = true, env = "PI_DASH_RUNNER_CONFIG_DIR")]
+    #[arg(long, global = true, env = "PIDASH_CONFIG_DIR")]
     pub config_dir: Option<std::path::PathBuf>,
 
     /// Override data directory (XDG data by default).
-    #[arg(long, global = true, env = "PI_DASH_RUNNER_DATA_DIR")]
+    #[arg(long, global = true, env = "PIDASH_DATA_DIR")]
     pub data_dir: Option<std::path::PathBuf>,
 
     /// Log level filter (trace|debug|info|warn|error).
     #[arg(
         long,
         global = true,
-        env = "PI_DASH_RUNNER_LOG",
+        env = "PIDASH_LOG",
         default_value = "info"
     )]
     pub log: String,

--- a/runner/src/cloud/register.rs
+++ b/runner/src/cloud/register.rs
@@ -108,6 +108,6 @@ pub async fn deregister(
 fn http_client() -> Result<reqwest::Client> {
     Ok(reqwest::Client::builder()
         .timeout(Duration::from_secs(30))
-        .user_agent(format!("pi-dash-runner/{}", crate::RUNNER_VERSION))
+        .user_agent(format!("pidash/{}", crate::RUNNER_VERSION))
         .build()?)
 }

--- a/runner/src/codex/bridge.rs
+++ b/runner/src/codex/bridge.rs
@@ -116,7 +116,7 @@ impl Bridge {
             "initialize",
             &InitializeParams {
                 client_info: ClientInfo {
-                    name: "pi-dash-runner".to_string(),
+                    name: "pidash".to_string(),
                     version: crate::RUNNER_VERSION.to_string(),
                 },
             },

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -1,7 +1,7 @@
 #![forbid(unsafe_code)]
 
 use anyhow::Result;
-use pi_dash_runner::cli;
+use pidash::cli;
 use clap::Parser;
 
 fn main() -> Result<()> {

--- a/runner/src/service/launchd.rs
+++ b/runner/src/service/launchd.rs
@@ -4,7 +4,7 @@ use tokio::process::Command;
 
 use crate::util::paths::Paths;
 
-const LABEL: &str = "so.pi-dash.runner";
+const LABEL: &str = "so.pidash.daemon";
 
 pub async fn install(paths: &Paths) -> Result<()> {
     let plist_path = plist_path()?;
@@ -31,8 +31,8 @@ pub async fn install(paths: &Paths) -> Result<()> {
   </array>
   <key>EnvironmentVariables</key>
   <dict>
-    <key>PI_DASH_RUNNER_CONFIG_DIR</key><string>{config}</string>
-    <key>PI_DASH_RUNNER_DATA_DIR</key><string>{data}</string>
+    <key>PIDASH_CONFIG_DIR</key><string>{config}</string>
+    <key>PIDASH_DATA_DIR</key><string>{data}</string>
     <key>XDG_RUNTIME_DIR</key><string>{runtime}</string>
   </dict>
   <key>KeepAlive</key><true/>

--- a/runner/src/service/systemd.rs
+++ b/runner/src/service/systemd.rs
@@ -4,7 +4,7 @@ use tokio::process::Command;
 
 use crate::util::paths::Paths;
 
-const UNIT_NAME: &str = "pi-dash-runner.service";
+const UNIT_NAME: &str = "pidash.service";
 
 pub async fn install(paths: &Paths) -> Result<()> {
     let unit_path = unit_path()?;
@@ -25,8 +25,8 @@ Wants=network-online.target
 [Service]
 Type=simple
 ExecStart={exe} start
-Environment=PI_DASH_RUNNER_CONFIG_DIR={config_dir}
-Environment=PI_DASH_RUNNER_DATA_DIR={data_dir}
+Environment=PIDASH_CONFIG_DIR={config_dir}
+Environment=PIDASH_DATA_DIR={data_dir}
 Environment=XDG_RUNTIME_DIR={runtime_dir}
 Restart=on-failure
 RestartSec=5

--- a/runner/src/tui/onboarding.rs
+++ b/runner/src/tui/onboarding.rs
@@ -1,4 +1,4 @@
-//! First-run onboarding wizard. Shown by `pi-dash-runner tui` when no
+//! First-run onboarding wizard. Shown by `pidash tui` when no
 //! configuration exists on disk. Mirrors the 4-step flow from tui-design.md.
 
 use anyhow::Result;
@@ -53,7 +53,7 @@ pub async fn run(paths: Paths) -> Result<()> {
     let mut state = Wizard {
         paths,
         step: Step::Cloud,
-        cloud_url: "https://cloud.pi-dash.so".to_string(),
+        cloud_url: "https://cloud.pidash.so".to_string(),
         token: String::new(),
         name: default_name,
         cursor_field: 0,
@@ -286,7 +286,7 @@ async fn handle_service_step(code: KeyCode, state: &mut Wizard) {
                 if state.install_service {
                     "Runner is installed as a service and connected.\nThe TUI dashboard will open next."
                 } else {
-                    "Configuration saved. Run `pi-dash-runner start` to connect."
+                    "Configuration saved. Run `pidash start` to connect."
                 }
                 .to_string(),
             );

--- a/runner/src/tui/views/status.rs
+++ b/runner/src/tui/views/status.rs
@@ -68,7 +68,7 @@ pub fn render(f: &mut ratatui::Frame<'_>, area: Rect, state: &AppState) {
     f.render_widget(body, chunks[1]);
 
     if state.onboarding_needed {
-        let msg = Paragraph::new("No configuration found. Run `pi-dash-runner configure --url ... --token ...` first.")
+        let msg = Paragraph::new("No configuration found. Run `pidash configure --url ... --token ...` first.")
             .style(Style::default().fg(Color::Yellow));
         f.render_widget(msg, chunks[0]);
     }

--- a/runner/src/util/paths.rs
+++ b/runner/src/util/paths.rs
@@ -62,7 +62,7 @@ impl Paths {
     }
 
     pub fn ipc_socket_path(&self) -> PathBuf {
-        self.runtime_dir.join("runner.sock")
+        self.runtime_dir.join("pidash.sock")
     }
 
     pub fn default_working_dir(&self) -> PathBuf {

--- a/runner/src/util/paths.rs
+++ b/runner/src/util/paths.rs
@@ -3,8 +3,8 @@ use directories::ProjectDirs;
 use std::path::{Path, PathBuf};
 
 const QUALIFIER: &str = "so";
-const ORG: &str = "pi-dash";
-const APP: &str = "runner";
+const ORG: &str = "pidash";
+const APP: &str = "pidash";
 
 #[derive(Debug, Clone)]
 pub struct Paths {
@@ -69,7 +69,7 @@ impl Paths {
         let base = std::env::var("TMPDIR")
             .map(PathBuf::from)
             .unwrap_or_else(|_| std::env::temp_dir());
-        base.join(".pi_dash")
+        base.join(".pidash")
     }
 
     pub fn ensure(&self) -> Result<()> {

--- a/runner/tests/cloud_ws_fake.rs
+++ b/runner/tests/cloud_ws_fake.rs
@@ -2,11 +2,11 @@
 //! runner's `Connection::open` against it, and verify the Hello/Welcome
 //! handshake + a few message round-trips.
 
-use pi_dash_runner::cloud::protocol::{
+use pidash::cloud::protocol::{
     ClientMsg, Envelope, RunnerStatus, ServerMsg, WIRE_VERSION,
 };
-use pi_dash_runner::cloud::ws::{Connection, run_connection};
-use pi_dash_runner::config::schema::Credentials;
+use pidash::cloud::ws::{Connection, run_connection};
+use pidash::config::schema::Credentials;
 use chrono::Utc;
 use futures_util::{SinkExt, StreamExt};
 use std::net::SocketAddr;

--- a/runner/tests/codex_bridge_fake.rs
+++ b/runner/tests/codex_bridge_fake.rs
@@ -2,9 +2,9 @@
 //! `codex app-server` and emits canned JSON-RPC responses; the Bridge drives
 //! it through `initialize → thread/start → turn/start → turn/completed`.
 
-use pi_dash_runner::codex::app_server::AppServer;
-use pi_dash_runner::codex::bridge::{Bridge, BridgeEvent, RunPayload};
-use pi_dash_runner::codex::jsonrpc::Incoming;
+use pidash::codex::app_server::AppServer;
+use pidash::codex::bridge::{Bridge, BridgeEvent, RunPayload};
+use pidash::codex::jsonrpc::Incoming;
 use std::path::PathBuf;
 use std::time::Duration;
 use tokio::process::Command;

--- a/runner/tests/protocol_roundtrip.rs
+++ b/runner/tests/protocol_roundtrip.rs
@@ -1,14 +1,14 @@
 //! Integration tests that exercise the cloud protocol serde and approval
 //! router state machine at their public API.
 
-use pi_dash_runner::approval::{
+use pidash::approval::{
     policy::{Decision, Policy},
     router::{ApprovalRecord, ApprovalRouter, ApprovalStatus, DecisionSource},
 };
-use pi_dash_runner::cloud::protocol::{
+use pidash::cloud::protocol::{
     ApprovalDecision, ApprovalKind, ClientMsg, Envelope, RunnerStatus, ServerMsg, WIRE_VERSION,
 };
-use pi_dash_runner::config::schema::ApprovalPolicySection;
+use pidash::config::schema::ApprovalPolicySection;
 use std::path::Path;
 use uuid::Uuid;
 


### PR DESCRIPTION
## Summary

- One short word (`pidash`) for the runner daemon CLI — drops the `-runner` suffix left over after the project-wide `apple-pi-dash → pi-dash` rebrand in #5.
- Renames the Cargo package, `[[bin]]`, `[lib]`, `default-run`, and the `pidash::` crate import path.
- Sweeps everything user-visible that names the binary: XDG paths (`~/.config/pidash/`, etc.), `pidash.service` systemd unit, `so.pidash.daemon` launchd label, `PIDASH_*` env vars, HTTP user-agent, Codex `clientInfo.name`, TUI titles, onboarding wizard prose, CLI `println!` next-step hint, README, design docs, and the displayed command in the Runners admin page.

## Out of scope

- **Prometheus metric names** (`pi_dash_runner_*`) stay as-is — server-side observability follows the project's snake_case `pi_dash` convention from #5, not the binary's identity.
- `runner/` source tree, the web "Runners" page, and the Django runner package keep "runner" as the conceptual feature name. Only on-disk artifacts and the executable change.

## Migration note

Existing developer installs need a clean reinstall — this changes systemd unit name, launchd label, env vars, and on-disk dirs. Run `pi-dash-runner service uninstall && pi-dash-runner remove` before installing the new binary, or move `~/.config/pi-dash-runner/` → `~/.config/pidash/` and equivalent for `~/.local/share/`.

## Test plan

- [x] `cargo check --all-targets` clean
- [x] `cargo test` — 32/32 pass (1 unit + 23 in lib + 8 across 3 integration suites)
- [ ] Manual smoke: build release binary, run `pidash configure` against a local cloud, confirm `~/.config/pidash/` is created and the daemon connects
- [ ] Manual smoke: `pidash service install && pidash service start` on Linux; confirm `systemctl --user status pidash` shows active

🤖 Generated with [Claude Code](https://claude.com/claude-code)