### PR TITLE
docs: upgrade CoC to Contributor Covenant v2.1

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,8 +6,8 @@ We as members, contributors, and leaders pledge to make participation in our
 community a harassment-free experience for everyone, regardless of age, body
 size, visible or invisible disability, ethnicity, sex characteristics, gender
 identity and expression, level of experience, education, socio-economic status,
-nationality, personal appearance, race, religion, or sexual identity
-and orientation.
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
 
 We pledge to act and interact in ways that contribute to an open, welcoming,
 diverse, inclusive, and healthy community.
@@ -115,8 +115,8 @@ the community.
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
-version 2.0, available at
-https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
 
 Community Impact Guidelines were inspired by [Mozilla's code of conduct
 enforcement ladder](https://github.com/mozilla/diversity).


### PR DESCRIPTION
## Summary
- Upgrade `CODE_OF_CONDUCT.md` from Contributor Covenant **v2.0** (2019) to **v2.1** (current upstream).
- Two substantive diffs vs the current v2.0 copy:
  - Pledge list gains **"caste, color"**.
  - Attribution links point to the v2.1 URL.
- Body text is verbatim from the upstream v2.1 template (https://www.contributor-covenant.org/version/2/1/code_of_conduct.html), so the CoC is clearly sourced from Contributor Covenant rather than inherited from any downstream fork.
- Confirmed no Plane-specific wording, domains, or trademarks remain in the file (grep for `[Pp]lane` returns no matches).

## Stacking
- Base branch: `fix/coc-contact-email` (PR #33). Retarget to `main` once #33 merges.

## Test plan
- [x] Diff limited to pledge list + attribution version/URL
- [x] Enforcement contact still `support@airepublic.com`
- [x] Grep confirms no Plane-specific content remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)