### PR TITLE
fix(build): hoist @tailwindcss/postcss so vite postcss loader can resolve it

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -52,3 +52,6 @@ public-hoist-pattern[] = eslint
 public-hoist-pattern[] = *@pi-dash/*
 public-hoist-pattern[] = vite
 public-hoist-pattern[] = turbo
+# Hoisted so postcss-load-config / jiti can resolve the plugin from the
+# app's search path even though the dep is declared in @pi-dash/tailwind-config.
+public-hoist-pattern[] = @tailwindcss/postcss


### PR DESCRIPTION
## Summary

- Under `node-linker = isolated`, `@tailwindcss/postcss` was only materialized at `packages/tailwind-config/node_modules/` because it is declared as a dep of `@pi-dash/tailwind-config`.
- Vite's PostCSS loader (`postcss-load-config` via `jiti`) resolves plugin names from the *consuming app's* search path (`apps/web`, `apps/admin`, `apps/space`), where the package is not reachable. Any CSS import (e.g. `@fontsource-variable/inter/index.css`) failed with `Cannot find module '@tailwindcss/postcss'` → `vite:css` internal server error → HTTP 500 on `/`.
- This has been latent since initial commit; it only surfaces on a clean install in an isolated-linker environment.

## Fix

Add one `public-hoist-pattern[]` entry to `.npmrc` so `@tailwindcss/postcss` is hoisted to the workspace root, where every app's search path can see it. Doesn't change any `package.json` or the shared `packages/tailwind-config/postcss.config.js`.

## Alternatives considered

1. Rewriting `packages/tailwind-config/postcss.config.js` to import the plugin directly (`import tailwindcss from "@tailwindcss/postcss"; plugins: [tailwindcss()]`). Tried locally — **didn't work**, because jiti still resolves the transitive module from the original search path.
2. Declaring `@tailwindcss/postcss` as a direct dep in each app's `package.json`. Works, but wider diff (3 files + lockfile) and duplicates the version pin.

## Test plan

- [x] `CI=true pnpm install` — lockfile unchanged; `node_modules/@tailwindcss/postcss` symlink now present at root.
- [x] `pnpm dev` — web starts on :3000, admin :3001, space :3002, live :3100. `curl http://localhost:3000/` → HTTP 200. No `Cannot find module '@tailwindcss/postcss'` entries in the dev log.
- [ ] Reviewer: pull, `rm -rf node_modules && CI=true pnpm install && pnpm dev`, hit `http://localhost:3000`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)