### PR TITLE
fix(runner): spawn agent binaries via login+interactive bash

### DIFF
--- a/runner/src/claude_code/process.rs
+++ b/runner/src/claude_code/process.rs
@@ -10,6 +10,7 @@ use tokio::process::{Child, ChildStdin, Command};
 use tokio::sync::mpsc;
 
 use crate::claude_code::schema::StreamEvent;
+use crate::util::shell::{is_benign_login_shell_warning, login_shell_command};
 
 /// Handles the `claude --print --output-format stream-json` subprocess
 /// lifecycle. Owns stdin (so we can push the user turn + signal EOF) and
@@ -36,20 +37,25 @@ pub struct SpawnArgs<'a> {
 
 impl ClaudeProcess {
     pub async fn spawn(args: SpawnArgs<'_>) -> Result<Self> {
-        let mut cmd = Command::new(args.binary);
-        cmd.current_dir(args.cwd)
-            .arg("--print")
-            .arg("--verbose")
-            .arg("--input-format")
-            .arg("stream-json")
-            .arg("--output-format")
-            .arg("stream-json");
+        // Route through a login bash so the agent binary is found via the
+        // user's interactive PATH (nvm/pyenv/asdf/brew). See
+        // `util::shell::login_shell_command` for why.
+        let mut argv: Vec<&str> = vec![
+            "--print",
+            "--verbose",
+            "--input-format",
+            "stream-json",
+            "--output-format",
+            "stream-json",
+        ];
         if args.bypass_permissions {
-            cmd.arg("--permission-mode").arg("bypassPermissions");
+            argv.extend(["--permission-mode", "bypassPermissions"]);
         }
         if let Some(model) = args.model {
-            cmd.arg("--model").arg(model);
+            argv.extend(["--model", model]);
         }
+        let mut cmd = login_shell_command(args.binary, &argv);
+        cmd.current_dir(args.cwd);
         Self::spawn_command(cmd).await
     }
 
@@ -180,6 +186,10 @@ async fn drain_stderr(stderr: tokio::process::ChildStderr) {
     // logged at `warn!`. Operators still have to dig through logs — a future
     // follow-up can buffer the last N lines into the `Failed` event detail —
     // but at least nothing is silently swallowed.
+    //
+    // The login-shell wrapper (see `util::shell`) always emits two TTY-less
+    // diagnostics before exec'ing claude; suppress those so logs aren't
+    // noisy on every spawn.
     let mut reader = BufReader::new(stderr);
     let mut line = String::new();
     loop {
@@ -188,9 +198,10 @@ async fn drain_stderr(stderr: tokio::process::ChildStderr) {
             Ok(0) => break,
             Ok(_) => {
                 let trimmed = line.trim_end();
-                if !trimmed.is_empty() {
-                    tracing::warn!(target: "claude.stderr", "{trimmed}");
+                if trimmed.is_empty() || is_benign_login_shell_warning(trimmed) {
+                    continue;
                 }
+                tracing::warn!(target: "claude.stderr", "{trimmed}");
             }
             Err(e) => {
                 tracing::warn!("claude stderr read error: {e}");

--- a/runner/src/cli/doctor.rs
+++ b/runner/src/cli/doctor.rs
@@ -6,6 +6,7 @@ use tokio::process::Command;
 
 use crate::config::file;
 use crate::util::paths::Paths;
+use crate::util::shell::login_shell_command;
 
 #[derive(Debug, ClapArgs)]
 pub struct Args {
@@ -177,13 +178,14 @@ pub async fn execute(paths: &Paths) -> Result<Report> {
 
 /// Shared `<binary> --version` check. Works for both `codex` and `claude`
 /// since both print a short version line on stdout and exit 0 on success.
+///
+/// Runs through the same login-shell wrapper the daemon uses so this check
+/// reflects what the daemon will actually see at spawn time — not just
+/// whether the binary is on the caller's interactive `PATH`.
 async fn check_version(binary: &str) -> Result<String> {
-    let out = Command::new(binary)
-        .arg("--version")
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .output()
-        .await?;
+    let mut cmd = login_shell_command(binary, &["--version"]);
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let out = cmd.output().await?;
     if !out.status.success() {
         anyhow::bail!(
             "{binary} --version exited {}: {}",
@@ -200,13 +202,9 @@ async fn check_version(binary: &str) -> Result<String> {
 
 async fn check_codex_auth(binary: &str) -> Result<String> {
     // codex has `account` as a subcommand in newer releases; fall back to `whoami`.
-    let out = Command::new(binary)
-        .args(["account", "status"])
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .output()
-        .await
-        .ok();
+    let mut cmd = login_shell_command(binary, &["account", "status"]);
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let out = cmd.output().await.ok();
     if let Some(o) = out
         && o.status.success()
     {

--- a/runner/src/codex/app_server.rs
+++ b/runner/src/codex/app_server.rs
@@ -7,6 +7,7 @@ use tokio::process::{Child, ChildStdin, Command};
 use tokio::sync::mpsc;
 
 use crate::codex::jsonrpc::Incoming;
+use crate::util::shell::{is_benign_login_shell_warning, login_shell_command};
 
 /// Handles the `codex app-server` subprocess lifecycle + JSON-RPC wire.
 pub struct AppServer {
@@ -18,8 +19,10 @@ pub struct AppServer {
 
 impl AppServer {
     pub async fn spawn(binary: &str, cwd: &Path) -> Result<Self> {
-        let mut cmd = Command::new(binary);
-        cmd.arg("app-server").current_dir(cwd);
+        // Route through a login bash so the agent binary is found via the
+        // user's interactive PATH. See `util::shell::login_shell_command`.
+        let mut cmd = login_shell_command(binary, &["app-server"]);
+        cmd.current_dir(cwd);
         Self::spawn_command(cmd).await
     }
 
@@ -105,13 +108,22 @@ async fn read_frames(stdout: tokio::process::ChildStdout, tx: mpsc::Sender<Incom
 }
 
 async fn drain_stderr(stderr: tokio::process::ChildStderr) {
+    // The login-shell wrapper (see `util::shell`) always emits two TTY-less
+    // diagnostics before exec'ing codex; suppress those so the debug stream
+    // only carries real codex output.
     let mut reader = BufReader::new(stderr);
     let mut line = String::new();
     loop {
         line.clear();
         match reader.read_line(&mut line).await {
             Ok(0) => break,
-            Ok(_) => tracing::debug!(target: "codex.stderr", "{}", line.trim_end()),
+            Ok(_) => {
+                let trimmed = line.trim_end();
+                if trimmed.is_empty() || is_benign_login_shell_warning(trimmed) {
+                    continue;
+                }
+                tracing::debug!(target: "codex.stderr", "{trimmed}");
+            }
             Err(e) => {
                 tracing::warn!("codex stderr read error: {e}");
                 break;

--- a/runner/src/util/mod.rs
+++ b/runner/src/util/mod.rs
@@ -2,4 +2,5 @@ pub mod backoff;
 pub mod logging;
 pub mod paths;
 pub mod runner_name;
+pub mod shell;
 pub mod signal;

--- a/runner/src/util/shell.rs
+++ b/runner/src/util/shell.rs
@@ -1,0 +1,141 @@
+//! Agent-spawn helper.
+//!
+//! The runner lives inside a daemon started by `systemd --user` on Linux
+//! and `launchd` on macOS. Both managers expose a stripped `PATH` that does
+//! not include anything the user's shell rc adds (nvm, pyenv, asdf, brew
+//! on Linux, …). A plain `Command::new("claude")` therefore fails with
+//! `ENOENT` on machines where `claude` works interactively.
+//!
+//! We sidestep this by wrapping every agent spawn in a login+interactive
+//! `bash`. The `-i` flag is load-bearing: Debian/Ubuntu's stock `.bashrc`
+//! (and nvm's default installer, which appends to `.bashrc`) short-circuits
+//! for non-interactive shells via `case $- in *i*) ;; *) return;; esac`. A
+//! pure `bash -lc` invocation therefore never reaches the nvm loader on a
+//! default dev-machine setup. `bash -ilc` passes the guard, sources the
+//! user's full interactive environment, and gives us the same PATH the
+//! operator sees in their terminal.
+//!
+//! The script we pass to `-c` is just `exec "$@"`: `exec` replaces bash
+//! with the target (so the spawned PID and any signals we deliver hit the
+//! agent, not a lingering shell), and `"$@"` preserves our structured argv
+//! with no shell re-parsing of agent flags.
+//!
+//! Running an interactive bash without a controlling TTY makes bash emit
+//! two diagnostic lines to stderr during startup:
+//!   `bash: cannot set terminal process group (-1): Inappropriate ioctl for device`
+//!   `bash: no job control in this shell`
+//! Those lines are harmless (bash just can't install a foreground job
+//! group), but they're emitted before our `-c` script runs so they can't be
+//! silenced from inside the script. Callers should filter them out of any
+//! captured stderr via [`is_benign_login_shell_warning`].
+
+use tokio::process::Command;
+
+/// Build a [`Command`] that runs `program args…` through a login+interactive
+/// bash. See the module docs for why `-i` is required alongside `-l`.
+///
+/// The returned command still needs the caller's usual stdio / cwd /
+/// `kill_on_drop` wiring before being spawned.
+pub fn login_shell_command(program: &str, args: &[&str]) -> Command {
+    let mut cmd = Command::new("bash");
+    cmd.arg("-ilc").arg(r#"exec "$@""#).arg("bash").arg(program);
+    cmd.args(args);
+    cmd
+}
+
+/// True for the two stderr lines bash always emits when started with `-i`
+/// under a daemon with no controlling TTY. Drain loops consuming a child's
+/// stderr should drop these so logs aren't polluted with a warning on every
+/// agent spawn.
+pub fn is_benign_login_shell_warning(line: &str) -> bool {
+    matches!(
+        line.trim_end(),
+        "bash: cannot set terminal process group (-1): Inappropriate ioctl for device"
+            | "bash: no job control in this shell"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsString;
+
+    fn argv(cmd: &Command) -> Vec<OsString> {
+        cmd.as_std().get_args().map(|a| a.to_os_string()).collect()
+    }
+
+    #[test]
+    fn wraps_program_and_args_in_login_bash() {
+        let cmd = login_shell_command("claude", &["--print", "--model", "sonnet-4"]);
+        assert_eq!(cmd.as_std().get_program(), "bash");
+        assert_eq!(
+            argv(&cmd),
+            vec![
+                OsString::from("-ilc"),
+                OsString::from(r#"exec "$@""#),
+                OsString::from("bash"),
+                OsString::from("claude"),
+                OsString::from("--print"),
+                OsString::from("--model"),
+                OsString::from("sonnet-4"),
+            ]
+        );
+    }
+
+    #[test]
+    fn no_args_produces_bare_invocation() {
+        let cmd = login_shell_command("codex", &[]);
+        assert_eq!(
+            argv(&cmd),
+            vec![
+                OsString::from("-ilc"),
+                OsString::from(r#"exec "$@""#),
+                OsString::from("bash"),
+                OsString::from("codex"),
+            ]
+        );
+    }
+
+    #[test]
+    fn recognises_bash_no_tty_warnings() {
+        assert!(is_benign_login_shell_warning(
+            "bash: cannot set terminal process group (-1): Inappropriate ioctl for device"
+        ));
+        assert!(is_benign_login_shell_warning(
+            "bash: no job control in this shell"
+        ));
+        assert!(is_benign_login_shell_warning(
+            "bash: no job control in this shell\n"
+        ));
+        assert!(!is_benign_login_shell_warning(
+            "claude: unexpected internal error"
+        ));
+        assert!(!is_benign_login_shell_warning(""));
+    }
+
+    #[tokio::test]
+    async fn round_trips_argv_through_bash() {
+        // Prove bash's `exec "$@"` preserves our argv exactly and the child
+        // actually runs. `printf '%s\n' "$@"` echoes each arg on its own
+        // line — verifies ordering and that args with spaces / `=` are not
+        // split or re-parsed by the shell. stderr is merged into stdout so
+        // the test passes regardless of whether bash emits its no-tty
+        // warnings (it does under `cargo test`, it doesn't under a tty).
+        let mut cmd =
+            login_shell_command("printf", &["%s\n", "first arg", "second-arg", "has=equal"]);
+        cmd.kill_on_drop(true);
+        let out = cmd
+            .output()
+            .await
+            .expect("spawn printf through login shell");
+        assert!(
+            out.status.success(),
+            "stderr: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&out.stdout),
+            "first arg\nsecond-arg\nhas=equal\n"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes `spawning claude subprocess: No such file or directory (os error 2)` on dev machines where the agent CLI is installed by a version manager (nvm, pyenv, asdf, brew-on-Linux). The daemon runs under `systemd --user` / `launchd`, both of which expose a stripped PATH that omits anything the user's shell rc adds. A plain `Command::new(\"claude\")` therefore fails with ENOENT even though `claude` works fine interactively.

## Approach

Wrap every agent spawn in `bash -ilc 'exec \"\$@\"' bash <prog> <args…>` via a new `util::shell::login_shell_command` helper. Inspired by Symphony's `bash -lc` pattern, with a critical adjustment for the common Ubuntu/nvm setup.

- **`-l`** sources `.profile` / `.bash_profile` → reconstructs login PATH.
- **`-i` is load-bearing.** Debian/Ubuntu's stock `.bashrc` short-circuits for non-interactive shells (`case \$- in *i*) ;; *) return;; esac`). nvm's default installer appends its loader to `.bashrc`. A pure `bash -lc` therefore never reaches the nvm loader on a default dev-machine setup — only `-i` passes the guard.
- **`exec \"\$@\"`** replaces bash with the target (PID preserved, signals reach the agent, structured argv passed through without shell re-parsing of flags).

Wired into all three spawn sites so the daemon and `pidash doctor` agree on what resolves:
- `claude_code::process::ClaudeProcess::spawn`
- `codex::app_server::AppServer::spawn`
- `cli::doctor::check_version` and `check_codex_auth`

## Side-effect handling

Running bash with `-i` without a controlling TTY emits two harmless startup lines to stderr:
```
bash: cannot set terminal process group (-1): Inappropriate ioctl for device
bash: no job control in this shell
```

They happen before the `-c` script runs so they can't be silenced in-shell. A shared `is_benign_login_shell_warning` helper filters them at the stderr-drain layer in both subprocess wrappers — logs stay clean.

## Context

Surfaced while reinstalling the CLI on the dev box after merging #47. `pidash status` worked, but the first actual task triggered `failed: spawning claude subprocess: No such file or directory (os error 2)`. Temporarily worked around by hardcoding the absolute nvm path in `config.toml`; this PR is the real fix.

Considered (and rejected): resolving the binary to an absolute path via \`which\` at configure time. Method-2 pins the path and breaks when the user upgrades Node via nvm, requires \`claude\` to be installed before \`pidash configure\`, and doesn't pick up per-workspace \`.nvmrc\`/\`.tool-versions\` pins.

## Test plan

- [x] \`cargo fmt\` / \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo test --lib\` — 66 tests pass (4 new: wrapper shape, no-args shape, bash warning classifier, argv round-trip through \`exec \"\$@\"\`)
- [x] \`cargo test --tests\` — 11 integration tests pass (fake-bridge tests unchanged — they use \`spawn_command\` directly, bypassing the wrapper with shell-script fakes)
- [x] Dev-box smoke test: \`systemd-run --user --pipe --wait -- bash -ilc 'exec \"\$@\"' bash claude --version\` exits 0 and emits \`2.1.118 (Claude Code)\` (proves the resolution works under the real service env)
- [x] Manual: \`pidash doctor\` on the dev box reports ✓ for \`claude\` with config set back to the bare name \`binary = \"claude\"\`
- [ ] Re-trigger the failing runner task end-to-end — daemon spawns claude successfully
- [ ] macOS / launchd: same change path exercised on a Mac (no tty behaviour under launchd differs slightly; the \`is_benign_login_shell_warning\` filter may need to extend if launchd surfaces different startup lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)