### PR TITLE
runner: persist optional api_token in credentials.toml

### DIFF
--- a/runner/src/cli/configure.rs
+++ b/runner/src/cli/configure.rs
@@ -74,6 +74,7 @@ pub async fn run(args: Args, paths: &Paths) -> Result<()> {
     let creds = Credentials {
         runner_id: resp.runner_id,
         runner_secret: resp.runner_secret,
+        api_token: resp.api_token,
         issued_at: chrono::Utc::now(),
     };
     crate::config::file::write_credentials(paths, &creds)?;

--- a/runner/src/cli/rotate.rs
+++ b/runner/src/cli/rotate.rs
@@ -18,6 +18,9 @@ pub async fn run(_args: Args, paths: &Paths) -> Result<()> {
     let new_creds = Credentials {
         runner_id: resp.runner_id,
         runner_secret: resp.runner_secret,
+        // The rotate endpoint only mints a new runner_secret; the existing
+        // api_token is unaffected, so preserve it across the rotation.
+        api_token: creds.api_token.clone(),
         issued_at: chrono::Utc::now(),
     };
     crate::config::file::write_credentials(paths, &new_creds)?;

--- a/runner/src/cloud/register.rs
+++ b/runner/src/cloud/register.rs
@@ -16,6 +16,11 @@ pub struct RegisterRequest {
 pub struct RegisterResponse {
     pub runner_id: Uuid,
     pub runner_secret: String,
+    /// Public REST API token (`X-Api-Key`) for `/api/v1/`. Optional so a
+    /// daemon built against the new server can also enroll against an older
+    /// server that hasn't shipped the dual-credential change yet.
+    #[serde(default)]
+    pub api_token: Option<String>,
     pub heartbeat_interval_secs: u64,
     pub protocol_version: u32,
 }

--- a/runner/src/config/file.rs
+++ b/runner/src/config/file.rs
@@ -137,10 +137,29 @@ mod tests {
         let creds = Credentials {
             runner_id: uuid::Uuid::new_v4(),
             runner_secret: "s".into(),
+            api_token: Some("pi_dash_api_test".into()),
             issued_at: chrono::Utc::now(),
         };
         write_credentials(&paths, &creds).unwrap();
         let loaded = load_credentials(&paths).unwrap();
         assert_eq!(loaded.runner_secret, "s");
+        assert_eq!(loaded.api_token.as_deref(), Some("pi_dash_api_test"));
+    }
+
+    #[test]
+    fn credentials_without_api_token_round_trip_via_serde_default() {
+        // A credentials file written before the api_token field existed
+        // (no `api_token = ...` line) must still parse, with the field
+        // defaulting to None.
+        let tmp = tempdir().unwrap();
+        let paths = paths_for(tmp.path());
+        std::fs::create_dir_all(&paths.config_dir).unwrap();
+        let body = format!(
+            "runner_id = \"{}\"\nrunner_secret = \"abc\"\nissued_at = \"2026-04-01T00:00:00Z\"\n",
+            uuid::Uuid::new_v4()
+        );
+        std::fs::write(paths.credentials_path(), body).unwrap();
+        let loaded = load_credentials(&paths).unwrap();
+        assert_eq!(loaded.api_token, None);
     }
 }

--- a/runner/src/config/schema.rs
+++ b/runner/src/config/schema.rs
@@ -90,5 +90,11 @@ impl Default for LoggingSection {
 pub struct Credentials {
     pub runner_id: Uuid,
     pub runner_secret: String,
+    /// Public REST API token (`X-Api-Key`) for `/api/v1/`. Issued by the
+    /// cloud alongside `runner_secret` and used by future `pidash` CRUD
+    /// subcommands. `None` for installs enrolled before the cloud started
+    /// minting these; a follow-up `pidash login` will retrofit them.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_token: Option<String>,
     pub issued_at: DateTime<Utc>,
 }

--- a/runner/src/tui/onboarding.rs
+++ b/runner/src/tui/onboarding.rs
@@ -223,6 +223,7 @@ async fn register_and_advance(state: &mut Wizard) {
             let creds = Credentials {
                 runner_id: resp.runner_id,
                 runner_secret: resp.runner_secret,
+                api_token: resp.api_token,
                 issued_at: chrono::Utc::now(),
             };
             if let Err(e) = crate::config::file::write_credentials(&state.paths, &creds) {

--- a/runner/tests/cloud_ws_fake.rs
+++ b/runner/tests/cloud_ws_fake.rs
@@ -84,6 +84,7 @@ async fn runner_connects_hello_welcome_and_receives_assign() {
     let creds = Credentials {
         runner_id: uuid::Uuid::new_v4(),
         runner_secret: "apd_rs_testsecret".into(),
+        api_token: None,
         issued_at: Utc::now(),
     };
 


### PR DESCRIPTION
## Summary

Step 2 of the pidash CLI work-item CRUD plan (server-side is #8). The Rust runner now reads `api_token` from the `/api/v1/runner/register/` response and writes it next to `runner_secret` in `credentials.toml` (still 0600).

## Independence from #8

The field is `Option<String>` everywhere so this PR can land before, after, or independently of #8:

- **`RegisterResponse.api_token`** uses `#[serde(default)]` — tolerates a server response that omits the field (pre-#8 server, or a self-hosted deployment lagging behind).
- **`Credentials.api_token`** uses `#[serde(default, skip_serializing_if = "Option::is_none")]` — existing `credentials.toml` files written without the field load cleanly with `None`, and a runner that didn't get a token doesn't write an empty `api_token = ""` line.
- **`pidash rotate`** preserves the existing `api_token` across rotation, since the rotate endpoint only mints a new `runner_secret`.

## What's still ahead in the plan

- The actual CLI subcommands that *use* `api_token`: `pidash issue list/view/create/update`. These will read `Credentials.api_token` and send it as `X-Api-Key`.
- A retrofit `pidash login` subcommand for installs that pre-date this PR (will hit a new runner-bearer-authed endpoint that mints an `api_token` for an existing runner).

## Test plan

- [x] `cargo check --all-targets` clean
- [x] `cargo test` 33/33 pass (was 32 — added one new test below)
- [x] **New test** `credentials_without_api_token_round_trip_via_serde_default` (`runner/src/config/file.rs`): writes a `credentials.toml` with no `api_token` line, confirms `load_credentials` succeeds with `api_token == None`. Pins the back-compat contract.
- [x] **Updated test** `writes_and_reads_credentials`: now also asserts the new field round-trips when set.
- [ ] Manual: enroll a runner against a server that has #8 merged → confirm `credentials.toml` contains `api_token = "pi_dash_api_..."`.
- [ ] Manual: enroll a runner against a server that does NOT have #8 → confirm enrollment still succeeds and `credentials.toml` simply omits the line.

## Files

| File | Change |
|---|---|
| `runner/src/cloud/register.rs` | Add `api_token: Option<String>` to `RegisterResponse`. |
| `runner/src/config/schema.rs` | Add `api_token: Option<String>` to `Credentials`. |
| `runner/src/cli/configure.rs` | Pipe `resp.api_token` into the new `Credentials`. |
| `runner/src/tui/onboarding.rs` | Same, in the wizard's `register_and_advance`. |
| `runner/src/cli/rotate.rs` | Preserve existing `api_token` across rotation. |
| `runner/src/config/file.rs` | New back-compat parse test + assertion in existing test. |
| `runner/tests/cloud_ws_fake.rs` | Add `api_token: None` to the test fixture's `Credentials`. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)