### PR TITLE
feat(runner): add Claude Code agent support (MVP)

### DIFF
--- a/runner/src/agent/mod.rs
+++ b/runner/src/agent/mod.rs
@@ -86,13 +86,17 @@ impl AgentCursor {
 
 impl AgentBridge {
     /// Spawn the agent subprocess selected by the runner's config.
-    pub async fn spawn_from_config(config: &Config, cwd: &Path) -> Result<Self> {
+    pub async fn spawn_from_config(
+        config: &Config,
+        cwd: &Path,
+        model_override: Option<String>,
+    ) -> Result<Self> {
         match config.agent.kind {
             AgentKind::Codex => {
                 let b = crate::codex::bridge::Bridge::spawn(
                     &config.codex.binary,
                     cwd,
-                    config.codex.model_default.clone(),
+                    selected_model(model_override, config.codex.model_default.clone()),
                 )
                 .await?;
                 Ok(AgentBridge::Codex(b))
@@ -101,7 +105,7 @@ impl AgentBridge {
                 let b = crate::claude_code::bridge::Bridge::spawn(
                     &config.claude_code.binary,
                     cwd,
-                    config.claude_code.model_default.clone(),
+                    selected_model(model_override, config.claude_code.model_default.clone()),
                 )
                 .await?;
                 Ok(AgentBridge::ClaudeCode(b))
@@ -155,5 +159,41 @@ impl AgentBridge {
             AgentBridge::Codex(b) => b.server.shutdown(grace).await,
             AgentBridge::ClaudeCode(b) => b.shutdown(grace).await,
         }
+    }
+}
+
+fn selected_model(
+    model_override: Option<String>,
+    configured_default: Option<String>,
+) -> Option<String> {
+    model_override.or(configured_default)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::selected_model;
+
+    #[test]
+    fn selected_model_prefers_run_override() {
+        assert_eq!(
+            selected_model(
+                Some("claude-override".into()),
+                Some("claude-default".into())
+            ),
+            Some("claude-override".into())
+        );
+    }
+
+    #[test]
+    fn selected_model_falls_back_to_config_default() {
+        assert_eq!(
+            selected_model(None, Some("claude-default".into())),
+            Some("claude-default".into())
+        );
+    }
+
+    #[test]
+    fn selected_model_returns_none_when_unset() {
+        assert_eq!(selected_model(None, None), None);
     }
 }

--- a/runner/src/agent/mod.rs
+++ b/runner/src/agent/mod.rs
@@ -1,0 +1,159 @@
+//! Agent abstraction layer. Both the Codex and Claude Code bridges expose
+//! the same behavioural surface (`spawn`, `run`, `next_events`, `send_approval`,
+//! `interrupt`, `shutdown`) through [`AgentBridge`], so the supervisor does
+//! not have to know which underlying CLI is driving a run.
+
+use anyhow::Result;
+use std::path::Path;
+use std::time::Duration;
+use uuid::Uuid;
+
+use crate::cloud::protocol::{ApprovalDecision, ApprovalKind, FailureReason};
+use crate::config::schema::{AgentKind, Config};
+
+/// Events the bridge surfaces to the daemon's state machine. Agent-agnostic:
+/// Codex and Claude both translate their native protocols into this shape.
+#[derive(Debug, Clone)]
+pub enum BridgeEvent {
+    RunStarted {
+        run_id: Uuid,
+        thread_id: String,
+    },
+    Raw {
+        run_id: Uuid,
+        method: String,
+        params: serde_json::Value,
+    },
+    ApprovalRequest {
+        run_id: Uuid,
+        approval_id: String,
+        kind: ApprovalKind,
+        payload: serde_json::Value,
+        reason: Option<String>,
+    },
+    AwaitingReauth {
+        run_id: Uuid,
+        detail: Option<String>,
+    },
+    Completed {
+        run_id: Uuid,
+        done_payload: serde_json::Value,
+    },
+    Failed {
+        run_id: Uuid,
+        reason: FailureReason,
+        detail: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct RunPayload {
+    pub run_id: Uuid,
+    pub prompt: String,
+    pub model: Option<String>,
+    pub resume_thread_id: Option<String>,
+}
+
+/// Enum dispatch over the concrete bridges. Each variant owns the agent's
+/// subprocess; the supervisor treats them uniformly.
+pub enum AgentBridge {
+    Codex(crate::codex::bridge::Bridge),
+    ClaudeCode(crate::claude_code::bridge::Bridge),
+}
+
+/// Per-run cursor, paired with an `AgentBridge`. Holds agent-specific frame
+/// translation state (sequence numbers, session ids).
+pub enum AgentCursor {
+    Codex(crate::codex::bridge::BridgeCursor),
+    ClaudeCode(crate::claude_code::bridge::BridgeCursor),
+}
+
+impl AgentCursor {
+    pub fn run_id(&self) -> Uuid {
+        match self {
+            AgentCursor::Codex(c) => c.run_id,
+            AgentCursor::ClaudeCode(c) => c.run_id,
+        }
+    }
+
+    pub fn thread_id(&self) -> &str {
+        match self {
+            AgentCursor::Codex(c) => &c.thread_id,
+            AgentCursor::ClaudeCode(c) => &c.thread_id,
+        }
+    }
+}
+
+impl AgentBridge {
+    /// Spawn the agent subprocess selected by the runner's config.
+    pub async fn spawn_from_config(config: &Config, cwd: &Path) -> Result<Self> {
+        match config.agent.kind {
+            AgentKind::Codex => {
+                let b = crate::codex::bridge::Bridge::spawn(
+                    &config.codex.binary,
+                    cwd,
+                    config.codex.model_default.clone(),
+                )
+                .await?;
+                Ok(AgentBridge::Codex(b))
+            }
+            AgentKind::ClaudeCode => {
+                let b = crate::claude_code::bridge::Bridge::spawn(
+                    &config.claude_code.binary,
+                    cwd,
+                    config.claude_code.model_default.clone(),
+                )
+                .await?;
+                Ok(AgentBridge::ClaudeCode(b))
+            }
+        }
+    }
+
+    pub async fn run(&mut self, payload: &RunPayload, cwd: &Path) -> Result<AgentCursor> {
+        match self {
+            AgentBridge::Codex(b) => Ok(AgentCursor::Codex(b.run(payload, cwd).await?)),
+            AgentBridge::ClaudeCode(b) => Ok(AgentCursor::ClaudeCode(b.run(payload, cwd).await?)),
+        }
+    }
+
+    /// Wait for the next batch of events from the agent. Returns `None` when
+    /// the subprocess has closed its output stream (no more events will ever
+    /// arrive); callers should surface that as a run failure.
+    pub async fn next_events(&mut self, cursor: &mut AgentCursor) -> Option<Vec<BridgeEvent>> {
+        match (self, cursor) {
+            (AgentBridge::Codex(b), AgentCursor::Codex(c)) => {
+                let frame = b.next_frame().await?;
+                Some(c.translate(frame))
+            }
+            (AgentBridge::ClaudeCode(b), AgentCursor::ClaudeCode(c)) => b.next_events(c).await,
+            // These pairings are constructed together by `run`, so a mismatch
+            // is a programmer error — fail loudly.
+            _ => panic!("agent bridge and cursor variants mismatched"),
+        }
+    }
+
+    pub async fn send_approval(
+        &mut self,
+        approval_id: &str,
+        decision: ApprovalDecision,
+    ) -> Result<()> {
+        match self {
+            AgentBridge::Codex(b) => b.send_approval(approval_id, decision).await,
+            AgentBridge::ClaudeCode(b) => b.send_approval(approval_id, decision).await,
+        }
+    }
+
+    pub async fn interrupt(&mut self) -> Result<()> {
+        match self {
+            AgentBridge::Codex(b) => b.interrupt().await,
+            AgentBridge::ClaudeCode(b) => b.interrupt().await,
+        }
+    }
+
+    pub async fn shutdown(self, grace: Duration) -> Result<()> {
+        match self {
+            AgentBridge::Codex(b) => b.server.shutdown(grace).await,
+            AgentBridge::ClaudeCode(b) => b.shutdown(grace).await,
+        }
+    }
+}

--- a/runner/src/approval/policy.rs
+++ b/runner/src/approval/policy.rs
@@ -59,12 +59,11 @@ impl<'a> Policy<'a> {
         }
         match kind {
             ApprovalKind::FileChange => {
-                if self.config.auto_approve_workspace_writes {
-                    if let Some(path) = payload.get("path").and_then(|v| v.as_str()) {
-                        if path_under_workspace(path, self.workspace_root) {
-                            return Decision::AutoAccept;
-                        }
-                    }
+                if self.config.auto_approve_workspace_writes
+                    && let Some(path) = payload.get("path").and_then(|v| v.as_str())
+                    && path_under_workspace(path, self.workspace_root)
+                {
+                    return Decision::AutoAccept;
                 }
                 Decision::Ask
             }

--- a/runner/src/approval/router.rs
+++ b/runner/src/approval/router.rs
@@ -122,15 +122,14 @@ impl ApprovalRouter {
             // Decision arrived before open() — buffer it so the eventual
             // open() can resolve immediately. Without this, a fast cloud
             // reply would strand the worker.
-            if s.early_decisions.len() >= EARLY_DECISIONS_CAP {
-                if let Some(oldest) = s
+            if s.early_decisions.len() >= EARLY_DECISIONS_CAP
+                && let Some(oldest) = s
                     .early_decisions
                     .iter()
                     .min_by_key(|(_, (_, _, ts))| *ts)
                     .map(|(k, _)| k.clone())
-                {
-                    s.early_decisions.remove(&oldest);
-                }
+            {
+                s.early_decisions.remove(&oldest);
             }
             s.early_decisions
                 .insert(approval_id.to_string(), (decision, source, Utc::now()));

--- a/runner/src/claude_code/bridge.rs
+++ b/runner/src/claude_code/bridge.rs
@@ -1,0 +1,241 @@
+//! Claude Code bridge. Drives the `claude --print` subprocess for one run
+//! and translates stream-json events into agent-agnostic
+//! [`crate::agent::BridgeEvent`]s.
+//!
+//! The public surface intentionally mirrors `codex::bridge::Bridge` so the
+//! agent dispatch layer can treat the two uniformly:
+//!
+//! - [`Bridge::spawn`] — launch the subprocess
+//! - [`Bridge::run`] — feed the user prompt, return a per-run cursor
+//! - [`Bridge::next_events`] — pump translated events until the run ends
+//! - [`Bridge::send_approval`] — stub for MVP (bypassPermissions is on)
+//! - [`Bridge::interrupt`] — cancel the run (SIGINT the child)
+//! - [`Bridge::shutdown`] — drain and exit
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use std::collections::VecDeque;
+use std::path::Path;
+use std::time::Duration;
+use uuid::Uuid;
+
+use crate::agent::{BridgeEvent, RunPayload};
+use crate::claude_code::process::{ClaudeProcess, SpawnArgs};
+use crate::claude_code::schema::{StreamEvent, UserInput};
+use crate::cloud::protocol::{ApprovalDecision, FailureReason};
+
+/// How long to wait for Claude's `system/init` frame before giving up on
+/// the run setup. Chosen to be generous: Claude can take several seconds to
+/// emit init when starting cold.
+const INIT_TIMEOUT: Duration = Duration::from_secs(30);
+
+pub struct Bridge {
+    proc: ClaudeProcess,
+    model_default: Option<String>,
+    /// Events received while we were waiting synchronously for `system/init`
+    /// inside `run()`. Drained by `next_events` before touching the mpsc so
+    /// no frame is lost across the run-setup boundary.
+    pending: VecDeque<StreamEvent>,
+}
+
+impl Bridge {
+    pub async fn spawn(binary: &str, cwd: &Path, model_default: Option<String>) -> Result<Self> {
+        let proc = ClaudeProcess::spawn(SpawnArgs {
+            binary,
+            cwd,
+            model: model_default.as_deref(),
+            bypass_permissions: true,
+        })
+        .await?;
+        Ok(Self {
+            proc,
+            model_default,
+            pending: VecDeque::new(),
+        })
+    }
+
+    /// Test-friendly constructor that wraps an already-built `ClaudeProcess`
+    /// (typically a shell-script fake).
+    pub fn from_process(proc: ClaudeProcess, model_default: Option<String>) -> Self {
+        Self {
+            proc,
+            model_default,
+            pending: VecDeque::new(),
+        }
+    }
+
+    /// Send the prompt and block until Claude emits its `system/init` frame
+    /// so the returned cursor carries a populated `thread_id`, matching the
+    /// Codex bridge's contract. Frames that arrive before init (rare but
+    /// allowed by the protocol) are buffered and replayed by `next_events`.
+    pub async fn run(&mut self, payload: &RunPayload, _cwd: &Path) -> Result<BridgeCursor> {
+        let _ = payload.model.as_ref().or(self.model_default.as_ref());
+        let input = UserInput::user_text(&payload.prompt);
+        let line = serde_json::to_string(&input)?;
+        self.proc.send_line(&line).await?;
+        // Half-close so Claude processes the turn and exits when done.
+        self.proc.close_stdin();
+
+        let deadline = tokio::time::Instant::now() + INIT_TIMEOUT;
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            let recv = tokio::time::timeout(remaining, self.proc.inbound.recv())
+                .await
+                .context("timed out waiting for claude system/init")?;
+            match recv {
+                Some(StreamEvent::System(ref sys)) if sys.subtype == "init" => {
+                    let thread_id = sys
+                        .session_id
+                        .clone()
+                        .unwrap_or_else(|| format!("claude-{}", payload.run_id));
+                    return Ok(BridgeCursor {
+                        run_id: payload.run_id,
+                        thread_id,
+                        init_consumed: true,
+                        terminal: false,
+                        seq: 0,
+                    });
+                }
+                Some(other) => self.pending.push_back(other),
+                None => anyhow::bail!("claude stdout closed before emitting system/init"),
+            }
+        }
+    }
+
+    /// Pull the next event off the subprocess (or the pre-init buffer) and
+    /// translate it. Returns `None` once the stdout stream closes for good;
+    /// callers should treat that as EOF and exit their pump loop.
+    pub async fn next_events(&mut self, cursor: &mut BridgeCursor) -> Option<Vec<BridgeEvent>> {
+        loop {
+            let ev = if let Some(buffered) = self.pending.pop_front() {
+                buffered
+            } else {
+                self.proc.inbound.recv().await?
+            };
+            let translated = cursor.translate(ev);
+            // Skip empty translations (e.g. duplicate init frames that get
+            // suppressed) so the supervisor isn't repeatedly woken for no
+            // reason.
+            if !translated.is_empty() {
+                return Some(translated);
+            }
+        }
+    }
+
+    /// Approvals aren't wired for Claude in the MVP (bypassPermissions is
+    /// set, so the subprocess never asks). We accept the call to keep the
+    /// agent dispatch interface uniform; it's an error if it ever fires.
+    pub async fn send_approval(
+        &mut self,
+        approval_id: &str,
+        _decision: ApprovalDecision,
+    ) -> Result<()> {
+        tracing::warn!(
+            approval_id,
+            "claude_code bridge received approval decision but approvals are \
+             bypassed in MVP; ignoring"
+        );
+        Ok(())
+    }
+
+    pub async fn interrupt(&mut self) -> Result<()> {
+        self.proc.interrupt().await
+    }
+
+    pub async fn shutdown(self, grace: Duration) -> Result<()> {
+        self.proc.shutdown(grace).await
+    }
+}
+
+/// Per-run translation state. The `system/init` frame is consumed inside
+/// `Bridge::run`, so by the time the cursor is handed to the supervisor the
+/// `thread_id` is already populated (matching Codex's lifecycle order).
+pub struct BridgeCursor {
+    pub run_id: Uuid,
+    pub thread_id: String,
+    /// True once `Bridge::run` has eaten the leading `init` frame. A second
+    /// `system/init` is silently dropped — Claude shouldn't emit one but we
+    /// defend against it anyway.
+    init_consumed: bool,
+    /// Flipped once we see a terminal `result` frame. Used to suppress any
+    /// trailing frames a stubborn subprocess might emit after completion.
+    terminal: bool,
+    pub seq: u64,
+}
+
+impl BridgeCursor {
+    pub fn translate(&mut self, ev: StreamEvent) -> Vec<BridgeEvent> {
+        if self.terminal {
+            return Vec::new();
+        }
+        self.seq = self.seq.saturating_add(1);
+
+        match ev {
+            StreamEvent::System(sys) => {
+                // Duplicate init is a no-op; the real init is handled in
+                // `Bridge::run` so the cursor's `thread_id` is always set.
+                if sys.subtype == "init" && self.init_consumed {
+                    return Vec::new();
+                }
+                let params = serde_json::to_value(&sys.rest).unwrap_or(serde_json::Value::Null);
+                vec![BridgeEvent::Raw {
+                    run_id: self.run_id,
+                    method: format!("system/{}", sys.subtype),
+                    params,
+                }]
+            }
+            StreamEvent::Assistant(a) => vec![BridgeEvent::Raw {
+                run_id: self.run_id,
+                method: "assistant/message".into(),
+                params: a.message,
+            }],
+            StreamEvent::User(u) => vec![BridgeEvent::Raw {
+                run_id: self.run_id,
+                method: "user/toolResult".into(),
+                params: u.message,
+            }],
+            StreamEvent::Result(r) => {
+                self.terminal = true;
+                let is_err = r.is_error.unwrap_or(false) || r.subtype.starts_with("error");
+                if is_err {
+                    let detail = r
+                        .result
+                        .clone()
+                        .or_else(|| Some(format!("claude result subtype: {}", r.subtype)));
+                    vec![BridgeEvent::Failed {
+                        run_id: self.run_id,
+                        reason: classify_failure(&r.subtype),
+                        detail,
+                    }]
+                } else {
+                    let done_payload = serde_json::json!({
+                        "conclusion": r.subtype,
+                        "result": r.result,
+                        "total_cost_usd": r.total_cost_usd,
+                        "usage": r.usage,
+                        "ended_at": Utc::now().to_rfc3339(),
+                    });
+                    vec![BridgeEvent::Completed {
+                        run_id: self.run_id,
+                        done_payload,
+                    }]
+                }
+            }
+            StreamEvent::Unknown(v) => vec![BridgeEvent::Raw {
+                run_id: self.run_id,
+                method: "unknown".into(),
+                params: v,
+            }],
+        }
+    }
+}
+
+/// Best-effort mapping from Claude's `result.subtype` to our
+/// `FailureReason`. We don't have a dedicated `ClaudeCrash` variant yet, so
+/// errors surface as `CodexCrash`; rename once we consolidate the enum.
+fn classify_failure(subtype: &str) -> FailureReason {
+    match subtype {
+        "error_max_turns" => FailureReason::Internal,
+        _ => FailureReason::CodexCrash,
+    }
+}

--- a/runner/src/claude_code/bridge.rs
+++ b/runner/src/claude_code/bridge.rs
@@ -120,19 +120,25 @@ impl Bridge {
     }
 
     /// Approvals aren't wired for Claude in the MVP (bypassPermissions is
-    /// set, so the subprocess never asks). We accept the call to keep the
-    /// agent dispatch interface uniform; it's an error if it ever fires.
+    /// set, so the subprocess never asks). Reaching this is a programmer
+    /// error — either the bypass flag was flipped without wiring the
+    /// permission-prompt MCP bridge, or the dispatch layer misrouted an
+    /// approval. Fail fast so the supervisor surfaces the bug instead of
+    /// silently dropping the operator's decision.
     pub async fn send_approval(
         &mut self,
         approval_id: &str,
         _decision: ApprovalDecision,
     ) -> Result<()> {
-        tracing::warn!(
+        tracing::error!(
             approval_id,
-            "claude_code bridge received approval decision but approvals are \
-             bypassed in MVP; ignoring"
+            "claude_code bridge received an approval decision but approvals are \
+             not wired (bypassPermissions=true); refusing to silently drop it"
         );
-        Ok(())
+        anyhow::bail!(
+            "claude_code bridge received approval {approval_id} but approvals are \
+             not wired in MVP"
+        );
     }
 
     pub async fn interrupt(&mut self) -> Result<()> {

--- a/runner/src/claude_code/bridge.rs
+++ b/runner/src/claude_code/bridge.rs
@@ -31,7 +31,6 @@ const INIT_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub struct Bridge {
     proc: ClaudeProcess,
-    model_default: Option<String>,
     /// Events received while we were waiting synchronously for `system/init`
     /// inside `run()`. Drained by `next_events` before touching the mpsc so
     /// no frame is lost across the run-setup boundary.
@@ -49,7 +48,6 @@ impl Bridge {
         .await?;
         Ok(Self {
             proc,
-            model_default,
             pending: VecDeque::new(),
         })
     }
@@ -57,9 +55,9 @@ impl Bridge {
     /// Test-friendly constructor that wraps an already-built `ClaudeProcess`
     /// (typically a shell-script fake).
     pub fn from_process(proc: ClaudeProcess, model_default: Option<String>) -> Self {
+        let _ = model_default;
         Self {
             proc,
-            model_default,
             pending: VecDeque::new(),
         }
     }
@@ -69,7 +67,6 @@ impl Bridge {
     /// Codex bridge's contract. Frames that arrive before init (rare but
     /// allowed by the protocol) are buffered and replayed by `next_events`.
     pub async fn run(&mut self, payload: &RunPayload, _cwd: &Path) -> Result<BridgeCursor> {
-        let _ = payload.model.as_ref().or(self.model_default.as_ref());
         let input = UserInput::user_text(&payload.prompt);
         let line = serde_json::to_string(&input)?;
         self.proc.send_line(&line).await?;

--- a/runner/src/claude_code/bridge.rs
+++ b/runner/src/claude_code/bridge.rs
@@ -234,11 +234,13 @@ impl BridgeCursor {
 }
 
 /// Best-effort mapping from Claude's `result.subtype` to our
-/// `FailureReason`. We don't have a dedicated `ClaudeCrash` variant yet, so
-/// errors surface as `CodexCrash`; rename once we consolidate the enum.
+/// `FailureReason`. `error_max_turns` is budget exhaustion (not an internal
+/// bug) so it gets its own variant. Everything else — including
+/// `error_during_execution` — is a generic agent crash; we use `AgentCrash`
+/// rather than `CodexCrash` so Claude failures don't pollute Codex telemetry.
 fn classify_failure(subtype: &str) -> FailureReason {
     match subtype {
-        "error_max_turns" => FailureReason::Internal,
-        _ => FailureReason::CodexCrash,
+        "error_max_turns" => FailureReason::MaxTurns,
+        _ => FailureReason::AgentCrash,
     }
 }

--- a/runner/src/claude_code/mod.rs
+++ b/runner/src/claude_code/mod.rs
@@ -1,0 +1,14 @@
+//! Claude Code agent integration. Drives `claude --print --output-format
+//! stream-json` as a one-turn subprocess per run and translates the emitted
+//! stream-json events into the agent-agnostic [`crate::agent::BridgeEvent`]
+//! shape used by the daemon.
+//!
+//! MVP limitations (tracked as follow-ups):
+//! - Approvals bypass: runs with `--permission-mode bypassPermissions`.
+//!   Wiring Claude's `--permission-prompt-tool` into the approval router
+//!   requires a small MCP server bridge; out of scope for the first pass.
+//! - Single-turn runs only: no `--resume` / session continuation.
+
+pub mod bridge;
+pub mod process;
+pub mod schema;

--- a/runner/src/claude_code/process.rs
+++ b/runner/src/claude_code/process.rs
@@ -106,12 +106,23 @@ impl ClaudeProcess {
                 let pid = Pid::from_raw(pid as i32);
                 // SIGINT is usually enough; the kill_on_drop on the child
                 // catches any process that ignores it when we later drop.
-                let _ = kill(pid, Signal::SIGINT);
-                return Ok(());
+                match kill(pid, Signal::SIGINT) {
+                    Ok(()) => return Ok(()),
+                    Err(e) => {
+                        // Reaped, permission denied, PID-namespace mismatch —
+                        // don't pretend the interrupt succeeded. Fall through
+                        // to SIGKILL so the caller still gets a best effort.
+                        tracing::warn!(
+                            "claude SIGINT failed ({e}); falling back to SIGKILL"
+                        );
+                    }
+                }
             }
         }
-        // Non-unix or pid-already-reaped: fall through to start_kill.
-        let _ = self.child.start_kill();
+        // Non-unix, pid-already-reaped, or SIGINT failure above.
+        self.child
+            .start_kill()
+            .context("failed to kill claude subprocess")?;
         Ok(())
     }
 
@@ -169,13 +180,23 @@ async fn read_events(stdout: tokio::process::ChildStdout, tx: mpsc::Sender<Strea
 }
 
 async fn drain_stderr(stderr: tokio::process::ChildStderr) {
+    // Claude surfaces auth, model, and runtime errors here. At the default
+    // `info` level these would be invisible, so every non-empty line is
+    // logged at `warn!`. Operators still have to dig through logs — a future
+    // follow-up can buffer the last N lines into the `Failed` event detail —
+    // but at least nothing is silently swallowed.
     let mut reader = BufReader::new(stderr);
     let mut line = String::new();
     loop {
         line.clear();
         match reader.read_line(&mut line).await {
             Ok(0) => break,
-            Ok(_) => tracing::debug!(target: "claude.stderr", "{}", line.trim_end()),
+            Ok(_) => {
+                let trimmed = line.trim_end();
+                if !trimmed.is_empty() {
+                    tracing::warn!(target: "claude.stderr", "{trimmed}");
+                }
+            }
             Err(e) => {
                 tracing::warn!("claude stderr read error: {e}");
                 break;

--- a/runner/src/claude_code/process.rs
+++ b/runner/src/claude_code/process.rs
@@ -1,0 +1,185 @@
+//! `claude` CLI subprocess wrapper. Mirrors the shape of
+//! `codex::app_server::AppServer` but speaks newline-delimited stream-JSON
+//! instead of JSON-RPC.
+
+use anyhow::{Context, Result};
+use std::path::Path;
+use std::process::Stdio;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, Command};
+use tokio::sync::mpsc;
+
+use crate::claude_code::schema::StreamEvent;
+
+/// Handles the `claude --print --output-format stream-json` subprocess
+/// lifecycle. Owns stdin (so we can push the user turn + signal EOF) and
+/// exposes an mpsc receiver of parsed events coming off stdout.
+pub struct ClaudeProcess {
+    child: Child,
+    /// `Option` so we can `take()` stdin when the caller wants to half-close
+    /// it (signalling end-of-input to Claude, which causes it to process the
+    /// queued turn and exit).
+    stdin: Option<ChildStdin>,
+    pub inbound: mpsc::Receiver<StreamEvent>,
+}
+
+/// Arguments passed to `claude` for a run. The defaults below match the MVP
+/// policy: non-interactive, bypass permissions, stream-json I/O.
+pub struct SpawnArgs<'a> {
+    pub binary: &'a str,
+    pub cwd: &'a Path,
+    pub model: Option<&'a str>,
+    /// When `true`, pass `--permission-mode bypassPermissions`. Always `true`
+    /// for MVP; wiring a real permission prompt needs an MCP bridge.
+    pub bypass_permissions: bool,
+}
+
+impl ClaudeProcess {
+    pub async fn spawn(args: SpawnArgs<'_>) -> Result<Self> {
+        let mut cmd = Command::new(args.binary);
+        cmd.current_dir(args.cwd)
+            .arg("--print")
+            .arg("--verbose")
+            .arg("--input-format")
+            .arg("stream-json")
+            .arg("--output-format")
+            .arg("stream-json");
+        if args.bypass_permissions {
+            cmd.arg("--permission-mode").arg("bypassPermissions");
+        }
+        if let Some(model) = args.model {
+            cmd.arg("--model").arg(model);
+        }
+        Self::spawn_command(cmd).await
+    }
+
+    /// Test-friendly constructor: any `Command` that writes newline-delimited
+    /// stream-JSON to stdout works (e.g. a shell script fake). Forces the
+    /// stdio disposition that the reader task expects.
+    pub async fn spawn_command(mut cmd: Command) -> Result<Self> {
+        cmd.stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        let mut child = cmd.spawn().context("spawning claude subprocess")?;
+        let stdin = child.stdin.take().context("claude stdin missing")?;
+        let stdout = child.stdout.take().context("claude stdout missing")?;
+        let stderr = child.stderr.take().context("claude stderr missing")?;
+
+        let (tx, rx) = mpsc::channel(128);
+        tokio::spawn(read_events(stdout, tx.clone()));
+        tokio::spawn(drain_stderr(stderr));
+        Ok(Self {
+            child,
+            stdin: Some(stdin),
+            inbound: rx,
+        })
+    }
+
+    /// Send one JSON line (plus a newline) to Claude's stdin.
+    pub async fn send_line(&mut self, line: &str) -> Result<()> {
+        let stdin = self
+            .stdin
+            .as_mut()
+            .context("claude stdin already closed")?;
+        stdin.write_all(line.as_bytes()).await?;
+        stdin.write_all(b"\n").await?;
+        stdin.flush().await?;
+        Ok(())
+    }
+
+    /// Close stdin so Claude knows no further input is coming and processes
+    /// the queued turn to completion. Safe to call more than once.
+    pub fn close_stdin(&mut self) {
+        self.stdin.take();
+    }
+
+    /// Best-effort interrupt: send SIGINT if we can, otherwise fall back to
+    /// SIGKILL via `start_kill`. Unlike Codex there's no in-protocol
+    /// `turn/interrupt` — the only lever we have is the OS.
+    pub async fn interrupt(&mut self) -> Result<()> {
+        #[cfg(unix)]
+        {
+            use nix::sys::signal::{Signal, kill};
+            use nix::unistd::Pid;
+            if let Some(pid) = self.child.id() {
+                let pid = Pid::from_raw(pid as i32);
+                // SIGINT is usually enough; the kill_on_drop on the child
+                // catches any process that ignores it when we later drop.
+                let _ = kill(pid, Signal::SIGINT);
+                return Ok(());
+            }
+        }
+        // Non-unix or pid-already-reaped: fall through to start_kill.
+        let _ = self.child.start_kill();
+        Ok(())
+    }
+
+    pub async fn shutdown(mut self, grace: std::time::Duration) -> Result<()> {
+        self.close_stdin();
+        match tokio::time::timeout(grace, self.child.wait()).await {
+            Ok(Ok(status)) => {
+                tracing::debug!(?status, "claude exited gracefully");
+            }
+            _ => {
+                tracing::warn!("claude did not exit within grace; sending SIGKILL");
+                self.child.start_kill().ok();
+                self.child.wait().await.ok();
+            }
+        }
+        Ok(())
+    }
+}
+
+async fn read_events(stdout: tokio::process::ChildStdout, tx: mpsc::Sender<StreamEvent>) {
+    let mut reader = BufReader::new(stdout);
+    let mut line = String::new();
+    loop {
+        line.clear();
+        match reader.read_line(&mut line).await {
+            Ok(0) => break,
+            Ok(_) => {
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                // Try structured parse first; fall back to stashing the raw
+                // value as `Unknown` so upstream changes don't crash the
+                // daemon.
+                let ev = match serde_json::from_str::<StreamEvent>(trimmed) {
+                    Ok(e) => e,
+                    Err(e) => {
+                        tracing::warn!("claude emitted unparsable stream-json ({e}): {trimmed}");
+                        match serde_json::from_str::<serde_json::Value>(trimmed) {
+                            Ok(v) => StreamEvent::Unknown(v),
+                            Err(_) => continue,
+                        }
+                    }
+                };
+                if tx.send(ev).await.is_err() {
+                    break;
+                }
+            }
+            Err(e) => {
+                tracing::warn!("claude stdout read error: {e}");
+                break;
+            }
+        }
+    }
+}
+
+async fn drain_stderr(stderr: tokio::process::ChildStderr) {
+    let mut reader = BufReader::new(stderr);
+    let mut line = String::new();
+    loop {
+        line.clear();
+        match reader.read_line(&mut line).await {
+            Ok(0) => break,
+            Ok(_) => tracing::debug!(target: "claude.stderr", "{}", line.trim_end()),
+            Err(e) => {
+                tracing::warn!("claude stderr read error: {e}");
+                break;
+            }
+        }
+    }
+}

--- a/runner/src/claude_code/schema.rs
+++ b/runner/src/claude_code/schema.rs
@@ -1,0 +1,141 @@
+//! Stream-JSON event shapes emitted by `claude --print --output-format
+//! stream-json`. We model the envelope (`type` + `subtype`) plus the fields
+//! we actually read; the full message body is retained as a
+//! `serde_json::Value` so the daemon can ship it to local history verbatim
+//! without us having to track every upstream schema revision.
+
+use serde::de::Error as _;
+use serde::{Deserialize, Deserializer, Serialize};
+
+/// Top-level stream-JSON event. Dispatch is on the top-level `type` tag;
+/// unknown tags collapse to [`StreamEvent::Unknown`] so forward-compatible
+/// upstream changes don't crash the bridge.
+#[derive(Debug, Clone)]
+pub enum StreamEvent {
+    /// `{"type":"system","subtype":"init","session_id":"...",...}` —
+    /// the very first frame. We capture `session_id` as the thread id so
+    /// history/IPC can link follow-up work to the same conversation.
+    System(SystemEvent),
+    /// `{"type":"assistant","message":{...}}` — one message from Claude.
+    /// May contain `text`, `tool_use`, or `thinking` content blocks.
+    Assistant(AssistantEvent),
+    /// `{"type":"user","message":{...}}` — tool-result echoes from the
+    /// harness back to the model. Useful for transcripts.
+    User(UserEvent),
+    /// `{"type":"result","subtype":"success|error_max_turns|error_during_execution",
+    ///   "result":"...","usage":{...}}` — terminal frame.
+    Result(ResultEvent),
+    /// Anything else: new event types Claude may emit that we don't map
+    /// yet. Preserved verbatim in history.
+    Unknown(serde_json::Value),
+}
+
+impl<'de> Deserialize<'de> for StreamEvent {
+    // We dispatch manually instead of using `#[serde(untagged)]` because
+    // several variants have overlapping field sets (e.g. `system` and
+    // `result` both carry `subtype` + `session_id`). An untagged enum
+    // would greedily match the first compatible variant and silently
+    // misroute frames. Tagging on `type` is unambiguous and keeps a
+    // catch-all for forward-compat.
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let v = serde_json::Value::deserialize(d)?;
+        let ty = v.get("type").and_then(|x| x.as_str()).unwrap_or("");
+        match ty {
+            "system" => serde_json::from_value(v)
+                .map(StreamEvent::System)
+                .map_err(D::Error::custom),
+            "assistant" => serde_json::from_value(v)
+                .map(StreamEvent::Assistant)
+                .map_err(D::Error::custom),
+            "user" => serde_json::from_value(v)
+                .map(StreamEvent::User)
+                .map_err(D::Error::custom),
+            "result" => serde_json::from_value(v)
+                .map(StreamEvent::Result)
+                .map_err(D::Error::custom),
+            _ => Ok(StreamEvent::Unknown(v)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SystemEvent {
+    pub subtype: String,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(flatten)]
+    pub rest: serde_json::Map<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AssistantEvent {
+    pub message: serde_json::Value,
+    #[serde(default)]
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct UserEvent {
+    pub message: serde_json::Value,
+    #[serde(default)]
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ResultEvent {
+    pub subtype: String,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub result: Option<String>,
+    #[serde(default)]
+    pub is_error: Option<bool>,
+    #[serde(default)]
+    pub total_cost_usd: Option<f64>,
+    #[serde(default)]
+    pub usage: Option<serde_json::Value>,
+    #[serde(flatten)]
+    pub rest: serde_json::Map<String, serde_json::Value>,
+}
+
+impl StreamEvent {
+    /// Stable event discriminator for routing + history. Mirrors the
+    /// `method` slot used by the Codex bridge so `HistoryEntry::CodexEvent`
+    /// (kept for on-disk JSONL compat) remains meaningful.
+    pub fn method(&self) -> &str {
+        match self {
+            StreamEvent::System(_) => "system",
+            StreamEvent::Assistant(_) => "assistant/message",
+            StreamEvent::User(_) => "user/toolResult",
+            StreamEvent::Result(_) => "result",
+            StreamEvent::Unknown(_) => "unknown",
+        }
+    }
+}
+
+/// Input envelope written to Claude's stdin when `--input-format stream-json`
+/// is in effect. For MVP we only ever send a single user turn.
+#[derive(Debug, Clone, Serialize)]
+pub struct UserInput<'a> {
+    #[serde(rename = "type")]
+    pub ty: &'static str,
+    pub message: UserMessage<'a>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UserMessage<'a> {
+    pub role: &'static str,
+    pub content: &'a str,
+}
+
+impl<'a> UserInput<'a> {
+    pub fn user_text(content: &'a str) -> Self {
+        Self {
+            ty: "user",
+            message: UserMessage {
+                role: "user",
+                content,
+            },
+        }
+    }
+}

--- a/runner/src/cli/configure.rs
+++ b/runner/src/cli/configure.rs
@@ -162,6 +162,8 @@ pub async fn execute(inputs: RegisterInputs, paths: &Paths, print_next_hint: boo
         },
         workspace: crate::config::schema::WorkspaceSection { working_dir },
         codex: crate::config::schema::CodexSection::default(),
+        claude_code: crate::config::schema::ClaudeCodeSection::default(),
+        agent: crate::config::schema::AgentSection::default(),
         approval_policy: crate::config::schema::ApprovalPolicySection::default(),
         logging: crate::config::schema::LoggingSection::default(),
     };

--- a/runner/src/cli/doctor.rs
+++ b/runner/src/cli/doctor.rs
@@ -207,10 +207,10 @@ async fn check_codex_auth(binary: &str) -> Result<String> {
         .output()
         .await
         .ok();
-    if let Some(o) = out {
-        if o.status.success() {
-            return Ok(String::from_utf8_lossy(&o.stdout).trim().to_string());
-        }
+    if let Some(o) = out
+        && o.status.success()
+    {
+        return Ok(String::from_utf8_lossy(&o.stdout).trim().to_string());
     }
     anyhow::bail!(
         "unable to confirm Codex auth; run `{} login` before starting the runner",

--- a/runner/src/cli/doctor.rs
+++ b/runner/src/cli/doctor.rs
@@ -61,39 +61,81 @@ pub async fn run(args: Args, paths: &Paths) -> Result<()> {
 pub async fn execute(paths: &Paths) -> Result<Report> {
     let mut checks = Vec::new();
 
-    // Codex binary.
-    let codex_binary = file::load_config_opt(paths)?
-        .map(|c| c.codex.binary)
-        .unwrap_or_else(|| "codex".to_string());
-    match check_codex_version(&codex_binary).await {
-        Ok(detail) => checks.push(Check {
-            name: "codex".to_string(),
-            ok: true,
-            detail,
-            blocker: true,
-        }),
-        Err(e) => checks.push(Check {
-            name: "codex".to_string(),
-            ok: false,
-            detail: e.to_string(),
-            blocker: true,
-        }),
-    }
-
-    // Codex auth.
-    match check_codex_auth(&codex_binary).await {
-        Ok(detail) => checks.push(Check {
-            name: "codex-auth".to_string(),
-            ok: true,
-            detail,
-            blocker: true,
-        }),
-        Err(e) => checks.push(Check {
-            name: "codex-auth".to_string(),
-            ok: false,
-            detail: e.to_string(),
-            blocker: true,
-        }),
+    // Agent binary check — which CLI we verify depends on `agent.kind`.
+    // Runs without a config file fall back to Codex (the historical default)
+    // so `pidash doctor` keeps working pre-`pidash configure`.
+    let cfg = file::load_config_opt(paths)?;
+    let agent_kind = cfg
+        .as_ref()
+        .map(|c| c.agent.kind)
+        .unwrap_or(crate::config::schema::AgentKind::Codex);
+    match agent_kind {
+        crate::config::schema::AgentKind::Codex => {
+            let codex_binary = cfg
+                .as_ref()
+                .map(|c| c.codex.binary.clone())
+                .unwrap_or_else(|| "codex".to_string());
+            match check_version(&codex_binary).await {
+                Ok(detail) => checks.push(Check {
+                    name: "codex".to_string(),
+                    ok: true,
+                    detail,
+                    blocker: true,
+                }),
+                Err(e) => checks.push(Check {
+                    name: "codex".to_string(),
+                    ok: false,
+                    detail: e.to_string(),
+                    blocker: true,
+                }),
+            }
+            match check_codex_auth(&codex_binary).await {
+                Ok(detail) => checks.push(Check {
+                    name: "codex-auth".to_string(),
+                    ok: true,
+                    detail,
+                    blocker: true,
+                }),
+                Err(e) => checks.push(Check {
+                    name: "codex-auth".to_string(),
+                    ok: false,
+                    detail: e.to_string(),
+                    blocker: true,
+                }),
+            }
+        }
+        crate::config::schema::AgentKind::ClaudeCode => {
+            let claude_binary = cfg
+                .as_ref()
+                .map(|c| c.claude_code.binary.clone())
+                .unwrap_or_else(|| "claude".to_string());
+            match check_version(&claude_binary).await {
+                Ok(detail) => checks.push(Check {
+                    name: "claude".to_string(),
+                    ok: true,
+                    detail,
+                    blocker: true,
+                }),
+                Err(e) => checks.push(Check {
+                    name: "claude".to_string(),
+                    ok: false,
+                    detail: e.to_string(),
+                    blocker: true,
+                }),
+            }
+            // There's no unattended `claude whoami`; Claude Code assumes the
+            // user is already signed in via the CLI's own onboarding. Surface
+            // a non-blocking note so the operator knows where to look.
+            checks.push(Check {
+                name: "claude-auth".to_string(),
+                ok: true,
+                detail: format!(
+                    "assumed ok (run `{} /login` if runs fail with auth errors)",
+                    claude_binary
+                ),
+                blocker: false,
+            });
+        }
     }
 
     // git.
@@ -113,7 +155,7 @@ pub async fn execute(paths: &Paths) -> Result<Report> {
     }
 
     // Cloud reachability (if we have config).
-    if let Some(cfg) = file::load_config_opt(paths)? {
+    if let Some(cfg) = cfg.as_ref() {
         match check_cloud(&cfg.runner.cloud_url).await {
             Ok(detail) => checks.push(Check {
                 name: "network".to_string(),
@@ -133,7 +175,9 @@ pub async fn execute(paths: &Paths) -> Result<Report> {
     Ok(Report { checks })
 }
 
-async fn check_codex_version(binary: &str) -> Result<String> {
+/// Shared `<binary> --version` check. Works for both `codex` and `claude`
+/// since both print a short version line on stdout and exit 0 on success.
+async fn check_version(binary: &str) -> Result<String> {
     let out = Command::new(binary)
         .arg("--version")
         .stdout(Stdio::piped())
@@ -142,7 +186,7 @@ async fn check_codex_version(binary: &str) -> Result<String> {
         .await?;
     if !out.status.success() {
         anyhow::bail!(
-            "codex --version exited {}: {}",
+            "{binary} --version exited {}: {}",
             out.status,
             String::from_utf8_lossy(&out.stderr).trim()
         );

--- a/runner/src/cloud/protocol.rs
+++ b/runner/src/cloud/protocol.rs
@@ -187,7 +187,17 @@ pub enum FailureReason {
     WorkspaceSetup,
     GitAuth,
     Network,
+    /// Codex subprocess crashed or exited abnormally. Kept agent-specific so
+    /// pre-existing dashboards filtering on `"codex_crash"` keep matching.
     CodexCrash,
+    /// Non-Codex agent subprocess crashed or exited abnormally. Introduced
+    /// with the Claude Code agent so its failures don't conflate with Codex
+    /// failures in telemetry.
+    AgentCrash,
+    /// Agent hit its turn/step budget (e.g. Claude `error_max_turns`). Not
+    /// the same as an internal bug: the run was deliberately bounded and
+    /// ran out of room to complete.
+    MaxTurns,
     Timeout,
     Internal,
     Cancelled,

--- a/runner/src/cloud/ws.rs
+++ b/runner/src/cloud/ws.rs
@@ -71,7 +71,7 @@ pub async fn run_connection(
                 match msg {
                     Some(frame) => {
                         let text = serde_json::to_string(&frame)?;
-                        conn.stream.send(Message::Text(text.into())).await?;
+                        conn.stream.send(Message::Text(text)).await?;
                     }
                     None => {
                         let _ = conn.stream.close(None).await;

--- a/runner/src/codex/bridge.rs
+++ b/runner/src/codex/bridge.rs
@@ -5,6 +5,10 @@ use std::path::Path;
 use std::time::Duration;
 use uuid::Uuid;
 
+// Re-export the shared types under their legacy `codex::bridge::` path so
+// existing integration tests and any downstream callers that imported them
+// from here keep compiling. The canonical definitions live in `agent::`.
+pub use crate::agent::{BridgeEvent, RunPayload};
 use crate::cloud::protocol::{ApprovalDecision, ApprovalKind, FailureReason};
 use crate::codex::app_server::AppServer;
 use crate::codex::jsonrpc::{self, Incoming};
@@ -12,48 +16,6 @@ use crate::codex::schema::{
     ApprovalResponseParams, ClientInfo, InitializeParams, NotificationKind, ThreadResumeParams,
     ThreadStartParams, TurnInputItem, TurnStartParams,
 };
-
-/// Events the bridge surfaces to the daemon's state machine.
-#[derive(Debug, Clone)]
-pub enum BridgeEvent {
-    RunStarted {
-        run_id: Uuid,
-        thread_id: String,
-    },
-    Raw {
-        run_id: Uuid,
-        method: String,
-        params: serde_json::Value,
-    },
-    ApprovalRequest {
-        run_id: Uuid,
-        approval_id: String,
-        kind: ApprovalKind,
-        payload: serde_json::Value,
-        reason: Option<String>,
-    },
-    AwaitingReauth {
-        run_id: Uuid,
-        detail: Option<String>,
-    },
-    Completed {
-        run_id: Uuid,
-        done_payload: serde_json::Value,
-    },
-    Failed {
-        run_id: Uuid,
-        reason: FailureReason,
-        detail: Option<String>,
-    },
-}
-
-#[derive(Debug, Clone)]
-pub struct RunPayload {
-    pub run_id: Uuid,
-    pub prompt: String,
-    pub model: Option<String>,
-    pub resume_thread_id: Option<String>,
-}
 
 pub struct Bridge {
     pub server: AppServer,

--- a/runner/src/config/file.rs
+++ b/runner/src/config/file.rs
@@ -116,6 +116,8 @@ mod tests {
                 working_dir: tmp.path().join("wd"),
             },
             codex: Default::default(),
+            claude_code: Default::default(),
+            agent: Default::default(),
             approval_policy: Default::default(),
             logging: Default::default(),
         };

--- a/runner/src/config/schema.rs
+++ b/runner/src/config/schema.rs
@@ -85,15 +85,23 @@ pub enum AgentKind {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ClaudeCodeSection {
+    /// Per-field default so a partial `[claude_code]` block (e.g. only
+    /// `model_default = "..."`) still parses. Without this, declaring the
+    /// section at all would require spelling out `binary = "claude"`.
+    #[serde(default = "default_claude_binary")]
     pub binary: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_default: Option<String>,
 }
 
+fn default_claude_binary() -> String {
+    "claude".to_string()
+}
+
 impl Default for ClaudeCodeSection {
     fn default() -> Self {
         Self {
-            binary: "claude".to_string(),
+            binary: default_claude_binary(),
             model_default: None,
         }
     }

--- a/runner/src/config/schema.rs
+++ b/runner/src/config/schema.rs
@@ -9,6 +9,16 @@ pub struct Config {
     pub runner: RunnerSection,
     pub workspace: WorkspaceSection,
     pub codex: CodexSection,
+    /// Claude Code agent settings. Missing section falls back to
+    /// `ClaudeCodeSection::default()` so existing `config.toml` files
+    /// (written before Claude Code support) still parse. Only consulted
+    /// when `agent.kind == claude_code`.
+    #[serde(default)]
+    pub claude_code: ClaudeCodeSection,
+    /// Which agent CLI the daemon drives for assigned runs. Defaults to
+    /// `codex` so existing deployments are unaffected.
+    #[serde(default)]
+    pub agent: AgentSection,
     /// Missing section falls back to the `ApprovalPolicySection::default()` so
     /// a minimal `config.toml` doesn't have to spell out every knob.
     #[serde(default)]
@@ -47,6 +57,44 @@ impl Default for CodexSection {
         Self {
             binary: "codex".to_string(),
             model_default: Some("gpt-5-codex".to_string()),
+        }
+    }
+}
+
+/// Runner-wide agent selector. Wrapped in its own section (rather than
+/// hoisted onto `RunnerSection`) so the file layout mirrors the per-agent
+/// `[codex]` / `[claude_code]` tables: `[agent]` with `kind = "..."`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AgentSection {
+    #[serde(default)]
+    pub kind: AgentKind,
+}
+
+/// Which agent CLI the runner drives for assigned runs. Serialised as a
+/// lowercase string (`"codex"` / `"claude_code"`) so the config file stays
+/// human-friendly.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentKind {
+    /// OpenAI Codex via `codex app-server`. Default for backward compatibility.
+    #[default]
+    Codex,
+    /// Anthropic Claude Code via `claude --print --output-format stream-json`.
+    ClaudeCode,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClaudeCodeSection {
+    pub binary: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_default: Option<String>,
+}
+
+impl Default for ClaudeCodeSection {
+    fn default() -> Self {
+        Self {
+            binary: "claude".to_string(),
+            model_default: None,
         }
     }
 }

--- a/runner/src/daemon/state.rs
+++ b/runner/src/daemon/state.rs
@@ -103,10 +103,7 @@ impl StateHandle {
     }
 
     pub async fn set_current_run(&self, s: Option<CurrentRunSummary>) {
-        let next = match &s {
-            Some(r) => Some(r.run_id),
-            None => None,
-        };
+        let next = s.as_ref().map(|r| r.run_id);
         *self.inner.current_run.lock().await = s;
         let _ = self.tx_in_flight.send(next);
         let status = if next.is_some() {

--- a/runner/src/daemon/supervisor.rs
+++ b/runner/src/daemon/supervisor.rs
@@ -676,7 +676,7 @@ impl AssignWorker {
                 .await
                 .ok();
                 // Only lifecycle-ish events are mirrored to cloud; raw deltas stay local.
-                tracing::trace!(%run_id, method, "codex event");
+                tracing::trace!(%run_id, method, "agent event");
                 Ok(None)
             }
             BridgeEvent::ApprovalRequest {

--- a/runner/src/daemon/supervisor.rs
+++ b/runner/src/daemon/supervisor.rs
@@ -10,7 +10,7 @@ use crate::cloud::protocol::{
     ClientMsg, Envelope, FailureReason, RunnerStatus, ServerMsg, WIRE_VERSION, WorkspaceState,
 };
 use crate::cloud::ws::ConnectionLoop;
-use crate::config::schema::{Config, Credentials};
+use crate::config::schema::{AgentKind, Config, Credentials};
 use crate::daemon::state::StateHandle;
 use crate::history::index::{RunSummary, RunsIndex};
 use crate::history::jsonl::{HistoryEntry, HistoryWriter};
@@ -386,6 +386,18 @@ struct AssignWorker {
 }
 
 impl AssignWorker {
+    /// Pick the right `FailureReason` when the agent subprocess crashes or
+    /// exits abnormally. Codex stays on `CodexCrash` so dashboards that
+    /// already filter on `"codex_crash"` keep working; Claude (and any
+    /// future non-Codex agent) surfaces as the agent-neutral `AgentCrash`
+    /// so the two aren't conflated in telemetry.
+    fn crash_reason(&self) -> FailureReason {
+        match self.config.agent.kind {
+            AgentKind::Codex => FailureReason::CodexCrash,
+            AgentKind::ClaudeCode => FailureReason::AgentCrash,
+        }
+    }
+
     async fn run(
         &mut self,
         run_id: uuid::Uuid,
@@ -513,9 +525,10 @@ impl AssignWorker {
                 })
                 .await
                 .ok();
+                let reason = self.crash_reason();
                 self.send(ClientMsg::RunFailed {
                     run_id,
-                    reason: FailureReason::CodexCrash,
+                    reason,
                     detail: Some(format!("{e:#}")),
                     ended_at: Utc::now(),
                 })
@@ -541,9 +554,10 @@ impl AssignWorker {
                 })
                 .await
                 .ok();
+                let reason = self.crash_reason();
                 self.send(ClientMsg::RunFailed {
                     run_id,
-                    reason: FailureReason::CodexCrash,
+                    reason,
                     detail: Some(format!("{e:#}")),
                     ended_at: Utc::now(),
                 })
@@ -626,9 +640,10 @@ impl AssignWorker {
                 }
                 events = bridge.next_events(cursor) => {
                     let Some(events) = events else {
+                        let reason = self.crash_reason();
                         self.send(ClientMsg::RunFailed {
                             run_id: cursor.run_id(),
-                            reason: FailureReason::CodexCrash,
+                            reason,
                             detail: Some("agent stdout closed".to_string()),
                             ended_at: Utc::now(),
                         }).await;

--- a/runner/src/daemon/supervisor.rs
+++ b/runner/src/daemon/supervisor.rs
@@ -273,7 +273,13 @@ impl RunnerLoop {
                             cancel,
                         };
                         if let Err(e) = worker
-                            .run(run_id, prompt, repo_url, git_work_branch, expected_codex_model)
+                            .run(
+                                run_id,
+                                prompt,
+                                repo_url,
+                                git_work_branch,
+                                expected_codex_model,
+                            )
                             .await
                         {
                             tracing::error!("run {run_id} failed: {e:#}");
@@ -388,8 +394,14 @@ impl AssignWorker {
         git_work_branch: Option<String>,
         expected_codex_model: Option<String>,
     ) -> Result<()> {
-        self.handle_assign(run_id, prompt, repo_url, git_work_branch, expected_codex_model)
-            .await
+        self.handle_assign(
+            run_id,
+            prompt,
+            repo_url,
+            git_work_branch,
+            expected_codex_model,
+        )
+        .await
     }
 
     async fn handle_assign(
@@ -484,7 +496,12 @@ impl AssignWorker {
         // Bridge to the configured agent (Codex or Claude Code). `AgentBridge`
         // hides which CLI is actually being driven from the rest of this
         // worker; the event flow below is identical for both.
-        let mut bridge = match AgentBridge::spawn_from_config(&self.config, &workspace_path).await
+        let mut bridge = match AgentBridge::spawn_from_config(
+            &self.config,
+            &workspace_path,
+            expected_codex_model.clone(),
+        )
+        .await
         {
             Ok(b) => b,
             Err(e) => {

--- a/runner/src/daemon/supervisor.rs
+++ b/runner/src/daemon/supervisor.rs
@@ -3,13 +3,13 @@ use chrono::Utc;
 use std::time::Duration;
 use tokio::sync::{mpsc, oneshot};
 
+use crate::agent::{AgentBridge, AgentCursor, BridgeEvent, RunPayload};
 use crate::approval::policy::Policy;
 use crate::approval::router::{ApprovalRecord, ApprovalRouter, ApprovalStatus, DecisionSource};
 use crate::cloud::protocol::{
     ClientMsg, Envelope, FailureReason, RunnerStatus, ServerMsg, WIRE_VERSION, WorkspaceState,
 };
 use crate::cloud::ws::ConnectionLoop;
-use crate::codex::bridge::{Bridge, BridgeCursor, BridgeEvent, RunPayload};
 use crate::config::schema::{Config, Credentials};
 use crate::daemon::state::StateHandle;
 use crate::history::index::{RunSummary, RunsIndex};
@@ -481,13 +481,10 @@ impl AssignWorker {
             }))
             .await;
 
-        // Bridge to Codex.
-        let mut bridge = match Bridge::spawn(
-            &self.config.codex.binary,
-            &workspace_path,
-            self.config.codex.model_default.clone(),
-        )
-        .await
+        // Bridge to the configured agent (Codex or Claude Code). `AgentBridge`
+        // hides which CLI is actually being driven from the rest of this
+        // worker; the event flow below is identical for both.
+        let mut bridge = match AgentBridge::spawn_from_config(&self.config, &workspace_path).await
         {
             Ok(b) => b,
             Err(e) => {
@@ -540,14 +537,14 @@ impl AssignWorker {
         };
         self.send(ClientMsg::RunStarted {
             run_id,
-            thread_id: cursor.thread_id.clone(),
+            thread_id: cursor.thread_id().to_string(),
             started_at: Utc::now(),
         })
         .await;
         hist.append(&HistoryEntry::Lifecycle {
             ts: Utc::now(),
             state: "started".to_string(),
-            detail: Some(cursor.thread_id.clone()),
+            detail: Some(cursor.thread_id().to_string()),
         })
         .await?;
 
@@ -556,7 +553,7 @@ impl AssignWorker {
             .pump_events(&mut bridge, &mut cursor, &mut hist, &workspace_path)
             .await?;
 
-        bridge.server.shutdown(Duration::from_secs(5)).await.ok();
+        bridge.shutdown(Duration::from_secs(5)).await.ok();
 
         let summary = RunSummary {
             run_id,
@@ -576,8 +573,8 @@ impl AssignWorker {
 
     async fn pump_events(
         &mut self,
-        bridge: &mut Bridge,
-        cursor: &mut BridgeCursor,
+        bridge: &mut AgentBridge,
+        cursor: &mut AgentCursor,
         hist: &mut HistoryWriter,
         workspace_root: &std::path::Path,
     ) -> Result<Outcome> {
@@ -594,7 +591,7 @@ impl AssignWorker {
                 _ = cancel.notified(), if !cancelled => {
                     bridge.interrupt().await.ok();
                     let _ = self.out.send(Envelope::new(ClientMsg::RunCancelled {
-                        run_id: cursor.run_id,
+                        run_id: cursor.run_id(),
                         cancelled_at: Utc::now(),
                     })).await;
                     hist.append(&HistoryEntry::Lifecycle {
@@ -602,31 +599,30 @@ impl AssignWorker {
                         state: "cancelled".into(),
                         detail: None,
                     }).await.ok();
-                    // Give Codex a short grace to wind down; if it doesn't, we
-                    // exit and rely on the Bridge's shutdown to SIGKILL.
+                    // Give the agent a short grace to wind down; if it doesn't, we
+                    // exit and rely on the bridge's shutdown to SIGKILL.
                     let _ = tokio::time::timeout(
                         Duration::from_secs(10),
-                        bridge.next_frame(),
+                        bridge.next_events(cursor),
                     ).await;
                     return Ok(Outcome { status_label: "cancelled".into() });
                 }
-                frame = bridge.next_frame() => {
-                    let Some(frame) = frame else {
+                events = bridge.next_events(cursor) => {
+                    let Some(events) = events else {
                         self.send(ClientMsg::RunFailed {
-                            run_id: cursor.run_id,
+                            run_id: cursor.run_id(),
                             reason: FailureReason::CodexCrash,
-                            detail: Some("codex stdout closed".to_string()),
+                            detail: Some("agent stdout closed".to_string()),
                             ended_at: Utc::now(),
                         }).await;
                         hist.append(&HistoryEntry::Footer {
                             ts: Utc::now(),
                             final_status: "failed".into(),
                             done_payload: None,
-                            error: Some("codex stdout closed".into()),
+                            error: Some("agent stdout closed".into()),
                         }).await?;
                         return Ok(Outcome { status_label: "failed".into() });
                     };
-                    let events = cursor.translate(frame);
                     for ev in events {
                         if let Some(out) = self
                             .handle_bridge_event(ev, bridge, hist, workspace_root)
@@ -643,7 +639,7 @@ impl AssignWorker {
     async fn handle_bridge_event(
         &mut self,
         ev: BridgeEvent,
-        bridge: &mut Bridge,
+        bridge: &mut AgentBridge,
         hist: &mut HistoryWriter,
         workspace_root: &std::path::Path,
     ) -> Result<Option<Outcome>> {

--- a/runner/src/lib.rs
+++ b/runner/src/lib.rs
@@ -1,8 +1,10 @@
 #![forbid(unsafe_code)]
 #![deny(rust_2018_idioms)]
 
+pub mod agent;
 pub mod api_client;
 pub mod approval;
+pub mod claude_code;
 pub mod cli;
 pub mod cloud;
 pub mod codex;

--- a/runner/src/tui/onboarding.rs
+++ b/runner/src/tui/onboarding.rs
@@ -213,6 +213,8 @@ async fn register_and_advance(state: &mut Wizard) {
                     working_dir: state.paths.default_working_dir(),
                 },
                 codex: Default::default(),
+                claude_code: Default::default(),
+                agent: Default::default(),
                 approval_policy: Default::default(),
                 logging: Default::default(),
             };

--- a/runner/src/tui/onboarding.rs
+++ b/runner/src/tui/onboarding.rs
@@ -468,10 +468,10 @@ fn mask(s: &str) -> String {
 }
 
 fn default_hostname() -> Option<String> {
-    if let Ok(h) = std::env::var("HOSTNAME") {
-        if !h.is_empty() {
-            return Some(h);
-        }
+    if let Ok(h) = std::env::var("HOSTNAME")
+        && !h.is_empty()
+    {
+        return Some(h);
     }
     nix::unistd::gethostname()
         .ok()

--- a/runner/tests/claude_bridge_fake.rs
+++ b/runner/tests/claude_bridge_fake.rs
@@ -1,0 +1,145 @@
+//! End-to-end Claude Code bridge test. A shell subprocess plays the role of
+//! `claude --print --output-format stream-json` and emits canned stream-JSON
+//! events; the Bridge drives it through `system/init → assistant message →
+//! result`.
+
+use pidash::agent::BridgeEvent;
+use pidash::agent::RunPayload;
+use pidash::claude_code::bridge::Bridge;
+use pidash::claude_code::process::ClaudeProcess;
+use std::path::PathBuf;
+use std::time::Duration;
+use tokio::process::Command;
+use uuid::Uuid;
+
+/// The script drains stdin (so the bridge's `send_line` + stdin close
+/// don't block on a full pipe), then emits a deterministic sequence of
+/// stream-JSON events on stdout: an init frame with a session id, one
+/// assistant message, and a terminal `result.success` frame.
+fn fake_claude_script() -> &'static str {
+    r#"
+        set -e
+        # Drain stdin in the background so the bridge can write + close it.
+        (cat >/dev/null) &
+        # system/init
+        printf '%s\n' '{"type":"system","subtype":"init","session_id":"sess_fake_001","model":"claude-sonnet-4-6","tools":["Read"]}'
+        # one assistant message
+        printf '%s\n' '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hello"}]},"session_id":"sess_fake_001"}'
+        # terminal: result.success
+        printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess_fake_001","result":"all done","total_cost_usd":0.0001,"usage":{"input_tokens":10,"output_tokens":5}}'
+        # Let the reader drain before we exit.
+        sleep 0.2
+    "#
+}
+
+#[tokio::test]
+async fn bridge_happy_path_drives_fake_claude_to_completion() {
+    let mut cmd = Command::new("sh");
+    cmd.arg("-c").arg(fake_claude_script());
+    let proc = ClaudeProcess::spawn_command(cmd)
+        .await
+        .expect("spawn fake claude");
+    let mut bridge = Bridge::from_process(proc, None);
+
+    let cwd = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let payload = RunPayload {
+        run_id: Uuid::new_v4(),
+        prompt: "hi".into(),
+        model: None,
+        resume_thread_id: None,
+    };
+
+    // run() should consume the init frame and surface its session id as the
+    // cursor's thread_id, matching the Codex bridge's contract.
+    let mut cursor = bridge
+        .run(&payload, &cwd)
+        .await
+        .expect("bridge run setup");
+    assert_eq!(cursor.thread_id, "sess_fake_001");
+
+    let mut saw_assistant = false;
+    let mut saw_completed = false;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+    while tokio::time::Instant::now() < deadline {
+        let Some(events) = tokio::time::timeout(
+            Duration::from_millis(500),
+            bridge.next_events(&mut cursor),
+        )
+        .await
+        .ok()
+        .flatten() else {
+            break;
+        };
+        for ev in events {
+            match ev {
+                BridgeEvent::Raw { method, .. } if method == "assistant/message" => {
+                    saw_assistant = true;
+                }
+                BridgeEvent::Completed { done_payload, .. } => {
+                    saw_completed = true;
+                    assert_eq!(
+                        done_payload.get("conclusion").and_then(|v| v.as_str()),
+                        Some("success"),
+                    );
+                    break;
+                }
+                BridgeEvent::Failed { detail, .. } => {
+                    panic!("unexpected Failed event: {detail:?}");
+                }
+                _ => {}
+            }
+        }
+        if saw_completed {
+            break;
+        }
+    }
+
+    assert!(saw_assistant, "expected to observe an assistant/message");
+    assert!(saw_completed, "expected to observe a Completed event");
+}
+
+#[tokio::test]
+async fn bridge_translates_result_error_to_failed() {
+    let script = r#"
+        set -e
+        (cat >/dev/null) &
+        printf '%s\n' '{"type":"system","subtype":"init","session_id":"sess_err_001"}'
+        printf '%s\n' '{"type":"result","subtype":"error_max_turns","session_id":"sess_err_001","is_error":true,"result":"exceeded turn budget"}'
+        sleep 0.2
+    "#;
+    let mut cmd = Command::new("sh");
+    cmd.arg("-c").arg(script);
+    let proc = ClaudeProcess::spawn_command(cmd)
+        .await
+        .expect("spawn fake claude");
+    let mut bridge = Bridge::from_process(proc, None);
+
+    let cwd = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let payload = RunPayload {
+        run_id: Uuid::new_v4(),
+        prompt: "will fail".into(),
+        model: None,
+        resume_thread_id: None,
+    };
+    let mut cursor = bridge
+        .run(&payload, &cwd)
+        .await
+        .expect("bridge run setup");
+
+    let events = tokio::time::timeout(Duration::from_secs(2), bridge.next_events(&mut cursor))
+        .await
+        .expect("pump should not time out")
+        .expect("expected a Failed event, got None");
+
+    let mut saw_failed = false;
+    for ev in events {
+        if let BridgeEvent::Failed { detail, .. } = ev {
+            saw_failed = true;
+            assert!(
+                detail.as_deref().unwrap_or("").contains("exceeded"),
+                "expected detail to include error message, got {detail:?}"
+            );
+        }
+    }
+    assert!(saw_failed, "expected a Failed event from result.error");
+}

--- a/runner/tests/cloud_ws_fake.rs
+++ b/runner/tests/cloud_ws_fake.rs
@@ -40,11 +40,9 @@ async fn start_fake_cloud() -> (SocketAddr, tokio::task::JoinHandle<()>) {
             heartbeat_interval_secs: 25,
             protocol_version: WIRE_VERSION,
         });
-        tx.send(Message::Text(
-            serde_json::to_string(&welcome).unwrap().into(),
-        ))
-        .await
-        .unwrap();
+        tx.send(Message::Text(serde_json::to_string(&welcome).unwrap()))
+            .await
+            .unwrap();
 
         // Expect a Hello from the runner.
         let frame = rx.next().await.unwrap().unwrap();
@@ -67,11 +65,9 @@ async fn start_fake_cloud() -> (SocketAddr, tokio::task::JoinHandle<()>) {
             approval_policy_overrides: None,
             deadline: None,
         });
-        tx.send(Message::Text(
-            serde_json::to_string(&assign).unwrap().into(),
-        ))
-        .await
-        .unwrap();
+        tx.send(Message::Text(serde_json::to_string(&assign).unwrap()))
+            .await
+            .unwrap();
         // Keep the socket open briefly so the test has time to read.
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     });


### PR DESCRIPTION
## Summary

- Adds Anthropic **Claude Code** as a second agent the runner can drive, alongside Codex. Selected per-runner via a new `[agent] kind = "codex" | "claude_code"` config section. Default stays `codex` so existing installs are unaffected.
- Introduces an agent-agnostic `AgentBridge` / `AgentCursor` abstraction so `daemon/supervisor.rs` no longer depends on `codex::bridge` directly.
- Preserves the on-disk config and JSONL history formats (new sections use `#[serde(default)]`, `HistoryEntry::CodexEvent` kept as-is).

## Design

- **`runner/src/agent/mod.rs`** — owns the shared `BridgeEvent`, `RunPayload`, and the enum-dispatch wrapper `AgentBridge` / `AgentCursor`. `codex::bridge` re-exports the shared types so existing imports (and integration tests) keep compiling.
- **`runner/src/claude_code/`** — parallel of `runner/src/codex/`:
  - `process.rs` spawns `claude --print --verbose --input-format stream-json --output-format stream-json --permission-mode bypassPermissions [--model …]` and reads newline-delimited events from stdout.
  - `schema.rs` models the top-level stream-JSON event via a manually-implemented `Deserialize` that dispatches on the `type` tag (an untagged enum would silently misroute `result` frames into the `system` shape).
  - `bridge.rs` mirrors the Codex bridge's contract: `spawn`, `run` (blocks on `system/init` so the cursor returns with a populated `thread_id`), `next_events`, `send_approval` (stub for MVP), `interrupt`, `shutdown`.
- **`daemon/supervisor.rs`** swaps the direct `Bridge::spawn` / `bridge.next_frame` / `cursor.translate` calls for `AgentBridge::spawn_from_config` and `bridge.next_events(cursor)`.
- **`cli/doctor.rs`** picks `codex --version` vs `claude --version` based on `config.agent.kind`; the shared version probe is factored into one helper.

## Known MVP limitations (tracked as follow-ups)

1. **Claude approvals bypass** — runs with \`--permission-mode bypassPermissions\`. Wiring the \`ApprovalRouter\` to Claude's \`--permission-prompt-tool\` needs a small MCP server bridge; out of scope for this pass. Codex approvals are unchanged.
2. **Single-turn per run** — no \`--resume\` / session continuation.
3. **\`HistoryEntry::CodexEvent\`** kept as-is to avoid breaking on-disk JSONL compatibility; Claude events use method names like \`"assistant/message"\`. Rename to \`AgentEvent\` deferred to its own PR with a migration.
4. **\`FailureReason::CodexCrash\`** is reused for Claude subprocess failures; dedicated variant can come with the rename above.

## Test plan

- [x] \`cargo test\` — 30/30 tests pass across 7 binaries, including:
  - [x] New \`tests/claude_bridge_fake.rs\` (2 tests): happy-path init → assistant → result.success, and result.error → Failed mapping. Uses a shell-script fake — no real \`claude\` binary required.
  - [x] Existing \`tests/codex_bridge_fake.rs\` (4 tests) continues to pass against the shared \`BridgeEvent\` / \`RunPayload\` types.
- [x] \`cargo check\` — clean.
- [x] \`cargo clippy --all-targets\` — 0 new warnings from files introduced in this PR (7 pre-existing warnings on \`main\` are unchanged and not addressed here).
- [ ] Manual smoke test with a real \`claude\` CLI install: set \`[agent] kind = "claude_code"\` in \`config.toml\`, run \`pidash doctor\` and a trivial assigned run end-to-end. (Not gating CI since it requires interactive Claude login.)

## Upgrade notes

No migration needed. Existing \`config.toml\` files load unchanged — \`[agent]\` and \`[claude_code]\` fall back to defaults (agent = codex, claude binary = \"claude\"). To switch a runner to Claude Code, add to \`config.toml\`:

\`\`\`toml
[agent]
kind = "claude_code"

[claude_code]
binary = "claude"
# model_default = "claude-sonnet-4-6"   # optional
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)