### PR TITLE
docs: fix CoC contact email to support@airepublic.com

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-squawk@pi-dash.so.
+support@airepublic.com.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the


### PR DESCRIPTION
## Summary
- Replace the placeholder enforcement contact `squawk@pi-dash.so` in `CODE_OF_CONDUCT.md` with `support@airepublic.com`. The old address is not a real mailbox and was unique to this file (the rest of the repo already uses `support@pi-dash.so`, but per request this file routes to `support@airepublic.com`).

## Test plan
- [x] `git diff` shows a one-line change in `CODE_OF_CONDUCT.md`
- [ ] No broken links to the old address elsewhere (confirmed via repo grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)