### PR TITLE
docs(readme): explain what setup.sh does for local dev env

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ chmod +x setup.sh
 ./setup.sh
 ```
 
+`setup.sh` copies every `.env.example` to its `.env` counterpart (the repo root plus `apps/web`, `apps/api`, `apps/space`, `apps/admin`, `apps/live`), generates a unique Django `SECRET_KEY` and appends it to `apps/api/.env`, then runs `pnpm install`. For the default loopback-dev setup you do not need to edit any `.env` file manually — the `.env.example` defaults (localhost URLs, `pi-dash` database credentials, a local MinIO endpoint, etc.) work out of the box. Edit them only if you're binding to a non-default host/port or wiring in external services.
+
 3. Start the containers
 
 ```bash


### PR DESCRIPTION
## Summary

The self-host quick-start in `README.md` treats `./setup.sh` as a black box — step 2 just says "Run setup.sh" with no explanation of what it does. Contributors who skip the script, or who read the README wondering whether they need to manage env vars themselves, get no answer without reading the script.

Adds a short paragraph after the `./setup.sh` command that explains the script:

- copies every `.env.example` to `.env` (root + `apps/{web,api,space,admin,live}`),
- generates a unique Django `SECRET_KEY` and appends it to `apps/api/.env`,
- runs `pnpm install`.

Also states explicitly that the default `.env.example` values work out of the box for the loopback-dev setup, so users don't need to edit anything unless they're binding to a non-default host or wiring in external services.

Follow-up to #39, which closed the shared-default-secret gap in the deploy paths but did not touch the root README's local-dev flow.

## Test plan

- [ ] Render the README on GitHub and confirm the new paragraph sits between "Run setup.sh" (step 2) and "Start the containers" (step 3).
- [ ] No behavior change; pure documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)