### PR TITLE
ci(release): define [profile.dist] for cargo-dist builds

### DIFF
--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -71,3 +71,9 @@ strip = true
 
 [profile.dev]
 opt-level = 0
+
+# Profile cargo-dist invokes via `cargo build --profile dist` for release
+# tarballs. Inherits release's settings (LTO, single codegen unit, strip)
+# rather than redefining them so any future tweak to release flows through.
+[profile.dist]
+inherits = "release"


### PR DESCRIPTION
## Summary

Follow-up to #26. Tagging \`v0.1.0\` triggered the Release workflow successfully, but every \`build-local-artifacts\` job failed in <15s with:

\`\`\`
error: profile \`dist\` is not defined
× failed to find bin pidash for path+file:///.../runner#pidash@0.1.0
\`\`\`

cargo-dist invokes \`cargo build --profile dist\` for the release tarballs. \`runner/Cargo.toml\` only declared \`release\` + \`dev\`. Add \`[profile.dist] inherits = \"release\"\` so the dist profile picks up our existing LTO / codegen-units / strip settings without duplication.

The bad \`v0.1.0\` tag has been deleted (locally + remotely) and the failed run cancelled — once this merges I'll re-tag.

## Test plan

- [x] Locally: \`cargo build --profile dist --manifest-path runner/Cargo.toml\` → succeeds, produces \`target/dist/pidash\`
- [ ] After merge: re-tag \`v0.1.0\`, full matrix builds, GitHub Release publishes \`pidash-installer.sh\` + 4 platform tarballs

🤖 Generated with [Claude Code](https://claude.com/claude-code)