### PR TITLE
fix(prompting): populate issue.project_states in template context

### DIFF
--- a/apps/api/pi_dash/prompting/context.py
+++ b/apps/api/pi_dash/prompting/context.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from typing import Any, Dict
 
 from pi_dash.db.models.issue import Issue
+from pi_dash.db.models.state import State
 from pi_dash.runner.models import AgentRun
 
 
@@ -57,6 +58,14 @@ def build_context(issue: Issue, run: AgentRun) -> Dict[str, Any]:
     assignees = [
         (u.display_name or u.email or "") for u in issue.assignees.all()
     ]
+    project_states = [
+        {
+            "name": s.name,
+            "group": s.group,
+            "description": s.description or "",
+        }
+        for s in State.objects.filter(project=project)
+    ]
 
     attempt = _compute_attempt(issue, run)
 
@@ -73,6 +82,7 @@ def build_context(issue: Issue, run: AgentRun) -> Dict[str, Any]:
             "assignees": assignees,
             "url": _absolute_issue_url(issue),
             "target_date": issue.target_date.isoformat() if issue.target_date else None,
+            "project_states": project_states,
         },
         "workspace": {
             "slug": workspace.slug,


### PR DESCRIPTION
## Summary

- Default prompt template (`apps/api/pi_dash/prompting/templates/default.j2`) references `issue.project_states` to render the "Available states" block for the `pidash` CLI, but `build_context` never populated it. With Jinja's `StrictUndefined`, every first-turn render failed the moment an issue moved to a trigger state, surfacing as `prompt render failed: 'dict object' has no attribute 'project_states'` on the `AgentRun` and aborting dispatch.
- The missing context key was introduced in b400defc without a matching `context.py` update; this PR closes that gap by emitting `project_states` as a list of `{name, group, description}` dicts sourced from `State.objects.filter(project=project)` (default manager already excludes triage states, ordering follows `State.Meta.ordering`).

## Test plan

- [x] `pytest pi_dash/tests/unit/prompting/` — 12 passed (composer / context / renderer).
- [ ] Manually move an issue into a trigger state on a local instance and confirm a `QUEUED` `AgentRun` is produced with a rendered prompt whose "Available states" block lists the project's non-triage states, rather than a `FAILED` run with `prompt render failed: …`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)