### PR TITLE
feat(runner): auto-enable systemd linger after configure

### DIFF
--- a/runner/src/cli/configure.rs
+++ b/runner/src/cli/configure.rs
@@ -91,6 +91,12 @@ pub struct Args {
     /// you only want to write the config files without bouncing a daemon.
     #[arg(long)]
     pub skip_service: bool,
+
+    /// Skip the `sudo loginctl enable-linger` step (Linux only). Without
+    /// linger the daemon only starts at login, not at boot. Set this in
+    /// CI / unattended installs where a sudo password prompt would hang.
+    #[arg(long)]
+    pub skip_linger: bool,
 }
 
 impl Args {
@@ -210,6 +216,7 @@ pub struct RegisterInputs {
     pub agent: Option<AgentKind>,
     pub skip_doctor: bool,
     pub skip_service: bool,
+    pub skip_linger: bool,
     /// Full clap Args, if we came from a direct CLI invocation. Lets the
     /// register path also apply any other `--<flag>` the user passed
     /// (e.g. `--codex-model gpt-5 --approval-auto-readonly true`) before
@@ -233,7 +240,8 @@ pub async fn run(args: Args, paths: &Paths) -> Result<()> {
         && args.token.is_none()
         && !args.has_edit_flags()
         && !args.skip_doctor
-        && !args.skip_service;
+        && !args.skip_service
+        && !args.skip_linger;
     if bare {
         return crate::tui::run(
             paths.clone(),
@@ -253,6 +261,7 @@ pub async fn run(args: Args, paths: &Paths) -> Result<()> {
                 agent: args.agent,
                 skip_doctor: args.skip_doctor,
                 skip_service: args.skip_service,
+                skip_linger: args.skip_linger,
                 extras: Some(args),
             };
             execute(inputs, paths).await
@@ -486,20 +495,50 @@ pub async fn execute(inputs: RegisterInputs, paths: &Paths) -> Result<()> {
     let svc = crate::service::detect();
     svc.write_unit(paths).await?;
     svc.enable_and_start().await?;
-    print_post_install_hints();
+    let boot_outcome = if inputs.skip_linger {
+        crate::service::BootStartOutcome::Skipped
+    } else {
+        svc.ensure_boot_start().await
+    };
+    print_post_install_hints(&boot_outcome);
 
     Ok(())
 }
 
-fn print_post_install_hints() {
+fn print_post_install_hints(boot: &crate::service::BootStartOutcome) {
+    use crate::service::BootStartOutcome::*;
     println!("Service installed and running.");
     if cfg!(target_os = "linux") {
         println!();
-        println!("For the service to start on OS boot (before you log in), run:");
-        println!("  sudo loginctl enable-linger $USER");
-        println!(
-            "Without lingering, the service still starts at every user login and restarts on crash."
-        );
+        match boot {
+            AlreadyEnabled => {
+                println!("Linger is enabled — the service will start automatically at boot.");
+            }
+            Enabled => {
+                println!("Enabled linger — the service will now start automatically at boot.");
+            }
+            NonInteractive => {
+                println!("No TTY available; skipped enabling linger.");
+                println!("To start the service at boot, run:");
+                println!("  sudo loginctl enable-linger $USER");
+            }
+            Skipped => {
+                println!("Skipped `loginctl enable-linger` (--skip-linger).");
+                println!("Without lingering, the service only starts at login.");
+                println!("To enable later, run:  sudo loginctl enable-linger $USER");
+            }
+            CheckFailed(err) => {
+                println!("Couldn't check linger state ({err}).");
+                println!("To start the service at boot, run:");
+                println!("  sudo loginctl enable-linger $USER");
+            }
+            EnableFailed(err) => {
+                println!("Couldn't enable linger ({err}).");
+                println!("The service is running now but won't restart at boot until you run:");
+                println!("  sudo loginctl enable-linger $USER");
+            }
+            NotApplicable => {}
+        }
     }
     println!();
     println!("Useful next commands:");

--- a/runner/src/cli/install.rs
+++ b/runner/src/cli/install.rs
@@ -28,6 +28,12 @@ pub struct Args {
     /// Use when running from CI / Ansible / Docker builds.
     #[arg(long)]
     pub no_configure: bool,
+
+    /// Skip the `sudo loginctl enable-linger` step (Linux only). Without
+    /// linger the daemon only starts at login, not at boot. Set this in
+    /// CI / unattended installs where a sudo password prompt would hang.
+    #[arg(long)]
+    pub skip_linger: bool,
 }
 
 pub async fn run(args: Args, paths: &Paths) -> Result<()> {
@@ -48,7 +54,7 @@ pub async fn run(args: Args, paths: &Paths) -> Result<()> {
         }
         // Interactive path: configure owns the whole end-to-end flow
         // (register → persist → doctor → write unit → enable + start).
-        let inputs = prompt_for_register_inputs(paths)?;
+        let inputs = prompt_for_register_inputs(paths, args.skip_linger)?;
         crate::cli::configure::execute(inputs, paths).await?;
         return Ok(());
     }
@@ -57,6 +63,11 @@ pub async fn run(args: Args, paths: &Paths) -> Result<()> {
     // the unit (e.g. after a binary upgrade). Rewrite + restart.
     svc.write_unit(paths).await?;
     svc.enable_and_start().await?;
+    if !args.skip_linger {
+        // Idempotent on already-lingering hosts; returns AlreadyEnabled and
+        // makes no sudo call in that case.
+        let _ = svc.ensure_boot_start().await;
+    }
     println!();
     println!("Service unit refreshed and daemon restarted.");
     println!();
@@ -81,7 +92,10 @@ fn print_unattended_hint(explicit_opt_out: bool) {
 /// Interactive prompts for URL + token + optional name. Stays minimal —
 /// anything else (`working_dir`, `skip_doctor`) can be provided by re-running
 /// `pidash configure` directly.
-fn prompt_for_register_inputs(paths: &Paths) -> Result<crate::cli::configure::RegisterInputs> {
+fn prompt_for_register_inputs(
+    paths: &Paths,
+    skip_linger: bool,
+) -> Result<crate::cli::configure::RegisterInputs> {
     println!();
     println!(
         "No runner config found at {}.",
@@ -124,6 +138,7 @@ fn prompt_for_register_inputs(paths: &Paths) -> Result<crate::cli::configure::Re
         // Install's interactive chain delegates fully to configure — let it
         // write the unit + start the daemon as part of the same flow.
         skip_service: false,
+        skip_linger,
         // Interactive install doesn't collect advanced field edits — those
         // can be done later via `pidash configure --<flag>` or the TUI.
         extras: None,

--- a/runner/src/service/mod.rs
+++ b/runner/src/service/mod.rs
@@ -28,6 +28,27 @@ pub enum Service {
     Launchd,
 }
 
+/// Outcome of `Service::ensure_boot_start`. Only two variants represent a
+/// hard failure mode (`CheckFailed` / `EnableFailed`); the others are normal
+/// and the caller just reports them in post-install hints.
+#[derive(Debug)]
+pub enum BootStartOutcome {
+    /// Linger was already on — nothing to do.
+    AlreadyEnabled,
+    /// We just ran `sudo loginctl enable-linger` successfully.
+    Enabled,
+    /// Platform doesn't need / support a linger-style opt-in (macOS launchd).
+    NotApplicable,
+    /// No TTY available — sudo would hang, so we didn't try.
+    NonInteractive,
+    /// The user explicitly passed `--skip-linger`.
+    Skipped,
+    /// `loginctl show-user` failed; we can't tell whether linger is on.
+    CheckFailed(String),
+    /// The sudo/loginctl call itself exited non-zero (bad password, Ctrl+C, …).
+    EnableFailed(String),
+}
+
 pub fn detect() -> Service {
     if cfg!(target_os = "macos") {
         Service::Launchd
@@ -51,6 +72,17 @@ impl Service {
         match self {
             Service::Systemd => systemd::enable_and_start().await,
             Service::Launchd => launchd::enable_and_start().await,
+        }
+    }
+
+    /// Ensure the daemon keeps running across reboots without a user login.
+    /// On systemd this means `loginctl enable-linger`; on launchd user agents
+    /// the equivalent is just "log in," which we can't automate. Never fails
+    /// — the returned outcome drives post-install messaging.
+    pub async fn ensure_boot_start(&self) -> BootStartOutcome {
+        match self {
+            Service::Systemd => systemd::ensure_linger().await,
+            Service::Launchd => BootStartOutcome::NotApplicable,
         }
     }
 

--- a/runner/src/service/systemd.rs
+++ b/runner/src/service/systemd.rs
@@ -1,7 +1,9 @@
 use anyhow::{Context, Result};
+use std::io::IsTerminal;
 use std::path::PathBuf;
 use tokio::process::Command;
 
+use super::BootStartOutcome;
 use crate::util::paths::Paths;
 
 const UNIT_NAME: &str = "pidash.service";
@@ -72,6 +74,60 @@ pub async fn start() -> Result<()> {
 
 pub async fn stop() -> Result<()> {
     run_systemctl(&["stop", UNIT_NAME]).await
+}
+
+/// Detect whether `loginctl enable-linger` has already been applied to the
+/// current user. Linger is what makes the user-level systemd manager (and
+/// therefore our user unit) start at boot rather than at first login.
+pub async fn is_linger_enabled() -> Result<bool> {
+    let user = std::env::var("USER").context("USER env not set")?;
+    let out = Command::new("loginctl")
+        .args(["show-user", &user, "--property=Linger"])
+        .output()
+        .await
+        .context("invoking loginctl show-user")?;
+    if !out.status.success() {
+        anyhow::bail!(
+            "loginctl show-user {user} failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).trim() == "Linger=yes")
+}
+
+/// Shell out to `sudo loginctl enable-linger <user>`. sudo runs inline on
+/// the caller's TTY, so any password prompt is surfaced to the user directly
+/// — we don't feed stdin or try to cache credentials ourselves.
+pub async fn enable_linger() -> Result<()> {
+    let user = std::env::var("USER").context("USER env not set")?;
+    let status = Command::new("sudo")
+        .args(["loginctl", "enable-linger", &user])
+        .status()
+        .await
+        .context("invoking sudo loginctl enable-linger")?;
+    if !status.success() {
+        anyhow::bail!("sudo loginctl enable-linger {user} exited with {status}");
+    }
+    Ok(())
+}
+
+/// Best-effort: enable linger so `pidash.service` survives reboot without a
+/// login. Never fails the caller — every branch that can't apply linger maps
+/// to an outcome the caller prints as a hint. Skips the sudo call entirely
+/// when there's no TTY (sudo would hang or fail on non-interactive runs).
+pub async fn ensure_linger() -> BootStartOutcome {
+    match is_linger_enabled().await {
+        Ok(true) => return BootStartOutcome::AlreadyEnabled,
+        Ok(false) => {}
+        Err(e) => return BootStartOutcome::CheckFailed(e.to_string()),
+    }
+    if !std::io::stdin().is_terminal() {
+        return BootStartOutcome::NonInteractive;
+    }
+    match enable_linger().await {
+        Ok(()) => BootStartOutcome::Enabled,
+        Err(e) => BootStartOutcome::EnableFailed(e.to_string()),
+    }
 }
 
 pub async fn status() -> Result<String> {


### PR DESCRIPTION
## Summary
- After `pidash configure` brings the service up on Linux, it now runs `sudo loginctl enable-linger $USER` automatically so the daemon restarts at boot instead of waiting for first login. If linger is already on, no sudo call is made.
- Falls back gracefully: skips the sudo call when there's no TTY, and if the call fails (bad password, Ctrl+C) configure still succeeds and prints the manual command.
- Adds `--skip-linger` on `pidash configure` and `pidash install` for CI / unattended flows where a sudo prompt would hang. `pidash install`'s re-install path also calls it idempotently so upgrading the binary keeps linger wired up.

## Test plan
- [ ] Fresh Linux host, no linger: `pidash configure --url … --token …` prompts for sudo password, then `loginctl show-user $USER --property=Linger` reports `Linger=yes`.
- [ ] Re-run `pidash configure` on the same host; no sudo prompt, post-install hint says "Linger is enabled."
- [ ] `pidash configure --skip-linger …`: no sudo prompt, hint says linger was skipped and shows the manual command.
- [ ] Run `pidash configure` piped (no TTY): sudo is not invoked; hint says no TTY detected.
- [ ] macOS: post-install output unchanged (no linger section printed).
- [x] `cargo check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)