### PR TITLE
fix(api): serve local dev via uvicorn so WebSockets work

### DIFF
--- a/apps/api/bin/docker-entrypoint-api-local.sh
+++ b/apps/api/bin/docker-entrypoint-api-local.sh
@@ -31,4 +31,8 @@ python manage.py create_bucket
 # Clear Cache before starting to remove stale values
 python manage.py clear_cache
 
-python manage.py runserver 0.0.0.0:8000 --settings=pi_dash.settings.local
+# `runserver` is WSGI-only, which drops Channels WebSocket routes (the runner
+# ↔ cloud link at /ws/runner/ returns 404). Use uvicorn directly so local dev
+# speaks ASGI, matching the gunicorn+UvicornWorker setup in production.
+export DJANGO_SETTINGS_MODULE=pi_dash.settings.local
+exec uvicorn pi_dash.asgi:application --host 0.0.0.0 --port 8000 --reload

--- a/apps/api/bin/docker-entrypoint-api-local.sh
+++ b/apps/api/bin/docker-entrypoint-api-local.sh
@@ -34,5 +34,5 @@ python manage.py clear_cache
 # `runserver` is WSGI-only, which drops Channels WebSocket routes (the runner
 # ↔ cloud link at /ws/runner/ returns 404). Use uvicorn directly so local dev
 # speaks ASGI, matching the gunicorn+UvicornWorker setup in production.
-export DJANGO_SETTINGS_MODULE=pi_dash.settings.local
+export DJANGO_SETTINGS_MODULE="${DJANGO_SETTINGS_MODULE:-pi_dash.settings.local}"
 exec uvicorn pi_dash.asgi:application --host 0.0.0.0 --port 8000 --reload

--- a/apps/api/requirements/base.txt
+++ b/apps/api/requirements/base.txt
@@ -32,12 +32,12 @@ jsonmodels==2.7.0
 django-storages==1.14.2
 # user management
 django-crum==0.7.9
-# web server
-uvicorn==0.29.0
-# WebSocket protocol for uvicorn / gunicorn's UvicornWorker. Without this
-# uvicorn can't upgrade WS requests and silently hands them to Django's
-# HTTP app, so `/ws/runner/` 404s through the URL router.
-websockets==12.0
+# web server. The `[standard]` extra pulls in websockets (required for
+# uvicorn / gunicorn's UvicornWorker to upgrade WS requests — without it
+# `/ws/runner/` 404s through the HTTP URL router), plus httptools, uvloop,
+# and watchfiles (so `--reload` uses the efficient watcher instead of the
+# legacy stat-polling fallback).
+uvicorn[standard]==0.29.0
 # sockets
 channels==4.1.0
 channels-redis==4.2.0

--- a/apps/api/requirements/base.txt
+++ b/apps/api/requirements/base.txt
@@ -34,6 +34,10 @@ django-storages==1.14.2
 django-crum==0.7.9
 # web server
 uvicorn==0.29.0
+# WebSocket protocol for uvicorn / gunicorn's UvicornWorker. Without this
+# uvicorn can't upgrade WS requests and silently hands them to Django's
+# HTTP app, so `/ws/runner/` 404s through the URL router.
+websockets==12.0
 # sockets
 channels==4.1.0
 channels-redis==4.2.0


### PR DESCRIPTION
## Summary
- `apps/api/bin/docker-entrypoint-api-local.sh` was launching Django via `manage.py runserver`, which is WSGI-only. That drops Channels' WebSocket route at `/ws/runner/`, so any locally-running runner gets `404 Not Found` on connect and stays stuck "offline" in the web UI.
- Swap the local entrypoint to `uvicorn pi_dash.asgi:application --reload`. `uvicorn` is already pinned in `apps/api/requirements/base.txt` and the prod entrypoint already uses it via `gunicorn -k uvicorn.workers.UvicornWorker`, so this aligns local dev with prod.
- `DJANGO_SETTINGS_MODULE=pi_dash.settings.local` is exported since `runserver`'s `--settings` flag has no uvicorn equivalent.

## Test plan
- [ ] `docker compose -f docker-compose-local.yml up --build api` comes up without errors and the api container serves on `:8000`.
- [ ] Plain HTTP still works: `curl -sI http://localhost:8000/` (or any known app route) returns 200/302.
- [ ] `./setup.sh && pnpm dev`, register + start a local runner via `pidash configure --url http://localhost:8000 --token <tok>`. UI at `localhost:3000` shows the runner as online within ~60s (runner's WS reconnect interval).
- [ ] Editing a Python file in `apps/api/` triggers uvicorn `--reload`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)