### PR TITLE
feat(web): add how-to tooltip next to "Add a runner"

### DIFF
--- a/apps/web/app/(all)/[workspaceSlug]/runners/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/page.tsx
@@ -6,13 +6,14 @@
 
 import { useEffect, useState } from "react";
 import { observer } from "mobx-react";
+import { HelpCircle } from "lucide-react";
 import useSWR from "swr";
 import { useTranslation } from "@pi-dash/i18n";
 import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
 import { RunnerService } from "@pi-dash/services";
 import type { IRunner, TRunnerStatus } from "@pi-dash/types";
 import type { TBadgeVariant } from "@pi-dash/ui";
-import { AlertModalCore, Badge, Button, Input } from "@pi-dash/ui";
+import { AlertModalCore, Badge, Button, Input, Tooltip } from "@pi-dash/ui";
 import { PageHead } from "@/components/core/page-title";
 import { useWorkspace } from "@/hooks/store/use-workspace";
 
@@ -100,7 +101,26 @@ const RunnersListPage = observer(function RunnersListPage() {
       <section className="rounded-md border border-subtle p-4">
         <div className="flex items-center justify-between">
           <div>
-            <div className="text-13 font-medium text-primary">{t("runners.list.add_runner")}</div>
+            <div className="flex items-center gap-1.5">
+              <div className="text-13 font-medium text-primary">{t("runners.list.add_runner")}</div>
+              <Tooltip
+                position="bottom"
+                tooltipContent={
+                  <div className="flex max-w-xs flex-col gap-1 p-1 text-12 whitespace-normal">
+                    <div className="font-medium">{t("runners.list.how_it_works_title")}</div>
+                    <div className="whitespace-pre-line text-secondary">{t("runners.list.how_it_works_body")}</div>
+                  </div>
+                }
+              >
+                <button
+                  type="button"
+                  aria-label={t("runners.list.how_it_works_title")}
+                  className="text-tertiary hover:text-primary"
+                >
+                  <HelpCircle className="size-4" />
+                </button>
+              </Tooltip>
+            </div>
             <div className="text-13 text-secondary">
               {t("runners.list.cap_count", { active: activeCount, max: MAX_RUNNERS_PER_USER })}
             </div>

--- a/packages/i18n/src/locales/en/core.ts
+++ b/packages/i18n/src/locales/en/core.ts
@@ -258,6 +258,9 @@ export default {
     },
     list: {
       add_runner: "Add a runner",
+      how_it_works_title: "How to add a runner",
+      how_it_works_body:
+        "1. Click Mint to generate a one-time code.\n2. On the machine that will host the runner, install the pidash CLI and run the shown `pidash configure` command.\n3. Run `pidash install && pidash start` to keep it running as a background service.\n4. The runner will appear online in the list once connected.\n\nPrerequisite: codex must already be installed on the host machine.",
       cap_count: "You have {active} of {max} runners registered.",
       label_placeholder: "optional label (e.g. my-laptop)",
       mint: "Mint registration code",


### PR DESCRIPTION
## Summary
New users landed on the Runners page and had no in-product hint about how enrollment actually works. This PR adds a small help-circle icon next to the **Add a runner** heading; hovering it shows a tooltip with the 4-step flow.

## What it looks like
- **How to add a runner**
  1. Click Mint to generate a one-time code.
  2. On the machine that will host the runner, install the pidash CLI and run the shown `pidash configure` command.
  3. Run `pidash install && pidash start` to keep it running as a background service.
  4. The runner will appear online in the list once connected.

  *Prerequisite: codex must already be installed on the host machine.*

## Changes
- `apps/web/app/(all)/[workspaceSlug]/runners/page.tsx` — import `Tooltip` from `@pi-dash/ui` and `HelpCircle` from `lucide-react`. Wrap a `<button aria-label=\"How to add a runner\">` next to the existing heading; tooltip content is structured (title + pre-line body).
- `packages/i18n/src/locales/en/core.ts` — add `runners.list.how_it_works_title` and `runners.list.how_it_works_body`.

## Notes
- EN-only for now. Other 19 locales will fall back to the raw key string until translations land — same pattern as `sidebar.runners` from PR #28.
- Uses the existing `Tooltip` component (blueprintjs popover2 under the hood) already used elsewhere in the app — no new UI dependency.
- The mint button and its surrounding behavior are unchanged.

## Test plan
- [ ] Load `/<workspaceSlug>/runners` → the `?` icon appears next to \"Add a runner\".
- [ ] Hover the icon → tooltip renders with title + multi-line body, line breaks respected.
- [ ] Keyboard accessible: tab focuses the icon button, tooltip shows on focus.
- [ ] `aria-label` is set so screen readers can announce it.
- [ ] No visual regression to the mint form / table below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)