### PR TITLE
fix(runner): stop overriding XDG_RUNTIME_DIR in unit/plist

### DIFF
--- a/runner/src/service/launchd.rs
+++ b/runner/src/service/launchd.rs
@@ -20,8 +20,18 @@ pub async fn write_unit(paths: &Paths) -> Result<()> {
     let logs = xml_escape(super::validate_path_for_unit(&logs_dir)?);
     let config = xml_escape(super::validate_path_for_unit(&paths.config_dir)?);
     let data = xml_escape(super::validate_path_for_unit(&paths.data_dir)?);
-    let runtime = xml_escape(super::validate_path_for_unit(&paths.runtime_dir)?);
-    let body = format!(
+    let body = render_plist(&exe_str, &config, &data, &logs);
+    tokio::fs::write(&plist_path, body).await?;
+    println!("installed launchd agent at {}", plist_path.display());
+    Ok(())
+}
+
+/// Render the LaunchAgent plist body. Deliberately does NOT set
+/// `XDG_RUNTIME_DIR`: on macOS `directories::ProjectDirs` ignores it (runtime
+/// dir is derived from `data_dir`), so the env var is a no-op that only
+/// obscures the real path contract between the daemon and the CLI client.
+fn render_plist(exe: &str, config: &str, data: &str, logs: &str) -> String {
+    format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -36,7 +46,6 @@ pub async fn write_unit(paths: &Paths) -> Result<()> {
   <dict>
     <key>PIDASH_CONFIG_DIR</key><string>{config}</string>
     <key>PIDASH_DATA_DIR</key><string>{data}</string>
-    <key>XDG_RUNTIME_DIR</key><string>{runtime}</string>
   </dict>
   <key>KeepAlive</key><true/>
   <key>RunAtLoad</key><true/>
@@ -46,11 +55,7 @@ pub async fn write_unit(paths: &Paths) -> Result<()> {
 </plist>
 "#,
         label = LABEL,
-        exe = exe_str,
-    );
-    tokio::fs::write(&plist_path, body).await?;
-    println!("installed launchd agent at {}", plist_path.display());
-    Ok(())
+    )
 }
 
 /// Load the LaunchAgent. `RunAtLoad=true` in the plist means `bootstrap`
@@ -150,4 +155,37 @@ fn xml_escape(s: &str) -> String {
         }
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plist_body_does_not_set_xdg_runtime_dir() {
+        // On macOS `directories::ProjectDirs` ignores XDG_RUNTIME_DIR — the
+        // env var was a misleading no-op. Keep it out so both backends share
+        // the same runtime-dir contract.
+        let body = render_plist(
+            "/usr/local/bin/pidash",
+            "/Users/user/Library/Application Support/pidash",
+            "/Users/user/Library/Application Support/pidash",
+            "/Users/user/Library/Application Support/pidash/logs",
+        );
+        assert!(
+            !body.contains("XDG_RUNTIME_DIR"),
+            "plist body must not set XDG_RUNTIME_DIR; got:\n{body}"
+        );
+    }
+
+    #[test]
+    fn plist_body_includes_program_args_and_logs() {
+        let body = render_plist("/bin/pidash", "/cfg", "/data", "/logs");
+        assert!(body.contains("<string>/bin/pidash</string>"));
+        assert!(body.contains("<string>__run</string>"));
+        assert!(body.contains("<key>PIDASH_CONFIG_DIR</key><string>/cfg</string>"));
+        assert!(body.contains("<key>PIDASH_DATA_DIR</key><string>/data</string>"));
+        assert!(body.contains("<string>/logs/runner.out.log</string>"));
+        assert!(body.contains("<string>/logs/runner.err.log</string>"));
+    }
 }

--- a/runner/src/service/systemd.rs
+++ b/runner/src/service/systemd.rs
@@ -17,11 +17,23 @@ pub async fn write_unit(paths: &Paths) -> Result<()> {
         tokio::fs::create_dir_all(parent).await?;
     }
     let exe = std::env::current_exe()?;
-    let exe_str = super::validate_path_for_unit(&exe)?.to_string();
-    let config_dir = super::validate_path_for_unit(&paths.config_dir)?.to_string();
-    let data_dir = super::validate_path_for_unit(&paths.data_dir)?.to_string();
-    let runtime_dir = super::validate_path_for_unit(&paths.runtime_dir)?.to_string();
-    let body = format!(
+    let exe_str = super::validate_path_for_unit(&exe)?;
+    let config_dir = super::validate_path_for_unit(&paths.config_dir)?;
+    let data_dir = super::validate_path_for_unit(&paths.data_dir)?;
+    let body = render_unit(exe_str, config_dir, data_dir);
+    tokio::fs::write(&unit_path, body).await?;
+    run_systemctl(&["daemon-reload"]).await?;
+    println!("installed systemd unit at {}", unit_path.display());
+    Ok(())
+}
+
+/// Render the user-unit body. Deliberately does NOT set `XDG_RUNTIME_DIR`:
+/// systemd's user manager already exports it as `/run/user/$UID`, and the
+/// daemon + CLI client both derive the socket path from that via
+/// `ProjectDirs`. Overriding it here once caused a double `pidash/` path
+/// component and left the client unable to reach the daemon.
+fn render_unit(exe: &str, config_dir: &str, data_dir: &str) -> String {
+    format!(
         r#"[Unit]
 Description=Pi Dash Runner
 After=network-online.target
@@ -32,19 +44,13 @@ Type=simple
 ExecStart={exe} __run
 Environment=PIDASH_CONFIG_DIR={config_dir}
 Environment=PIDASH_DATA_DIR={data_dir}
-Environment=XDG_RUNTIME_DIR={runtime_dir}
 Restart=on-failure
 RestartSec=5
 
 [Install]
 WantedBy=default.target
-"#,
-        exe = exe_str,
-    );
-    tokio::fs::write(&unit_path, body).await?;
-    run_systemctl(&["daemon-reload"]).await?;
-    println!("installed systemd unit at {}", unit_path.display());
-    Ok(())
+"#
+    )
 }
 
 /// Enable the unit at boot/login and bring it up. `restart` (not `start`) so
@@ -162,4 +168,34 @@ fn dirs_home() -> Result<PathBuf> {
     std::env::var_os("HOME")
         .map(PathBuf::from)
         .context("HOME not set")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unit_body_does_not_set_xdg_runtime_dir() {
+        // Regression: setting XDG_RUNTIME_DIR to the project-scoped runtime
+        // dir caused `ProjectDirs::runtime_dir()` inside the daemon to append
+        // `pidash/` a second time, producing a socket path the CLI client
+        // couldn't reach.
+        let body = render_unit(
+            "/home/user/.cargo/bin/pidash",
+            "/home/user/.config/pidash",
+            "/home/user/.local/share/pidash",
+        );
+        assert!(
+            !body.contains("XDG_RUNTIME_DIR"),
+            "unit body must not set XDG_RUNTIME_DIR; got:\n{body}"
+        );
+    }
+
+    #[test]
+    fn unit_body_includes_exec_start_and_dirs() {
+        let body = render_unit("/bin/pidash", "/etc/pidash", "/var/lib/pidash");
+        assert!(body.contains("ExecStart=/bin/pidash __run"));
+        assert!(body.contains("Environment=PIDASH_CONFIG_DIR=/etc/pidash"));
+        assert!(body.contains("Environment=PIDASH_DATA_DIR=/var/lib/pidash"));
+    }
 }


### PR DESCRIPTION
## Summary
- Generated systemd unit set `Environment=XDG_RUNTIME_DIR=/run/user/\$UID/pidash`. The daemon re-ran `ProjectDirs::runtime_dir()` against that overridden XDG root, appending `pidash/` again and binding its IPC socket at `/run/user/\$UID/pidash/pidash/pidash.sock`. The CLI client (running in the user's normal shell with `XDG_RUNTIME_DIR=/run/user/\$UID`) looked at `/run/user/\$UID/pidash/pidash.sock` and missed — `pidash status` reported "daemon: not reachable via IPC" even while the daemon was healthy.
- Drop the override on both backends. systemd already exports `XDG_RUNTIME_DIR` correctly, so both sides now agree on `/run/user/\$UID/pidash/pidash.sock`. On macOS `ProjectDirs` ignores `XDG_RUNTIME_DIR` entirely (runtime dir comes from `data_dir`), so removing it is a no-op for behaviour and keeps the plist consistent with systemd.
- Extract `render_unit` / `render_plist` so the unit body can be tested as a pure string. Add regression tests asserting neither body contains `XDG_RUNTIME_DIR`.

## Test plan
- [x] \`cargo fmt\` / \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo test --lib\` — 62 tests pass (includes 4 new render tests)
- [x] Manually verified on the affected dev box: edit the live unit to drop the line, \`systemctl --user daemon-reload && systemctl --user restart pidash.service\`; socket now at \`/run/user/1000/pidash/pidash.sock\`; \`pidash status\` returns \`connected — idle\` instead of \`not reachable via IPC\`.
- [ ] macOS: \`pidash install\` writes a plist without \`<key>XDG_RUNTIME_DIR</key>\` and \`pidash status\` reaches the daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)