### PR TITLE
feat(runner): fresh-install gate, strict config schema, remove teardown

### DIFF
--- a/runner/src/cli/configure.rs
+++ b/runner/src/cli/configure.rs
@@ -29,9 +29,41 @@ pub struct Args {
     pub skip_doctor: bool,
 }
 
+/// Inputs for the core registration flow. `cli::install::run` also builds one
+/// of these — once via clap, once via interactive prompts.
+pub struct RegisterInputs {
+    pub url: String,
+    pub token: String,
+    pub name: Option<String>,
+    pub working_dir: Option<PathBuf>,
+    pub skip_doctor: bool,
+}
+
+impl From<Args> for RegisterInputs {
+    fn from(a: Args) -> Self {
+        Self {
+            url: a.url,
+            token: a.token,
+            name: a.name,
+            working_dir: a.working_dir,
+            skip_doctor: a.skip_doctor,
+        }
+    }
+}
+
 pub async fn run(args: Args, paths: &Paths) -> Result<()> {
-    validate_cloud_url(&args.url)?;
-    let name = args
+    execute(args.into(), paths, /* print_next_hint = */ true).await
+}
+
+/// Core registration flow — hits the cloud register endpoint, persists
+/// `config.toml` + `credentials.toml`, and optionally runs the doctor.
+///
+/// `print_next_hint` controls whether the trailing "Next: …" banner appears.
+/// `pidash configure` sets it true; when `pidash install` chains into this,
+/// it sets false because install itself is doing the "next" step.
+pub async fn execute(inputs: RegisterInputs, paths: &Paths, print_next_hint: bool) -> Result<()> {
+    validate_cloud_url(&inputs.url)?;
+    let name = inputs
         .name
         .clone()
         .unwrap_or_else(|| hostname_default().unwrap_or_else(|| "runner".to_string()));
@@ -40,8 +72,8 @@ pub async fn run(args: Args, paths: &Paths) -> Result<()> {
     let version = crate::RUNNER_VERSION.to_string();
 
     let resp = register(
-        &args.url,
-        &args.token,
+        &inputs.url,
+        &inputs.token,
         &RegisterRequest {
             runner_name: name.clone(),
             os: os.clone(),
@@ -53,7 +85,7 @@ pub async fn run(args: Args, paths: &Paths) -> Result<()> {
     .await
     .context("cloud registration failed")?;
 
-    let working_dir = args
+    let working_dir = inputs
         .working_dir
         .clone()
         .unwrap_or_else(|| paths.default_working_dir());
@@ -75,7 +107,7 @@ pub async fn run(args: Args, paths: &Paths) -> Result<()> {
         version: 1,
         runner: crate::config::schema::RunnerSection {
             name,
-            cloud_url: args.url.clone(),
+            cloud_url: inputs.url.clone(),
             workspace_slug: resp.workspace_slug.clone(),
         },
         workspace: crate::config::schema::WorkspaceSection { working_dir },
@@ -93,7 +125,7 @@ pub async fn run(args: Args, paths: &Paths) -> Result<()> {
     };
     crate::config::file::write_credentials(paths, &creds)?;
 
-    if !args.skip_doctor {
+    if !inputs.skip_doctor {
         let report = crate::cli::doctor::execute(paths).await?;
         report.print_compact();
         if report.has_blockers() {
@@ -101,10 +133,17 @@ pub async fn run(args: Args, paths: &Paths) -> Result<()> {
         }
     }
 
-    println!(
-        "\nRegistered runner '{}' with id {}.\nNext: `pidash install && pidash start`\n",
-        config.runner.name, creds.runner_id,
-    );
+    if print_next_hint {
+        println!(
+            "\nRegistered runner '{}' with id {}.\nNext: `pidash install` to run as a background service.\n",
+            config.runner.name, creds.runner_id,
+        );
+    } else {
+        println!(
+            "\nRegistered runner '{}' with id {}.",
+            config.runner.name, creds.runner_id,
+        );
+    }
     Ok(())
 }
 

--- a/runner/src/cli/install.rs
+++ b/runner/src/cli/install.rs
@@ -1,18 +1,135 @@
-//! `pidash install` — write the OS service unit (systemd user unit or launchd
-//! agent) and enable it.
+//! `pidash install` — write the OS service unit and bring the service up.
 //!
-//! PR 1 scope: moves the old `pidash service install` behavior up to a
-//! top-level verb with no behavior change. The fresh-install gate + interactive
-//! `configure` chaining lands in PR 2.
+//! Three phases:
+//!
+//! 1. **Write unit** — always. `service::write_unit` is idempotent, so it's
+//!    safe to re-run. On its own it doesn't activate anything.
+//!
+//! 2. **Fresh-install gate** — if `config.toml` doesn't exist, the daemon
+//!    has no credentials to run with. On a TTY (and without `--no-configure`),
+//!    prompt for URL + token and chain into `pidash configure`. Non-TTY or
+//!    with `--no-configure`, print a next-step hint and exit without
+//!    enabling the service. Nothing auto-starts a runner that isn't
+//!    configured.
+//!
+//! 3. **Enable + start** — run once the machine has both a unit file and a
+//!    valid `config.toml` + `credentials.toml`. Also prints the Linux
+//!    `loginctl enable-linger` hint so on-boot autostart actually works.
 
 use anyhow::Result;
 use clap::Args as ClapArgs;
+use std::io::{BufRead, IsTerminal, Write};
 
 use crate::util::paths::Paths;
 
 #[derive(Debug, ClapArgs)]
-pub struct Args {}
+pub struct Args {
+    /// Skip the interactive `pidash configure` prompt on a fresh install.
+    /// Writes the service unit, then exits without enabling the service.
+    /// Use when running from CI / Ansible / Docker builds.
+    #[arg(long)]
+    pub no_configure: bool,
+}
 
-pub async fn run(_args: Args, paths: &Paths) -> Result<()> {
-    crate::service::detect().install(paths).await
+pub async fn run(args: Args, paths: &Paths) -> Result<()> {
+    let svc = crate::service::detect();
+    svc.write_unit(paths).await?;
+
+    let fresh = !paths.config_path().exists();
+    if fresh {
+        if args.no_configure || !std::io::stdin().is_terminal() {
+            print_unattended_hint(args.no_configure);
+            return Ok(());
+        }
+        // TTY + not opted-out → chain into configure interactively.
+        let inputs = prompt_for_register_inputs()?;
+        crate::cli::configure::execute(inputs, paths, /* print_next_hint = */ false).await?;
+    }
+
+    svc.enable_and_start().await?;
+    print_post_install_hints();
+    Ok(())
+}
+
+fn print_unattended_hint(explicit_opt_out: bool) {
+    let reason = if explicit_opt_out {
+        "--no-configure was set"
+    } else {
+        "no TTY detected (CI or piped input)"
+    };
+    println!();
+    println!("Service unit installed but NOT enabled ({reason}).");
+    println!();
+    println!("Next steps:");
+    println!("  1. pidash configure --url <URL> --token <ONE_TIME_TOKEN>");
+    println!("  2. pidash start");
+    println!();
+}
+
+fn print_post_install_hints() {
+    println!();
+    println!("Service installed and running.");
+    if cfg!(target_os = "linux") {
+        println!();
+        println!("For the service to start on OS boot (before you log in), run:");
+        println!("  sudo loginctl enable-linger $USER");
+        println!(
+            "Without lingering, the service still starts at every user login and restarts on crash."
+        );
+    }
+    println!();
+    println!("Useful next commands:");
+    println!("  pidash status         # service + daemon state");
+    println!("  pidash tui            # interactive UI");
+    println!("  pidash stop           # stop the service");
+    println!();
+}
+
+/// Interactive prompts for URL + token + optional name. Stays minimal —
+/// anything else (`working_dir`, `skip_doctor`) can be provided by re-running
+/// `pidash configure` directly.
+fn prompt_for_register_inputs() -> Result<crate::cli::configure::RegisterInputs> {
+    println!();
+    println!("No config found at {:?}.", std::env::var_os("HOME"));
+    println!("Let's register this runner with Pi Dash cloud.");
+    println!("(Press Ctrl+C to abort and run `pidash install --no-configure` instead.)");
+    println!();
+
+    let url = prompt_required("Pi Dash cloud URL [https://cloud.pidash.so]: ")?;
+    let url = if url.trim().is_empty() {
+        "https://cloud.pidash.so".to_string()
+    } else {
+        url.trim().to_string()
+    };
+
+    let token = prompt_required("One-time registration token: ")?;
+    let token = token.trim().to_string();
+    if token.is_empty() {
+        anyhow::bail!("registration token is required; aborting install");
+    }
+
+    let name = prompt_required("Runner name (blank for host default): ")?;
+    let name = name.trim();
+    let name = if name.is_empty() {
+        None
+    } else {
+        Some(name.to_string())
+    };
+
+    Ok(crate::cli::configure::RegisterInputs {
+        url,
+        token,
+        name,
+        working_dir: None,
+        skip_doctor: false,
+    })
+}
+
+fn prompt_required(msg: &str) -> Result<String> {
+    print!("{msg}");
+    std::io::stdout().flush()?;
+    let stdin = std::io::stdin();
+    let mut line = String::new();
+    stdin.lock().read_line(&mut line)?;
+    Ok(line)
 }

--- a/runner/src/cli/install.rs
+++ b/runner/src/cli/install.rs
@@ -35,14 +35,17 @@ pub async fn run(args: Args, paths: &Paths) -> Result<()> {
     let svc = crate::service::detect();
     svc.write_unit(paths).await?;
 
-    let fresh = !paths.config_path().exists();
+    // Treat a missing config.toml OR a missing credentials.toml as "fresh" —
+    // `enable_and_start`ing against a partial state would crash-loop the daemon
+    // on the new `__run` missing-creds bail.
+    let fresh = !paths.config_path().exists() || !paths.credentials_path().exists();
     if fresh {
         if args.no_configure || !std::io::stdin().is_terminal() {
             print_unattended_hint(args.no_configure);
             return Ok(());
         }
         // TTY + not opted-out → chain into configure interactively.
-        let inputs = prompt_for_register_inputs()?;
+        let inputs = prompt_for_register_inputs(paths)?;
         crate::cli::configure::execute(inputs, paths, /* print_next_hint = */ false).await?;
     }
 
@@ -88,9 +91,9 @@ fn print_post_install_hints() {
 /// Interactive prompts for URL + token + optional name. Stays minimal —
 /// anything else (`working_dir`, `skip_doctor`) can be provided by re-running
 /// `pidash configure` directly.
-fn prompt_for_register_inputs() -> Result<crate::cli::configure::RegisterInputs> {
+fn prompt_for_register_inputs(paths: &Paths) -> Result<crate::cli::configure::RegisterInputs> {
     println!();
-    println!("No config found at {:?}.", std::env::var_os("HOME"));
+    println!("No runner config found at {}.", paths.config_path().display());
     println!("Let's register this runner with Pi Dash cloud.");
     println!("(Press Ctrl+C to abort and run `pidash install --no-configure` instead.)");
     println!();

--- a/runner/src/cli/mod.rs
+++ b/runner/src/cli/mod.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use clap::{Parser, Subcommand};
 
 mod comment;
-mod configure;
+pub mod configure;
 pub mod doctor;
 mod install;
 mod issue;
@@ -18,6 +18,18 @@ mod stop;
 mod tui;
 mod uninstall;
 mod workspace;
+
+/// Re-exported for integration tests that want to exercise the daemon-entry
+/// error paths without routing through clap.
+pub use run::Args as RunArgs;
+
+/// Test-only shim: invoke the hidden `__run` handler directly. Exposed so
+/// `tests/pidash_run_errors.rs` can assert the error-message contract when
+/// `config.toml` or `credentials.toml` is missing.
+#[doc(hidden)]
+pub async fn run_for_tests(args: RunArgs, paths: &crate::util::paths::Paths) -> anyhow::Result<()> {
+    run::run(args, paths).await
+}
 
 #[derive(Debug, Parser)]
 #[command(name = "pidash", version, about, long_about = None)]

--- a/runner/src/cli/remove.rs
+++ b/runner/src/cli/remove.rs
@@ -33,11 +33,14 @@ pub async fn run(args: Args, paths: &Paths) -> Result<()> {
     // wasn't running, because that's the expected path for a never-installed
     // or already-cleaned machine.
     let svc = crate::service::detect();
+    // Warn-level so a partial teardown is visible at default log config —
+    // a silent uninstall failure can leave the unit file behind pointing at
+    // about-to-be-deleted creds, recreating the crash-loop on next restart.
     if let Err(e) = svc.stop().await {
-        tracing::debug!("service stop failed (ok if not running): {e:#}");
+        tracing::warn!("service stop failed (ok if not running): {e:#}");
     }
     if let Err(e) = svc.uninstall(paths).await {
-        tracing::debug!("service uninstall failed (ok if not installed): {e:#}");
+        tracing::warn!("service uninstall failed (ok if not installed): {e:#}");
     }
 
     // Step 3: deregister with the cloud while we still have creds.

--- a/runner/src/cli/remove.rs
+++ b/runner/src/cli/remove.rs
@@ -1,3 +1,15 @@
+//! `pidash remove` — the full teardown command.
+//!
+//! Inverse of `pidash install` + `pidash configure` in one call. Ordering is
+//! deliberate: stop + uninstall the service first so the daemon isn't still
+//! talking to the cloud (or holding the IPC socket) when we delete local
+//! state and notify the cloud.
+//!
+//! 1. Stop the service (tolerant; no-op if not running).
+//! 2. Uninstall the service unit (tolerant; no-op if not installed).
+//! 3. Deregister with the cloud (skipped with `--local-only` or if no creds).
+//! 4. Delete local `config.toml` + `credentials.toml`.
+
 use anyhow::Result;
 use clap::Args as ClapArgs;
 
@@ -15,26 +27,42 @@ pub struct Args {
 }
 
 pub async fn run(args: Args, paths: &Paths) -> Result<()> {
-    let (config, creds) = match crate::config::file::load_all(paths) {
-        Ok(v) => v,
-        Err(e) => {
-            eprintln!("no local configuration found: {e}");
-            return Ok(());
+    // Step 1 + 2: tear down the service before touching local state, so the
+    // daemon isn't still running against to-be-deleted creds. Both calls are
+    // tolerant: they return Ok even when the service was never installed /
+    // wasn't running, because that's the expected path for a never-installed
+    // or already-cleaned machine.
+    let svc = crate::service::detect();
+    if let Err(e) = svc.stop().await {
+        tracing::debug!("service stop failed (ok if not running): {e:#}");
+    }
+    if let Err(e) = svc.uninstall(paths).await {
+        tracing::debug!("service uninstall failed (ok if not installed): {e:#}");
+    }
+
+    // Step 3: deregister with the cloud while we still have creds.
+    match crate::config::file::load_all(paths) {
+        Ok((config, creds)) => {
+            if !args.local_only {
+                match crate::cloud::register::deregister(
+                    &config.runner.cloud_url,
+                    &creds.runner_id,
+                    &creds.runner_secret,
+                    args.token.as_deref(),
+                )
+                .await
+                {
+                    Ok(()) => tracing::info!("cloud deregistration acknowledged"),
+                    Err(e) => tracing::warn!("cloud deregistration failed: {e:#}"),
+                }
+            }
         }
-    };
-    if !args.local_only {
-        match crate::cloud::register::deregister(
-            &config.runner.cloud_url,
-            &creds.runner_id,
-            &creds.runner_secret,
-            args.token.as_deref(),
-        )
-        .await
-        {
-            Ok(()) => tracing::info!("cloud deregistration acknowledged"),
-            Err(e) => tracing::warn!("cloud deregistration failed: {e:#}"),
+        Err(e) => {
+            eprintln!("no local configuration found to deregister: {e}");
         }
     }
+
+    // Step 4: delete local config + creds. Idempotent when files are absent.
     crate::config::file::remove_all(paths)?;
     println!("local runner state removed.");
     Ok(())

--- a/runner/src/cli/run.rs
+++ b/runner/src/cli/run.rs
@@ -8,7 +8,7 @@
 //! The body is the old `pidash start` foreground flow: load config + creds,
 //! run the supervisor loop, block until shutdown.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
 
 use crate::util::paths::Paths;
@@ -21,7 +21,25 @@ pub struct Args {
 }
 
 pub async fn run(args: Args, paths: &Paths) -> Result<()> {
-    let (config, creds) = crate::config::file::load_all(paths)?;
+    let config_path = paths.config_path();
+    let creds_path = paths.credentials_path();
+    if !config_path.exists() {
+        anyhow::bail!(
+            "no config.toml at {config_path:?}. \
+             Run `pidash configure --url <URL> --token <ONE_TIME_TOKEN>` \
+             (or `pidash install` for a fresh setup)."
+        );
+    }
+    if !creds_path.exists() {
+        anyhow::bail!(
+            "no credentials.toml at {creds_path:?}. \
+             Run `pidash configure --url <URL> --token <ONE_TIME_TOKEN>` \
+             to re-register this runner."
+        );
+    }
+
+    let (config, creds) = crate::config::file::load_all(paths)
+        .context("failed to load runner config; re-run `pidash configure` if the files are corrupt")?;
     tracing::info!(
         runner = %config.runner.name,
         runner_id = %creds.runner_id,

--- a/runner/src/config/file.rs
+++ b/runner/src/config/file.rs
@@ -189,6 +189,66 @@ retention_days = 14
     }
 
     #[test]
+    fn minimal_config_without_optional_sections_parses_with_defaults() {
+        // A config.toml missing [approval_policy] and [logging] must still
+        // parse — PR 2 adds `#[serde(default)]` on those sections so fresh
+        // installs can ship a leaner toml and still get sensible defaults.
+        let tmp = tempdir().unwrap();
+        let paths = paths_for(tmp.path());
+        std::fs::create_dir_all(&paths.config_dir).unwrap();
+        let body = r#"
+version = 1
+
+[runner]
+name = "t"
+cloud_url = "https://x"
+
+[workspace]
+working_dir = "/tmp/wd"
+
+[codex]
+binary = "codex"
+"#;
+        std::fs::write(paths.config_path(), body).unwrap();
+        let loaded = load_config(&paths).unwrap();
+        assert_eq!(loaded.runner.name, "t");
+        // Defaults applied to the omitted sections:
+        assert!(!loaded.approval_policy.auto_approve_network);
+        assert_eq!(loaded.logging.level, "info");
+        assert_eq!(loaded.logging.retention_days, 14);
+        // Optional codex.model_default is allowed to be absent:
+        assert_eq!(loaded.codex.model_default, None);
+    }
+
+    #[test]
+    fn config_without_required_field_fails_loudly() {
+        // `runner.cloud_url` is required. A config without it must fail to
+        // parse so `__run` never boots a half-configured daemon.
+        let tmp = tempdir().unwrap();
+        let paths = paths_for(tmp.path());
+        std::fs::create_dir_all(&paths.config_dir).unwrap();
+        let body = r#"
+version = 1
+
+[runner]
+name = "t"
+
+[workspace]
+working_dir = "/tmp/wd"
+
+[codex]
+binary = "codex"
+"#;
+        std::fs::write(paths.config_path(), body).unwrap();
+        let err = load_config(&paths).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("cloud_url") || msg.contains("runner"),
+            "error should mention the missing field: {msg}",
+        );
+    }
+
+    #[test]
     fn credentials_without_api_token_round_trip_via_serde_default() {
         // A credentials file written before the api_token field existed
         // (no `api_token = ...` line) must still parse, with the field

--- a/runner/src/config/schema.rs
+++ b/runner/src/config/schema.rs
@@ -9,7 +9,12 @@ pub struct Config {
     pub runner: RunnerSection,
     pub workspace: WorkspaceSection,
     pub codex: CodexSection,
+    /// Missing section falls back to the `ApprovalPolicySection::default()` so
+    /// a minimal `config.toml` doesn't have to spell out every knob.
+    #[serde(default)]
     pub approval_policy: ApprovalPolicySection,
+    /// Missing section falls back to the `LoggingSection::default()`.
+    #[serde(default)]
     pub logging: LoggingSection,
 }
 
@@ -33,6 +38,7 @@ pub struct WorkspaceSection {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CodexSection {
     pub binary: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_default: Option<String>,
 }
 

--- a/runner/src/service/launchd.rs
+++ b/runner/src/service/launchd.rs
@@ -6,7 +6,10 @@ use crate::util::paths::Paths;
 
 const LABEL: &str = "so.pidash.daemon";
 
-pub async fn install(paths: &Paths) -> Result<()> {
+/// Write the LaunchAgent plist. Does NOT bootstrap (load) it; that's deferred
+/// to `enable_and_start` so `pidash install` can gate activation on
+/// `pidash configure` completing first.
+pub async fn write_unit(paths: &Paths) -> Result<()> {
     let plist_path = plist_path()?;
     if let Some(parent) = plist_path.parent() {
         tokio::fs::create_dir_all(parent).await?;
@@ -46,18 +49,30 @@ pub async fn install(paths: &Paths) -> Result<()> {
         exe = exe_str,
     );
     tokio::fs::write(&plist_path, body).await?;
+    println!("installed launchd agent at {}", plist_path.display());
+    Ok(())
+}
+
+/// Load the LaunchAgent. `RunAtLoad=true` in the plist means `bootstrap`
+/// also starts the process immediately. If already loaded, falls back to
+/// `kickstart -k` so re-running `pidash install` after a crash-free run
+/// doesn't fail — it just ensures the service is running.
+pub async fn enable_and_start() -> Result<()> {
+    let plist = plist_path()?;
     let uid = get_uid();
     let target = format!("gui/{uid}");
     let status = Command::new("launchctl")
-        .args(["bootstrap", &target, &plist_path.display().to_string()])
+        .args(["bootstrap", &target, &plist.display().to_string()])
         .status()
         .await
         .context("launchctl bootstrap")?;
-    if !status.success() {
-        anyhow::bail!("launchctl bootstrap failed: {status}");
+    if status.success() {
+        return Ok(());
     }
-    println!("installed launchd agent at {}", plist_path.display());
-    Ok(())
+    // Already loaded → make sure it's running. `kickstart -k` restarts a
+    // loaded service; on a fresh machine (no prior load) this branch isn't
+    // taken because bootstrap succeeded above.
+    start().await
 }
 
 pub async fn uninstall(_: &Paths) -> Result<()> {

--- a/runner/src/service/mod.rs
+++ b/runner/src/service/mod.rs
@@ -36,10 +36,20 @@ pub fn detect() -> Service {
 }
 
 impl Service {
-    pub async fn install(&self, paths: &Paths) -> Result<()> {
+    /// Write the unit file (systemd) or plist (launchd). Does not enable or
+    /// start. Allows `pidash install` to gate activation on configuration.
+    pub async fn write_unit(&self, paths: &Paths) -> Result<()> {
         match self {
-            Service::Systemd => systemd::install(paths).await,
-            Service::Launchd => launchd::install(paths).await,
+            Service::Systemd => systemd::write_unit(paths).await,
+            Service::Launchd => launchd::write_unit(paths).await,
+        }
+    }
+
+    /// Enable at boot/login and start now. Must run after `write_unit`.
+    pub async fn enable_and_start(&self) -> Result<()> {
+        match self {
+            Service::Systemd => systemd::enable_and_start().await,
+            Service::Launchd => launchd::enable_and_start().await,
         }
     }
 

--- a/runner/src/service/systemd.rs
+++ b/runner/src/service/systemd.rs
@@ -6,7 +6,10 @@ use crate::util::paths::Paths;
 
 const UNIT_NAME: &str = "pidash.service";
 
-pub async fn install(paths: &Paths) -> Result<()> {
+/// Write the unit file and reload the systemd user manager. Does NOT enable
+/// or start the unit — that's a separate step so `pidash install` can gate
+/// it on `pidash configure` completing first.
+pub async fn write_unit(paths: &Paths) -> Result<()> {
     let unit_path = unit_path()?;
     if let Some(parent) = unit_path.parent() {
         tokio::fs::create_dir_all(parent).await?;
@@ -38,8 +41,14 @@ WantedBy=default.target
     );
     tokio::fs::write(&unit_path, body).await?;
     run_systemctl(&["daemon-reload"]).await?;
-    run_systemctl(&["enable", UNIT_NAME]).await?;
     println!("installed systemd unit at {}", unit_path.display());
+    Ok(())
+}
+
+/// Enable the unit at boot/login and start it now. Idempotent.
+pub async fn enable_and_start() -> Result<()> {
+    run_systemctl(&["enable", UNIT_NAME]).await?;
+    run_systemctl(&["start", UNIT_NAME]).await?;
     Ok(())
 }
 

--- a/runner/src/tui/onboarding.rs
+++ b/runner/src/tui/onboarding.rs
@@ -286,12 +286,12 @@ async fn handle_service_step(code: KeyCode, state: &mut Wizard) {
             state.busy = true;
             if state.install_service {
                 let svc = crate::service::detect();
-                if let Err(e) = svc.install(&state.paths).await {
+                if let Err(e) = svc.write_unit(&state.paths).await {
                     state.error = Some(format!("service install failed: {e:#}"));
                     state.busy = false;
                     return;
                 }
-                if let Err(e) = svc.start().await {
+                if let Err(e) = svc.enable_and_start().await {
                     state.error = Some(format!("service start failed: {e:#}"));
                     // Not fatal — user can start manually.
                 }
@@ -300,7 +300,7 @@ async fn handle_service_step(code: KeyCode, state: &mut Wizard) {
                 if state.install_service {
                     "Runner is installed as a service and connected.\nThe TUI dashboard will open next."
                 } else {
-                    "Configuration saved. Run `pidash start` to connect."
+                    "Configuration saved. Run `pidash install` to set up and start the background service."
                 }
                 .to_string(),
             );

--- a/runner/tests/pidash_run_errors.rs
+++ b/runner/tests/pidash_run_errors.rs
@@ -1,0 +1,83 @@
+//! PR 2: verify `pidash __run` bails with an action-guiding error when the
+//! machine hasn't been configured yet. This is the error users see when
+//! systemd/launchd starts the service before `pidash configure` has run.
+//!
+//! We call the handler directly (not through a subprocess) so the test is
+//! fast and platform-independent.
+
+use pidash::cli::RunArgs;
+use pidash::util::paths::Paths;
+use tempfile::tempdir;
+
+fn empty_paths(root: &std::path::Path) -> Paths {
+    Paths {
+        config_dir: root.join("config"),
+        data_dir: root.join("data"),
+        runtime_dir: root.join("runtime"),
+    }
+}
+
+fn ensure_dirs(paths: &Paths) {
+    std::fs::create_dir_all(&paths.config_dir).unwrap();
+    std::fs::create_dir_all(&paths.data_dir).unwrap();
+    std::fs::create_dir_all(&paths.runtime_dir).unwrap();
+}
+
+#[tokio::test]
+async fn run_errors_when_config_missing() {
+    let tmp = tempdir().unwrap();
+    let paths = empty_paths(tmp.path());
+    ensure_dirs(&paths);
+    let args = RunArgs { offline: true };
+    let err = pidash::cli::run_for_tests(args, &paths)
+        .await
+        .expect_err("__run with no config should fail");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("config.toml"),
+        "error should mention config.toml: {msg}",
+    );
+    assert!(
+        msg.contains("pidash configure") || msg.contains("pidash install"),
+        "error should point at `pidash configure` or `pidash install`: {msg}",
+    );
+}
+
+#[tokio::test]
+async fn run_errors_when_creds_missing_but_config_present() {
+    let tmp = tempdir().unwrap();
+    let paths = empty_paths(tmp.path());
+    ensure_dirs(&paths);
+    // Config exists, credentials do not.
+    std::fs::write(
+        paths.config_path(),
+        r#"
+version = 1
+
+[runner]
+name = "t"
+cloud_url = "https://x"
+
+[workspace]
+working_dir = "/tmp/wd"
+
+[codex]
+binary = "codex"
+"#,
+    )
+    .unwrap();
+    let args = RunArgs { offline: true };
+    let err = pidash::cli::run_for_tests(args, &paths)
+        .await
+        .expect_err("__run with config but no creds should fail");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("credentials.toml"),
+        "error should mention credentials.toml: {msg}",
+    );
+    assert!(
+        msg.contains("pidash configure"),
+        "error should point at `pidash configure`: {msg}",
+    );
+}
+


### PR DESCRIPTION
Re-opens #15 — original PR auto-closed when its base branch `feat/cli-restructure-pr1` was deleted after #14 merged. Branch has been rebased onto `main` and includes the code-review fixes from that PR's thread.

## Summary

Turns `pidash install` into a one-stop command and closes the `pidash remove` crash-loop gap.

### `pidash install` — three phases
1. Always write the unit file (idempotent).
2. If `config.toml` or `credentials.toml` is missing on a TTY (and `--no-configure` isn't set), prompt for URL / token / name and chain into `pidash configure`. Non-TTY or `--no-configure` → print next-step hint and exit without enabling. Nothing auto-starts a runner that isn't configured.
3. Once config + creds exist, enable + start. On Linux, print the `sudo loginctl enable-linger $USER` hint so the service starts before interactive login.

### `service::install` split
- `write_unit(paths)` — writes the unit/plist (idempotent, no activation)
- `enable_and_start()` — `systemctl enable+start` on Linux; `launchctl bootstrap` on macOS with a `kickstart -k` fallback so re-running `install` doesn't fail on an already-loaded agent

### `pidash remove` becomes the true inverse
Stop + uninstall the service **before** touching local state, so systemd/launchd don't keep restarting a deregistered daemon with no credentials. Stop/uninstall failures surface at `warn!` so partial teardown is visible.

### Config schema tightened
- `[approval_policy]` and `[logging]` get `#[serde(default)]` — minimal TOMLs parse with the existing `Default` impls.
- `codex.model_default` is marked optional with default and skipped when `None` on serialize.
- Required fields (`runner.cloud_url` / `workspace.working_dir` / `codex.binary`) **still fail loudly on parse**; `__run` bubbles that up with action-guiding text.

### `__run` error messages
On missing `config.toml` or `credentials.toml`, bails with text pointing at `pidash configure` / `pidash install`. No more silent systemd crash loops with cryptic TOML errors.

### Review fixups (folded in)
- Fresh-install gate now also checks `credentials.toml`, not just `config.toml` — partial state no longer slips past to `enable_and_start`.
- Interactive prompt shows the actual config path instead of `\$HOME`.
- `remove` logs stop/uninstall failures at `warn!` so a silent partial teardown is visible at default log level.

## Test plan

- [x] `cargo test` — all tests green
- [x] New lib tests: minimal config with default sections parses; missing required field fails loudly
- [x] New integration test `tests/pidash_run_errors.rs` — `__run` error contract when config / creds are missing
- [ ] Manual: fresh install with TTY (chains configure), non-TTY (prints hint), `--no-configure` flag, `pidash remove` leaves machine clean

## Follow-ups

PR 3 (#16): per-workspace `runner.name` uniqueness with charset rules — currently stacked on this branch; may need retargeting once this lands.