### PR TITLE
prompting: UI for viewing and workspace-admin editing of prompt templates

### DIFF
--- a/apps/api/pi_dash/prompting/renderer.py
+++ b/apps/api/pi_dash/prompting/renderer.py
@@ -14,12 +14,21 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-from jinja2 import StrictUndefined, TemplateError
+from jinja2 import StrictUndefined, TemplateError, TemplateSyntaxError
 from jinja2.sandbox import SandboxedEnvironment
 
 
 class PromptRenderError(Exception):
     """Raised when a prompt template fails to render."""
+
+
+class PromptSyntaxError(PromptRenderError):
+    """Raised when a prompt template has invalid Jinja syntax.
+
+    Distinct from :class:`PromptRenderError` so callers that only care about
+    syntax (e.g. save-time validation) can ignore runtime issues like missing
+    context variables.
+    """
 
 
 _ENV = SandboxedEnvironment(
@@ -41,3 +50,14 @@ def render(body: str, context: Dict[str, Any]) -> str:
         return template.render(**context)
     except TemplateError as exc:
         raise PromptRenderError(str(exc)) from exc
+
+
+def validate_syntax(body: str) -> None:
+    """Raise :class:`PromptSyntaxError` iff ``body`` is not a valid Jinja
+    template. Does not execute the template or require any context — useful
+    for save-time validation where missing runtime variables are expected.
+    """
+    try:
+        _ENV.parse(body)
+    except TemplateSyntaxError as exc:
+        raise PromptSyntaxError(str(exc)) from exc

--- a/apps/api/pi_dash/prompting/serializers.py
+++ b/apps/api/pi_dash/prompting/serializers.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Serializers for the prompt-template REST surface."""
+
+from __future__ import annotations
+
+from rest_framework import serializers
+
+from pi_dash.prompting.models import PromptTemplate
+from pi_dash.prompting.renderer import PromptRenderError, render
+
+
+class PromptTemplateSerializer(serializers.ModelSerializer):
+    is_global_default = serializers.BooleanField(read_only=True)
+    can_edit = serializers.SerializerMethodField(read_only=True)
+
+    class Meta:
+        model = PromptTemplate
+        fields = [
+            "id",
+            "workspace",
+            "name",
+            "body",
+            "is_active",
+            "version",
+            "is_global_default",
+            "can_edit",
+            "updated_by",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = [
+            "id",
+            "workspace",
+            "is_active",
+            "version",
+            "updated_by",
+            "created_at",
+            "updated_at",
+        ]
+
+    def get_can_edit(self, obj: PromptTemplate) -> bool:
+        # Workspace-scoped rows are editable by workspace admins (the view gates
+        # the mutation endpoints). The global default is never editable via this
+        # surface — platform operators edit it out-of-band.
+        return not obj.is_global_default
+
+    def validate_body(self, value: str) -> str:
+        # Fail loud on Jinja syntax errors at save time rather than at the next
+        # run, where a broken template would take down an AgentRun with a
+        # `render-failed` reason.
+        try:
+            render(value, {})
+        except PromptRenderError as exc:
+            # StrictUndefined will complain about missing context vars — that's
+            # expected and fine at save time. Only real syntax errors should
+            # block the save.
+            msg = str(exc).lower()
+            if "undefined" in msg or "strictundefined" in msg:
+                return value
+            raise serializers.ValidationError(f"template body is invalid: {exc}")
+        return value

--- a/apps/api/pi_dash/prompting/serializers.py
+++ b/apps/api/pi_dash/prompting/serializers.py
@@ -9,12 +9,17 @@ from __future__ import annotations
 from rest_framework import serializers
 
 from pi_dash.prompting.models import PromptTemplate
-from pi_dash.prompting.renderer import PromptRenderError, render
+from pi_dash.prompting.renderer import PromptSyntaxError, validate_syntax
+
+#: Upper bound on template body size. The shipped default is ~9 KB; 100 KB is
+#: ~10× headroom without allowing obvious DoS via multi-MB payloads. Enforced
+#: at save time only — reading existing rows that somehow exceed this is not
+#: blocked.
+MAX_BODY_LENGTH = 100_000
 
 
 class PromptTemplateSerializer(serializers.ModelSerializer):
     is_global_default = serializers.BooleanField(read_only=True)
-    can_edit = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
         model = PromptTemplate
@@ -26,7 +31,6 @@ class PromptTemplateSerializer(serializers.ModelSerializer):
             "is_active",
             "version",
             "is_global_default",
-            "can_edit",
             "updated_by",
             "created_at",
             "updated_at",
@@ -41,24 +45,20 @@ class PromptTemplateSerializer(serializers.ModelSerializer):
             "updated_at",
         ]
 
-    def get_can_edit(self, obj: PromptTemplate) -> bool:
-        # Workspace-scoped rows are editable by workspace admins (the view gates
-        # the mutation endpoints). The global default is never editable via this
-        # surface — platform operators edit it out-of-band.
-        return not obj.is_global_default
-
     def validate_body(self, value: str) -> str:
-        # Fail loud on Jinja syntax errors at save time rather than at the next
-        # run, where a broken template would take down an AgentRun with a
-        # `render-failed` reason.
+        # Size cap. Rendering a huge template is cheap in Jinja but storing
+        # it and re-serializing it on every list response isn't — cheap DoS
+        # surface worth closing at the API boundary.
+        if len(value) > MAX_BODY_LENGTH:
+            raise serializers.ValidationError(
+                f"template body exceeds {MAX_BODY_LENGTH}-character limit "
+                f"(got {len(value)} characters)"
+            )
+        # Syntax-only check. We deliberately do NOT try rendering the template
+        # against a fake context here — missing context variables are expected
+        # at save time and don't indicate a broken template.
         try:
-            render(value, {})
-        except PromptRenderError as exc:
-            # StrictUndefined will complain about missing context vars — that's
-            # expected and fine at save time. Only real syntax errors should
-            # block the save.
-            msg = str(exc).lower()
-            if "undefined" in msg or "strictundefined" in msg:
-                return value
+            validate_syntax(value)
+        except PromptSyntaxError as exc:
             raise serializers.ValidationError(f"template body is invalid: {exc}")
         return value

--- a/apps/api/pi_dash/prompting/urls.py
+++ b/apps/api/pi_dash/prompting/urls.py
@@ -4,11 +4,31 @@
 
 from django.urls import path
 
-from pi_dash.prompting.views import PromptTemplatePreviewEndpoint
+from pi_dash.prompting.views import (
+    PromptTemplateArchiveEndpoint,
+    PromptTemplateDetailEndpoint,
+    PromptTemplateListCreateEndpoint,
+    PromptTemplatePreviewEndpoint,
+)
 
 app_name = "prompting"
 
 urlpatterns = [
+    path(
+        "workspaces/<slug:slug>/prompt-templates",
+        PromptTemplateListCreateEndpoint.as_view(),
+        name="prompt-template-list-create",
+    ),
+    path(
+        "workspaces/<slug:slug>/prompt-templates/<uuid:template_id>",
+        PromptTemplateDetailEndpoint.as_view(),
+        name="prompt-template-detail",
+    ),
+    path(
+        "workspaces/<slug:slug>/prompt-templates/<uuid:template_id>/archive",
+        PromptTemplateArchiveEndpoint.as_view(),
+        name="prompt-template-archive",
+    ),
     path(
         "workspaces/<slug:slug>/prompt-templates/<uuid:template_id>/preview",
         PromptTemplatePreviewEndpoint.as_view(),

--- a/apps/api/pi_dash/prompting/views.py
+++ b/apps/api/pi_dash/prompting/views.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import uuid
 
-from django.db.models import Q
+from django.db.models import F, Q
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -122,10 +122,14 @@ class PromptTemplateListCreateEndpoint(APIView):
         if not _is_workspace_member(request.user, workspace):
             return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
 
+        # nulls_last=True so the workspace override (non-null workspace_id)
+        # lands before the global default — the UI doesn't depend on this
+        # order today but making it explicit avoids future bugs if consumers
+        # start trusting the response order.
         qs = (
             PromptTemplate.objects.filter(is_active=True)
             .filter(_visible_to(workspace))
-            .order_by("workspace_id", "name")
+            .order_by(F("workspace_id").asc(nulls_last=True), "name")
         )
         serializer = PromptTemplateSerializer(qs, many=True)
         return Response(serializer.data)
@@ -137,7 +141,11 @@ class PromptTemplateListCreateEndpoint(APIView):
         if not _is_workspace_admin(request.user, workspace):
             return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
 
-        name = request.data.get("name") or PromptTemplate.DEFAULT_NAME
+        # MVP scope (Option 1): one template kind per workspace — the built-in
+        # "coding-task" slot that the composer actually reads. Client-supplied
+        # names are ignored on purpose; accepting them would let callers
+        # create rows that orchestration never loads.
+        name = PromptTemplate.DEFAULT_NAME
         existing = PromptTemplate.objects.filter(
             workspace=workspace, name=name, is_active=True
         ).first()

--- a/apps/api/pi_dash/prompting/views.py
+++ b/apps/api/pi_dash/prompting/views.py
@@ -2,10 +2,25 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # See the LICENSE file for details.
 
-"""Prompt-template preview endpoint.
+"""Prompt-template REST surface.
 
-Lets a workspace admin render a template against an issue *without* creating an
-``AgentRun``. Critical for iterating on the handbook.
+- ``GET    /api/workspaces/<slug>/prompt-templates`` — list templates visible
+  to this workspace (the global default plus any workspace-scoped override).
+  Readable by any workspace member.
+- ``POST   /api/workspaces/<slug>/prompt-templates`` — create a workspace
+  override. Workspace admins only. Pre-fills the body from the global default
+  when the request omits ``body``.
+- ``GET    /api/workspaces/<slug>/prompt-templates/<id>`` — detail. Any
+  workspace member.
+- ``PATCH  /api/workspaces/<slug>/prompt-templates/<id>`` — edit in place.
+  Bumps ``version``. Workspace admins only. Refuses edits on the global
+  default.
+- ``POST   /api/workspaces/<slug>/prompt-templates/<id>/archive`` — flip
+  ``is_active=False`` so the workspace falls back to the global default.
+  Workspace admins only.
+- ``POST   /api/workspaces/<slug>/prompt-templates/<id>/preview`` — render
+  against a real issue without creating an ``AgentRun``. Workspace admins
+  only.
 """
 
 from __future__ import annotations
@@ -24,10 +39,11 @@ from pi_dash.db.models.workspace import Workspace, WorkspaceMember
 from pi_dash.prompting.context import build_context
 from pi_dash.prompting.models import PromptTemplate
 from pi_dash.prompting.renderer import PromptRenderError, render
+from pi_dash.prompting.serializers import PromptTemplateSerializer
 
 #: Numeric value of ``WorkspaceMember.role`` for the "Admin" role. Mirrors
 #: ``db.models.workspace.ROLE_CHOICES`` — kept as a named constant here so
-#: preview access checks don't rely on an unlabelled literal.
+#: access checks don't rely on an unlabelled literal.
 WORKSPACE_ADMIN_ROLE = 20
 
 
@@ -41,11 +57,9 @@ class _FakeRun:
 
 
 def _is_workspace_admin(user, workspace: Workspace) -> bool:
-    """Preview is locked to workspace-scoped admins (role 20) plus Django
-    superusers for ops. `is_staff` alone is *not* sufficient — a staff flag
-    doesn't imply membership in this workspace, and the design (§9 Q2) is
-    explicit that preview must be workspace-admin-gated until we build a
-    richer auth model."""
+    """Write access: workspace-scoped admins (role 20) plus Django superusers.
+    ``is_staff`` alone is not sufficient — a staff flag doesn't imply
+    membership in this workspace."""
     if user.is_superuser:
         return True
     return WorkspaceMember.objects.filter(
@@ -56,25 +70,211 @@ def _is_workspace_admin(user, workspace: Workspace) -> bool:
     ).exists()
 
 
-class PromptTemplatePreviewEndpoint(APIView):
-    """``POST /api/workspaces/<slug>/prompt-templates/<uuid>/preview``.
+def _is_workspace_member(user, workspace: Workspace) -> bool:
+    """Read access: any active member of the workspace, at any role."""
+    if user.is_superuser:
+        return True
+    return WorkspaceMember.objects.filter(
+        workspace=workspace,
+        member=user,
+        is_active=True,
+    ).exists()
 
-    Session-authenticated, workspace-admin-gated. Mounted on the app API
-    surface (``/api/``) rather than the external ``/api/v1/`` API-key surface.
 
-    Body: ``{"issue_id": "<uuid>"}``.
-    Returns: ``{"prompt": "<rendered>"}``.
+def _visible_to(workspace):
+    """Templates visible to a workspace: the workspace's own rows plus the
+    global default."""
+    return Q(workspace=workspace) | Q(workspace__isnull=True)
 
-    Does **not** create an ``AgentRun`` and does not touch the runner.
+
+def _get_workspace_or_404(slug: str):
+    try:
+        return Workspace.objects.get(slug=slug)
+    except Workspace.DoesNotExist:
+        return None
+
+
+def _get_global_default_body() -> str:
+    """Current body of the global default template, or empty string if the
+    seed row is missing."""
+    row = (
+        PromptTemplate.objects.filter(
+            workspace__isnull=True,
+            name=PromptTemplate.DEFAULT_NAME,
+            is_active=True,
+        )
+        .order_by("-updated_at")
+        .first()
+    )
+    return row.body if row is not None else ""
+
+
+class PromptTemplateListCreateEndpoint(APIView):
+    """``GET|POST /api/workspaces/<slug>/prompt-templates``."""
+
+    permission_classes = [IsAuthenticated]
+    throttle_classes = [UserRateThrottle]
+
+    def get(self, request, slug: str):
+        workspace = _get_workspace_or_404(slug)
+        if workspace is None:
+            return Response({"error": "workspace not found"}, status=status.HTTP_404_NOT_FOUND)
+        if not _is_workspace_member(request.user, workspace):
+            return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
+
+        qs = (
+            PromptTemplate.objects.filter(is_active=True)
+            .filter(_visible_to(workspace))
+            .order_by("workspace_id", "name")
+        )
+        serializer = PromptTemplateSerializer(qs, many=True)
+        return Response(serializer.data)
+
+    def post(self, request, slug: str):
+        workspace = _get_workspace_or_404(slug)
+        if workspace is None:
+            return Response({"error": "workspace not found"}, status=status.HTTP_404_NOT_FOUND)
+        if not _is_workspace_admin(request.user, workspace):
+            return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
+
+        name = request.data.get("name") or PromptTemplate.DEFAULT_NAME
+        existing = PromptTemplate.objects.filter(
+            workspace=workspace, name=name, is_active=True
+        ).first()
+        if existing is not None:
+            return Response(
+                {
+                    "error": "workspace already has an active template with this name",
+                    "existing_id": str(existing.id),
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        body = request.data.get("body")
+        if not body:
+            body = _get_global_default_body()
+        if not body:
+            return Response(
+                {"error": "no body provided and no global default available to copy from"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        serializer = PromptTemplateSerializer(data={"name": name, "body": body})
+        serializer.is_valid(raise_exception=True)
+        template = PromptTemplate.objects.create(
+            workspace=workspace,
+            name=serializer.validated_data["name"],
+            body=serializer.validated_data["body"],
+            is_active=True,
+            version=1,
+            updated_by=request.user,
+        )
+        return Response(
+            PromptTemplateSerializer(template).data, status=status.HTTP_201_CREATED
+        )
+
+
+class PromptTemplateDetailEndpoint(APIView):
+    """``GET|PATCH /api/workspaces/<slug>/prompt-templates/<id>``."""
+
+    permission_classes = [IsAuthenticated]
+    throttle_classes = [UserRateThrottle]
+
+    def _lookup(self, workspace, template_id):
+        return (
+            PromptTemplate.objects.filter(id=template_id)
+            .filter(_visible_to(workspace))
+            .first()
+        )
+
+    def get(self, request, slug: str, template_id: uuid.UUID):
+        workspace = _get_workspace_or_404(slug)
+        if workspace is None:
+            return Response({"error": "workspace not found"}, status=status.HTTP_404_NOT_FOUND)
+        if not _is_workspace_member(request.user, workspace):
+            return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
+
+        template = self._lookup(workspace, template_id)
+        if template is None:
+            return Response({"error": "template not found"}, status=status.HTTP_404_NOT_FOUND)
+        return Response(PromptTemplateSerializer(template).data)
+
+    def patch(self, request, slug: str, template_id: uuid.UUID):
+        workspace = _get_workspace_or_404(slug)
+        if workspace is None:
+            return Response({"error": "workspace not found"}, status=status.HTTP_404_NOT_FOUND)
+        if not _is_workspace_admin(request.user, workspace):
+            return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
+
+        template = self._lookup(workspace, template_id)
+        if template is None:
+            return Response({"error": "template not found"}, status=status.HTTP_404_NOT_FOUND)
+        if template.is_global_default:
+            return Response(
+                {"error": "the global default template is read-only on this surface"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        serializer = PromptTemplateSerializer(template, data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        # Edit-in-place: bump version counter, persist new body, stamp the
+        # editor. History is not retained on the row itself.
+        new_body = serializer.validated_data.get("body", template.body)
+        template.body = new_body
+        template.version = (template.version or 0) + 1
+        template.updated_by = request.user
+        template.save(update_fields=["body", "version", "updated_by", "updated_at"])
+        return Response(PromptTemplateSerializer(template).data)
+
+
+class PromptTemplateArchiveEndpoint(APIView):
+    """``POST /api/workspaces/<slug>/prompt-templates/<id>/archive``.
+
+    Flips ``is_active=False`` on a workspace-scoped row so lookup falls back
+    to the global default. Refuses to archive the global default itself.
     """
 
     permission_classes = [IsAuthenticated]
     throttle_classes = [UserRateThrottle]
 
     def post(self, request, slug: str, template_id: uuid.UUID):
-        try:
-            workspace = Workspace.objects.get(slug=slug)
-        except Workspace.DoesNotExist:
+        workspace = _get_workspace_or_404(slug)
+        if workspace is None:
+            return Response({"error": "workspace not found"}, status=status.HTTP_404_NOT_FOUND)
+        if not _is_workspace_admin(request.user, workspace):
+            return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
+
+        template = (
+            PromptTemplate.objects.filter(
+                id=template_id, workspace=workspace, is_active=True
+            ).first()
+        )
+        if template is None:
+            return Response(
+                {"error": "active workspace-scoped template not found"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        template.is_active = False
+        template.updated_by = request.user
+        template.save(update_fields=["is_active", "updated_by", "updated_at"])
+        return Response(PromptTemplateSerializer(template).data)
+
+
+class PromptTemplatePreviewEndpoint(APIView):
+    """``POST /api/workspaces/<slug>/prompt-templates/<uuid>/preview``.
+
+    Workspace-admin-gated. Renders the template against a real issue without
+    creating an ``AgentRun``. Accepts an optional ``body`` override so the
+    editor can preview unsaved drafts.
+    """
+
+    permission_classes = [IsAuthenticated]
+    throttle_classes = [UserRateThrottle]
+
+    def post(self, request, slug: str, template_id: uuid.UUID):
+        workspace = _get_workspace_or_404(slug)
+        if workspace is None:
             return Response({"error": "workspace not found"}, status=status.HTTP_404_NOT_FOUND)
 
         if not _is_workspace_admin(request.user, workspace):
@@ -102,17 +302,12 @@ class PromptTemplatePreviewEndpoint(APIView):
             return Response({"error": "issue not found"}, status=status.HTTP_404_NOT_FOUND)
 
         context = build_context(issue, _FakeRun(run_id=uuid.uuid4()))
+        body = request.data.get("body") or template.body
         try:
-            rendered = render(template.body, context)
+            rendered = render(body, context)
         except PromptRenderError as exc:
             return Response(
                 {"error": "render failed", "detail": str(exc)},
                 status=status.HTTP_422_UNPROCESSABLE_ENTITY,
             )
         return Response({"prompt": rendered})
-
-
-def _visible_to(workspace):
-    """Templates visible to a workspace: the workspace's own rows plus the
-    global default."""
-    return Q(workspace=workspace) | Q(workspace__isnull=True)

--- a/apps/api/pi_dash/tests/contract/prompting/test_crud.py
+++ b/apps/api/pi_dash/tests/contract/prompting/test_crud.py
@@ -1,0 +1,234 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Contract tests for the prompt-template CRUD surface."""
+
+import pytest
+from crum import impersonate
+from django.urls import reverse
+
+from pi_dash.db.models import User, Workspace, WorkspaceMember
+from pi_dash.prompting.models import PromptTemplate
+from pi_dash.prompting.seed import seed_default_template
+
+
+@pytest.fixture
+def seeded(db):
+    seed_default_template()
+
+
+@pytest.fixture
+def admin_user(create_user, workspace):
+    # ``create_user`` is already the workspace owner+admin via the ``workspace``
+    # fixture (it creates a WorkspaceMember with role=20). Return it unchanged.
+    return create_user
+
+
+@pytest.fixture
+def member_user(db, workspace):
+    member = User.objects.create(
+        email="member@pi-dash.so", username="member-user"
+    )
+    member.set_password("p")
+    member.save()
+    WorkspaceMember.objects.create(
+        workspace=workspace, member=member, role=15, is_active=True
+    )
+    return member
+
+
+@pytest.fixture
+def outsider(db):
+    other = User.objects.create(
+        email="outsider@pi-dash.so", username="outsider-user"
+    )
+    other.set_password("p")
+    other.save()
+    return other
+
+
+def _list_url(ws: Workspace) -> str:
+    return reverse(
+        "prompting:prompt-template-list-create", kwargs={"slug": ws.slug}
+    )
+
+
+def _detail_url(ws: Workspace, template_id) -> str:
+    return reverse(
+        "prompting:prompt-template-detail",
+        kwargs={"slug": ws.slug, "template_id": template_id},
+    )
+
+
+def _archive_url(ws: Workspace, template_id) -> str:
+    return reverse(
+        "prompting:prompt-template-archive",
+        kwargs={"slug": ws.slug, "template_id": template_id},
+    )
+
+
+@pytest.mark.contract
+def test_list_returns_global_default_when_no_override(
+    seeded, api_client, workspace, admin_user
+):
+    api_client.force_authenticate(user=admin_user)
+    response = api_client.get(_list_url(workspace))
+    assert response.status_code == 200, response.content
+    body = response.json()
+    assert len(body) == 1
+    assert body[0]["is_global_default"] is True
+    assert body[0]["can_edit"] is False
+    assert body[0]["workspace"] is None
+
+
+@pytest.mark.contract
+def test_list_forbidden_to_non_members(
+    seeded, api_client, workspace, outsider
+):
+    api_client.force_authenticate(user=outsider)
+    response = api_client.get(_list_url(workspace))
+    assert response.status_code == 403
+
+
+@pytest.mark.contract
+def test_member_can_list_but_not_create(
+    seeded, api_client, workspace, member_user
+):
+    api_client.force_authenticate(user=member_user)
+    list_response = api_client.get(_list_url(workspace))
+    assert list_response.status_code == 200
+
+    create_response = api_client.post(_list_url(workspace), {}, format="json")
+    assert create_response.status_code == 403
+
+
+@pytest.mark.contract
+def test_admin_create_copies_global_default_body(
+    seeded, api_client, workspace, admin_user
+):
+    api_client.force_authenticate(user=admin_user)
+    response = api_client.post(_list_url(workspace), {}, format="json")
+    assert response.status_code == 201, response.content
+    body = response.json()
+    assert body["workspace"] == str(workspace.id)
+    assert body["is_global_default"] is False
+    assert body["can_edit"] is True
+    assert body["version"] == 1
+    # Body must be non-empty — copied from the global default.
+    assert len(body["body"]) > 100
+
+
+@pytest.mark.contract
+def test_admin_create_rejects_when_override_exists(
+    seeded, api_client, workspace, admin_user
+):
+    api_client.force_authenticate(user=admin_user)
+    first = api_client.post(_list_url(workspace), {}, format="json")
+    assert first.status_code == 201
+
+    second = api_client.post(
+        _list_url(workspace), {"body": "custom body"}, format="json"
+    )
+    assert second.status_code == 409
+    assert "existing_id" in second.json()
+
+
+@pytest.mark.contract
+def test_admin_patch_bumps_version_and_stamps_updater(
+    seeded, api_client, workspace, admin_user
+):
+    api_client.force_authenticate(user=admin_user)
+    created = api_client.post(
+        _list_url(workspace), {"body": "Hello {{ issue.title }}"}, format="json"
+    )
+    template_id = created.json()["id"]
+
+    response = api_client.patch(
+        _detail_url(workspace, template_id),
+        {"body": "Hi {{ issue.title }}"},
+        format="json",
+    )
+    assert response.status_code == 200, response.content
+    body = response.json()
+    assert body["body"] == "Hi {{ issue.title }}"
+    assert body["version"] == 2
+    assert body["updated_by"] == str(admin_user.id)
+
+
+@pytest.mark.contract
+def test_patch_rejects_global_default(
+    seeded, api_client, workspace, admin_user
+):
+    api_client.force_authenticate(user=admin_user)
+    global_default = PromptTemplate.objects.filter(workspace__isnull=True).first()
+    response = api_client.patch(
+        _detail_url(workspace, global_default.id),
+        {"body": "tampered"},
+        format="json",
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.contract
+def test_patch_rejects_jinja_syntax_errors(
+    seeded, api_client, workspace, admin_user
+):
+    api_client.force_authenticate(user=admin_user)
+    created = api_client.post(
+        _list_url(workspace), {"body": "valid {{ issue.title }}"}, format="json"
+    )
+    template_id = created.json()["id"]
+
+    response = api_client.patch(
+        _detail_url(workspace, template_id),
+        {"body": "broken {% if %}"},
+        format="json",
+    )
+    assert response.status_code == 400
+    assert "body" in response.json()
+
+
+@pytest.mark.contract
+def test_archive_flips_is_active_and_creates_can_retry(
+    seeded, api_client, workspace, admin_user
+):
+    api_client.force_authenticate(user=admin_user)
+    created = api_client.post(_list_url(workspace), {}, format="json")
+    template_id = created.json()["id"]
+
+    archive = api_client.post(_archive_url(workspace, template_id))
+    assert archive.status_code == 200, archive.content
+    assert archive.json()["is_active"] is False
+
+    # After archiving, the list should show only the global default again.
+    listed = api_client.get(_list_url(workspace)).json()
+    assert len(listed) == 1
+    assert listed[0]["is_global_default"] is True
+
+    # And the admin can create a fresh override.
+    retry = api_client.post(_list_url(workspace), {}, format="json")
+    assert retry.status_code == 201
+
+
+@pytest.mark.contract
+def test_archive_rejects_global_default(
+    seeded, api_client, workspace, admin_user
+):
+    api_client.force_authenticate(user=admin_user)
+    global_default = PromptTemplate.objects.filter(workspace__isnull=True).first()
+    response = api_client.post(_archive_url(workspace, global_default.id))
+    assert response.status_code == 404  # cannot archive what doesn't belong to this workspace
+
+
+@pytest.mark.contract
+def test_member_cannot_archive(
+    seeded, api_client, workspace, admin_user, member_user
+):
+    api_client.force_authenticate(user=admin_user)
+    created = api_client.post(_list_url(workspace), {}, format="json")
+    template_id = created.json()["id"]
+
+    api_client.force_authenticate(user=member_user)
+    response = api_client.post(_archive_url(workspace, template_id))
+    assert response.status_code == 403

--- a/apps/api/pi_dash/tests/contract/prompting/test_crud.py
+++ b/apps/api/pi_dash/tests/contract/prompting/test_crud.py
@@ -78,7 +78,6 @@ def test_list_returns_global_default_when_no_override(
     body = response.json()
     assert len(body) == 1
     assert body[0]["is_global_default"] is True
-    assert body[0]["can_edit"] is False
     assert body[0]["workspace"] is None
 
 
@@ -113,7 +112,6 @@ def test_admin_create_copies_global_default_body(
     body = response.json()
     assert body["workspace"] == str(workspace.id)
     assert body["is_global_default"] is False
-    assert body["can_edit"] is True
     assert body["version"] == 1
     # Body must be non-empty — copied from the global default.
     assert len(body["body"]) > 100
@@ -232,3 +230,81 @@ def test_member_cannot_archive(
     api_client.force_authenticate(user=member_user)
     response = api_client.post(_archive_url(workspace, template_id))
     assert response.status_code == 403
+
+
+@pytest.mark.contract
+def test_archive_does_not_bump_version(
+    seeded, api_client, workspace, admin_user
+):
+    """Archiving is a state flip, not an edit; leaving ``version`` stable lets
+    orchestration reason about "last edited body" separately from "currently
+    active". Regression for a refactor that would silently bump on archive."""
+    api_client.force_authenticate(user=admin_user)
+    created = api_client.post(_list_url(workspace), {}, format="json")
+    created_id = created.json()["id"]
+
+    # Edit to bump the version above v1 so an accidental increment on archive
+    # would show up as v3 rather than blending with the natural bump.
+    edited = api_client.patch(
+        _detail_url(workspace, created_id),
+        {"body": "custom {{ issue.title }}"},
+        format="json",
+    )
+    assert edited.status_code == 200
+    assert edited.json()["version"] == 2
+
+    archived = api_client.post(_archive_url(workspace, created_id))
+    assert archived.status_code == 200
+    assert archived.json()["version"] == 2, "archive must not bump version"
+    assert archived.json()["is_active"] is False
+
+
+@pytest.mark.contract
+def test_patch_unknown_workspace_returns_404(
+    seeded, api_client, workspace, admin_user
+):
+    api_client.force_authenticate(user=admin_user)
+    created = api_client.post(_list_url(workspace), {}, format="json")
+    template_id = created.json()["id"]
+
+    url = reverse(
+        "prompting:prompt-template-detail",
+        kwargs={"slug": "no-such-workspace", "template_id": template_id},
+    )
+    response = api_client.patch(url, {"body": "whatever"}, format="json")
+    assert response.status_code == 404
+
+
+@pytest.mark.contract
+def test_patch_body_size_limit(
+    seeded, api_client, workspace, admin_user
+):
+    api_client.force_authenticate(user=admin_user)
+    created = api_client.post(_list_url(workspace), {}, format="json")
+    template_id = created.json()["id"]
+
+    huge_body = "x" * 100_001
+    response = api_client.patch(
+        _detail_url(workspace, template_id),
+        {"body": huge_body},
+        format="json",
+    )
+    assert response.status_code == 400
+    assert "body" in response.json()
+
+
+@pytest.mark.contract
+def test_create_ignores_client_supplied_name(
+    seeded, api_client, workspace, admin_user
+):
+    """MVP locks the workspace slot to ``coding-task``. A client supplying a
+    different name must NOT create a second row the composer would never
+    read — we silently fall back to the default slot instead."""
+    api_client.force_authenticate(user=admin_user)
+    response = api_client.post(
+        _list_url(workspace),
+        {"name": "bug-triage", "body": "hi {{ issue.title }}"},
+        format="json",
+    )
+    assert response.status_code == 201, response.content
+    assert response.json()["name"] == PromptTemplate.DEFAULT_NAME

--- a/apps/api/pi_dash/tests/contract/prompting/test_preview.py
+++ b/apps/api/pi_dash/tests/contract/prompting/test_preview.py
@@ -112,3 +112,27 @@ def test_preview_missing_issue_returns_400(seeded, session_client, workspace):
     )
     response = session_client.post(url, {}, format="json")
     assert response.status_code == 400
+
+
+@pytest.mark.contract
+def test_preview_renders_draft_body_override(
+    seeded, session_client, workspace, issue
+):
+    """The editor previews unsaved drafts by passing ``body`` alongside
+    ``issue_id``; the server must render the draft, not the stored body."""
+    template = PromptTemplate.objects.filter(workspace__isnull=True).first()
+    url = reverse(
+        "prompting:prompt-template-preview",
+        kwargs={"slug": workspace.slug, "template_id": template.id},
+    )
+    draft = "DRAFT: {{ issue.title }}"
+    response = session_client.post(
+        url,
+        {"issue_id": str(issue.id), "body": draft},
+        format="json",
+    )
+    assert response.status_code == 200, response.content
+    rendered = response.json()["prompt"]
+    assert rendered == f"DRAFT: {issue.name}"
+    # The stored (global default) body is NOT returned.
+    assert "Session framing" not in rendered

--- a/apps/web/app/(all)/[workspaceSlug]/prompts/[promptId]/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/prompts/[promptId]/page.tsx
@@ -1,0 +1,211 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useEffect, useState } from "react";
+import { observer } from "mobx-react";
+import { Link, useParams } from "react-router";
+import useSWR from "swr";
+import { EUserPermissions, EUserPermissionsLevel } from "@pi-dash/constants";
+import { useTranslation } from "@pi-dash/i18n";
+import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
+import type { IPromptTemplate } from "@pi-dash/types";
+import { Badge, Button, Input } from "@pi-dash/ui";
+import { PageHead } from "@/components/core/page-title";
+import { usePromptTemplate } from "@/hooks/store/use-prompt-template";
+import { useUserPermissions } from "@/hooks/store/user";
+
+/**
+ * Prompt template detail + editor. Read-only for members / guests; admins
+ * get an editable textarea for workspace-scoped rows with a side-by-side
+ * preview pane that calls the server preview endpoint against an issue
+ * id they paste in.
+ *
+ * The global default is always read-only here — platform operators edit
+ * it out-of-band.
+ */
+const PromptDetailPage = observer(function PromptDetailPage() {
+  const { workspaceSlug, promptId } = useParams<{
+    workspaceSlug: string;
+    promptId: string;
+  }>();
+  const { allowPermissions } = useUserPermissions();
+  const { t } = useTranslation();
+  const promptStore = usePromptTemplate();
+
+  const slug = workspaceSlug ?? "";
+  const id = promptId ?? "";
+
+  const { data: templates } = useSWR<IPromptTemplate[]>(slug ? ["prompt-templates", slug] : null, () =>
+    promptStore.fetchTemplates(slug)
+  );
+
+  const record = promptStore.getTemplateById(id);
+
+  const canEdit =
+    allowPermissions([EUserPermissions.ADMIN], EUserPermissionsLevel.WORKSPACE, slug) &&
+    record !== null &&
+    !record.is_global_default;
+
+  const [draft, setDraft] = useState<string>("");
+  const [dirty, setDirty] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [issueId, setIssueId] = useState<string>("");
+  const [preview, setPreview] = useState<string>("");
+  const [previewing, setPreviewing] = useState(false);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+
+  // Seed the draft once the record has loaded, and re-seed when we switch
+  // to a different template id or the server's version counter advances.
+  // Depending on the full record would re-run on every observable mutation;
+  // keying on id+version keeps the draft stable while the user is typing.
+  const recordId = record?.id;
+  const recordVersion = record?.version;
+  const recordBody = record?.body;
+  useEffect(() => {
+    if (recordBody !== undefined) {
+      setDraft(recordBody);
+      setDirty(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [recordId, recordVersion]);
+
+  if (!record) {
+    return (
+      <div className="p-6 text-13 text-secondary">
+        {templates === undefined ? t("prompts.detail.loading") : t("prompts.detail.not_found")}
+      </div>
+    );
+  }
+
+  async function handleSave() {
+    if (!canEdit || !dirty || saving) return;
+    setSaving(true);
+    try {
+      await promptStore.updateTemplate(slug, id, { body: draft });
+      setDirty(false);
+      setToast({
+        type: TOAST_TYPE.SUCCESS,
+        title: t("prompts.toast.saved_title"),
+        message: t("prompts.toast.saved_message"),
+      });
+    } catch (e: unknown) {
+      const err = e as { error?: string; body?: string[] } | null;
+      const message = err?.body?.[0] ?? err?.error ?? t("prompts.toast.save_failed");
+      setToast({
+        type: TOAST_TYPE.ERROR,
+        title: t("prompts.toast.error_title"),
+        message,
+      });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handlePreview() {
+    if (previewing) return;
+    if (!issueId) {
+      setPreviewError(t("prompts.preview.missing_issue_id"));
+      return;
+    }
+    setPreviewing(true);
+    setPreviewError(null);
+    try {
+      const resp = await promptStore.previewTemplate(slug, id, issueId, canEdit ? draft : undefined);
+      setPreview(resp.prompt);
+    } catch (e: unknown) {
+      const err = e as { error?: string; detail?: string } | null;
+      setPreviewError(err?.detail ?? err?.error ?? t("prompts.preview.failed"));
+      setPreview("");
+    } finally {
+      setPreviewing(false);
+    }
+  }
+
+  const pageTitle = record.is_global_default ? t("prompts.detail.default_title") : t("prompts.detail.workspace_title");
+
+  return (
+    <div className="flex flex-col gap-4 p-6">
+      <PageHead title={pageTitle} />
+
+      <header className="flex items-start justify-between gap-4">
+        <div>
+          <div className="flex items-center gap-2">
+            <h1 className="text-16 font-semibold text-primary">{record.name}</h1>
+            <Badge variant={record.is_global_default ? "accent-neutral" : "accent-primary"} size="sm">
+              {record.is_global_default ? t("prompts.scope.default") : t("prompts.scope.workspace")}
+            </Badge>
+            <span className="text-13 text-secondary">v{record.version}</span>
+          </div>
+          <p className="mt-1 text-13 text-secondary">
+            {record.is_global_default
+              ? t("prompts.detail.default_description")
+              : t("prompts.detail.workspace_description")}
+          </p>
+        </div>
+        <Link to={`/${slug}/prompts`} className="text-13 text-secondary hover:text-primary">
+          {t("prompts.detail.back")}
+        </Link>
+      </header>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <section className="flex flex-col gap-2">
+          <div className="flex items-center justify-between">
+            <h2 className="text-13 font-medium text-primary">{t("prompts.detail.body")}</h2>
+            {canEdit && (
+              <div className="flex items-center gap-2">
+                {dirty && <span className="text-11 text-secondary">{t("prompts.detail.unsaved")}</span>}
+                <Button onClick={handleSave} loading={saving} disabled={!dirty || saving} size="sm">
+                  {t("prompts.detail.save")}
+                </Button>
+              </div>
+            )}
+          </div>
+          <textarea
+            value={draft}
+            onChange={(e) => {
+              setDraft(e.target.value);
+              setDirty(e.target.value !== record.body);
+            }}
+            readOnly={!canEdit}
+            spellCheck={false}
+            className="bg-layer-base font-mono focus:border-primary min-h-[60vh] w-full resize-y rounded-md border border-subtle p-3 text-11 leading-5 text-primary focus:outline-none"
+          />
+        </section>
+
+        <section className="flex flex-col gap-2">
+          <h2 className="text-13 font-medium text-primary">{t("prompts.preview.title")}</h2>
+          <div className="flex items-center gap-2">
+            <Input
+              value={issueId}
+              onChange={(e) => setIssueId(e.target.value)}
+              placeholder={t("prompts.preview.issue_id_placeholder")}
+              className="font-mono flex-1 text-11"
+            />
+            <Button
+              onClick={handlePreview}
+              loading={previewing}
+              disabled={previewing || !issueId}
+              size="sm"
+              variant="outline-primary"
+            >
+              {t("prompts.preview.run")}
+            </Button>
+          </div>
+          {previewError && (
+            <div className="border-destructive text-destructive rounded border bg-layer-1 p-2 text-11">
+              {previewError}
+            </div>
+          )}
+          <pre className="font-mono min-h-[60vh] w-full overflow-auto rounded-md border border-subtle bg-layer-1 p-3 text-11 leading-5 whitespace-pre-wrap text-primary">
+            {preview || t("prompts.preview.empty")}
+          </pre>
+        </section>
+      </div>
+    </div>
+  );
+});
+
+export default PromptDetailPage;

--- a/apps/web/app/(all)/[workspaceSlug]/prompts/[promptId]/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/prompts/[promptId]/page.tsx
@@ -175,34 +175,45 @@ const PromptDetailPage = observer(function PromptDetailPage() {
           />
         </section>
 
-        <section className="flex flex-col gap-2">
-          <h2 className="text-13 font-medium text-primary">{t("prompts.preview.title")}</h2>
-          <div className="flex items-center gap-2">
-            <Input
-              value={issueId}
-              onChange={(e) => setIssueId(e.target.value)}
-              placeholder={t("prompts.preview.issue_id_placeholder")}
-              className="font-mono flex-1 text-11"
-            />
-            <Button
-              onClick={handlePreview}
-              loading={previewing}
-              disabled={previewing || !issueId}
-              size="sm"
-              variant="outline-primary"
-            >
-              {t("prompts.preview.run")}
-            </Button>
-          </div>
-          {previewError && (
-            <div className="border-destructive text-destructive rounded border bg-layer-1 p-2 text-11">
-              {previewError}
+        {canEdit ? (
+          <section className="flex flex-col gap-2">
+            <h2 className="text-13 font-medium text-primary">{t("prompts.preview.title")}</h2>
+            <div className="flex items-center gap-2">
+              <Input
+                value={issueId}
+                onChange={(e) => setIssueId(e.target.value)}
+                placeholder={t("prompts.preview.issue_id_placeholder")}
+                className="font-mono flex-1 text-11"
+              />
+              <Button
+                onClick={handlePreview}
+                loading={previewing}
+                disabled={previewing || !issueId}
+                size="sm"
+                variant="outline-primary"
+              >
+                {t("prompts.preview.run")}
+              </Button>
             </div>
-          )}
-          <pre className="font-mono min-h-[60vh] w-full overflow-auto rounded-md border border-subtle bg-layer-1 p-3 text-11 leading-5 whitespace-pre-wrap text-primary">
-            {preview || t("prompts.preview.empty")}
-          </pre>
-        </section>
+            {previewError && (
+              <div className="border-destructive text-destructive rounded border bg-layer-1 p-2 text-11">
+                {previewError}
+              </div>
+            )}
+            <pre className="font-mono min-h-[60vh] w-full overflow-auto rounded-md border border-subtle bg-layer-1 p-3 text-11 leading-5 whitespace-pre-wrap text-primary">
+              {preview || t("prompts.preview.empty")}
+            </pre>
+          </section>
+        ) : (
+          // Preview is workspace-admin-only on the backend (403 otherwise), so
+          // members / guests see a read-only body pane without the preview
+          // controls. Keep the column reservation so the layout doesn't jump
+          // when role changes mid-session.
+          <section className="flex flex-col gap-2">
+            <h2 className="text-13 font-medium text-primary">{t("prompts.detail.body")}</h2>
+            <p className="text-13 text-secondary">{t("prompts.preview.admin_only")}</p>
+          </section>
+        )}
       </div>
     </div>
   );

--- a/apps/web/app/(all)/[workspaceSlug]/prompts/layout.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/prompts/layout.tsx
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { observer } from "mobx-react";
+import { Outlet } from "react-router";
+import { EUserPermissions, EUserPermissionsLevel } from "@pi-dash/constants";
+import { NotAuthorizedView } from "@/components/auth-screens/not-authorized-view";
+import { useUserPermissions } from "@/hooks/store/user";
+
+/**
+ * Wrapper for the ``/:workspaceSlug/prompts/*`` routes. Any active workspace
+ * member (Admin / Member / Guest) can *view* prompt templates; create and
+ * edit operations are gated per-action on the page, not here.
+ */
+const PromptsLayout = observer(function PromptsLayout() {
+  const { workspaceUserInfo, allowPermissions } = useUserPermissions();
+
+  const canView = allowPermissions(
+    [EUserPermissions.ADMIN, EUserPermissions.MEMBER, EUserPermissions.GUEST],
+    EUserPermissionsLevel.WORKSPACE
+  );
+
+  if (workspaceUserInfo && !canView) {
+    return <NotAuthorizedView section="general" className="h-auto" />;
+  }
+
+  return (
+    <div className="flex h-full w-full flex-col">
+      <div className="flex-1 overflow-auto">
+        <Outlet />
+      </div>
+    </div>
+  );
+});
+
+export default PromptsLayout;

--- a/apps/web/app/(all)/[workspaceSlug]/prompts/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/prompts/page.tsx
@@ -1,0 +1,218 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useState } from "react";
+import { observer } from "mobx-react";
+import { Link, useNavigate, useParams } from "react-router";
+import useSWR from "swr";
+import { EUserPermissions, EUserPermissionsLevel } from "@pi-dash/constants";
+import { useTranslation } from "@pi-dash/i18n";
+import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
+import type { IPromptTemplate } from "@pi-dash/types";
+import { AlertModalCore, Badge, Button } from "@pi-dash/ui";
+import { PageHead } from "@/components/core/page-title";
+import { usePromptTemplate } from "@/hooks/store/use-prompt-template";
+import { useUserPermissions } from "@/hooks/store/user";
+import { useWorkspace } from "@/hooks/store/use-workspace";
+
+/**
+ * Prompt templates list. Shows:
+ *   - The effective "Pi Dash default" (workspace=null) template.
+ *   - The workspace-scoped override, if one is active.
+ *
+ * Admins see a "Customize" button when no override exists, and
+ * "Edit" / "Revert to default" actions on any existing override. Members and
+ * guests see the rows as read-only.
+ */
+const PromptsListPage = observer(function PromptsListPage() {
+  const { workspaceSlug } = useParams<{ workspaceSlug: string }>();
+  const { currentWorkspace } = useWorkspace();
+  const { allowPermissions } = useUserPermissions();
+  const navigate = useNavigate();
+  const { t } = useTranslation();
+
+  const promptStore = usePromptTemplate();
+
+  const slug = workspaceSlug ?? "";
+  const { data: templates, mutate } = useSWR<IPromptTemplate[]>(slug ? ["prompt-templates", slug] : null, () =>
+    promptStore.fetchTemplates(slug)
+  );
+
+  const canEdit = allowPermissions([EUserPermissions.ADMIN], EUserPermissionsLevel.WORKSPACE, slug);
+
+  const [customizing, setCustomizing] = useState(false);
+  const [archiveTarget, setArchiveTarget] = useState<IPromptTemplate | null>(null);
+  const [archiving, setArchiving] = useState(false);
+
+  const rows = templates ?? [];
+  const workspaceOverride = rows.find((r) => !r.is_global_default);
+  const globalDefault = rows.find((r) => r.is_global_default);
+
+  async function handleCustomize() {
+    if (!canEdit || customizing) return;
+    setCustomizing(true);
+    try {
+      const created = await promptStore.createOverride(slug);
+      mutate();
+      setToast({
+        type: TOAST_TYPE.SUCCESS,
+        title: t("prompts.toast.created_title"),
+        message: t("prompts.toast.created_message"),
+      });
+      navigate(`/${slug}/prompts/${created.id}`);
+    } catch (e: unknown) {
+      const err = e as { error?: string } | null;
+      setToast({
+        type: TOAST_TYPE.ERROR,
+        title: t("prompts.toast.error_title"),
+        message: err?.error ?? t("prompts.toast.customize_failed"),
+      });
+    } finally {
+      setCustomizing(false);
+    }
+  }
+
+  async function confirmArchive() {
+    if (!archiveTarget) return;
+    setArchiving(true);
+    try {
+      await promptStore.archiveTemplate(slug, archiveTarget.id);
+      setArchiveTarget(null);
+      mutate();
+      setToast({
+        type: TOAST_TYPE.SUCCESS,
+        title: t("prompts.toast.reverted_title"),
+        message: t("prompts.toast.reverted_message"),
+      });
+    } catch (e: unknown) {
+      const err = e as { error?: string } | null;
+      setToast({
+        type: TOAST_TYPE.ERROR,
+        title: t("prompts.toast.error_title"),
+        message: err?.error ?? t("prompts.toast.revert_failed"),
+      });
+    } finally {
+      setArchiving(false);
+    }
+  }
+
+  const pageTitle = currentWorkspace?.name ? `${currentWorkspace.name} · ${t("prompts.title")}` : t("prompts.title");
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <PageHead title={pageTitle} />
+
+      <header className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-16 font-semibold text-primary">{t("prompts.title")}</h1>
+          <p className="mt-1 text-13 text-secondary">{t("prompts.subtitle")}</p>
+        </div>
+        {canEdit && !workspaceOverride && (
+          <Button onClick={handleCustomize} loading={customizing} disabled={customizing}>
+            {t("prompts.customize")}
+          </Button>
+        )}
+      </header>
+
+      <section className="rounded-md border border-subtle">
+        <table className="w-full text-13">
+          <thead className="bg-layer-1 text-left text-secondary">
+            <tr>
+              <th className="px-3 py-2">{t("prompts.columns.name")}</th>
+              <th className="px-3 py-2">{t("prompts.columns.scope")}</th>
+              <th className="px-3 py-2">{t("prompts.columns.version")}</th>
+              <th className="px-3 py-2">{t("prompts.columns.updated")}</th>
+              <th className="px-3 py-2"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {workspaceOverride && (
+              <TemplateRow
+                key={workspaceOverride.id}
+                template={workspaceOverride}
+                slug={slug}
+                canEdit={canEdit}
+                onArchive={() => setArchiveTarget(workspaceOverride)}
+              />
+            )}
+            {globalDefault && (
+              <TemplateRow
+                key={globalDefault.id}
+                template={globalDefault}
+                slug={slug}
+                canEdit={canEdit}
+                onArchive={null}
+              />
+            )}
+            {rows.length === 0 && (
+              <tr>
+                <td colSpan={5} className="px-3 py-8 text-center text-secondary">
+                  {t("prompts.list.empty")}
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </section>
+
+      <AlertModalCore
+        isOpen={!!archiveTarget}
+        handleClose={() => (archiving ? null : setArchiveTarget(null))}
+        handleSubmit={confirmArchive}
+        isSubmitting={archiving}
+        title={t("prompts.revert.confirm_title")}
+        content={t("prompts.revert.confirm_body")}
+        primaryButtonText={{
+          default: t("prompts.revert.confirm"),
+          loading: t("prompts.revert.confirm"),
+        }}
+      />
+    </div>
+  );
+});
+
+type RowProps = {
+  template: IPromptTemplate;
+  slug: string;
+  canEdit: boolean;
+  onArchive: (() => void) | null;
+};
+
+function TemplateRow({ template, slug, canEdit, onArchive }: RowProps) {
+  const { t } = useTranslation();
+  return (
+    <tr className="border-t border-subtle">
+      <td className="px-3 py-2 font-medium text-primary">{template.name}</td>
+      <td className="px-3 py-2">
+        {template.is_global_default ? (
+          <Badge variant="accent-neutral" size="sm">
+            {t("prompts.scope.default")}
+          </Badge>
+        ) : (
+          <Badge variant="accent-primary" size="sm">
+            {t("prompts.scope.workspace")}
+          </Badge>
+        )}
+      </td>
+      <td className="px-3 py-2 text-secondary">v{template.version}</td>
+      <td className="px-3 py-2 text-secondary">{new Date(template.updated_at).toLocaleString()}</td>
+      <td className="px-3 py-2 text-right">
+        <div className="flex items-center justify-end gap-2">
+          <Link to={`/${slug}/prompts/${template.id}`} className="text-13 text-secondary hover:text-primary">
+            {canEdit && !template.is_global_default ? t("prompts.actions.edit") : t("prompts.actions.view")}
+          </Link>
+          {canEdit && onArchive && (
+            <Button variant="tertiary-danger" size="sm" onClick={onArchive}>
+              {t("prompts.actions.revert")}
+            </Button>
+          )}
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+export default PromptsListPage;

--- a/apps/web/app/routes/core.ts
+++ b/apps/web/app/routes/core.ts
@@ -112,6 +112,12 @@ export const coreRoutes: RouteConfigEntry[] = [
           route(":workspaceSlug/runners/approvals", "./(all)/[workspaceSlug]/runners/approvals/page.tsx"),
         ]),
 
+        // Prompts (prompt templates: view for members, create/edit for workspace admins)
+        layout("./(all)/[workspaceSlug]/prompts/layout.tsx", [
+          route(":workspaceSlug/prompts", "./(all)/[workspaceSlug]/prompts/page.tsx"),
+          route(":workspaceSlug/prompts/:promptId", "./(all)/[workspaceSlug]/prompts/[promptId]/page.tsx"),
+        ]),
+
         // Workspace Views
         layout("./(all)/[workspaceSlug]/(projects)/workspace-views/layout.tsx", [
           route(":workspaceSlug/workspace-views", "./(all)/[workspaceSlug]/(projects)/workspace-views/page.tsx"),

--- a/apps/web/ce/components/workspace/sidebar/helper.tsx
+++ b/apps/web/ce/components/workspace/sidebar/helper.tsx
@@ -4,6 +4,7 @@
  * See the LICENSE file for details.
  */
 
+import { FileText } from "lucide-react";
 import {
   AnalyticsIcon,
   ArchiveIcon,
@@ -40,5 +41,7 @@ export const getSidebarNavigationItemIcon = (key: string, className: string = ""
       return <ArchiveIcon className={cn("size-4 flex-shrink-0", className)} />;
     case "stickies":
       return <MultipleStickyIcon className={cn("size-4 flex-shrink-0", className)} />;
+    case "prompts":
+      return <FileText className={cn("size-4 flex-shrink-0", className)} />;
   }
 };

--- a/apps/web/core/components/workspace/sidebar/sidebar-item.tsx
+++ b/apps/web/core/components/workspace/sidebar/sidebar-item.tsx
@@ -51,6 +51,7 @@ export const SidebarItemBase = observer(function SidebarItemBase({
     "home",
     "pi_chat",
     "projects",
+    "prompts",
     "your_work",
     "stickies",
     "drafts",

--- a/apps/web/core/hooks/store/use-prompt-template.ts
+++ b/apps/web/core/hooks/store/use-prompt-template.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useContext } from "react";
+// mobx store
+import { StoreContext } from "@/lib/store-context";
+// types
+import type { IPromptTemplateStore } from "@/store/prompt-template.store";
+
+export const usePromptTemplate = (): IPromptTemplateStore => {
+  const context = useContext(StoreContext);
+  if (context === undefined) throw new Error("usePromptTemplate must be used within StoreProvider");
+  return context.promptTemplate;
+};

--- a/apps/web/core/store/prompt-template.store.ts
+++ b/apps/web/core/store/prompt-template.store.ts
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { set, unset } from "lodash-es";
+import { action, computed, makeObservable, observable, runInAction } from "mobx";
+import { computedFn } from "mobx-utils";
+// pi dash imports
+import type {
+  IPromptTemplate,
+  IPromptTemplateCreatePayload,
+  IPromptTemplatePreviewResponse,
+  IPromptTemplateUpdatePayload,
+} from "@pi-dash/types";
+import { PromptTemplateService } from "@pi-dash/services";
+// store
+import type { CoreRootStore } from "./root.store";
+
+export interface IPromptTemplateStore {
+  // observable
+  templateMap: Record<string, IPromptTemplate>;
+  fetchedMap: Record<string, boolean>;
+  loader: boolean;
+  // computed
+  workspaceTemplates: IPromptTemplate[];
+  // actions
+  getTemplatesForWorkspace: (workspaceSlug: string) => IPromptTemplate[];
+  getTemplateById: (templateId: string) => IPromptTemplate | null;
+  getEffectiveTemplate: (workspaceSlug: string) => IPromptTemplate | null;
+  fetchTemplates: (workspaceSlug: string) => Promise<IPromptTemplate[]>;
+  createOverride: (workspaceSlug: string, payload?: IPromptTemplateCreatePayload) => Promise<IPromptTemplate>;
+  updateTemplate: (
+    workspaceSlug: string,
+    templateId: string,
+    payload: IPromptTemplateUpdatePayload
+  ) => Promise<IPromptTemplate>;
+  archiveTemplate: (workspaceSlug: string, templateId: string) => Promise<IPromptTemplate>;
+  previewTemplate: (
+    workspaceSlug: string,
+    templateId: string,
+    issueId: string,
+    draftBody?: string
+  ) => Promise<IPromptTemplatePreviewResponse>;
+}
+
+/**
+ * Holds the prompt templates visible to the *currently routed* workspace (the
+ * global default plus any workspace-scoped override). Mutating actions return
+ * the updated row so callers can thread it through SWR / toasts without
+ * refetching the list.
+ */
+export class PromptTemplateStore implements IPromptTemplateStore {
+  // observable
+  templateMap: Record<string, IPromptTemplate> = {};
+  fetchedMap: Record<string, boolean> = {};
+  loader = false;
+  // root
+  rootStore: CoreRootStore;
+  // service
+  promptTemplateService: PromptTemplateService;
+
+  constructor(_rootStore: CoreRootStore) {
+    makeObservable(this, {
+      templateMap: observable,
+      fetchedMap: observable,
+      loader: observable,
+      workspaceTemplates: computed,
+      fetchTemplates: action,
+      createOverride: action,
+      updateTemplate: action,
+      archiveTemplate: action,
+    });
+    this.rootStore = _rootStore;
+    this.promptTemplateService = new PromptTemplateService();
+  }
+
+  get workspaceTemplates(): IPromptTemplate[] {
+    const slug = this.rootStore.router.workspaceSlug;
+    if (!slug) return [];
+    return this.getTemplatesForWorkspace(slug);
+  }
+
+  getTemplatesForWorkspace = computedFn((workspaceSlug: string): IPromptTemplate[] => {
+    const workspace = this.rootStore.workspaceRoot.getWorkspaceBySlug(workspaceSlug);
+    if (!workspace) return [];
+    const filtered = Object.values(this.templateMap).filter(
+      (t) => t.is_active && (t.workspace === workspace.id || t.workspace === null)
+    );
+    // Copy first, then sort — the filter output is a fresh array but
+    // keeping the spread explicit makes this obvious to readers, and
+    // oxlint's `no-array-sort` rule no longer flags a mutating sort on a
+    // not-obviously-owned value.
+    return [...filtered].sort((a, b) => {
+      // Workspace-scoped override first, then the global default, so the UI
+      // displays "your customization" ahead of the fallback.
+      if (a.workspace && !b.workspace) return -1;
+      if (!a.workspace && b.workspace) return 1;
+      return a.name.localeCompare(b.name);
+    });
+  });
+
+  getTemplateById = computedFn((templateId: string): IPromptTemplate | null => this.templateMap[templateId] ?? null);
+
+  getEffectiveTemplate = computedFn((workspaceSlug: string): IPromptTemplate | null => {
+    const templates = this.getTemplatesForWorkspace(workspaceSlug);
+    if (templates.length === 0) return null;
+    // First entry is the workspace override if present, else the global default.
+    return templates[0] ?? null;
+  });
+
+  fetchTemplates = async (workspaceSlug: string): Promise<IPromptTemplate[]> => {
+    this.loader = true;
+    try {
+      const response = await this.promptTemplateService.list(workspaceSlug);
+      runInAction(() => {
+        response.forEach((t) => set(this.templateMap, [t.id], t));
+        set(this.fetchedMap, workspaceSlug, true);
+      });
+      return response;
+    } finally {
+      runInAction(() => {
+        this.loader = false;
+      });
+    }
+  };
+
+  createOverride = async (
+    workspaceSlug: string,
+    payload: IPromptTemplateCreatePayload = {}
+  ): Promise<IPromptTemplate> => {
+    const response = await this.promptTemplateService.create(workspaceSlug, payload);
+    runInAction(() => {
+      set(this.templateMap, [response.id], response);
+    });
+    return response;
+  };
+
+  updateTemplate = async (
+    workspaceSlug: string,
+    templateId: string,
+    payload: IPromptTemplateUpdatePayload
+  ): Promise<IPromptTemplate> => {
+    const response = await this.promptTemplateService.update(workspaceSlug, templateId, payload);
+    runInAction(() => {
+      set(this.templateMap, [response.id], response);
+    });
+    return response;
+  };
+
+  archiveTemplate = async (workspaceSlug: string, templateId: string): Promise<IPromptTemplate> => {
+    const response = await this.promptTemplateService.archive(workspaceSlug, templateId);
+    // Archived rows must drop out of the active list so the UI falls back to
+    // the global default.
+    runInAction(() => {
+      unset(this.templateMap, templateId);
+    });
+    return response;
+  };
+
+  previewTemplate = async (
+    workspaceSlug: string,
+    templateId: string,
+    issueId: string,
+    draftBody?: string
+  ): Promise<IPromptTemplatePreviewResponse> =>
+    this.promptTemplateService.preview(workspaceSlug, templateId, {
+      issue_id: issueId,
+      ...(draftBody ? { body: draftBody } : {}),
+    });
+}

--- a/apps/web/core/store/root.store.ts
+++ b/apps/web/core/store/root.store.ts
@@ -59,6 +59,8 @@ import type { IProjectRootStore } from "./project";
 import { ProjectRootStore } from "./project";
 import type { IProjectViewStore } from "./project-view.store";
 import { ProjectViewStore } from "./project-view.store";
+import type { IPromptTemplateStore } from "./prompt-template.store";
+import { PromptTemplateStore } from "./prompt-template.store";
 import type { IRouterStore } from "./router.store";
 import { RouterStore } from "./router.store";
 import type { IStickyStore } from "./sticky/sticky.store";
@@ -101,6 +103,7 @@ export class CoreRootStore {
   editorAssetStore: IEditorAssetStore;
   workItemFilters: IWorkItemFilterStore;
   powerK: IPowerKStore;
+  promptTemplate: IPromptTemplateStore;
 
   constructor() {
     this.router = new RouterStore();
@@ -132,6 +135,7 @@ export class CoreRootStore {
     this.analytics = new AnalyticsStore();
     this.workItemFilters = new WorkItemFilterStore();
     this.powerK = new PowerKStore();
+    this.promptTemplate = new PromptTemplateStore(this);
   }
 
   resetOnSignOut() {
@@ -165,5 +169,6 @@ export class CoreRootStore {
     this.editorAssetStore = new EditorAssetStore();
     this.workItemFilters = new WorkItemFilterStore();
     this.powerK = new PowerKStore();
+    this.promptTemplate = new PromptTemplateStore(this);
   }
 }

--- a/packages/constants/src/workspace.ts
+++ b/packages/constants/src/workspace.ts
@@ -271,6 +271,13 @@ export const WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS: Record<string, IWorkspac
     access: [EUserWorkspaceRoles.ADMIN, EUserWorkspaceRoles.MEMBER, EUserWorkspaceRoles.GUEST],
     highlight: (pathname: string, url: string) => pathname === url,
   },
+  prompts: {
+    key: "prompts",
+    labelTranslationKey: "sidebar.prompts",
+    href: `/prompts/`,
+    access: [EUserWorkspaceRoles.ADMIN, EUserWorkspaceRoles.MEMBER, EUserWorkspaceRoles.GUEST],
+    highlight: (pathname: string, url: string) => pathname.includes(url),
+  },
 };
 
 export const WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS_LINKS: IWorkspaceSidebarNavigationItem[] = [
@@ -279,6 +286,7 @@ export const WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS_LINKS: IWorkspaceSidebarN
 
 export const WORKSPACE_SIDEBAR_STATIC_PINNED_NAVIGATION_ITEMS_LINKS: IWorkspaceSidebarNavigationItem[] = [
   WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS["projects"],
+  WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS["prompts"],
 ];
 
 export const IS_FAVORITE_MENU_OPEN = "is_favorite_menu_open";

--- a/packages/i18n/src/locales/cs/translations.ts
+++ b/packages/i18n/src/locales/cs/translations.ts
@@ -24,6 +24,7 @@ export default {
     pro: "Pro",
     upgrade: "Upgrade",
     stickies: "Poznámky",
+    prompts: "Prompts",
   },
   auth: {
     common: {

--- a/packages/i18n/src/locales/de/translations.ts
+++ b/packages/i18n/src/locales/de/translations.ts
@@ -24,6 +24,7 @@ export default {
     pro: "Pro",
     upgrade: "Upgrade",
     stickies: "Notizen",
+    prompts: "Prompts",
   },
   auth: {
     common: {

--- a/packages/i18n/src/locales/en/core.ts
+++ b/packages/i18n/src/locales/en/core.ts
@@ -71,6 +71,8 @@ export default {
       empty: "Paste an issue id and click Preview to render the template against a real issue.",
       failed: "Render failed.",
       missing_issue_id: "Enter an issue id first.",
+      admin_only:
+        "Previewing the rendered prompt is a workspace-admin action. Ask your workspace admin if you need to see it rendered against a specific issue.",
     },
     revert: {
       confirm_title: "Revert to the Pi Dash default?",

--- a/packages/i18n/src/locales/en/core.ts
+++ b/packages/i18n/src/locales/en/core.ts
@@ -24,6 +24,72 @@ export default {
     pro: "Pro",
     upgrade: "Upgrade",
     stickies: "Stickies",
+    prompts: "Prompts",
+  },
+
+  prompts: {
+    title: "Prompts",
+    subtitle:
+      "System prompt templates that get rendered against each issue before an agent run. Workspace admins can customize the default for this workspace.",
+    customize: "Customize for this workspace",
+    columns: {
+      name: "Name",
+      scope: "Scope",
+      version: "Version",
+      updated: "Updated",
+    },
+    scope: {
+      default: "Pi Dash default",
+      workspace: "Workspace override",
+    },
+    actions: {
+      view: "View",
+      edit: "Edit",
+      revert: "Revert to default",
+    },
+    list: {
+      empty: "No prompt templates available. The Pi Dash default will be seeded on the next migrate.",
+    },
+    detail: {
+      default_title: "Prompt template (Pi Dash default)",
+      workspace_title: "Prompt template (workspace override)",
+      default_description:
+        "This is the built-in Pi Dash default. Workspace admins cannot edit it here — customize for your workspace to override.",
+      workspace_description:
+        "Your workspace's override of the Pi Dash default. Edits bump the version and apply to the next agent run for this workspace.",
+      body: "Template body (Jinja + Markdown)",
+      save: "Save",
+      unsaved: "Unsaved changes",
+      back: "Back to list",
+      loading: "Loading…",
+      not_found: "Template not found.",
+    },
+    preview: {
+      title: "Preview",
+      issue_id_placeholder: "Issue id (UUID)",
+      run: "Preview",
+      empty: "Paste an issue id and click Preview to render the template against a real issue.",
+      failed: "Render failed.",
+      missing_issue_id: "Enter an issue id first.",
+    },
+    revert: {
+      confirm_title: "Revert to the Pi Dash default?",
+      confirm_body:
+        "This archives your workspace-scoped template. New agent runs in this workspace will use the Pi Dash default until you create another override.",
+      confirm: "Revert",
+    },
+    toast: {
+      created_title: "Workspace override created",
+      created_message: "We copied the current Pi Dash default. Edit and save to customize it.",
+      saved_title: "Prompt saved",
+      saved_message: "Subsequent agent runs will use the updated prompt.",
+      reverted_title: "Reverted to Pi Dash default",
+      reverted_message: "This workspace is back on the shared default template.",
+      error_title: "Something went wrong",
+      customize_failed: "Could not create the workspace override.",
+      save_failed: "Could not save the prompt.",
+      revert_failed: "Could not revert the prompt.",
+    },
   },
 
   auth: {

--- a/packages/i18n/src/locales/es/translations.ts
+++ b/packages/i18n/src/locales/es/translations.ts
@@ -24,6 +24,7 @@ export default {
     pro: "Pro",
     upgrade: "Mejorar",
     stickies: "Notas adhesivas",
+    prompts: "Prompts",
   },
   auth: {
     common: {

--- a/packages/i18n/src/locales/fr/translations.ts
+++ b/packages/i18n/src/locales/fr/translations.ts
@@ -24,6 +24,7 @@ export default {
     pro: "Pro",
     upgrade: "Mettre à niveau",
     stickies: "Post-it",
+    prompts: "Prompts",
   },
   auth: {
     common: {

--- a/packages/i18n/src/locales/id/translations.ts
+++ b/packages/i18n/src/locales/id/translations.ts
@@ -24,6 +24,7 @@ export default {
     pro: "Pro",
     upgrade: "Upgrade",
     stickies: "Catatan tempel",
+    prompts: "Prompts",
   },
   auth: {
     common: {

--- a/packages/i18n/src/locales/it/translations.ts
+++ b/packages/i18n/src/locales/it/translations.ts
@@ -24,6 +24,7 @@ export default {
     pro: "Pro",
     upgrade: "Aggiorna",
     stickies: "Stickies",
+    prompts: "Prompts",
   },
   auth: {
     common: {

--- a/packages/i18n/src/locales/ja/translations.ts
+++ b/packages/i18n/src/locales/ja/translations.ts
@@ -24,6 +24,7 @@ export default {
     pro: "プロ",
     upgrade: "アップグレード",
     stickies: "付箋",
+    prompts: "Prompts",
   },
   auth: {
     common: {

--- a/packages/i18n/src/locales/ko/translations.ts
+++ b/packages/i18n/src/locales/ko/translations.ts
@@ -24,6 +24,7 @@ export default {
     pro: "프로",
     upgrade: "업그레이드",
     stickies: "스티키",
+    prompts: "Prompts",
   },
   auth: {
     common: {

--- a/packages/i18n/src/locales/pl/translations.ts
+++ b/packages/i18n/src/locales/pl/translations.ts
@@ -24,6 +24,7 @@ export default {
     pro: "Pro",
     upgrade: "Uaktualnij",
     stickies: "Notatki",
+    prompts: "Prompts",
   },
   auth: {
     common: {

--- a/packages/i18n/src/locales/pt-BR/translations.ts
+++ b/packages/i18n/src/locales/pt-BR/translations.ts
@@ -24,6 +24,7 @@ export default {
     pro: "Pro",
     upgrade: "Upgrade",
     stickies: "Anotações",
+    prompts: "Prompts",
   },
   auth: {
     common: {

--- a/packages/i18n/src/locales/ro/translations.ts
+++ b/packages/i18n/src/locales/ro/translations.ts
@@ -24,6 +24,7 @@ export default {
     pro: "Pro",
     upgrade: "Treci la versiunea superioară",
     stickies: "Notițe",
+    prompts: "Prompts",
   },
   auth: {
     common: {

--- a/packages/i18n/src/locales/ru/translations.ts
+++ b/packages/i18n/src/locales/ru/translations.ts
@@ -24,6 +24,7 @@ export default {
     pro: "Pro",
     upgrade: "Обновить",
     stickies: "Стикеры",
+    prompts: "Prompts",
   },
   auth: {
     common: {

--- a/packages/i18n/src/locales/sk/translations.ts
+++ b/packages/i18n/src/locales/sk/translations.ts
@@ -24,6 +24,7 @@ export default {
     pro: "Pro",
     upgrade: "Upgrade",
     stickies: "Poznámky",
+    prompts: "Prompts",
   },
   auth: {
     common: {

--- a/packages/i18n/src/locales/tr-TR/translations.ts
+++ b/packages/i18n/src/locales/tr-TR/translations.ts
@@ -24,6 +24,7 @@ export default {
     pro: "Pro",
     upgrade: "Yükselt",
     stickies: "Yapışkan notlar",
+    prompts: "Prompts",
   },
   auth: {
     common: {

--- a/packages/i18n/src/locales/ua/translations.ts
+++ b/packages/i18n/src/locales/ua/translations.ts
@@ -12,6 +12,7 @@ export default {
     home: "Головна",
     your_work: "Ваша робота",
     stickies: "Нотатки",
+    prompts: "Prompts",
     inbox: "Вхідні",
     workspace: "Робочий простір",
     views: "Подання",

--- a/packages/i18n/src/locales/vi-VN/translations.ts
+++ b/packages/i18n/src/locales/vi-VN/translations.ts
@@ -24,6 +24,7 @@ export default {
     pro: "Phiên bản Pro",
     upgrade: "Nâng cấp",
     stickies: "Ghi chú",
+    prompts: "Prompts",
   },
   auth: {
     common: {

--- a/packages/i18n/src/locales/zh-CN/translations.ts
+++ b/packages/i18n/src/locales/zh-CN/translations.ts
@@ -24,6 +24,7 @@ export default {
     pro: "专业版",
     upgrade: "升级",
     stickies: "便签",
+    prompts: "Prompts",
   },
   auth: {
     common: {

--- a/packages/i18n/src/locales/zh-TW/translations.ts
+++ b/packages/i18n/src/locales/zh-TW/translations.ts
@@ -24,6 +24,7 @@ export default {
     pro: "專業版",
     upgrade: "升級",
     stickies: "便利貼",
+    prompts: "Prompts",
   },
   auth: {
     common: {

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -14,6 +14,7 @@ export * from "./intake";
 export * from "./module";
 export * from "./user";
 export * from "./project";
+export * from "./prompt-template";
 export * from "./workspace";
 export * from "./file";
 export * from "./label";

--- a/packages/services/src/prompt-template/index.ts
+++ b/packages/services/src/prompt-template/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+export * from "./prompt-template.service";

--- a/packages/services/src/prompt-template/prompt-template.service.ts
+++ b/packages/services/src/prompt-template/prompt-template.service.ts
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { API_BASE_URL } from "@pi-dash/constants";
+import type {
+  IPromptTemplate,
+  IPromptTemplateCreatePayload,
+  IPromptTemplatePreviewPayload,
+  IPromptTemplatePreviewResponse,
+  IPromptTemplateUpdatePayload,
+} from "@pi-dash/types";
+import { APIService } from "../api.service";
+
+/**
+ * Workspace-scoped prompt template CRUD + preview.
+ *
+ * Backed by the Django REST endpoints under
+ * ``/api/workspaces/<slug>/prompt-templates``. Read access (``list``,
+ * ``retrieve``) is any active workspace member; ``create``, ``update``,
+ * ``archive``, and ``preview`` are workspace-admin-gated on the server.
+ */
+export class PromptTemplateService extends APIService {
+  constructor(BASE_URL?: string) {
+    super(BASE_URL || API_BASE_URL);
+  }
+
+  async list(workspaceSlug: string): Promise<IPromptTemplate[]> {
+    return this.get(`/api/workspaces/${workspaceSlug}/prompt-templates`)
+      .then((res) => res?.data)
+      .catch((err) => {
+        throw err?.response?.data;
+      });
+  }
+
+  async retrieve(workspaceSlug: string, templateId: string): Promise<IPromptTemplate> {
+    return this.get(`/api/workspaces/${workspaceSlug}/prompt-templates/${templateId}`)
+      .then((res) => res?.data)
+      .catch((err) => {
+        throw err?.response?.data;
+      });
+  }
+
+  async create(workspaceSlug: string, payload: IPromptTemplateCreatePayload = {}): Promise<IPromptTemplate> {
+    return this.post(`/api/workspaces/${workspaceSlug}/prompt-templates`, payload)
+      .then((res) => res?.data)
+      .catch((err) => {
+        throw err?.response?.data;
+      });
+  }
+
+  async update(
+    workspaceSlug: string,
+    templateId: string,
+    payload: IPromptTemplateUpdatePayload
+  ): Promise<IPromptTemplate> {
+    return this.patch(`/api/workspaces/${workspaceSlug}/prompt-templates/${templateId}`, payload)
+      .then((res) => res?.data)
+      .catch((err) => {
+        throw err?.response?.data;
+      });
+  }
+
+  async archive(workspaceSlug: string, templateId: string): Promise<IPromptTemplate> {
+    return this.post(`/api/workspaces/${workspaceSlug}/prompt-templates/${templateId}/archive`, {})
+      .then((res) => res?.data)
+      .catch((err) => {
+        throw err?.response?.data;
+      });
+  }
+
+  async preview(
+    workspaceSlug: string,
+    templateId: string,
+    payload: IPromptTemplatePreviewPayload
+  ): Promise<IPromptTemplatePreviewResponse> {
+    return this.post(`/api/workspaces/${workspaceSlug}/prompt-templates/${templateId}/preview`, payload)
+      .then((res) => res?.data)
+      .catch((err) => {
+        throw err?.response?.data;
+      });
+  }
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -37,6 +37,7 @@ export * from "./page";
 export * from "./payment";
 export * from "./pragmatic";
 export * from "./project";
+export * from "./prompt-template";
 export * from "./publish";
 export * from "./reaction";
 export * from "./runner";

--- a/packages/types/src/prompt-template.ts
+++ b/packages/types/src/prompt-template.ts
@@ -12,7 +12,6 @@ export interface IPromptTemplate {
   is_active: boolean;
   version: number;
   is_global_default: boolean;
-  can_edit: boolean;
   updated_by: string | null;
   created_at: string;
   updated_at: string;

--- a/packages/types/src/prompt-template.ts
+++ b/packages/types/src/prompt-template.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+export interface IPromptTemplate {
+  id: string;
+  workspace: string | null;
+  name: string;
+  body: string;
+  is_active: boolean;
+  version: number;
+  is_global_default: boolean;
+  can_edit: boolean;
+  updated_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface IPromptTemplateCreatePayload {
+  name?: string;
+  body?: string;
+}
+
+export interface IPromptTemplateUpdatePayload {
+  body: string;
+}
+
+export interface IPromptTemplatePreviewPayload {
+  issue_id: string;
+  body?: string;
+}
+
+export interface IPromptTemplatePreviewResponse {
+  prompt: string;
+}


### PR DESCRIPTION
## Summary

Adds the web surface the prior PR (#6) explicitly deferred: a new "Prompts" entry in the left sidebar, a list page, and a detail/editor page with side-by-side live preview. Workspace admins can now customize, edit, and revert their workspace's prompt template without touching the DB directly; members and guests get a read-only view.

Scope discussion: went with **Option 1** from the design thread — one template kind per workspace (the existing `coding-task`), edit-in-place, "revert to default" = archive. Option 2 (multiple named templates + a per-project picker) is an explicit follow-up.

## What's in the PR

### Backend (`apps/api/pi_dash/prompting/`)
- `PromptTemplateSerializer` with computed `is_global_default` / `can_edit` fields, plus a Jinja-syntax validator that rejects broken templates at save time (HTTP 400) rather than at run-render time.
- Four DRF endpoints under `/api/workspaces/<slug>/prompt-templates`:
  - `GET` + `POST` (list / create) — read by any member, create admin-only.
  - `GET` + `PATCH` (detail / update) — read by any member, update admin-only; PATCH bumps `version`.
  - `POST /archive` — flips `is_active=False` so lookup falls back to global default.
  - `POST /preview` — existing endpoint now also accepts an optional `body` override for previewing drafts.
- `POST /prompt-templates` without a `body` auto-copies the current global default, so "Customize" is a single click from the UI.
- 11 new contract tests: role gating, body auto-copy, 409 on duplicate override, version bump + `updated_by`, 400 on Jinja syntax errors, global-default read-only, archive-then-recreate round-trip.

### Frontend
- **`@pi-dash/types`**: `IPromptTemplate` + create/update/preview payload interfaces.
- **`@pi-dash/services`**: `PromptTemplateService` with `list`/`retrieve`/`create`/`update`/`archive`/`preview`.
- **MobX store** (`apps/web/core/store/prompt-template.store.ts`) wired into `CoreRootStore` for both initial construction and `resetOnSignOut`, plus a `use-prompt-template` hook.
- **Sidebar**: "Prompts" pinned alongside Projects (`WORKSPACE_SIDEBAR_STATIC_PINNED_NAVIGATION_ITEMS_LINKS`), icon (`lucide FileText`) registered in `apps/web/ce/components/workspace/sidebar/helper.tsx`, label seeded in all 20 locales (English placeholder where not translated).
- **Routes** (`apps/web/app/routes/core.ts`): `/<workspaceSlug>/prompts` and `/<workspaceSlug>/prompts/:promptId`.
- **Pages**:
  - `prompts/layout.tsx` — workspace-member gate.
  - `prompts/page.tsx` — list showing the Pi Dash default + any active workspace override. Admins see Customize / Edit / Revert; non-admins see read-only rows.
  - `prompts/[promptId]/page.tsx` — side-by-side monospaced editor + preview. Admins get an editable body for the workspace row (global default stays read-only even for them); paste an issue UUID to preview the rendered template against a real issue via the server preview endpoint. Admins preview their draft body; members preview the stored body.
- All error paths surface via `@pi-dash/propel/toast`.

## Requirements check

| Requirement | Status | Where |
|---|---|---|
| 1. New "Prompts" entry in left panel, same level as Projects | ✅ | `packages/constants/src/workspace.ts` adds `prompts` to `WORKSPACE_SIDEBAR_STATIC_PINNED_NAVIGATION_ITEMS_LINKS` right after `projects`. Pinned so it's always visible. |
| 2. Workspace admins can view, create new, and edit prompt templates | ✅ | Backend gates POST/PATCH on `role=20`; UI shows Customize (no override exists) / Edit / Revert affordances only to admins. Covered by 5 contract tests. |
| 3. Project / normal users can only view (no create / edit) | ✅ | Backend returns 403 on POST/PATCH for non-admins; UI hides all mutating affordances via `useUserPermissions().allowPermissions([ADMIN], WORKSPACE)` checks. Covered by `test_member_can_list_but_not_create` and `test_member_cannot_archive`. |

## Test plan

- [ ] `pnpm turbo run check:types --filter=web` — passes on this branch
- [ ] `docker compose -f docker-compose-local.yml up` then `pytest pi_dash/tests/unit/prompting pi_dash/tests/unit/orchestration pi_dash/tests/contract/prompting` — 42/42 pass
- [ ] Sign in as workspace admin, click Prompts in the sidebar, click Customize → URL lands on the new workspace-scoped template detail page, body pre-filled with the Pi Dash default
- [ ] Edit the body, Save → toast confirms, version bumps from v1 to v2
- [ ] Paste an issue UUID from your workspace into the preview pane, click Preview → rendered prompt appears in the right panel
- [ ] Back to list, click Revert to default → confirm modal, then the workspace override disappears and only the Pi Dash default row remains
- [ ] Sign in as a workspace Member (role 15): Prompts entry still appears in sidebar; list + detail pages render without Customize / Edit / Revert buttons; textarea is read-only; Preview button is not shown
- [ ] As a non-member / outsider: navigating to `/<workspaceSlug>/prompts` directly shows the "Not authorized" view

## Follow-ups (explicitly deferred)

- Multiple named templates per workspace (the composer still hardcodes `name="coding-task"`). Option 2 from the design discussion.
- Per-project prompt picker (`Project.prompt_template_name` column).
- Richer editor — Monaco / CodeMirror with Jinja + Markdown syntax highlighting. Today it's a plain monospaced `<textarea>`.
- Non-English translations for the `prompts.*` i18n namespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)