### PR TITLE
chore: PR #17 follow-ups (branch validation, tests, UX)

### DIFF
--- a/apps/api/pi_dash/db/migrations/0125_branch_name_validators.py
+++ b/apps/api/pi_dash/db/migrations/0125_branch_name_validators.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+from django.core import validators
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("db", "0124_issue_git_work_branch"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="project",
+            name="base_branch",
+            field=models.CharField(
+                blank=True,
+                default="main",
+                max_length=128,
+                validators=[
+                    validators.RegexValidator(
+                        message=(
+                            "Branch name may contain only letters, numbers, and . _ / -"
+                        ),
+                        regex="^[A-Za-z0-9._/-]*$",
+                    )
+                ],
+            ),
+        ),
+        migrations.AlterField(
+            model_name="issue",
+            name="git_work_branch",
+            field=models.CharField(
+                blank=True,
+                default="",
+                max_length=128,
+                validators=[
+                    validators.RegexValidator(
+                        message=(
+                            "Branch name may contain only letters, numbers, and . _ / -"
+                        ),
+                        regex="^[A-Za-z0-9._/-]*$",
+                    )
+                ],
+            ),
+        ),
+    ]

--- a/apps/api/pi_dash/db/models/issue.py
+++ b/apps/api/pi_dash/db/models/issue.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import ValidationError
-from django.core.validators import MaxValueValidator, MinValueValidator
+from django.core.validators import MaxValueValidator, MinValueValidator, RegexValidator
 from django.db import models, transaction, connection
 from django.utils import timezone
 from django.db.models import Q
@@ -166,7 +166,17 @@ class Issue(ProjectBaseModel):
         null=True,
         blank=True,
     )
-    git_work_branch = models.CharField(max_length=128, blank=True, default="")
+    git_work_branch = models.CharField(
+        max_length=128,
+        blank=True,
+        default="",
+        validators=[
+            RegexValidator(
+                regex=r"^[A-Za-z0-9._/-]*$",
+                message="Branch name may contain only letters, numbers, and . _ / -",
+            ),
+        ],
+    )
 
     issue_objects = IssueManager()
 

--- a/apps/api/pi_dash/db/models/project.py
+++ b/apps/api/pi_dash/db/models/project.py
@@ -9,7 +9,7 @@ from enum import Enum
 
 # Django imports
 from django.conf import settings
-from django.core.validators import MaxValueValidator, MinValueValidator
+from django.core.validators import MaxValueValidator, MinValueValidator, RegexValidator
 from django.db import models
 from django.db.models import Q
 
@@ -122,7 +122,17 @@ class Project(BaseModel):
     # Repository fields consumed by the prompting system when composing agent
     # prompts. See `.ai_design/prompt_system/prompt-system-design.md` §4.
     repo_url = models.CharField(max_length=512, blank=True, default="")
-    base_branch = models.CharField(max_length=128, blank=True, default="main")
+    base_branch = models.CharField(
+        max_length=128,
+        blank=True,
+        default="main",
+        validators=[
+            RegexValidator(
+                regex=r"^[A-Za-z0-9._/-]*$",
+                message="Branch name may contain only letters, numbers, and . _ / -",
+            ),
+        ],
+    )
 
     def __init__(self, *args, **kwargs):
         # Track if timezone is provided, if so, don't override it with the workspace timezone when saving

--- a/apps/api/pi_dash/tests/unit/models/test_branch_name_validators.py
+++ b/apps/api/pi_dash/tests/unit/models/test_branch_name_validators.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+import pytest
+from django.core.exceptions import ValidationError
+
+from pi_dash.db.models import Issue, Project, State
+
+
+@pytest.fixture
+def project(workspace, create_user):
+    return Project.objects.create(
+        name="Branch Validators",
+        identifier="BV",
+        workspace=workspace,
+        created_by=create_user,
+    )
+
+
+@pytest.fixture
+def issue(workspace, project, create_user):
+    state = State.objects.create(name="Todo", project=project, group="unstarted")
+    return Issue.objects.create(
+        name="Task",
+        workspace=workspace,
+        project=project,
+        state=state,
+        created_by=create_user,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "branch",
+    [
+        "",
+        "main",
+        "develop",
+        "feat/pinned",
+        "release/1.2.3",
+        "user/jdoe/fix_42",
+    ],
+)
+def test_project_base_branch_accepts_valid_names(project, branch):
+    project.base_branch = branch
+    project.full_clean()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "branch",
+    [
+        "feat branch",          # space
+        "feat\tname",           # tab
+        "branch;rm -rf /",      # shell metacharacter
+        "ref@{1}",              # git reflog syntax, but disallowed charset here
+        "feat*",                # glob
+        "branch~1",             # ancestor ref
+    ],
+)
+def test_project_base_branch_rejects_invalid_names(project, branch):
+    project.base_branch = branch
+    with pytest.raises(ValidationError):
+        project.full_clean()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "branch",
+    [
+        "",
+        "feat/pinned",
+        "hotfix/oom_crash",
+    ],
+)
+def test_issue_git_work_branch_accepts_valid_names(issue, branch):
+    issue.git_work_branch = branch
+    issue.full_clean()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "branch",
+    [
+        "feat branch",
+        "feat\nname",
+        "-rf",
+    ],
+)
+def test_issue_git_work_branch_rejects_invalid_names(issue, branch):
+    issue.git_work_branch = branch
+    with pytest.raises(ValidationError):
+        issue.full_clean()

--- a/apps/api/pi_dash/tests/unit/models/test_branch_name_validators.py
+++ b/apps/api/pi_dash/tests/unit/models/test_branch_name_validators.py
@@ -79,13 +79,19 @@ def test_issue_git_work_branch_accepts_valid_names(issue, branch):
     issue.full_clean()
 
 
+# Note: the server-side regex is intentionally a subset of git's own
+# `check-ref-format`; it mirrors the client-side form regex. It does not
+# reject leading-dash names (e.g. "-rf") because `-` is a valid branch
+# character. The runner's `validate_branch_name` is the load-bearing
+# guard against `git` flag smuggling.
 @pytest.mark.unit
 @pytest.mark.parametrize(
     "branch",
     [
-        "feat branch",
-        "feat\nname",
-        "-rf",
+        "feat branch",      # space
+        "feat\nname",       # newline
+        "ref@{1}",          # `@` and braces are outside the charset
+        "feat branch?",     # `?`
     ],
 )
 def test_issue_git_work_branch_rejects_invalid_names(issue, branch):

--- a/apps/api/pi_dash/tests/unit/orchestration/test_service.py
+++ b/apps/api/pi_dash/tests/unit/orchestration/test_service.py
@@ -129,3 +129,42 @@ def test_non_trigger_state_does_nothing(seeded, issue, states):
     )
     assert outcome.reason == "not-a-trigger-state"
     assert outcome.created_run is None
+
+
+@pytest.mark.unit
+def test_run_config_carries_git_fields_from_issue_and_project(
+    seeded, project, issue, states
+):
+    project.repo_url = "git@github.com:acme/web.git"
+    project.base_branch = "develop"
+    project.save(update_fields=["repo_url", "base_branch"])
+    issue.git_work_branch = "feat/pinned"
+    issue.save(update_fields=["git_work_branch"])
+
+    outcome = service.handle_issue_state_transition(
+        issue=issue,
+        from_state=states["todo"],
+        to_state=states["in_progress"],
+    )
+    assert outcome.reason == "created"
+    cfg = outcome.created_run.run_config
+    assert cfg["repo_url"] == "git@github.com:acme/web.git"
+    assert cfg["repo_ref"] == "develop"
+    assert cfg["git_work_branch"] == "feat/pinned"
+
+
+@pytest.mark.unit
+def test_run_config_empty_git_fields_surface_as_none(seeded, issue, states):
+    # Project defaults to blank repo_url; issue defaults to blank work branch.
+    # Both must land as ``None`` so the runner / prompt fallbacks kick in
+    # rather than comparing against empty strings.
+    outcome = service.handle_issue_state_transition(
+        issue=issue,
+        from_state=states["todo"],
+        to_state=states["in_progress"],
+    )
+    cfg = outcome.created_run.run_config
+    assert cfg["repo_url"] is None
+    assert cfg["git_work_branch"] is None
+
+

--- a/apps/api/pi_dash/tests/unit/orchestration/test_service.py
+++ b/apps/api/pi_dash/tests/unit/orchestration/test_service.py
@@ -166,5 +166,3 @@ def test_run_config_empty_git_fields_surface_as_none(seeded, issue, states):
     cfg = outcome.created_run.run_config
     assert cfg["repo_url"] is None
     assert cfg["git_work_branch"] is None
-
-

--- a/apps/web/core/components/issues/issue-modal/components/issue-git-advanced.tsx
+++ b/apps/web/core/components/issues/issue-modal/components/issue-git-advanced.tsx
@@ -6,7 +6,7 @@
 
 import { useState } from "react";
 import type { Control } from "react-hook-form";
-import { Controller } from "react-hook-form";
+import { Controller, useWatch } from "react-hook-form";
 import { ChevronRight } from "lucide-react";
 import { useTranslation } from "@pi-dash/i18n";
 import type { TIssue } from "@pi-dash/types";
@@ -25,7 +25,11 @@ type Props = {
 export function IssueGitAdvanced(props: Props) {
   const { control, handleFormChange } = props;
   const { t } = useTranslation();
-  const [open, setOpen] = useState(false);
+  // Auto-expand when the issue already carries a value so the user can see /
+  // edit it without a disclosure hunt. Kept out of state deps so it only
+  // applies on mount; user-driven toggles still win after that.
+  const initialWorkBranch = useWatch({ control, name: "git_work_branch", defaultValue: "" });
+  const [open, setOpen] = useState(() => Boolean(initialWorkBranch));
 
   return (
     <div className="px-5">

--- a/runner/src/daemon/supervisor.rs
+++ b/runner/src/daemon/supervisor.rs
@@ -432,19 +432,18 @@ impl AssignWorker {
         // Pre-flight checkout: if the issue pins an existing branch, land on
         // it before the agent runs so it commits onto that branch directly.
         // When not set, the agent handles branch creation per the prompt.
-        if let Some(branch) = git_work_branch.as_deref().filter(|s| !s.is_empty()) {
-            if let Err(e) =
+        if let Some(branch) = git_work_branch.as_deref().filter(|s| !s.is_empty())
+            && let Err(e) =
                 crate::workspace::git::checkout_work_branch(&workspace_path, branch).await
-            {
-                self.send(ClientMsg::RunFailed {
-                    run_id,
-                    reason: FailureReason::WorkspaceSetup,
-                    detail: Some(format!("checkout {branch}: {e:#}")),
-                    ended_at: Utc::now(),
-                })
-                .await;
-                return Ok(());
-            }
+        {
+            self.send(ClientMsg::RunFailed {
+                run_id,
+                reason: FailureReason::WorkspaceSetup,
+                detail: Some(format!("checkout {branch}: {e:#}")),
+                ended_at: Utc::now(),
+            })
+            .await;
+            return Ok(());
         }
 
         let ws_state = crate::workspace::git::workspace_state(&workspace_path)

--- a/runner/src/workspace/git.rs
+++ b/runner/src/workspace/git.rs
@@ -61,17 +61,12 @@ pub async fn workspace_state(path: &Path) -> Result<WorkspaceState> {
 /// Fetch from origin and check out the given branch so the agent can commit
 /// directly onto an existing feature branch. Called before the Codex process
 /// spawns when an issue specifies `git_work_branch`.
+///
+/// Assumes the workspace is ephemeral / server-owned: `git checkout -B`
+/// force-resets the local branch pointer to match `origin/<branch>`, which
+/// would discard any unpushed local commits on that branch.
 pub async fn checkout_work_branch(path: &Path, branch: &str) -> Result<()> {
-    // Reject shell metacharacters / flag-like values up front. Branches with
-    // these characters cannot be valid git refs, and passing them to git would
-    // either error cryptically or (worst case) let a crafted ref smuggle flags
-    // through as `git` command options.
-    if branch.is_empty()
-        || branch.starts_with('-')
-        || branch.chars().any(|c| c.is_control() || c == ' ')
-    {
-        anyhow::bail!("invalid work branch name: {branch:?}");
-    }
+    validate_branch_name(branch)?;
 
     git_output(path, &["fetch", "origin", branch])
         .await
@@ -82,6 +77,20 @@ pub async fn checkout_work_branch(path: &Path, branch: &str) -> Result<()> {
     git_output(path, &["checkout", "-B", branch, remote_ref.as_str()])
         .await
         .with_context(|| format!("git checkout {branch}"))?;
+    Ok(())
+}
+
+/// Injection-level validation: reject names that could be mistaken for a git
+/// flag or contain characters that don't belong in a branch name. Does not
+/// enforce the full `git check-ref-format` rules — git itself catches those
+/// when the command runs and surfaces the error via `WorkspaceSetup`.
+fn validate_branch_name(branch: &str) -> Result<()> {
+    if branch.is_empty()
+        || branch.starts_with('-')
+        || branch.chars().any(|c| c.is_control() || c == ' ')
+    {
+        anyhow::bail!("invalid work branch name: {branch:?}");
+    }
     Ok(())
 }
 
@@ -99,4 +108,38 @@ async fn git_output(path: &Path, args: &[&str]) -> Result<String> {
         );
     }
     Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_branch_name;
+
+    #[test]
+    fn rejects_empty() {
+        assert!(validate_branch_name("").is_err());
+    }
+
+    #[test]
+    fn rejects_leading_dash() {
+        // `-rf`, `--upload-pack=...` could otherwise smuggle a flag past `git`.
+        assert!(validate_branch_name("-rf").is_err());
+        assert!(validate_branch_name("--upload-pack=evil").is_err());
+    }
+
+    #[test]
+    fn rejects_whitespace_and_control_chars() {
+        assert!(validate_branch_name(" ").is_err());
+        assert!(validate_branch_name("feat/with space").is_err());
+        assert!(validate_branch_name("feat\tname").is_err());
+        assert!(validate_branch_name("feat\nname").is_err());
+        assert!(validate_branch_name("feat\0name").is_err());
+    }
+
+    #[test]
+    fn accepts_normal_branch_names() {
+        assert!(validate_branch_name("main").is_ok());
+        assert!(validate_branch_name("feat/pinned-branch").is_ok());
+        assert!(validate_branch_name("release/1.2.3").is_ok());
+        assert!(validate_branch_name("user/jdoe/fix_42").is_ok());
+    }
 }


### PR DESCRIPTION
## Summary

Follow-ups from the code review of #17. All changes are additive / internal; no API shape or UX regression.

- **Server-side branch validation** — `RegexValidator(r\"^[A-Za-z0-9._/-]*$\")` on `Project.base_branch` and `Issue.git_work_branch` (migration `0125`). Matches the client-side regex the web forms already enforce. Closes the defense-in-depth gap the review flagged.
- **Runner `validate_branch_name` unit tests** — empty / leading-dash / whitespace / control-char rejections, plus happy-path names. Locks down the guard that prevents a crafted branch name from smuggling a flag to `git`.
- **Clippy clean-up in `supervisor.rs`** — collapse the nested `if` that PR #17 introduced. Drops the runner clippy error count from 8 → 7 (remaining 7 are pre-existing).
- **`IssueGitAdvanced` auto-expand** — when an issue already carries a non-empty `git_work_branch`, mount with the panel open so the user isn't hunting for a hidden disclosure.
- **Orchestration tests** — two cases asserting `run_config` carries `repo_url` / `repo_ref` / `git_work_branch` through (populated + empty→`None`).
- **Doc comment** — note on `checkout_work_branch` that `git checkout -B` assumes an ephemeral, server-owned workspace (force-resets local branch pointer).

## Test plan

- [x] `cargo test` in `runner/` — 47/47 pass
- [x] `cargo clippy -- -D warnings` — no new errors introduced (went 8 → 7)
- [x] Python syntax check on changed files
- [ ] CI to run `pytest apps/api` and `pnpm check` (can't run locally without env setup)
- [ ] Apply migration `0125_branch_name_validators` locally; should be a no-op on the DB (validators are Python-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)