### PR TITLE
feat(web): add Runners item to workspace sidebar

### DIFF
--- a/apps/web/ce/components/workspace/sidebar/helper.tsx
+++ b/apps/web/ce/components/workspace/sidebar/helper.tsx
@@ -4,7 +4,7 @@
  * See the LICENSE file for details.
  */
 
-import { FileText } from "lucide-react";
+import { FileText, Server } from "lucide-react";
 import {
   AnalyticsIcon,
   ArchiveIcon,
@@ -43,5 +43,7 @@ export const getSidebarNavigationItemIcon = (key: string, className: string = ""
       return <MultipleStickyIcon className={cn("size-4 flex-shrink-0", className)} />;
     case "prompts":
       return <FileText className={cn("size-4 flex-shrink-0", className)} />;
+    case "runners":
+      return <Server className={cn("size-4 flex-shrink-0", className)} />;
   }
 };

--- a/apps/web/core/components/workspace/sidebar/sidebar-item.tsx
+++ b/apps/web/core/components/workspace/sidebar/sidebar-item.tsx
@@ -51,6 +51,7 @@ export const SidebarItemBase = observer(function SidebarItemBase({
     "home",
     "pi_chat",
     "projects",
+    "runners",
     "prompts",
     "your_work",
     "stickies",

--- a/packages/constants/src/workspace.ts
+++ b/packages/constants/src/workspace.ts
@@ -275,7 +275,7 @@ export const WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS: Record<string, IWorkspac
     key: "runners",
     labelTranslationKey: "sidebar.runners",
     href: `/runners/`,
-    access: [EUserWorkspaceRoles.ADMIN, EUserWorkspaceRoles.MEMBER, EUserWorkspaceRoles.GUEST],
+    access: [EUserWorkspaceRoles.ADMIN, EUserWorkspaceRoles.MEMBER],
     highlight: (pathname: string, url: string) => pathname.includes(url),
   },
   prompts: {

--- a/packages/constants/src/workspace.ts
+++ b/packages/constants/src/workspace.ts
@@ -271,6 +271,13 @@ export const WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS: Record<string, IWorkspac
     access: [EUserWorkspaceRoles.ADMIN, EUserWorkspaceRoles.MEMBER, EUserWorkspaceRoles.GUEST],
     highlight: (pathname: string, url: string) => pathname === url,
   },
+  runners: {
+    key: "runners",
+    labelTranslationKey: "sidebar.runners",
+    href: `/runners/`,
+    access: [EUserWorkspaceRoles.ADMIN, EUserWorkspaceRoles.MEMBER, EUserWorkspaceRoles.GUEST],
+    highlight: (pathname: string, url: string) => pathname.includes(url),
+  },
   prompts: {
     key: "prompts",
     labelTranslationKey: "sidebar.prompts",
@@ -286,6 +293,7 @@ export const WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS_LINKS: IWorkspaceSidebarN
 
 export const WORKSPACE_SIDEBAR_STATIC_PINNED_NAVIGATION_ITEMS_LINKS: IWorkspaceSidebarNavigationItem[] = [
   WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS["projects"],
+  WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS["runners"],
   WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS["prompts"],
 ];
 

--- a/packages/i18n/src/locales/en/core.ts
+++ b/packages/i18n/src/locales/en/core.ts
@@ -25,6 +25,7 @@ export default {
     upgrade: "Upgrade",
     stickies: "Stickies",
     prompts: "Prompts",
+    runners: "Runners",
   },
 
   prompts: {


### PR DESCRIPTION
## Summary
- Surfaces the existing `/[workspaceSlug]/runners` page in the left sidebar between **Projects** and **Prompts**. Until now that page was only reachable by typing the URL manually.
- No new backend or UI behavior — the page already handles list / mint registration token (add) / revoke (remove). This PR is nav wiring only.

## Changes
- `packages/constants/src/workspace.ts` — register `runners` in `WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS` and insert it into `WORKSPACE_SIDEBAR_STATIC_PINNED_NAVIGATION_ITEMS_LINKS` between projects and prompts.
- `apps/web/core/components/workspace/sidebar/sidebar-item.tsx` — allow-list `"runners"` in the `staticItems` array so it renders without the user having to pin it.
- `apps/web/ce/components/workspace/sidebar/helper.tsx` — map the `runners` key to the lucide `Server` icon.
- `packages/i18n/src/locales/en/core.ts` — add `sidebar.runners: "Runners"`.

## Notes
- Access is `ADMIN | MEMBER | GUEST`, matching Projects/Prompts. Guests who can already hit the page directly can now see it in the nav.
- Only the EN locale string is added; other locales will fall back to the EN value until translated.
- "Edit" wasn't wired because a runner's identity (`workspace`, `name`, `os/arch/version/heartbeat`) is owned by the daemon at enrollment — the only server-side mutations exposed are `revoke` and bearer-auth `rotate`/`deregister`. If we want an editable display label we'd need a new API field + endpoint; happy to do that in a follow-up.

## Test plan
- [ ] `pnpm install && pnpm --filter @pi-dash/constants build && pnpm --filter @pi-dash/i18n build && pnpm --filter web dev`
- [ ] Load any workspace as ADMIN/MEMBER/GUEST and confirm "Runners" appears between Projects and Prompts in the workspace sidebar section, with the Server icon.
- [ ] Click the item → lands on `/<workspaceSlug>/runners`, existing list/mint-token/revoke flows work.
- [ ] Active-route highlight lights up on `/runners` and its sub-paths (`/runs`, `/approvals`).
- [ ] Sidebar item is hidden for users without WORKSPACE access (expected — gated by the same access matrix as Projects/Prompts).