### PR TITLE
fix(web): point runner registration command at API origin, not web origin

### DIFF
--- a/apps/web/app/(all)/[workspaceSlug]/runners/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/page.tsx
@@ -8,6 +8,7 @@ import { useEffect, useState } from "react";
 import { observer } from "mobx-react";
 import { HelpCircle } from "lucide-react";
 import useSWR from "swr";
+import { API_BASE_URL } from "@pi-dash/constants";
 import { useTranslation } from "@pi-dash/i18n";
 import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
 import { RunnerService } from "@pi-dash/services";
@@ -54,7 +55,8 @@ const RunnersListPage = observer(function RunnersListPage() {
     if (typeof window !== "undefined") setOrigin(window.location.origin);
   }, []);
 
-  const configureCommand = mintedToken ? `pidash configure --url ${origin} --token ${mintedToken}` : "";
+  const apiOrigin = API_BASE_URL || origin;
+  const configureCommand = mintedToken ? `pidash configure --url ${apiOrigin} --token ${mintedToken}` : "";
 
   async function copyToClipboard(text: string, kind: "command" | "token") {
     if (!text) return;


### PR DESCRIPTION
## Summary
- The "Mint registration code" snippet on the Runners page emitted `window.location.origin` for `pidash configure --url`, which breaks local dev: web is on :3000 but `/api/v1/runner/register/` is served by Django on :8000, so the POST hit the React Router dev server and returned HTTP 405 (`<!DOCTYPE html>...`).
- Reuse the existing `API_BASE_URL` (`VITE_API_BASE_URL`) and fall back to `window.location.origin`, so CE/Caddy-proxied deployments (where web and API share an origin) keep working unchanged.

## Test plan
- [ ] Local dev: click **Mint registration code** on `/[workspaceSlug]/runners`, confirm the snippet reads `pidash configure --url http://localhost:8000 --token …`.
- [ ] Run the emitted command against a built `pidash` — `configure` should succeed instead of 405ing.
- [ ] CE / Caddy-proxied deploy: `VITE_API_BASE_URL` unset, confirm the snippet still uses the page origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)