### PR TITLE
runner: mint API token alongside runner_secret on register

### DIFF
--- a/apps/api/pi_dash/runner/serializers.py
+++ b/apps/api/pi_dash/runner/serializers.py
@@ -55,6 +55,10 @@ class RegistrationRequestSerializer(serializers.Serializer):
 class RegistrationResponseSerializer(serializers.Serializer):
     runner_id = serializers.UUIDField()
     runner_secret = serializers.CharField()
+    # Public REST API token (``X-Api-Key``) issued alongside the runner
+    # secret so the same install can also drive ``/api/v1/`` for work-item
+    # CRUD via the pidash CLI. Independently revocable.
+    api_token = serializers.CharField()
     heartbeat_interval_secs = serializers.IntegerField()
     protocol_version = serializers.IntegerField()
 

--- a/apps/api/pi_dash/runner/views/register.py
+++ b/apps/api/pi_dash/runner/views/register.py
@@ -9,6 +9,7 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from pi_dash.db.models import APIToken
 from pi_dash.runner.authentication import RunnerBearerAuthentication
 from pi_dash.runner.models import (
     Runner,
@@ -40,7 +41,14 @@ class HealthEndpoint(APIView):
 class RegisterEndpoint(APIView):
     """POST /api/v1/runner/register/ — one-time-token to runner-secret exchange.
 
-    Called by the daemon during ``pi-dash-runner configure``.
+    Called by the daemon during ``pi-dash-runner configure``. Issues two
+    independent credentials in a single response:
+
+    - ``runner_secret`` — long-lived bearer for the daemon's WS connection.
+    - ``api_token``    — ``X-Api-Key`` for the public REST API at
+      ``/api/v1/`` so the same install can drive work-item CRUD without
+      re-authenticating. Tied to ``reg.created_by`` and revocable
+      independently of the runner.
     """
 
     authentication_classes: list = []
@@ -91,10 +99,22 @@ class RegisterEndpoint(APIView):
         reg.consumed_by_runner = runner
         reg.save(update_fields=["consumed_at", "consumed_by_runner"])
 
+        # Mint a CLI API token alongside the runner secret. Different
+        # threat model than the runner secret (interactive user actions
+        # vs. background daemon), so kept as a separate row that can be
+        # revoked independently in the user's API tokens UI.
+        api_token = APIToken.objects.create(
+            user=reg.created_by,
+            workspace=reg.workspace,
+            label=f"runner: {data['runner_name'][:96]}",
+            description="Auto-issued at runner enrollment for the pidash CLI.",
+        )
+
         payload = RegistrationResponseSerializer(
             {
                 "runner_id": runner.id,
                 "runner_secret": minted.raw,
+                "api_token": api_token.token,
                 "heartbeat_interval_secs": HEARTBEAT_INTERVAL_SECS,
                 "protocol_version": PROTOCOL_VERSION,
             }

--- a/apps/api/pi_dash/runner/views/register.py
+++ b/apps/api/pi_dash/runner/views/register.py
@@ -105,6 +105,7 @@ class RegisterEndpoint(APIView):
         # revoked independently in the user's API tokens UI.
         api_token = APIToken.objects.create(
             user=reg.created_by,
+            user_type=1 if reg.created_by.is_bot else 0,
             workspace=reg.workspace,
             label=f"runner: {data['runner_name'][:96]}",
             description="Auto-issued at runner enrollment for the pidash CLI.",

--- a/apps/api/pi_dash/tests/contract/runner/test_registration.py
+++ b/apps/api/pi_dash/tests/contract/runner/test_registration.py
@@ -8,6 +8,7 @@ import pytest
 from django.urls import reverse
 from django.utils import timezone
 
+from pi_dash.db.models.api import APIToken
 from pi_dash.runner.models import (
     AgentRunStatus,
     Runner,
@@ -46,12 +47,57 @@ def test_register_exchanges_token_for_secret(api_client, registration):
     assert resp.status_code == 201
     body = resp.json()
     assert body["runner_secret"].startswith("apd_rs_")
+    assert body["api_token"].startswith("pi_dash_api_")
     assert body["protocol_version"] == 1
     runner = Runner.objects.get(id=body["runner_id"])
     assert runner.owner_id == record.created_by_id
     record.refresh_from_db()
     assert record.consumed_at is not None
     assert record.consumed_by_runner_id == runner.id
+
+    # The minted APIToken is owned by the same user as the runner, scoped
+    # to the same workspace, and classified Human (user_type=0) since
+    # create_user is not a bot.
+    api_token_row = APIToken.objects.get(token=body["api_token"])
+    assert api_token_row.user_id == record.created_by_id
+    assert api_token_row.workspace_id == record.workspace_id
+    assert api_token_row.user_type == 0
+    assert api_token_row.is_service is False
+
+
+@pytest.mark.contract
+def test_register_classifies_bot_owned_token_correctly(
+    api_client, db, create_bot_user, workspace
+):
+    # Registration tokens can be minted by bot users (the endpoint only
+    # requires IsAuthenticated), so the auto-issued APIToken must inherit
+    # user_type=1 rather than falling back to the Human default.
+    minted = tokens.mint_registration_token()
+    RunnerRegistrationToken.objects.create(
+        workspace=workspace,
+        created_by=create_bot_user,
+        token_hash=minted.hashed,
+        label="bot-test",
+        expires_at=minted.expires_at,
+    )
+    url = reverse("runner:register")
+    resp = api_client.post(
+        url,
+        {
+            "token": minted.raw,
+            "runner_name": "bot-laptop",
+            "os": "linux",
+            "arch": "x86_64",
+            "version": "0.1.0",
+            "protocol_version": 1,
+        },
+        format="json",
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    api_token_row = APIToken.objects.get(token=body["api_token"])
+    assert api_token_row.user_id == create_bot_user.id
+    assert api_token_row.user_type == 1
 
 
 @pytest.mark.contract


### PR DESCRIPTION
## Summary

Step 1 of the pidash CLI work-item CRUD plan: `/api/v1/runner/register/` now returns **two** independent credentials instead of one.

- `runner_secret` (existing) — long-lived bearer for the daemon's WebSocket connection.
- `api_token` (new) — `X-Api-Key` for the public REST API at `/api/v1/`. Reuses the existing `APIToken` model + `APIKeyAuthentication` middleware. Tied to the same user as the runner, manageable from the user's existing API tokens UI.

## Why two credentials

Different threat models. The runner secret is a long-lived machine credential intended for a background daemon — compromise means "attacker runs Codex on your laptop." The `api_token` authorizes interactive user actions like editing work items — compromise means "attacker edits your tickets as you." Keeping them as separate `APIToken` / `Runner` rows means either can be rotated without disturbing the other.

## What's intentionally not in this PR

- **Rust-side persistence of `api_token`.** Next PR — extend `Credentials` schema in `runner/src/config/schema.rs`, write the field on `pidash configure`.
- **The `pidash` CLI subcommands** (`issue list`, etc.). PR after that.
- **Retrofit for already-enrolled runners.** Will add a `pidash login` subcommand backed by a separate runner-bearer-authed endpoint that mints an `api_token` for an existing runner.

## Backward compatibility

The Rust `RegisterResponse` struct in `runner/src/cloud/register.rs` doesn't `deny_unknown_fields`, so adding `api_token` to the JSON response is silently ignored by existing runner builds. No client breakage; they just won't pick up the new token until the next PR ships.

## Test plan

- [x] Both files pass `python3 -m py_compile`.
- [x] `RegistrationResponseSerializer` accepts the new field (the change is purely additive — new `CharField`, same shape pattern as adjacent fields).
- [x] `APIToken.objects.create(user=…, workspace=…, label=…, description=…)` matches the existing pattern from `apps/api/pi_dash/app/views/api.py:29` (user-facing API token creation endpoint).
- [ ] Manual: register a new runner against a local cloud, confirm response includes `api_token` starting with `pi_dash_api_`, confirm `APIToken` row exists in the user's API tokens UI.
- [ ] Manual: hit `GET /api/v1/workspaces/<slug>/projects/<id>/issues/` with `X-Api-Key: <api_token>` to confirm the issued token authenticates against the existing public API.
- [ ] No new tests added (no existing tests for `RegisterEndpoint` to extend); a small contract test would be a worthwhile follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)