### PR TITLE
feat(web): add hover tooltips to workspace sidebar pinned items

### DIFF
--- a/apps/web/core/components/workspace/sidebar/sidebar-item.tsx
+++ b/apps/web/core/components/workspace/sidebar/sidebar-item.tsx
@@ -12,6 +12,7 @@ import { useParams, usePathname } from "next/navigation";
 import type { IWorkspaceSidebarNavigationItem } from "@pi-dash/constants";
 import { EUserPermissionsLevel } from "@pi-dash/constants";
 import { useTranslation } from "@pi-dash/i18n";
+import { Tooltip } from "@pi-dash/propel/tooltip";
 import { joinUrlPath } from "@pi-dash/utils";
 // components
 import { SidebarNavItem } from "@/components/sidebar/sidebar-navigation";
@@ -68,8 +69,9 @@ export const SidebarItemBase = observer(function SidebarItemBase({
   const itemHref =
     item.key === "your_work" && data?.id ? joinUrlPath(slug, item.href, data?.id) : joinUrlPath(slug, item.href);
   const icon = getSidebarNavigationItemIcon(item.key);
+  const tooltipContent = item.tooltipTranslationKey ? t(item.tooltipTranslationKey) : null;
 
-  return (
+  const link = (
     <Link href={itemHref} onClick={handleLinkClick}>
       <SidebarNavItem isActive={item.highlight(pathname, itemHref)}>
         <div className="flex items-center gap-1.5 py-[1px]">
@@ -80,4 +82,14 @@ export const SidebarItemBase = observer(function SidebarItemBase({
       </SidebarNavItem>
     </Link>
   );
+
+  if (tooltipContent) {
+    return (
+      <Tooltip tooltipContent={tooltipContent} position="right" className="ml-8">
+        {link}
+      </Tooltip>
+    );
+  }
+
+  return link;
 });

--- a/packages/constants/src/workspace.ts
+++ b/packages/constants/src/workspace.ts
@@ -196,6 +196,7 @@ export interface IWorkspaceSidebarNavigationItem {
   href: string;
   access: EUserWorkspaceRoles[];
   highlight: (pathname: string, url: string) => boolean;
+  tooltipTranslationKey?: string;
 }
 
 export const WORKSPACE_SIDEBAR_DYNAMIC_NAVIGATION_ITEMS: Record<string, IWorkspaceSidebarNavigationItem> = {
@@ -270,6 +271,7 @@ export const WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS: Record<string, IWorkspac
     href: `/projects/`,
     access: [EUserWorkspaceRoles.ADMIN, EUserWorkspaceRoles.MEMBER, EUserWorkspaceRoles.GUEST],
     highlight: (pathname: string, url: string) => pathname === url,
+    tooltipTranslationKey: "sidebar.tooltips.projects",
   },
   runners: {
     key: "runners",
@@ -277,6 +279,7 @@ export const WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS: Record<string, IWorkspac
     href: `/runners/`,
     access: [EUserWorkspaceRoles.ADMIN, EUserWorkspaceRoles.MEMBER],
     highlight: (pathname: string, url: string) => pathname.includes(url),
+    tooltipTranslationKey: "sidebar.tooltips.runners",
   },
   prompts: {
     key: "prompts",
@@ -284,6 +287,7 @@ export const WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS: Record<string, IWorkspac
     href: `/prompts/`,
     access: [EUserWorkspaceRoles.ADMIN, EUserWorkspaceRoles.MEMBER, EUserWorkspaceRoles.GUEST],
     highlight: (pathname: string, url: string) => pathname.includes(url),
+    tooltipTranslationKey: "sidebar.tooltips.prompts",
   },
 };
 

--- a/packages/i18n/src/locales/en/core.ts
+++ b/packages/i18n/src/locales/en/core.ts
@@ -26,6 +26,11 @@ export default {
     stickies: "Stickies",
     prompts: "Prompts",
     runners: "Runners",
+    tooltips: {
+      projects: "Browse projects",
+      runners: "Manage your AI Agent connectivities",
+      prompts: "AI Prompt Templates",
+    },
   },
 
   prompts: {


### PR DESCRIPTION
## Summary
- Add hover tooltips to **Projects**, **Runners**, and **Prompts** in the left sidebar's Workspace section.
- Tooltip strings: Projects → "Browse projects"; Runners → "Manage your AI Agent connectivities"; Prompts → "AI Prompt Templates".
- Wired via a new optional `tooltipTranslationKey` on `IWorkspaceSidebarNavigationItem`, so other sidebar items can opt in later just by setting the field.

## Implementation notes
- `packages/constants/src/workspace.ts` — adds the optional field and populates it on the three pinned static items.
- `packages/i18n/src/locales/en/core.ts` — adds `sidebar.tooltips.{projects,runners,prompts}` (only `core.ts` is English-only in this repo, matching the existing `sidebar.runners` / `sidebar.prompts` keys).
- `apps/web/core/components/workspace/sidebar/sidebar-item.tsx` — wraps the `Link` in propel's `Tooltip` (right-positioned, mirroring `favorite-folder.tsx`) only when `tooltipTranslationKey` is set; other items render unchanged.

## Test plan
- [ ] `pnpm dev` (or just `--filter=web`), open the app, hover **Projects** / **Runners** / **Prompts** in the left sidebar's Workspace section and confirm the tooltips appear with the expected text and right-side placement.
- [ ] Confirm other sidebar items (Home, Views, Analytics, etc.) still render and are tooltip-free.
- [ ] `pnpm check:types` (already verified locally on `@pi-dash/constants`, `@pi-dash/i18n`, `web`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)