### PR TITLE
feat(runner,api): runner-install-UX redesign (PRs 1+2+3 combined)

### DIFF
--- a/apps/api/pi_dash/runner/migrations/0003_runner_name_unique_per_workspace.py
+++ b/apps/api/pi_dash/runner/migrations/0003_runner_name_unique_per_workspace.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+"""Add ``UNIQUE(workspace_id, name)`` on ``runner``.
+
+Part of PR 3 of the runner-install-UX redesign. Makes ``runner.name`` the
+per-workspace human handle the CLI can address, while ``runner.id`` (UUID)
+stays the wire identity.
+
+See .ai_design/runner_install_ux/cli-restructure-and-install-flow.md.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("runner", "0002_agentrun_parent_run_blocked_status"),
+    ]
+
+    operations = [
+        migrations.AddConstraint(
+            model_name="runner",
+            constraint=models.UniqueConstraint(
+                fields=["workspace", "name"],
+                name="runner_unique_name_per_workspace",
+            ),
+        ),
+    ]

--- a/apps/api/pi_dash/runner/migrations/0003_runner_name_unique_per_workspace.py
+++ b/apps/api/pi_dash/runner/migrations/0003_runner_name_unique_per_workspace.py
@@ -7,6 +7,13 @@ Part of PR 3 of the runner-install-UX redesign. Makes ``runner.name`` the
 per-workspace human handle the CLI can address, while ``runner.id`` (UUID)
 stays the wire identity.
 
+Deployment note: this migration fails with ``ERROR 23505`` if the target
+database already contains duplicate ``(workspace_id, name)`` pairs. Any
+environment with pre-existing runner data must be de-duped before running
+``migrate``. For the pre-release project this was authored against there
+should be no production rows; staging may still have test runners and is
+worth eyeballing first.
+
 See .ai_design/runner_install_ux/cli-restructure-and-install-flow.md.
 """
 

--- a/apps/api/pi_dash/runner/models.py
+++ b/apps/api/pi_dash/runner/models.py
@@ -83,6 +83,15 @@ class Runner(models.Model):
     class Meta:
         db_table = "runner"
         ordering = ("-last_heartbeat_at", "-created_at")
+        # Per-workspace name uniqueness. `(workspace, name)` is the human key
+        # the CLI uses to address a runner; the UUID `id` is the internal
+        # auth identity. See .ai_design/runner_install_ux/ for the rationale.
+        constraints = [
+            models.UniqueConstraint(
+                fields=["workspace", "name"],
+                name="runner_unique_name_per_workspace",
+            ),
+        ]
         indexes = [
             models.Index(fields=["owner", "status"]),
             models.Index(fields=["workspace", "status"]),

--- a/apps/api/pi_dash/runner/serializers.py
+++ b/apps/api/pi_dash/runner/serializers.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # See the LICENSE file for details.
 
+from django.core.validators import RegexValidator
 from rest_framework import serializers
 
 from pi_dash.runner.models import (
@@ -12,6 +13,17 @@ from pi_dash.runner.models import (
     ApprovalStatus,
     Runner,
     RunnerRegistrationToken,
+)
+
+
+# Mirrors the runner-side charset rule in `runner/src/util/runner_name.rs`.
+# Applied on registration so the cloud rejects garbage before it hits the
+# `UNIQUE(workspace_id, name)` constraint. Defense in depth.
+RUNNER_NAME_CHARSET = RegexValidator(
+    regex=r"^[A-Za-z0-9_-]+$",
+    message=(
+        "runner_name may only contain letters, digits, underscore, and dash"
+    ),
 )
 
 
@@ -45,7 +57,11 @@ class RegistrationRequestSerializer(serializers.Serializer):
     # Minted tokens are ``apd_reg_`` (8) + ~32 chars of entropy. Reject
     # obvious garbage before we spend a DB round-trip on it.
     token = serializers.CharField(min_length=16, max_length=128)
-    runner_name = serializers.CharField(min_length=1, max_length=128)
+    runner_name = serializers.CharField(
+        min_length=1,
+        max_length=128,
+        validators=[RUNNER_NAME_CHARSET],
+    )
     os = serializers.CharField(max_length=32)
     arch = serializers.CharField(max_length=32)
     version = serializers.CharField(max_length=32)

--- a/apps/api/pi_dash/runner/views/register.py
+++ b/apps/api/pi_dash/runner/views/register.py
@@ -88,7 +88,7 @@ class RegisterEndpoint(APIView):
             runner = Runner.objects.create(
                 owner=reg.created_by,
                 workspace=reg.workspace,
-                name=data["runner_name"][:128],
+                name=data["runner_name"],
                 credential_hash=minted.hashed,
                 credential_fingerprint=minted.fingerprint,
                 os=data["os"][:32],
@@ -97,11 +97,15 @@ class RegisterEndpoint(APIView):
                 protocol_version=data["protocol_version"],
             )
         except IntegrityError:
-            # `UNIQUE(workspace_id, name)` violation. Keep the registration
-            # token unconsumed by aborting the transaction (@transaction.atomic
-            # takes care of that) so the client can retry with a different
-            # name. The runner retries auto-generated names transparently;
-            # a user-supplied `--name` collision surfaces as a loud error.
+            # `UNIQUE(workspace_id, name)` violation. The registration token
+            # stays unconsumed because the `reg.consumed_at` / `reg.save(...)`
+            # writes are below this return path — they simply never execute.
+            # (Returning a Response does not by itself roll back the atomic
+            # block; it commits. The Runner.create() failed so no row landed,
+            # and the token-consume writes haven't been issued yet, so the
+            # end state is "nothing changed" regardless.) The runner retries
+            # auto-generated names transparently; a user-supplied `--name`
+            # collision surfaces as a loud error client-side.
             return Response(
                 {"error": "runner_name_taken"},
                 status=status.HTTP_409_CONFLICT,

--- a/apps/api/pi_dash/runner/views/register.py
+++ b/apps/api/pi_dash/runner/views/register.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # See the LICENSE file for details.
 
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.permissions import AllowAny, IsAuthenticated
@@ -84,17 +84,28 @@ class RegisterEndpoint(APIView):
             )
 
         minted = tokens.mint_runner_secret()
-        runner = Runner.objects.create(
-            owner=reg.created_by,
-            workspace=reg.workspace,
-            name=data["runner_name"][:128],
-            credential_hash=minted.hashed,
-            credential_fingerprint=minted.fingerprint,
-            os=data["os"][:32],
-            arch=data["arch"][:32],
-            runner_version=data["version"][:32],
-            protocol_version=data["protocol_version"],
-        )
+        try:
+            runner = Runner.objects.create(
+                owner=reg.created_by,
+                workspace=reg.workspace,
+                name=data["runner_name"][:128],
+                credential_hash=minted.hashed,
+                credential_fingerprint=minted.fingerprint,
+                os=data["os"][:32],
+                arch=data["arch"][:32],
+                runner_version=data["version"][:32],
+                protocol_version=data["protocol_version"],
+            )
+        except IntegrityError:
+            # `UNIQUE(workspace_id, name)` violation. Keep the registration
+            # token unconsumed by aborting the transaction (@transaction.atomic
+            # takes care of that) so the client can retry with a different
+            # name. The runner retries auto-generated names transparently;
+            # a user-supplied `--name` collision surfaces as a loud error.
+            return Response(
+                {"error": "runner_name_taken"},
+                status=status.HTTP_409_CONFLICT,
+            )
         reg.consumed_at = timezone.now()
         reg.consumed_by_runner = runner
         reg.save(update_fields=["consumed_at", "consumed_by_runner"])

--- a/apps/api/pi_dash/tests/contract/runner/test_registration.py
+++ b/apps/api/pi_dash/tests/contract/runner/test_registration.py
@@ -8,6 +8,7 @@ import pytest
 from django.urls import reverse
 from django.utils import timezone
 
+from pi_dash.db.models import Workspace, WorkspaceMember
 from pi_dash.db.models.api import APIToken
 from pi_dash.runner.models import (
     AgentRunStatus,
@@ -176,6 +177,124 @@ def test_register_enforces_runner_cap(api_client, db, create_user, workspace):
         format="json",
     )
     assert resp.status_code == 409
+
+
+@pytest.mark.contract
+def test_register_rejects_duplicate_name_in_same_workspace(
+    api_client, db, create_user, workspace
+):
+    # Pre-existing runner with the name we're about to try to register.
+    Runner.objects.create(
+        owner=create_user,
+        workspace=workspace,
+        name="dup-name",
+        credential_hash="h-existing",
+        credential_fingerprint="f" * 12,
+        status=RunnerStatus.OFFLINE,
+    )
+    minted = tokens.mint_registration_token()
+    reg = RunnerRegistrationToken.objects.create(
+        workspace=workspace,
+        created_by=create_user,
+        token_hash=minted.hashed,
+        expires_at=minted.expires_at,
+    )
+    url = reverse("runner:register")
+    resp = api_client.post(
+        url,
+        {
+            "token": minted.raw,
+            "runner_name": "dup-name",
+            "os": "linux",
+            "arch": "x86_64",
+            "version": "0.1.0",
+            "protocol_version": 1,
+        },
+        format="json",
+    )
+    assert resp.status_code == 409
+    assert resp.json() == {"error": "runner_name_taken"}
+    # @transaction.atomic rolls back the consume, so the runner can retry
+    # with a different name on the same token.
+    reg.refresh_from_db()
+    assert reg.consumed_at is None
+    assert reg.consumed_by_runner_id is None
+
+
+@pytest.mark.contract
+def test_register_allows_duplicate_name_in_different_workspace(
+    api_client, db, create_user, workspace
+):
+    # Same name in a second workspace is fine — uniqueness is per-workspace.
+    Runner.objects.create(
+        owner=create_user,
+        workspace=workspace,
+        name="shared-name",
+        credential_hash="h-other-ws",
+        credential_fingerprint="f" * 12,
+        status=RunnerStatus.OFFLINE,
+    )
+    other_ws = Workspace.objects.create(
+        name="Other Workspace", owner=create_user, slug="other-workspace"
+    )
+    WorkspaceMember.objects.create(
+        workspace=other_ws, member=create_user, role=20
+    )
+    minted = tokens.mint_registration_token()
+    RunnerRegistrationToken.objects.create(
+        workspace=other_ws,
+        created_by=create_user,
+        token_hash=minted.hashed,
+        expires_at=minted.expires_at,
+    )
+    url = reverse("runner:register")
+    resp = api_client.post(
+        url,
+        {
+            "token": minted.raw,
+            "runner_name": "shared-name",
+            "os": "linux",
+            "arch": "x86_64",
+            "version": "0.1.0",
+            "protocol_version": 1,
+        },
+        format="json",
+    )
+    assert resp.status_code == 201
+
+
+@pytest.mark.contract
+@pytest.mark.parametrize(
+    "bad_name",
+    [
+        "has space",
+        "dot.separated",
+        "slash/separator",
+        "emoji-💥",
+        "semicolon;",
+    ],
+)
+def test_register_rejects_invalid_runner_name_charset(
+    api_client, registration, bad_name
+):
+    minted, _ = registration
+    url = reverse("runner:register")
+    resp = api_client.post(
+        url,
+        {
+            "token": minted.raw,
+            "runner_name": bad_name,
+            "os": "linux",
+            "arch": "x86_64",
+            "version": "0.1.0",
+            "protocol_version": 1,
+        },
+        format="json",
+    )
+    assert resp.status_code == 400
+    body = resp.json()
+    # DRF serializer validation puts the field-level error under the field name.
+    assert "runner_name" in body, f"expected runner_name error, got {body}"
 
 
 @pytest.mark.contract

--- a/runner/src/cli/configure.rs
+++ b/runner/src/cli/configure.rs
@@ -2,9 +2,15 @@ use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
 use std::path::PathBuf;
 
-use crate::cloud::register::{RegisterRequest, register};
+use crate::cloud::register::{RegisterError, RegisterRequest, register};
 use crate::config::schema::{Config, Credentials};
 use crate::util::paths::Paths;
+use crate::util::runner_name;
+
+/// Max attempts when the auto-generated runner name happens to collide. 62³
+/// (≈238k) possible suffixes per workspace — five tries is far more than
+/// enough absent a truly pathological collision.
+const MAX_AUTO_NAME_RETRIES: u32 = 5;
 
 #[derive(Debug, ClapArgs)]
 pub struct Args {
@@ -63,27 +69,69 @@ pub async fn run(args: Args, paths: &Paths) -> Result<()> {
 /// it sets false because install itself is doing the "next" step.
 pub async fn execute(inputs: RegisterInputs, paths: &Paths, print_next_hint: bool) -> Result<()> {
     validate_cloud_url(&inputs.url)?;
-    let name = inputs
-        .name
-        .clone()
-        .unwrap_or_else(|| hostname_default().unwrap_or_else(|| "runner".to_string()));
+
+    // User-supplied names are charset-checked up front; an invalid `--name`
+    // is a hard error, not something we try to fix by retrying. Auto-generated
+    // names are charset-safe by construction.
+    let user_supplied_name = inputs.name.is_some();
+    if let Some(n) = &inputs.name {
+        runner_name::validate(n)
+            .with_context(|| format!("invalid --name value {n:?}"))?;
+    }
+
     let os = std::env::consts::OS.to_string();
     let arch = std::env::consts::ARCH.to_string();
     let version = crate::RUNNER_VERSION.to_string();
 
-    let resp = register(
-        &inputs.url,
-        &inputs.token,
-        &RegisterRequest {
-            runner_name: name.clone(),
-            os: os.clone(),
-            arch: arch.clone(),
-            version: version.clone(),
-            protocol_version: crate::PROTOCOL_VERSION,
-        },
-    )
-    .await
-    .context("cloud registration failed")?;
+    // On auto-generated names, transparently retry if the cloud says the
+    // name is already taken in this workspace. On user-supplied names, a
+    // collision is a loud error — we don't silently rename what the user
+    // typed.
+    let (resp, final_name) = {
+        let mut attempts = 0u32;
+        loop {
+            attempts += 1;
+            let attempt_name = inputs
+                .name
+                .clone()
+                .unwrap_or_else(runner_name::generate_default);
+            let req = RegisterRequest {
+                runner_name: attempt_name.clone(),
+                os: os.clone(),
+                arch: arch.clone(),
+                version: version.clone(),
+                protocol_version: crate::PROTOCOL_VERSION,
+            };
+            match register(&inputs.url, &inputs.token, &req).await {
+                Ok(resp) => break (resp, attempt_name),
+                Err(RegisterError::NameTaken)
+                    if !user_supplied_name && attempts < MAX_AUTO_NAME_RETRIES =>
+                {
+                    tracing::info!(
+                        attempt = attempts,
+                        name = %attempt_name,
+                        "auto-generated runner name already taken; retrying with a fresh suffix"
+                    );
+                    continue;
+                }
+                Err(RegisterError::NameTaken) if user_supplied_name => {
+                    anyhow::bail!(
+                        "runner name {attempt_name:?} is already taken in this workspace. \
+                         Choose a different --name, or omit --name so the client generates a unique one."
+                    );
+                }
+                Err(RegisterError::NameTaken) => {
+                    anyhow::bail!(
+                        "could not generate a unique runner name after {MAX_AUTO_NAME_RETRIES} attempts. \
+                         This is extremely unlikely; check the cloud for stale runners, or pass --name explicitly."
+                    );
+                }
+                Err(RegisterError::Other(e)) => {
+                    return Err(e).context("cloud registration failed");
+                }
+            }
+        }
+    };
 
     let working_dir = inputs
         .working_dir
@@ -106,7 +154,7 @@ pub async fn execute(inputs: RegisterInputs, paths: &Paths, print_next_hint: boo
     let config = Config {
         version: 1,
         runner: crate::config::schema::RunnerSection {
-            name,
+            name: final_name,
             cloud_url: inputs.url.clone(),
             workspace_slug: resp.workspace_slug.clone(),
         },
@@ -168,13 +216,3 @@ fn validate_cloud_url(url: &str) -> Result<()> {
     anyhow::bail!("cloud URL must start with https:// (or http:// for localhost), got {url}")
 }
 
-fn hostname_default() -> Option<String> {
-    if let Ok(h) = std::env::var("HOSTNAME") {
-        if !h.is_empty() {
-            return Some(h);
-        }
-    }
-    nix::unistd::gethostname()
-        .ok()
-        .and_then(|os| os.into_string().ok())
-}

--- a/runner/src/cli/configure.rs
+++ b/runner/src/cli/configure.rs
@@ -86,13 +86,15 @@ pub async fn execute(inputs: RegisterInputs, paths: &Paths, print_next_hint: boo
     // On auto-generated names, transparently retry if the cloud says the
     // name is already taken in this workspace. On user-supplied names, a
     // collision is a loud error — we don't silently rename what the user
-    // typed.
+    // typed. Hoist the user-supplied name outside the loop: it doesn't
+    // change between attempts (and for user-supplied input the loop breaks
+    // or bails on the first iteration anyway).
+    let supplied_name = inputs.name.clone();
     let (resp, final_name) = {
         let mut attempts = 0u32;
         loop {
             attempts += 1;
-            let attempt_name = inputs
-                .name
+            let attempt_name = supplied_name
                 .clone()
                 .unwrap_or_else(runner_name::generate_default);
             let req = RegisterRequest {

--- a/runner/src/cloud/register.rs
+++ b/runner/src/cloud/register.rs
@@ -152,12 +152,11 @@ pub async fn deregister(
 ///   auto-generated name, loud error for a user-supplied one).
 /// - Anything else non-2xx → `Other` with the status + body captured.
 fn classify_register_error(status: reqwest::StatusCode, body: &str) -> RegisterError {
-    if status == reqwest::StatusCode::CONFLICT {
-        if let Ok(parsed) = serde_json::from_str::<ErrorBody>(body) {
-            if parsed.error.as_deref() == Some("runner_name_taken") {
-                return RegisterError::NameTaken;
-            }
-        }
+    if status == reqwest::StatusCode::CONFLICT
+        && let Ok(parsed) = serde_json::from_str::<ErrorBody>(body)
+        && parsed.error.as_deref() == Some("runner_name_taken")
+    {
+        return RegisterError::NameTaken;
     }
     RegisterError::Other(anyhow::anyhow!(
         "registration failed: HTTP {status}: {body}"

--- a/runner/src/cloud/register.rs
+++ b/runner/src/cloud/register.rs
@@ -3,6 +3,28 @@ use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use uuid::Uuid;
 
+/// Typed failure modes for the register endpoint so `configure` can distinguish
+/// a name collision (retryable when auto-generated, loud-fail when user-supplied)
+/// from a generic network / auth / cap error.
+#[derive(Debug, thiserror::Error)]
+pub enum RegisterError {
+    /// Cloud rejected the request because `runner_name` already exists in the
+    /// target workspace. Triggered by `UNIQUE(workspace_id, name)` on the cloud
+    /// side and surfaced as `409 {"error": "runner_name_taken"}`.
+    #[error("runner name already taken in this workspace")]
+    NameTaken,
+    /// Anything else — transport failure, HTTP non-200 other than the specific
+    /// 409 shape above, malformed response body, etc. Keeps the anyhow context
+    /// chain intact for debugging.
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+#[derive(Debug, Deserialize)]
+struct ErrorBody {
+    error: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct RegisterRequest {
     pub runner_name: String,
@@ -43,24 +65,29 @@ pub async fn register(
     cloud_url: &str,
     token: &str,
     req: &RegisterRequest,
-) -> Result<RegisterResponse> {
+) -> std::result::Result<RegisterResponse, RegisterError> {
     let url = format!(
         "{}/api/v1/runner/register/",
         cloud_url.trim_end_matches('/')
     );
-    let client = http_client()?;
+    let client = http_client().map_err(RegisterError::Other)?;
     let resp = client
         .post(&url)
         .json(&RegisterEnvelope { req, token })
         .send()
         .await
-        .with_context(|| format!("POST {url}"))?;
+        .with_context(|| format!("POST {url}"))
+        .map_err(RegisterError::Other)?;
     let status = resp.status();
     if !status.is_success() {
         let body = resp.text().await.unwrap_or_default();
-        anyhow::bail!("registration failed: HTTP {status}: {body}");
+        return Err(classify_register_error(status, &body));
     }
-    let out = resp.json::<RegisterResponse>().await?;
+    let out = resp
+        .json::<RegisterResponse>()
+        .await
+        .context("parsing register response")
+        .map_err(RegisterError::Other)?;
     Ok(out)
 }
 
@@ -117,6 +144,26 @@ pub async fn deregister(
     Ok(())
 }
 
+/// Translate an HTTP error response into a `RegisterError`. Extracted so
+/// `configure`'s retry decision can be unit-tested without standing up a
+/// fake HTTP server. The cloud-side contract is:
+///
+/// - `409 {"error": "runner_name_taken"}` → `NameTaken` (retryable for an
+///   auto-generated name, loud error for a user-supplied one).
+/// - Anything else non-2xx → `Other` with the status + body captured.
+fn classify_register_error(status: reqwest::StatusCode, body: &str) -> RegisterError {
+    if status == reqwest::StatusCode::CONFLICT {
+        if let Ok(parsed) = serde_json::from_str::<ErrorBody>(body) {
+            if parsed.error.as_deref() == Some("runner_name_taken") {
+                return RegisterError::NameTaken;
+            }
+        }
+    }
+    RegisterError::Other(anyhow::anyhow!(
+        "registration failed: HTTP {status}: {body}"
+    ))
+}
+
 fn http_client() -> Result<reqwest::Client> {
     Ok(reqwest::Client::builder()
         .timeout(Duration::from_secs(30))
@@ -155,5 +202,48 @@ mod tests {
         }"#;
         let resp: RegisterResponse = serde_json::from_str(body).unwrap();
         assert_eq!(resp.workspace_slug.as_deref(), Some("acme"));
+    }
+
+    #[test]
+    fn classify_409_runner_name_taken_maps_to_name_taken() {
+        // Pin the cloud-side contract: configure uses this to decide whether
+        // to retry an auto-generated name or error out a user-supplied one.
+        let err = classify_register_error(
+            reqwest::StatusCode::CONFLICT,
+            r#"{"error": "runner_name_taken"}"#,
+        );
+        assert!(
+            matches!(err, RegisterError::NameTaken),
+            "expected NameTaken, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn classify_409_runner_cap_reached_maps_to_other() {
+        // The same endpoint also returns 409 for the per-user cap. That one
+        // must NOT trigger the auto-name retry — it's a hard error.
+        let err = classify_register_error(
+            reqwest::StatusCode::CONFLICT,
+            r#"{"error": "runner cap reached (5)"}"#,
+        );
+        assert!(
+            matches!(err, RegisterError::Other(_)),
+            "expected Other, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn classify_non_409_status_maps_to_other() {
+        for status in [
+            reqwest::StatusCode::UNAUTHORIZED,
+            reqwest::StatusCode::BAD_REQUEST,
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+        ] {
+            let err = classify_register_error(status, "some body");
+            assert!(
+                matches!(err, RegisterError::Other(_)),
+                "{status} should map to Other, got {err:?}",
+            );
+        }
     }
 }

--- a/runner/src/util/mod.rs
+++ b/runner/src/util/mod.rs
@@ -1,4 +1,5 @@
 pub mod backoff;
 pub mod logging;
 pub mod paths;
+pub mod runner_name;
 pub mod signal;

--- a/runner/src/util/runner_name.rs
+++ b/runner/src/util/runner_name.rs
@@ -92,6 +92,21 @@ mod tests {
     }
 
     #[test]
+    fn whitespace_only_name_is_rejected_as_bad_char() {
+        // A whitespace-only input is not empty (so it gets past the empty
+        // check), but every character is outside the charset. Pins the
+        // behavior explicitly so a future validator refactor can't silently
+        // start accepting names like `"   "`.
+        for bad in [" ", "   ", "\t", "\n"] {
+            assert_eq!(
+                validate(bad),
+                Err(NameValidationError::BadChar),
+                "expected BadChar for whitespace-only {bad:?}",
+            );
+        }
+    }
+
+    #[test]
     fn overlong_name_is_rejected() {
         let too_long = "a".repeat(129);
         assert_eq!(validate(&too_long), Err(NameValidationError::TooLong));

--- a/runner/src/util/runner_name.rs
+++ b/runner/src/util/runner_name.rs
@@ -1,0 +1,141 @@
+//! `runner.name` rules: charset validation + default-name generator.
+//!
+//! Mirror of the cloud-side regex in `apps/api/pi_dash/runner/serializers.py`
+//! (`RUNNER_NAME_CHARSET`). Charset is `[A-Za-z0-9_-]`, length 1..=128.
+//!
+//! Defaults follow the scheme `pidash_runner_<3 random chars from [A-Za-z0-9]>`.
+//! The collision domain is per-workspace (enforced by the cloud DB's
+//! `UNIQUE(workspace_id, name)` constraint), and 62³ ≈ 238k suffixes is ample
+//! at that scope — `configure` retries up to 5 times on `runner_name_taken`
+//! when the name was auto-generated, so a realistic collision rate is near
+//! zero even at thousands of runners per workspace.
+//!
+//! See `.ai_design/runner_install_ux/cli-restructure-and-install-flow.md` §5.
+
+use rand::Rng;
+
+const MAX_LEN: usize = 128;
+
+/// The 62-char alphabet used for the random suffix. No underscore or dash
+/// because the suffix is cosmetic — keeping it purely alphanumeric avoids
+/// awkward names like `pidash_runner_---`.
+const SUFFIX_CHARSET: &[u8] =
+    b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+const SUFFIX_LEN: usize = 3;
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum NameValidationError {
+    #[error("runner name cannot be empty")]
+    Empty,
+    #[error("runner name is longer than {MAX_LEN} characters")]
+    TooLong,
+    #[error(
+        "runner name may only contain letters, digits, underscore, and dash (no spaces or other characters)"
+    )]
+    BadChar,
+}
+
+/// Validate a candidate `runner.name`. Applied to user-supplied `--name`
+/// input; auto-generated names are charset-safe by construction but are
+/// still cheap to re-validate in tests.
+pub fn validate(name: &str) -> Result<(), NameValidationError> {
+    if name.is_empty() {
+        return Err(NameValidationError::Empty);
+    }
+    if name.len() > MAX_LEN {
+        return Err(NameValidationError::TooLong);
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    {
+        return Err(NameValidationError::BadChar);
+    }
+    Ok(())
+}
+
+/// Generate `pidash_runner_<3 random chars>`. Uses the thread-local RNG so
+/// callers don't need to thread one through.
+pub fn generate_default() -> String {
+    let mut rng = rand::thread_rng();
+    let suffix: String = (0..SUFFIX_LEN)
+        .map(|_| SUFFIX_CHARSET[rng.gen_range(0..SUFFIX_CHARSET.len())] as char)
+        .collect();
+    format!("pidash_runner_{suffix}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_names_pass() {
+        for name in [
+            "a",
+            "laptop",
+            "my-laptop",
+            "my_laptop",
+            "pidash_runner_aB3",
+            "CAPS",
+            "abc123",
+            "a-b_c-1",
+            &"a".repeat(128),
+        ] {
+            assert!(validate(name).is_ok(), "expected ok: {name:?}");
+        }
+    }
+
+    #[test]
+    fn empty_name_is_rejected() {
+        assert_eq!(validate(""), Err(NameValidationError::Empty));
+    }
+
+    #[test]
+    fn overlong_name_is_rejected() {
+        let too_long = "a".repeat(129);
+        assert_eq!(validate(&too_long), Err(NameValidationError::TooLong));
+    }
+
+    #[test]
+    fn names_with_disallowed_chars_are_rejected() {
+        for bad in [
+            "has space",
+            "dot.separated",
+            "slash/separator",
+            "emoji-💥",
+            "semicolon;",
+            "plus+sign",
+            "at@host",
+            "paren(s)",
+        ] {
+            assert_eq!(validate(bad), Err(NameValidationError::BadChar), "{bad:?}");
+        }
+    }
+
+    #[test]
+    fn generated_default_has_expected_shape() {
+        for _ in 0..100 {
+            let name = generate_default();
+            assert!(
+                name.starts_with("pidash_runner_"),
+                "missing prefix: {name}"
+            );
+            assert_eq!(
+                name.len(),
+                "pidash_runner_".len() + SUFFIX_LEN,
+                "unexpected length: {name}"
+            );
+            // Every generated default must pass the validator — otherwise the
+            // cloud would reject our own output.
+            assert!(validate(&name).is_ok(), "generated name failed validation: {name}");
+            let suffix = &name["pidash_runner_".len()..];
+            assert!(
+                suffix
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric()),
+                "suffix must be alphanumeric only: {suffix}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Replaces closed #16 (accidental close during base flip-flopping). This PR now targets `main` directly and contains the combined changes from:

- **PR 1 (#14)** — CLI restructure: flatten service-lifecycle verbs to top-level (`pidash install / uninstall / start / stop / restart / status`), hide daemon entry as `__run`, drop the `service` subgroup, regenerate unit files.
- **PR 2 (#15)** — Install flow + config strictness + remove teardown: `pidash install` fresh-install gate with interactive configure chaining on TTY (`--no-configure` for CI), required-field validation in `config.toml`, action-guiding errors from `__run`, `pidash remove` now stops + uninstalls the service, `loginctl enable-linger` hint on Linux.
- **PR 3 (#16, closed)** — Per-workspace `runner.name` uniqueness with charset rules: `util/runner_name.rs` validator + generator, `RegisterError::NameTaken` typed error with retry loop in `configure`, cloud-side `UNIQUE(workspace_id, name)` + regex validator + 409 response.

## Design doc

`.ai_design/runner_install_ux/cli-restructure-and-install-flow.md`

## Test plan

- [x] `cargo test` — 70+ tests green (5 runner_name tests, 3 classify tests, 2 run_errors tests, 5 cli_structure tests, plus existing suite)
- [x] New Python contract tests: duplicate name same workspace → 409 + token unconsumed, duplicate name other workspace → 201, parametrized charset rejection
- [ ] `python manage.py migrate` against staging DB snapshot to confirm migration 0003 applies cleanly

## Upgrade note

Dogfooding installs with the old `ExecStart={exe} start` unit file must run `pidash uninstall` with the OLD binary before installing the new one. The new `pidash start` means "start the service" and would infinite-loop against the old unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)