### PR TITLE
ci(release): drop x86_64-apple-darwin from prebuilt matrix

### DIFF
--- a/.ai_design/runner_install_ux/cli-restructure-and-install-flow.md
+++ b/.ai_design/runner_install_ux/cli-restructure-and-install-flow.md
@@ -182,10 +182,10 @@ Officially (per `dist-workspace.toml`):
 | OS    | Arch                    | Service backend |
 | ----- | ----------------------- | --------------- |
 | macOS | aarch64 (Apple Silicon) | launchd         |
-| macOS | x86_64 (Intel)          | launchd         |
+| Linux | aarch64 (glibc)         | systemd (user)  |
 | Linux | x86_64 (glibc)          | systemd (user)  |
 
-Build-from-source also works on Unix-likes with Rust 1.93 when the init system is systemd or launchd. Not supported: Windows, musl, BSDs, non-systemd Linux inits.
+Intel Mac (`x86_64-apple-darwin`) is **not** in the prebuilt matrix: GitHub retired the `macos-13` runner image, leaving no scheduler for that target. Build-from-source still works on Intel Macs with Rust 1.93. Also not supported in prebuilts: Windows, musl, BSDs, non-systemd Linux inits.
 
 ## Implementation plan
 

--- a/README.md
+++ b/README.md
@@ -88,8 +88,10 @@ For production deployments, see the [`deployments/`](./deployments) directory fo
 
 Install the CLI on any machine where you want agents to pick up and execute tasks. Currently supported platforms:
 
-- **macOS** — Apple Silicon (arm64) and Intel (x86_64)
+- **macOS** — Apple Silicon (arm64)
 - **Linux** — arm64 and x86_64
+
+> Intel Macs are not in the prebuilt matrix — GitHub retired the `macos-13` runner image. You can still build from source on Intel macOS with Rust 1.93+.
 
 Run the following command in your dev machine terminal:
 
@@ -115,12 +117,12 @@ The runner daemon runs in the background, polls for assigned tasks, dispatches t
 
 Useful commands:
 
-| Command | Description |
-|---------|-------------|
-| `pidash status` | Print service and daemon status |
-| `pidash tui` | Open interactive terminal UI to monitor the daemon |
+| Command         | Description                                                                |
+| --------------- | -------------------------------------------------------------------------- |
+| `pidash status` | Print service and daemon status                                            |
+| `pidash tui`    | Open interactive terminal UI to monitor the daemon                         |
 | `pidash doctor` | Run preflight checks (agent installed, git configured, platform reachable) |
-| `pidash stop` | Stop the daemon |
+| `pidash stop`   | Stop the daemon                                                            |
 
 See `pidash --help` for all available commands.
 

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -15,15 +15,18 @@ installers = ["shell"]
 allow-dirty = ["ci"]
 targets = [
     "aarch64-apple-darwin",
-    "x86_64-apple-darwin",
     "aarch64-unknown-linux-gnu",
     "x86_64-unknown-linux-gnu",
 ]
 pr-run-mode = "plan"
 install-path = "$HOME/.local/bin"
 
+# x86_64-apple-darwin (Intel Mac) intentionally omitted: GitHub's
+# macos-13 runner pool is effectively unavailable in 2026, so the build
+# job sits queued for hours. Apple stopped selling Intel Macs in 2023;
+# Apple Silicon (aarch64-apple-darwin) covers the modern user base.
+# Revisit via cross-compile from macos-14 if Intel Mac demand appears.
 [dist.github-custom-runners]
 aarch64-apple-darwin = "macos-14"
-x86_64-apple-darwin = "macos-13"
 aarch64-unknown-linux-gnu = "ubuntu-22.04-arm"
 x86_64-unknown-linux-gnu = "ubuntu-22.04"

--- a/runner/README.md
+++ b/runner/README.md
@@ -4,7 +4,7 @@ Local daemon + TUI (`pidash` binary) that connects a developer machine to the Pi
 
 ## Install
 
-Prebuilt binaries for macOS (arm64, x86_64) and Linux (arm64, x86_64) are published to GitHub Releases. The one-liner below downloads the installer, verifies checksums, and drops `pidash` into `$HOME/.local/bin`:
+Prebuilt binaries for macOS (arm64) and Linux (arm64, x86_64) are published to GitHub Releases. The one-liner below downloads the installer, verifies checksums, and drops `pidash` into `$HOME/.local/bin`:
 
 ```bash
 curl --proto '=https' --tlsv1.2 -LsSf \
@@ -87,11 +87,11 @@ Wire version is `1` — bumped on incompatible shape changes. See `src/cloud/pro
 
 - **Unit:** `cargo test` — deterministic table-driven tests for protocol serde, approval policy, reconnect backoff, workspace resolve, config roundtrip.
 - **Integration:** `tests/protocol_roundtrip.rs` — every client/server variant round-trips; router state machine invariants.
-- **Manual QA** (per release): macOS arm64/x64 + Linux x64 → first-run `configure` → `install` → `start` → TUI shows connected → synthetic run via `/api/runners/runs/` → approval prompt → decision.
+- **Manual QA** (per release): macOS arm64 + Linux x64 → first-run `configure` → `install` → `start` → TUI shows connected → synthetic run via `/api/runners/runs/` → approval prompt → decision.
 
 ## Release
 
-Managed by `cargo-dist` (see `dist-workspace.toml` + `.github/workflows/release.yml`). Pushing a SemVer tag (e.g. `v0.1.0`) triggers the workflow, which builds binaries for macOS arm64/x64 and Linux arm64/x64, generates the shell installer, and publishes everything to a GitHub Release.
+Managed by `cargo-dist` (see `dist-workspace.toml` + `.github/workflows/release.yml`). Pushing a SemVer tag (e.g. `v0.1.0`) triggers the workflow, which builds binaries for macOS arm64 and Linux arm64/x64, generates the shell installer, and publishes everything to a GitHub Release.
 
 To cut a release:
 


### PR DESCRIPTION
## Summary

GitHub retired the \`macos-13\` runner image. On the v0.1.0 release attempt the \`x86_64-apple-darwin\` build sat queued for **3+ hours** while the three other targets built in ~3 minutes each and the rest of the pipeline (\`host\`, \`announce\`) blocked on it. Same pattern we already fixed for \`ubuntu-20.04\` in #26.

Remove \`x86_64-apple-darwin\` from \`dist-workspace.toml\`'s target list and custom-runner map, and reflect the change in \`README.md\`, \`runner/README.md\`, and the install-flow design doc. Apple stopped selling Intel Macs in 2023; Apple Silicon (\`aarch64-apple-darwin\`, already builds green) covers the modern macOS base. Intel Mac users can still build from source with Rust 1.93+. A cross-compile-from-macos-14 path is a reasonable follow-up if Intel demand appears.

## Test plan

- [x] \`cargo dist plan\` locally → announces v0.1.0 with 3 targets (mac arm64, linux arm64, linux x86_64) + \`pidash-installer.sh\`
- [ ] After merge: re-tag \`v0.1.0\`, full matrix completes, GitHub Release publishes \`pidash-installer.sh\`
- [ ] Smoke-test: \`curl --proto '=https' --tlsv1.2 -LsSf https://github.com/The-AI-Republic/pi-dash/releases/latest/download/pidash-installer.sh | sh\` — exits 0 and installs \`pidash\` to \`\$HOME/.local/bin/\`

## Follow-ups out of scope

- Cross-compile \`x86_64-apple-darwin\` from the \`macos-14\` runner
- \`x86_64-unknown-linux-musl\` (Alpine / minimal containers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)