### PR TITLE
feat(runner): prompt for agent kind + gate on auth during configure

### DIFF
--- a/runner/src/cli/configure.rs
+++ b/runner/src/cli/configure.rs
@@ -1,9 +1,10 @@
 use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
+use std::io::{BufRead, IsTerminal, Write};
 use std::path::PathBuf;
 
 use crate::cloud::register::{RegisterError, RegisterRequest, register};
-use crate::config::schema::{Config, Credentials};
+use crate::config::schema::{AgentKind, Config, Credentials};
 use crate::util::paths::Paths;
 use crate::util::runner_name;
 
@@ -30,7 +31,14 @@ pub struct Args {
     #[arg(long)]
     pub working_dir: Option<PathBuf>,
 
-    /// Skip on-install doctor checks (not recommended).
+    /// Which AI agent CLI the runner should drive. Omit on a TTY to be
+    /// prompted (default / Enter = `codex`). Required to run non-interactively
+    /// with a non-default choice.
+    #[arg(long, value_enum)]
+    pub agent: Option<AgentKind>,
+
+    /// Skip on-install doctor checks (not recommended). Also skips the
+    /// auth-gate retry loop, since there's nothing to re-check.
     #[arg(long)]
     pub skip_doctor: bool,
 }
@@ -42,6 +50,9 @@ pub struct RegisterInputs {
     pub token: String,
     pub name: Option<String>,
     pub working_dir: Option<PathBuf>,
+    /// Explicit agent choice; `None` means "ask on a TTY, else keep the
+    /// existing config's kind, else Codex."
+    pub agent: Option<AgentKind>,
     pub skip_doctor: bool,
 }
 
@@ -52,6 +63,7 @@ impl From<Args> for RegisterInputs {
             token: a.token,
             name: a.name,
             working_dir: a.working_dir,
+            agent: a.agent,
             skip_doctor: a.skip_doctor,
         }
     }
@@ -69,6 +81,15 @@ pub async fn run(args: Args, paths: &Paths) -> Result<()> {
 /// it sets false because install itself is doing the "next" step.
 pub async fn execute(inputs: RegisterInputs, paths: &Paths, print_next_hint: bool) -> Result<()> {
     validate_cloud_url(&inputs.url)?;
+
+    // Pre-load any existing config so we can pre-fill the agent prompt with
+    // the user's prior choice. Harmless if the file is absent or garbled —
+    // `load_config_opt` swallows NotFound and we fall back to Codex.
+    let existing_kind = crate::config::file::load_config_opt(paths)
+        .ok()
+        .flatten()
+        .map(|c| c.agent.kind);
+    let agent_kind = resolve_agent_kind(inputs.agent, existing_kind)?;
 
     // User-supplied names are charset-checked up front; an invalid `--name`
     // is a hard error, not something we try to fix by retrying. Auto-generated
@@ -163,7 +184,7 @@ pub async fn execute(inputs: RegisterInputs, paths: &Paths, print_next_hint: boo
         workspace: crate::config::schema::WorkspaceSection { working_dir },
         codex: crate::config::schema::CodexSection::default(),
         claude_code: crate::config::schema::ClaudeCodeSection::default(),
-        agent: crate::config::schema::AgentSection::default(),
+        agent: crate::config::schema::AgentSection { kind: agent_kind },
         approval_policy: crate::config::schema::ApprovalPolicySection::default(),
         logging: crate::config::schema::LoggingSection::default(),
     };
@@ -178,11 +199,7 @@ pub async fn execute(inputs: RegisterInputs, paths: &Paths, print_next_hint: boo
     crate::config::file::write_credentials(paths, &creds)?;
 
     if !inputs.skip_doctor {
-        let report = crate::cli::doctor::execute(paths).await?;
-        report.print_compact();
-        if report.has_blockers() {
-            eprintln!("\nWarning: some preflight checks failed. Resolve them before starting.");
-        }
+        run_doctor_with_auth_gate(paths, agent_kind).await?;
     }
 
     if print_next_hint {
@@ -197,6 +214,97 @@ pub async fn execute(inputs: RegisterInputs, paths: &Paths, print_next_hint: boo
         );
     }
     Ok(())
+}
+
+/// Picks the agent for this run. Precedence:
+/// 1. `--agent` flag (always wins, scriptable).
+/// 2. Interactive TTY prompt, pre-filled with the existing config's kind
+///    if one exists (otherwise `codex`). Enter accepts the default.
+/// 3. Non-TTY with no flag: keep the existing config's kind, or Codex.
+fn resolve_agent_kind(flag: Option<AgentKind>, existing: Option<AgentKind>) -> Result<AgentKind> {
+    if let Some(k) = flag {
+        return Ok(k);
+    }
+    if std::io::stdin().is_terminal() {
+        return prompt_agent_kind(existing.unwrap_or_default());
+    }
+    Ok(existing.unwrap_or_default())
+}
+
+fn prompt_agent_kind(default: AgentKind) -> Result<AgentKind> {
+    let default_label = match default {
+        AgentKind::Codex => "codex",
+        AgentKind::ClaudeCode => "claude-code",
+    };
+    print!("Choose AI agent [codex/claude-code] (default: {default_label}): ");
+    std::io::stdout().flush()?;
+    let stdin = std::io::stdin();
+    let mut line = String::new();
+    stdin.lock().read_line(&mut line)?;
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return Ok(default);
+    }
+    // Accept both the CLI spelling (`claude-code`) and the config-file
+    // spelling (`claude_code`) so the prompt forgives either.
+    match trimmed.to_ascii_lowercase().as_str() {
+        "codex" => Ok(AgentKind::Codex),
+        "claude-code" | "claude_code" | "claude" => Ok(AgentKind::ClaudeCode),
+        other => anyhow::bail!(
+            "unrecognised agent {other:?}; expected `codex` or `claude-code`"
+        ),
+    }
+}
+
+/// Runs the doctor and, on a TTY, loops on a failing agent-auth blocker so
+/// the operator can authenticate in another terminal and continue without
+/// re-running `pidash configure`. Non-TTY keeps the old warn-and-continue
+/// behaviour so scripts don't deadlock.
+async fn run_doctor_with_auth_gate(paths: &Paths, agent_kind: AgentKind) -> Result<()> {
+    let auth_check_name = match agent_kind {
+        AgentKind::Codex => "codex-auth",
+        AgentKind::ClaudeCode => "claude-auth",
+    };
+    let tty = std::io::stdin().is_terminal();
+
+    loop {
+        let report = crate::cli::doctor::execute(paths).await?;
+        report.print_compact();
+
+        let auth_failing = report
+            .checks
+            .iter()
+            .any(|c| c.name == auth_check_name && c.blocker && !c.ok);
+
+        if !auth_failing {
+            if report.has_blockers() {
+                eprintln!("\nWarning: some preflight checks failed. Resolve them before starting.");
+            }
+            return Ok(());
+        }
+
+        if !tty {
+            eprintln!("\nWarning: some preflight checks failed. Resolve them before starting.");
+            return Ok(());
+        }
+
+        let login_hint = match agent_kind {
+            AgentKind::Codex => "codex login",
+            AgentKind::ClaudeCode => "claude /login",
+        };
+        print!(
+            "\nAgent auth check failed. Run `{login_hint}` in another terminal, then press Enter to retry (Ctrl-C to finish setup later): "
+        );
+        std::io::stdout().flush()?;
+        let stdin = std::io::stdin();
+        let mut line = String::new();
+        // EOF (0 bytes) = user closed stdin / piped-in empty input; treat as
+        // "give up" rather than a busy-loop. Matches Ctrl-C semantics.
+        if stdin.lock().read_line(&mut line)? == 0 {
+            eprintln!("\nFinishing setup without auth; resolve it before starting the runner.");
+            return Ok(());
+        }
+    }
 }
 
 /// Refuse `http://` URLs that point at non-localhost hosts. Sending the

--- a/runner/src/cli/configure.rs
+++ b/runner/src/cli/configure.rs
@@ -89,7 +89,7 @@ pub async fn execute(inputs: RegisterInputs, paths: &Paths, print_next_hint: boo
         .ok()
         .flatten()
         .map(|c| c.agent.kind);
-    let agent_kind = resolve_agent_kind(inputs.agent, existing_kind)?;
+    let agent_kind = resolve_agent_kind(inputs.agent, existing_kind);
 
     // User-supplied names are charset-checked up front; an invalid `--name`
     // is a hard error, not something we try to fix by retrying. Auto-generated
@@ -219,40 +219,79 @@ pub async fn execute(inputs: RegisterInputs, paths: &Paths, print_next_hint: boo
 /// Picks the agent for this run. Precedence:
 /// 1. `--agent` flag (always wins, scriptable).
 /// 2. Interactive TTY prompt, pre-filled with the existing config's kind
-///    if one exists (otherwise `codex`). Enter accepts the default.
+///    if one exists (otherwise `codex`). Enter accepts the default; EOF
+///    also accepts the default (matches `install.rs` prompt conventions).
 /// 3. Non-TTY with no flag: keep the existing config's kind, or Codex.
-fn resolve_agent_kind(flag: Option<AgentKind>, existing: Option<AgentKind>) -> Result<AgentKind> {
+fn resolve_agent_kind(flag: Option<AgentKind>, existing: Option<AgentKind>) -> AgentKind {
     if let Some(k) = flag {
-        return Ok(k);
+        return k;
     }
     if std::io::stdin().is_terminal() {
         return prompt_agent_kind(existing.unwrap_or_default());
     }
-    Ok(existing.unwrap_or_default())
+    existing.unwrap_or_default()
 }
 
-fn prompt_agent_kind(default: AgentKind) -> Result<AgentKind> {
+/// Result of parsing one line of user input at the agent prompt. Kept pure
+/// (no I/O) so the parser can be unit-tested without a terminal.
+#[derive(Debug, PartialEq, Eq)]
+enum AgentInput {
+    /// Empty / whitespace-only input: accept the pre-filled default.
+    UseDefault,
+    /// A recognised agent name.
+    Parsed(AgentKind),
+    /// The input didn't match any known name; caller should re-prompt.
+    Unknown,
+}
+
+/// Accepts the CLI spelling (`codex`, `claude-code`), the config-file
+/// spelling (`claude_code`), and `claude` as a shorthand — so the prompt
+/// forgives whichever a user might type. Case-insensitive.
+fn parse_agent_input(raw: &str) -> AgentInput {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return AgentInput::UseDefault;
+    }
+    match trimmed.to_ascii_lowercase().as_str() {
+        "codex" => AgentInput::Parsed(AgentKind::Codex),
+        "claude-code" | "claude_code" | "claude" => AgentInput::Parsed(AgentKind::ClaudeCode),
+        _ => AgentInput::Unknown,
+    }
+}
+
+/// Reads a single line from stdin, loops on unrecognised input so a typo
+/// doesn't force the user to re-run `pidash configure` (and re-paste the
+/// one-time token). Returns the pre-filled default on empty input or EOF.
+fn prompt_agent_kind(default: AgentKind) -> AgentKind {
     let default_label = match default {
         AgentKind::Codex => "codex",
         AgentKind::ClaudeCode => "claude-code",
     };
-    print!("Choose AI agent [codex/claude-code] (default: {default_label}): ");
-    std::io::stdout().flush()?;
-    let stdin = std::io::stdin();
-    let mut line = String::new();
-    stdin.lock().read_line(&mut line)?;
-    let trimmed = line.trim();
-    if trimmed.is_empty() {
-        return Ok(default);
-    }
-    // Accept both the CLI spelling (`claude-code`) and the config-file
-    // spelling (`claude_code`) so the prompt forgives either.
-    match trimmed.to_ascii_lowercase().as_str() {
-        "codex" => Ok(AgentKind::Codex),
-        "claude-code" | "claude_code" | "claude" => Ok(AgentKind::ClaudeCode),
-        other => anyhow::bail!(
-            "unrecognised agent {other:?}; expected `codex` or `claude-code`"
-        ),
+    loop {
+        // Ignore flush errors: if stdout is broken we can't recover here
+        // anyway, and the read_line below will fail loudly.
+        print!("Choose AI agent [codex/claude-code] (default: {default_label}): ");
+        let _ = std::io::stdout().flush();
+        let mut line = String::new();
+        // EOF on stdin also yields an empty string ⇒ default, matching
+        // the install.rs `prompt_required` convention.
+        match std::io::stdin().lock().read_line(&mut line) {
+            Ok(0) => return default,
+            Ok(_) => {}
+            Err(e) => {
+                eprintln!("warning: could not read agent prompt ({e}); using default");
+                return default;
+            }
+        }
+        match parse_agent_input(&line) {
+            AgentInput::UseDefault => return default,
+            AgentInput::Parsed(k) => return k,
+            AgentInput::Unknown => {
+                eprintln!(
+                    "unrecognised agent; expected `codex` or `claude-code` (or press Enter for the default)."
+                );
+            }
+        }
     }
 }
 
@@ -326,5 +365,70 @@ fn validate_cloud_url(url: &str) -> Result<()> {
         );
     }
     anyhow::bail!("cloud URL must start with https:// (or http:// for localhost), got {url}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_agent_input_empty_is_default() {
+        assert_eq!(parse_agent_input(""), AgentInput::UseDefault);
+        assert_eq!(parse_agent_input("   "), AgentInput::UseDefault);
+        assert_eq!(parse_agent_input("\n"), AgentInput::UseDefault);
+        assert_eq!(parse_agent_input("  \t\n"), AgentInput::UseDefault);
+    }
+
+    #[test]
+    fn parse_agent_input_codex_variants() {
+        assert_eq!(parse_agent_input("codex"), AgentInput::Parsed(AgentKind::Codex));
+        assert_eq!(parse_agent_input("CODEX"), AgentInput::Parsed(AgentKind::Codex));
+        assert_eq!(parse_agent_input("  Codex\n"), AgentInput::Parsed(AgentKind::Codex));
+    }
+
+    #[test]
+    fn parse_agent_input_claude_variants() {
+        // CLI spelling, config-file spelling, and shorthand — all map to ClaudeCode.
+        assert_eq!(
+            parse_agent_input("claude-code"),
+            AgentInput::Parsed(AgentKind::ClaudeCode)
+        );
+        assert_eq!(
+            parse_agent_input("claude_code"),
+            AgentInput::Parsed(AgentKind::ClaudeCode)
+        );
+        assert_eq!(
+            parse_agent_input("claude"),
+            AgentInput::Parsed(AgentKind::ClaudeCode)
+        );
+        assert_eq!(
+            parse_agent_input("CLAUDE-CODE"),
+            AgentInput::Parsed(AgentKind::ClaudeCode)
+        );
+        assert_eq!(
+            parse_agent_input("  Claude_Code  "),
+            AgentInput::Parsed(AgentKind::ClaudeCode)
+        );
+    }
+
+    #[test]
+    fn parse_agent_input_unknown_values() {
+        // Typos and adjacent names ⇒ Unknown, so the caller can re-prompt
+        // instead of bailing out of `pidash configure`.
+        assert_eq!(parse_agent_input("nope"), AgentInput::Unknown);
+        assert_eq!(parse_agent_input("codexx"), AgentInput::Unknown);
+        assert_eq!(parse_agent_input("anthropic"), AgentInput::Unknown);
+        assert_eq!(parse_agent_input("gpt"), AgentInput::Unknown);
+    }
+
+    #[test]
+    fn resolve_agent_kind_flag_wins_over_existing() {
+        // We can't assert the TTY branch from a unit test, but we can assert
+        // that an explicit `--agent` flag bypasses both the prompt and the
+        // existing-config fallback — which is the important guarantee for
+        // non-interactive callers.
+        let got = resolve_agent_kind(Some(AgentKind::Codex), Some(AgentKind::ClaudeCode));
+        assert_eq!(got, AgentKind::Codex);
+    }
 }
 

--- a/runner/src/cli/install.rs
+++ b/runner/src/cli/install.rs
@@ -124,6 +124,9 @@ fn prompt_for_register_inputs(paths: &Paths) -> Result<crate::cli::configure::Re
         token,
         name,
         working_dir: None,
+        // Leave `agent: None` so configure::execute handles the prompt in
+        // one place (install is always interactive here).
+        agent: None,
         skip_doctor: false,
     })
 }

--- a/runner/src/config/schema.rs
+++ b/runner/src/config/schema.rs
@@ -72,8 +72,9 @@ pub struct AgentSection {
 
 /// Which agent CLI the runner drives for assigned runs. Serialised as a
 /// lowercase string (`"codex"` / `"claude_code"`) so the config file stays
-/// human-friendly.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
+/// human-friendly. `ValueEnum` lets `--agent` accept the kebab-case spelling
+/// on the CLI (`codex`, `claude-code`).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq, clap::ValueEnum)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentKind {
     /// OpenAI Codex via `codex app-server`. Default for backward compatibility.


### PR DESCRIPTION
## Summary
- `pidash configure` now selects the agent CLI up front (and re-runs the doctor until the agent is authenticated), removing the manual `config.toml` edit that the Claude Code MVP shipped with (#29).
- **Agent selection**: new `--agent <codex|claude-code>` flag (scriptable) + interactive TTY prompt. Default is pre-filled from the existing config's kind so re-running `configure` doesn't silently flip a Claude Code runner back to Codex.
- **Auth gate**: after the doctor, a failing agent-auth blocker in TTY mode prints the login hint (`codex login` / `claude /login`) and pauses on Enter, re-running the doctor each iteration. EOF on stdin or Ctrl-C lets the operator finish setup later. Non-TTY preserves the previous warn-and-continue so scripts don't deadlock.
- `install`'s interactive flow passes `agent: None` so the prompt lives in one place.

## Test plan
- [x] `cargo build` — clean
- [x] `cargo test` — 54/54 pass (lib + integration)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `pidash configure --help` shows `--agent` with `codex` / `claude-code` values
- [ ] Fresh TTY run: `pidash configure --url http://localhost:8000 --token <t>` prompts for agent (default `codex`), then if `codex-auth` fails asks to press Enter after `codex login`; re-running the doctor goes green on retry
- [ ] Re-configure after selecting `claude-code`: prompt shows `(default: claude-code)`
- [ ] `--agent claude-code` skips the prompt entirely
- [ ] Non-TTY (piped stdin) + no flag: uses existing kind / Codex without prompting or pausing

🤖 Generated with [Claude Code](https://claude.com/claude-code)