### PR TITLE
feat(runner): introduce pods — workspace-shared runners with per-pod queue

### DIFF
--- a/.ai_design/issue_runner/design.md
+++ b/.ai_design/issue_runner/design.md
@@ -26,6 +26,14 @@
 >   to reflect soft-delete preconditions; removed vestigial validation bullet
 >   and renamed `_resolve_owner` consistently to `_resolve_fallback_creator`;
 >   added billing-capture and user-deletion tests.
+> - Fresh-install simplification: no production data exists yet, so the
+>   three-stage migration (schema → backfill → tighten) collapses to a
+>   single initial schema migration. Decision #7 (opt-in cooperation) is
+>   removed — there's nothing to migrate from. New decision: every workspace
+>   auto-creates a default pod named `<workspace.name>-pod` on creation, so
+>   the first-run experience requires zero pod setup. Runner registration
+>   and issue creation both default to the workspace pod when unspecified.
+>   Soft-delete now guards against removing the last pod of a workspace.
 
 ## 1. Goal
 
@@ -52,20 +60,21 @@
 
 Carried over from prior conversations; several reframed to match the new model.
 
-| #   | Question                                              | Decision                                                                                                                                                                                                                                                                                                                                                                                    | Source                                     |
-| --- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
-| 1   | Whose runner pool does "default" draw from?           | Reframed: it's the workspace's default pod. No personal pool.                                                                                                                                                                                                                                                                                                                               | revised                                    |
-| 2   | Pinned pod's runners all busy at run time?            | Queue the run in the pod's queue. Drain on runner completion.                                                                                                                                                                                                                                                                                                                               | earlier "trust the runner to queue"        |
-| 3   | Pod deleted / all runners in pod revoked?             | Pods are **soft-deleted** (see decision #11), so `Issue.assigned_pod` FKs remain valid. On soft-delete, the same transaction explicitly sweeps pointing issues to `assigned_pod=NULL`, re-defaults at next run creation, and notifies creators. No `SET_NULL` FK behavior is relied on.                                                                                                     | earlier revoke policy, reconciled with #11 |
-| 4   | Backfill existing issues?                             | No. `Issue.assigned_pod` nullable, existing rows stay NULL.                                                                                                                                                                                                                                                                                                                                 | earlier                                    |
-| 5   | Billing (who pays for tokens/compute)?                | **Runner owner.** Digital-employee metaphor: each agent has a cost center attached to its operator. Deferred implementation; design keeps the hook explicit.                                                                                                                                                                                                                                | new                                        |
-| 6   | Approvals routing (runner asks before write/network)? | **Run creator** approves per-run. Runner owner retains revoke-any-time as the circuit breaker.                                                                                                                                                                                                                                                                                              | new                                        |
-| 7   | Cross-user runners on upgrade — silent or opt-in?     | **Opt-in.** Migration creates one personal pod per existing runner-owner containing only their runners; a shared workspace pod must be explicitly created. No silent privilege escalation.                                                                                                                                                                                                  | new                                        |
-| 8   | Workspace admin role                                  | Reuse `WorkspaceMember.role=20 (Admin)` at `apps/api/pi_dash/db/models/workspace.py:19`.                                                                                                                                                                                                                                                                                                    | verified                                   |
-| 9   | Run identity — `owner` vs `created_by`?               | Introduce `AgentRun.created_by` as a **non-null** FK to User, set at every creation path. **All permission checks migrate to `created_by`**: list, detail, cancel, approval list/decide. `AgentRun.owner` is retired from permission logic and semantically reinterpreted as "billable party" — populated as `runner.owner` at assignment time (nullable until assigned).                   | codex-feedback                             |
-| 10  | Runner revocation and in-flight runs                  | Revocation must **synchronously finalize** all non-terminal runs belonging to the revoked runner. Current `Runner.revoke()` only flips the runner row; design adds explicit cancellation of active `AgentRun` rows in the same transaction. Without this, runs stay `ASSIGNED/RUNNING` forever after a force-close.                                                                         | codex-feedback                             |
-| 11  | Pod deletion vs. AgentRun history                     | **Soft-delete pods**: add `Pod.deleted_at` + `objects` manager that filters it out. Pod rows are never physically deleted, so `AgentRun.pod` FK stays valid and historical attribution is preserved. Deletion requires (a) zero runners in the pod AND (b) zero non-terminal `AgentRun` rows in the pod. Issues pointing at a soft-deleted pod get their `assigned_pod` cleared (see §7.2). | codex-feedback                             |
-| 12  | Direct run-creation endpoint — workspace validation   | `POST /api/v1/runner/runs/` **must** validate, before creation: (a) caller is a `WorkspaceMember` of `workspace_id` (403 otherwise), (b) `work_item.workspace_id == workspace_id` if `work_item` provided (400), (c) `pod.workspace_id == workspace_id` if pod is derived/passed (400), (d) caller has at least Member role in the workspace.                                               | codex-feedback                             |
+| #   | Question                                              | Decision                                                                                                                                                                                                                                                                                                                                                                                                                | Source                                     |
+| --- | ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| 1   | Whose runner pool does "default" draw from?           | Reframed: it's the workspace's default pod. No personal pool.                                                                                                                                                                                                                                                                                                                                                           | revised                                    |
+| 2   | Pinned pod's runners all busy at run time?            | Queue the run in the pod's queue. Drain on runner completion.                                                                                                                                                                                                                                                                                                                                                           | earlier "trust the runner to queue"        |
+| 3   | Pod deleted / all runners in pod revoked?             | Pods are **soft-deleted** (see decision #11), so `Issue.assigned_pod` FKs remain valid. On soft-delete, the same transaction explicitly sweeps pointing issues to `assigned_pod=NULL`, re-defaults at next run creation, and notifies creators. No `SET_NULL` FK behavior is relied on.                                                                                                                                 | earlier revoke policy, reconciled with #11 |
+| 4   | Backfill existing issues?                             | No. `Issue.assigned_pod` nullable, existing rows stay NULL.                                                                                                                                                                                                                                                                                                                                                             | earlier                                    |
+| 5   | Billing (who pays for tokens/compute)?                | **Runner owner.** Digital-employee metaphor: each agent has a cost center attached to its operator. Deferred implementation; design keeps the hook explicit.                                                                                                                                                                                                                                                            | new                                        |
+| 6   | Approvals routing (runner asks before write/network)? | **Run creator** approves per-run. Runner owner retains revoke-any-time as the circuit breaker.                                                                                                                                                                                                                                                                                                                          | new                                        |
+| 7   | Fresh-install rollout (no production data exists)     | **Zero-setup default pod.** On workspace creation, the backend auto-creates a pod named `<workspace.name>-pod` with `is_default=True`. Runner registration defaults to the workspace pod when no pod is specified. Issue creation auto-fills `assigned_pod = workspace.default_pod`. First-time users never touch pod UI to get a working delegation flow. No migration of legacy data is required because none exists. | new, supersedes the earlier opt-in plan    |
+| 8   | Workspace admin role                                  | Reuse `WorkspaceMember.role=20 (Admin)` at `apps/api/pi_dash/db/models/workspace.py:19`.                                                                                                                                                                                                                                                                                                                                | verified                                   |
+| 9   | Run identity — `owner` vs `created_by`?               | Introduce `AgentRun.created_by` as a **non-null** FK to User, set at every creation path. **All permission checks migrate to `created_by`**: list, detail, cancel, approval list/decide. `AgentRun.owner` is retired from permission logic and semantically reinterpreted as "billable party" — populated as `runner.owner` at assignment time (nullable until assigned).                                               | codex-feedback                             |
+| 10  | Runner revocation and in-flight runs                  | Revocation must **synchronously finalize** all non-terminal runs belonging to the revoked runner. Current `Runner.revoke()` only flips the runner row; design adds explicit cancellation of active `AgentRun` rows in the same transaction. Without this, runs stay `ASSIGNED/RUNNING` forever after a force-close.                                                                                                     | codex-feedback                             |
+| 11  | Pod deletion vs. AgentRun history                     | **Soft-delete pods**: add `Pod.deleted_at` + `objects` manager that filters it out. Pod rows are never physically deleted, so `AgentRun.pod` FK stays valid and historical attribution is preserved. Deletion requires (a) zero runners in the pod AND (b) zero non-terminal `AgentRun` rows in the pod. Issues pointing at a soft-deleted pod get their `assigned_pod` cleared (see §7.2).                             | codex-feedback                             |
+| 12  | Direct run-creation endpoint — workspace validation   | `POST /api/v1/runner/runs/` **must** validate, before creation: (a) caller is a `WorkspaceMember` of `workspace_id` (403 otherwise), (b) `work_item.workspace_id == workspace_id` if `work_item` provided (400), (c) `pod.workspace_id == workspace_id` if pod is derived/passed (400), (d) caller has at least Member role in the workspace.                                                                           | codex-feedback                             |
+| 13  | Every workspace has at least one pod (invariant)      | Workspace creation auto-creates a default pod (decision #7). Soft-deletion of a pod is blocked if it's the workspace's last active pod — admin must create a replacement first. This invariant lets every downstream code path (issue creation, runner registration, dispatch) assume `workspace.default_pod` is always resolvable without a null-check fallback.                                                       | new                                        |
 
 ## 4. Data Model
 
@@ -143,12 +152,12 @@ pod = models.ForeignKey(
     "runner.Pod",
     on_delete=models.PROTECT,
     related_name="runners",
-    null=True,   # Temporarily nullable for migration. Backfilled then tightened.
+    null=False,   # Every runner belongs to exactly one pod. Enforced at DB level.
 )
 ```
 
-- `on_delete=PROTECT`: deleting a pod with runners requires moving or revoking them first. Prevents accidental orphaning.
-- After the migration completes, set `null=False` in a follow-up migration.
+- `on_delete=PROTECT`: deleting (soft-deleting) a pod with runners is blocked; admin must move or revoke them first.
+- `null=False` from the start — there's no legacy data to backfill. Registration flow resolves a pod before insert (defaulting to `workspace.default_pod` when none is explicitly requested).
 - **`owner` stays** — it continues to mean "responsible human for this specific runner instance" (billing, revoke). It no longer gates usage.
 - Name uniqueness changes from `(workspace, name)` to `(pod, name)` — so two pods in the same workspace can each have a runner named "mac-mini". Tradeoff: human-friendly addressing via `(workspace, name)` is less direct, but pod scope is the natural namespace.
 
@@ -175,7 +184,7 @@ owner = models.ForeignKey(
 pod = models.ForeignKey(
     "runner.Pod",
     on_delete=models.PROTECT,  # See §7.2 — pods are soft-deleted so the FK is always safe.
-    null=True,                 # Nullable only for legacy rows; new rows must resolve a pod before insert.
+    null=False,                # Every run belongs to a pod. Resolved before insert (§6.5).
     related_name="agent_runs",
 )
 
@@ -190,7 +199,7 @@ created_by = models.ForeignKey(
 )
 ```
 
-- `pod` is set at run creation. Derived from `issue.assigned_pod` when the run was triggered by an issue, or from `workspace.default_pod` if the issue has no pin, or from an explicit `pod` parameter when directly POSTed. **Never null for new rows**: if resolution fails, run creation fails and no `AgentRun` row is inserted (see validation §6.5 and orchestration behavior §6.4). `on_delete=PROTECT` is safe because pods are soft-deleted, not physically removed.
+- `pod` is set at run creation. Derived from `issue.assigned_pod` when the run was triggered by an issue, or from `workspace.default_pod` if the issue has no pin, or from an explicit `pod` parameter when directly POSTed. Because every workspace has a default pod (invariant #13), resolution effectively never fails in normal operation — the `no pod available` path in §6.5 remains as a defense-in-depth guard for pathological states (e.g. all workspace pods soft-deleted by an admin, which §7.2 blocks). `on_delete=PROTECT` is safe because pods are soft-deleted, not physically removed.
 - The run's queue position is implicitly `pod` × `status=QUEUED` × `created_at`.
 - `runner` FK is still nullable; it's populated only when a runner actually picks up the run.
 
@@ -220,10 +229,10 @@ assigned_pod = models.ForeignKey(
 )
 ```
 
-- Nullable. NULL means "use the workspace default pod at run time" (or fail with "no pod available" if no default exists).
-- Auto-populated at issue creation to `workspace.default_pod` if one exists. No per-user default logic.
+- Nullable. NULL means "use the workspace default pod at run time."
+- Auto-populated at issue creation to `workspace.default_pod`. Because invariant #13 guarantees every workspace has a default pod, this always resolves to a concrete pod on new issues.
 - User can change on the issue detail page; choice restricted to non-soft-deleted pods in the issue's workspace.
-- When a pinned pod is soft-deleted (see §7.2), pointing issues are swept to `assigned_pod=NULL` in the same transaction as the soft-delete, and their creators are notified.
+- When a pinned pod is soft-deleted (see §7.2), pointing issues are swept to `assigned_pod=NULL` in the same transaction as the soft-delete, and their creators are notified. The next run creation re-resolves to `workspace.default_pod`.
 
 ## 5. Permission Model
 
@@ -275,7 +284,7 @@ def is_workspace_admin(user, workspace_id) -> bool:
 
 - **At creation**: `owner = NULL`. This requires changing the field to `null=True, blank=True`; the field is no longer written by views or the orchestrator.
 - **At assignment (inside `drain_pod`)**: `owner = runner.owner` — the assigned runner's administrative operator, captured for billing attribution. This is set in the same write that sets `run.runner` and `run.status = ASSIGNED` (see §6.3 code block); no background task is involved.
-- **Legacy rows**: a one-time data migration backfills `created_by` from the existing `owner` value (under the old model, `owner` was always the triggering user, so this is an accurate interpretation for historical rows). `owner` on legacy rows is left alone.
+- **Legacy rows**: pi-dash has no production data, so there's no backfill to run. The `AgentRun.created_by` field is `NOT NULL` from migration day 1 because every future row sets it. In an environment with legacy data, a separate data migration would copy `owner → created_by` for historical rows (under the old model, `owner` was always the triggering user, so this would be an accurate interpretation) — out of scope here.
 - **Why not reuse `owner`**: the old `owner` semantic conflated two identities (run creator vs. billable party). Once runners become workspace-shared, these diverge — creator = who typed the prompt; billable party = whose machine ran it. The split is structural, not cosmetic.
 
 > Removed: the earlier draft mentioned a nightly background task as an alternative billing-capture path. Rejected because (a) it doubles the write for every run, (b) it leaves a window where `owner` is NULL and billing is ambiguous, and (c) `drain_pod` already has the transaction and the data. Assignment-time capture is strictly better.
@@ -386,8 +395,22 @@ A shared helper `validate_run_creation(user, workspace_id, work_item_id, pod_id)
 
 ### 7.1 Pod creation
 
-- Admin calls `POST /api/v1/workspaces/<id>/pods/` with `name`, `description`.
-- First created pod in a workspace is marked `is_default=True` automatically. Subsequent pods are non-default unless the admin explicitly toggles.
+Two pod-creation paths:
+
+**Automatic — on workspace creation** (decision #7, invariant #13):
+
+- A `post_save` signal on `Workspace` (or equivalent hook in the workspace-creation view) fires when `created=True`. If the workspace has zero pods, the handler inserts one row:
+  - `name = f"{workspace.name}-pod"`
+  - `description = "Auto-created default pod. Rename or add more pods anytime."`
+  - `is_default = True`
+  - `created_by = workspace.owner` (or the workspace-creator user)
+- The signal is idempotent: if a pod already exists (e.g. fixtures seeded one), the handler no-ops. This makes test setup easy.
+- Pod name is taken verbatim from `workspace.name`. Django `CharField(max_length=128)` accommodates workspace names up to 124 characters (`name + "-pod"` fits comfortably since workspace names are capped shorter in practice). If the user creates a second workspace with the same name in a hypothetical edge case, it's a different workspace row with its own pod — names are unique per-workspace only.
+
+**Manual — via API** (admin / power-user flow):
+
+- Admin calls `POST /api/v1/workspaces/<id>/pods/` with `name` and optional `description`.
+- The new pod is **not** marked default. Existing default pod stays default until the admin explicitly toggles via `PATCH` (see §7.3).
 
 ### 7.2 Pod soft-deletion
 
@@ -397,13 +420,16 @@ Per decision #11, pods are **never physically deleted**. The `DELETE` endpoint s
 
 1. `pod.runners.count() == 0` — all runners must be moved to another pod or revoked first. The UI forces a "move or revoke runners" step.
 2. `pod.agent_runs.filter(status__in=NON_TERMINAL_STATUSES).count() == 0` — no active (QUEUED / ASSIGNED / RUNNING / AWAITING_APPROVAL / AWAITING_REAUTH) runs. Prevents the "silently strand QUEUED runs" failure Codex flagged. Operator must cancel or let them complete first.
+3. **Last-pod guard** (invariant #13) — if this is the workspace's only active (non-soft-deleted) pod, deletion is rejected with `{"error": "cannot delete the last pod in a workspace; create a replacement first"}`. Admin must `POST` a new pod before deleting the old one. Keeps every workspace resolvable to a default pod at all times.
 
 **Soft-delete side effects** (same transaction):
 
-1. Clear `is_default` (so the workspace no longer auto-assigns to this pod).
+1. Clear `is_default` (if this was the default pod; the last-pod guard ensures another pod exists and the admin should promote one).
 2. Sweep all `Issue.assigned_pod = pod` → `assigned_pod = NULL`. These issues will use `workspace.default_pod` at next run creation.
 3. Terminal `AgentRun.pod` FKs are left intact — the row is a tombstone, not gone, so historical analytics still resolve.
 4. Fire notification to each affected issue's creator: "Pod _<name>_ was deleted. Issue _<X>_ has been unassigned."
+
+**Interaction with `is_default`**: if the admin soft-deletes the current default pod (permitted because guard #3 confirms another pod exists), the default flag is cleared. The system does **not** auto-promote another pod. A separate `PATCH` call from the admin is required to mark a replacement as default. During the window, `workspace.default_pod` resolves to NULL — which is fine because the `get_default_pod(workspace)` helper falls back to "any active pod in this workspace, oldest first" as a safety net. The admin should promote a real default promptly via UI nudge.
 
 **Restoration**: not exposed in MVP. The schema supports it (clearing `deleted_at` resurrects the row, subject to the conditional unique constraints) but no API endpoint is provided. Mistaken deletion is recovered via DB fixup. Revisit if product demand appears.
 
@@ -490,41 +516,37 @@ def revoke(self) -> None:
 - `RunnerSerializer` adds: `pod` (UUID) and `pod_detail` (nested `{id, name}`).
 - `IssueSerializer` adds: `assigned_pod` (UUID, writeable) and `assigned_pod_detail` (nested, read-only).
 
-## 9. Migration
+## 9. Migration — Initial schema (no legacy data)
 
-Sequencing matters. Four migrations in order.
+pi-dash has no production data yet, so the three-stage migration (nullable → backfill → tighten) that earlier drafts proposed is unnecessary. The design collapses to **two migrations**, one per Django app, both applying final constraints directly.
 
-### 9.1 Schema migration 1 — add Pod model + nullable FKs + AgentRun.created_by (nullable) + AgentRun.owner nullable
+### 9.1 `apps/api/pi_dash/runner/migrations/0004_add_pod_and_run_identity.py`
 
-- Create `pod` table with `deleted_at`.
-- Alter `agent_run.owner_id` to allow `NULL` (semantic change: billable party is unknown until assignment).
-- Add nullable `runner.pod_id`, `agent_run.pod_id`, `issue.assigned_pod_id`, `agent_run.created_by_id`.
+Single schema migration, no `RunPython` step:
 
-### 9.2 Data migration — backfill (decisions #7 and #9: opt-in cooperation + run identity split)
+- Create `pod` table with `deleted_at`, `PodManager`, conditional unique constraints (§4.1).
+- Add `runner.pod_id` as `NOT NULL` FK with `on_delete=PROTECT`. Because no `Runner` rows exist yet, the NOT NULL constraint is satisfied trivially.
+- Add `agent_run.pod_id` as `NOT NULL` FK with `on_delete=PROTECT`.
+- Add `agent_run.created_by_id` as `NOT NULL` FK to `auth_user` with `on_delete=PROTECT`.
+- Alter `agent_run.owner_id` to `NULL=TRUE`, `on_delete=SET_NULL` (decision #9).
+- Drop unique constraint `(workspace, name)` on `runner`; add `(pod, name)`.
 
-For each **(owner, workspace)** tuple that currently has runners:
+### 9.2 `apps/api/pi_dash/db/migrations/0126_issue_assigned_pod.py`
 
-1. Create a pod named `"<Owner Display Name>'s Agents"` (unique within workspace by appending numeric suffix on collision), `deleted_at=NULL`, `is_default=False`.
-2. Move all runners owned by that user in that workspace into this pod.
+- Add `issue.assigned_pod_id` as nullable FK to `runner.Pod` with `on_delete=PROTECT` (§4.4).
 
-Backfill `AgentRun.created_by` from the existing `AgentRun.owner` value for all historical rows. **Rationale**: under the old ownership model, `owner` was always the user who triggered the run (either directly via `runs.py` POST or via `orchestration.service._resolve_owner` → `issue.created_by`). So for historical rows, `owner == created_by` is the correct interpretation. `owner` is left intact for billing continuity.
+### 9.3 Post-migration setup
 
-Existing `agent_run.pod_id` stays NULL. Terminal rows keep their historical runner FK; the NULL pod is acceptable because analytics can derive pod via `agent_run.runner.pod` for assigned runs.
+Nothing required. When the backend starts, any existing workspaces (none in prod; possibly some in dev/test fixtures) can lazily get their default pods via the `post_save` signal on new workspaces. For dev/test fixtures that create workspaces before the signal is wired in, a management command `pi_dash.runner.management.commands.ensure_workspace_pods` idempotently backfills default pods for any workspace that doesn't have one — run it once after deploy in non-prod environments to be safe.
 
-Existing `issue.assigned_pod_id` stays NULL. No backfill.
+### 9.4 First-run behavior
 
-### 9.3 Schema migration 2 — tighten constraints
+- User creates workspace → signal fires → `<workspace.name>-pod` pod created with `is_default=True`.
+- User generates runner registration token → registers runner → runner lands in `workspace.default_pod`.
+- User creates issue → `issue.assigned_pod = workspace.default_pod`.
+- User moves issue to In Progress → dispatcher resolves `assigned_pod`, finds the runner, dispatches work.
 
-- `runner.pod` set `null=False`.
-- `agent_run.created_by` set `null=False` (after backfill in 9.2 ensures every row is populated).
-- `agent_run.owner` remains nullable by design.
-- Update `runner` name uniqueness constraint from `(workspace, name)` to `(pod, name)`.
-
-### 9.4 Upgrade behavior summary
-
-- Day 0 (pre-upgrade): Alice uses only her runners. Bob uses only his. Permission checks key off `AgentRun.owner`.
-- Day 1 (post-upgrade): same behavior. Alice's runners are in "Alice's Agents" pod; Bob's are in "Bob's Agents" pod. Workspace has no default pod, so new issues don't auto-assign. Permission checks now key off `AgentRun.created_by` (backfilled from `owner`, so no behavior change for historical rows). Alice's issues created via the UI may now fail delegation with `"no pod available"` until an admin creates a default/shared pod — we either (a) require admins to create a shared default pod before turning this on, or (b) gate the dispatcher behind a feature flag. **Recommend (a)** with an in-app nudge for admins.
-- Day N: admin creates "Workspace Agents" pod and marks it default. Moves selected runners into it. Issues now auto-assign to the workspace pod; cooperation starts. New runs created under the cooperation model will have `created_by` = run-trigger user and `owner` = runner-owner-at-assignment (different identities).
+Zero pod-related setup required for the golden path. Pods only become visible in UI when the user explicitly navigates to the pod section or the issue's advanced settings.
 
 ## 10. Tests (pytest — matches `rules/python/testing.md`)
 
@@ -546,6 +568,13 @@ Unit — `tests/unit/runner/test_pod.py`:
 - Soft-deleting a pod with non-terminal runs is blocked (409).
 - Soft-deleting a pod with only terminal runs succeeds; `AgentRun.pod` FKs remain intact.
 - Issues pointing at a soft-deleted pod are swept to `assigned_pod=NULL`.
+- **Last-pod guard**: soft-deleting the workspace's only active pod returns 409; soft-deleting when a second pod exists succeeds.
+
+Unit — `tests/unit/runner/test_workspace_signal.py` **(new)**:
+
+- Creating a new `Workspace` auto-creates one pod named `<workspace.name>-pod` with `is_default=True`.
+- Creating a workspace with pre-existing pods (e.g. via fixture) is a no-op — no duplicate default pod.
+- Signal is idempotent: calling `ensure_workspace_pods` management command on a workspace that already has a default pod creates nothing.
 
 Integration — `tests/integration/runner/test_dispatch.py`:
 
@@ -588,12 +617,12 @@ Integration — `tests/integration/runner/test_revocation.py` **(new)**:
 - Revoking the last runner in a non-empty-queue pod → QUEUED runs remain QUEUED; notification fires to each run's `created_by`.
 - Pod drain is re-invoked after revoke so any remaining runners in the pod pick up the work.
 
-Data migration — `tests/integration/runner/test_migration.py`:
+Schema / fresh-install — `tests/integration/runner/test_fresh_install.py` **(replaces the legacy-migration test)**:
 
-- Pre-existing runners from three users in one workspace → three personal pods created, each runner placed correctly.
-- No default pod created.
-- `AgentRun.created_by` backfilled from `AgentRun.owner` for every historical row.
-- `AgentRun.created_by` constraint tightened to NOT NULL after backfill without violating any row.
+- A brand-new workspace has exactly one pod (`<name>-pod`, `is_default=True`) immediately after creation.
+- Registering a runner with no explicit pod lands it in the workspace default pod.
+- Creating an issue with no explicit pod pins it to the workspace default pod.
+- End-to-end: create workspace → register runner → create issue → move to In Progress → run dispatches to runner. No pod UI touched.
 
 ## 11. Open Questions / Deferred
 
@@ -620,14 +649,17 @@ Data migration — `tests/integration/runner/test_migration.py`:
 - `runner/views/pods.py` — **new** CRUD for pods (soft-delete semantics).
 - `runner/serializers.py` — add `PodSerializer`, extend `RunnerSerializer` with `pod`/`pod_detail`, extend `AgentRunSerializer` with `pod` + `created_by` detail; keep `owner` as billable-party read-only.
 - `runner/consumers.py` — `_finalize_run` triggers `drain_pod(runner.pod)` on completion.
+- `runner/signals.py` — **new** `post_save` handler on `Workspace` that creates `<workspace.name>-pod` with `is_default=True` when `created=True` and the workspace has no pods (§7.1).
+- `runner/apps.py` — wire the signal in `ready()`.
+- `runner/management/commands/ensure_workspace_pods.py` — **new** idempotent backfill for dev/test environments where workspaces may have been created before the signal was wired in.
+- `runner/views/register.py` — runner registration resolves `pod` from the request (or falls back to `workspace.default_pod`) and validates the pod belongs to the workspace.
 - `orchestration/service.py` — `_dispatch_to_runner` rewritten to resolve pod and call `drain_pod`. `_create_and_dispatch_run` sets `AgentRun.created_by = actor` (required). `_resolve_owner` becomes `_resolve_fallback_creator` and is used only when `actor is None` on legacy call sites.
 - `db/models/issue.py` — add `assigned_pod`.
 - `space/views/issue.py` — populate default pod on create; accept `assigned_pod` on PATCH with workspace validation and non-deleted pod check.
 - `space/serializers/issue.py` — expose `assigned_pod` + nested detail.
-- Migrations:
-  - `NNNN_add_pod_model.py` — create `pod`, alter `agent_run.owner` to nullable, add nullable FKs (`runner.pod`, `agent_run.pod`, `agent_run.created_by`, `issue.assigned_pod`).
-  - `NNNN_backfill_pods_and_created_by.py` — per-user pods + `AgentRun.created_by` backfill from `owner`.
-  - `NNNN_tighten_constraints.py` — `runner.pod` and `agent_run.created_by` set `NOT NULL`; move runner name uniqueness from `(workspace, name)` to `(pod, name)`.
+- Migrations (two, both with final constraints applied directly — no backfill ceremony because no production data exists):
+  - `apps/api/pi_dash/runner/migrations/0004_add_pod_and_run_identity.py` — create `pod` table; add `runner.pod` (NOT NULL), `agent_run.pod` (NOT NULL), `agent_run.created_by` (NOT NULL); alter `agent_run.owner` to nullable + `SET_NULL`; replace `(workspace, name)` uniqueness on `runner` with `(pod, name)`.
+  - `apps/api/pi_dash/db/migrations/0126_issue_assigned_pod.py` — add `issue.assigned_pod` (nullable).
 - Tests as listed in §10.
 
 ### Frontend (apps/web)
@@ -647,3 +679,4 @@ Specific files deferred until implementation.
 - No change to the runner authentication / registration handshake.
 - No change to the Rust runner binary in this phase.
 - **No change to `AgentRun.owner` semantics on historical rows.** Legacy rows retain whatever value they had; `owner` on new rows becomes the runner-owner-at-assignment (nullable until assigned). All permission logic moves to `created_by` to sidestep the ambiguity rather than rewriting `owner` in place.
+- **No legacy data migration.** pi-dash has no production data; the initial schema migration applies final constraints directly. No `(owner, workspace)`-based personal-pod creation, no `AgentRun.created_by` backfill, no constraint-tightening stage. If this design is later applied to an environment with real data, a separate migration PR would add those stages.

--- a/apps/api/pi_dash/app/serializers/issue.py
+++ b/apps/api/pi_dash/app/serializers/issue.py
@@ -131,6 +131,22 @@ class IssueCreateSerializer(BaseSerializer):
         ):
             raise serializers.ValidationError("Start date cannot exceed target date")
 
+        # assigned_pod must belong to the issue's workspace and be active.
+        # See .ai_design/issue_runner/design.md §4.4 / §8.3.
+        if "assigned_pod" in attrs and attrs["assigned_pod"] is not None:
+            pod = attrs["assigned_pod"]
+            workspace_id = self.context.get("workspace_id")
+            if workspace_id is None and self.instance is not None:
+                workspace_id = self.instance.workspace_id
+            if workspace_id is not None and str(pod.workspace_id) != str(workspace_id):
+                raise serializers.ValidationError(
+                    {"assigned_pod": "pod is in a different workspace"}
+                )
+            if pod.deleted_at is not None:
+                raise serializers.ValidationError(
+                    {"assigned_pod": "pod has been deleted"}
+                )
+
         # Validate description content for security
         if "description_html" in attrs and attrs["description_html"]:
             is_valid, error_msg, sanitized_html = validate_html_content(attrs["description_html"])

--- a/apps/api/pi_dash/db/migrations/0126_issue_assigned_pod.py
+++ b/apps/api/pi_dash/db/migrations/0126_issue_assigned_pod.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Add ``Issue.assigned_pod`` nullable FK to ``runner.Pod``.
+
+Issues pin to a pod; dispatch uses the pinned pod if set, else falls back to
+``workspace.default_pod``. See ``.ai_design/issue_runner/design.md`` §4.4.
+"""
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("db", "0125_branch_name_validators"),
+        ("runner", "0004_add_pod_and_run_identity"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="issue",
+            name="assigned_pod",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="assigned_issues",
+                to="runner.pod",
+            ),
+        ),
+    ]

--- a/apps/api/pi_dash/db/models/issue.py
+++ b/apps/api/pi_dash/db/models/issue.py
@@ -177,6 +177,16 @@ class Issue(ProjectBaseModel):
             ),
         ],
     )
+    # Pod this issue's agent runs dispatch to. NULL means "use the workspace
+    # default pod at run time." See .ai_design/issue_runner/design.md §4.4.
+    # PROTECT is safe because pods are soft-deleted, never physically removed.
+    assigned_pod = models.ForeignKey(
+        "runner.Pod",
+        null=True,
+        blank=True,
+        on_delete=models.PROTECT,
+        related_name="assigned_issues",
+    )
 
     issue_objects = IssueManager()
 

--- a/apps/api/pi_dash/db/models/issue.py
+++ b/apps/api/pi_dash/db/models/issue.py
@@ -197,6 +197,26 @@ class Issue(ProjectBaseModel):
         ordering = ("-created_at",)
 
     def save(self, *args, **kwargs):
+        # Auto-resolve assigned_pod to workspace default for new issues so the
+        # UI never has to think about pods. See .ai_design/issue_runner/design.md
+        # §4.4 and §7.1. Only fires on creation; PATCH-driven changes are
+        # handled by the serializer's validate_assigned_pod.
+        if self._state.adding and self.assigned_pod_id is None:
+            try:
+                from pi_dash.runner.models import Pod
+
+                workspace_id = self.workspace_id
+                if workspace_id is None and self.project_id is not None:
+                    # workspace is set in ProjectBaseModel.save() before super().save();
+                    # at this stage we may not have it yet, so derive from project.
+                    workspace_id = self.project.workspace_id
+                if workspace_id is not None:
+                    default_pod = Pod.default_for_workspace_id(workspace_id)
+                    if default_pod is not None:
+                        self.assigned_pod = default_pod
+            except ImportError:
+                pass
+
         if self.state is None:
             try:
                 from pi_dash.db.models import State

--- a/apps/api/pi_dash/orchestration/service.py
+++ b/apps/api/pi_dash/orchestration/service.py
@@ -102,34 +102,71 @@ def handle_issue_state_transition(
 
     parent = _latest_prior_run(issue)
 
-    owner = actor or _resolve_owner(issue)
-    if owner is None:
+    creator = actor or _resolve_fallback_creator(issue)
+    if creator is None:
         logger.warning(
-            "orchestration: no owner for issue %s; skipping run creation",
+            "orchestration: no creator for issue %s; skipping run creation",
             issue.id,
         )
-        return TransitionOutcome(reason="no-owner")
+        return TransitionOutcome(reason="no-creator")
 
-    return _create_and_dispatch_run(issue=issue, parent=parent, owner=owner)
+    pod = _resolve_pod_for_issue(issue)
+    if pod is None:
+        logger.warning(
+            "orchestration: no pod available for workspace %s; "
+            "leaving issue %s unhandled",
+            issue.workspace_id,
+            issue.id,
+        )
+        return TransitionOutcome(reason="no-pod-available")
+
+    return _create_and_dispatch_run(
+        issue=issue, parent=parent, creator=creator, pod=pod
+    )
 
 
-def _resolve_owner(issue: Issue):
-    """Pick the user the run is billed to. Prefer the issue's creator; fall back
-    to the project lead. The runner matcher uses this to pick a runner owned by
-    the same user."""
+def _resolve_fallback_creator(issue: Issue):
+    """Pick a fallback ``created_by`` for legacy callers that don't pass ``actor``.
+
+    Renamed from ``_resolve_owner``: under the new model the returned user
+    becomes ``AgentRun.created_by`` (the access principal), not ``owner``
+    (the billable party).
+
+    Prefer the issue's creator; fall back to the project lead. New call sites
+    must always pass ``actor`` explicitly; this helper is a back-compat shim.
+    """
     if issue.created_by_id:
         return issue.created_by
     project = issue.project
     return project.project_lead or project.default_assignee
 
 
+def _resolve_pod_for_issue(issue: Issue):
+    """Resolve the pod a run for this issue should belong to.
+
+    Priority: ``issue.assigned_pod`` if set and active, else
+    ``workspace.default_pod``. Returns ``None`` only when both are gone (a
+    pathological state since invariant #13 keeps a default pod alive).
+    """
+    from pi_dash.runner.models import Pod
+
+    if issue.assigned_pod_id is not None:
+        pinned = Pod.objects.filter(pk=issue.assigned_pod_id).first()
+        if pinned is not None:
+            return pinned
+    return Pod.default_for_workspace_id(issue.workspace_id)
+
+
 def _create_and_dispatch_run(
-    *, issue: Issue, parent: Optional[AgentRun], owner
+    *, issue: Issue, parent: Optional[AgentRun], creator, pod
 ) -> TransitionOutcome:
+    from pi_dash.runner.services import matcher
+
     with transaction.atomic():
         run = AgentRun.objects.create(
-            owner=owner,
             workspace=issue.workspace,
+            created_by=creator,
+            pod=pod,
             work_item=issue,
             parent_run=parent,
             status=AgentRunStatus.QUEUED,
@@ -139,6 +176,7 @@ def _create_and_dispatch_run(
                 "repo_ref": (issue.project.base_branch or None),
                 "git_work_branch": (issue.git_work_branch or None),
             },
+            # owner stays NULL until assignment captures runner.owner.
         )
         try:
             run.prompt = build_first_turn(issue, run)
@@ -151,53 +189,9 @@ def _create_and_dispatch_run(
             return TransitionOutcome(created_run=run, reason="render-failed")
 
         run.save(update_fields=["prompt"])
-        transaction.on_commit(lambda: _dispatch_to_runner(run.id))
+        # Drain the pod's queue after the run row has landed. drain_pod is
+        # idempotent and uses select_for_update(skip_locked=True), so it's
+        # safe to run unconditionally.
+        transaction.on_commit(lambda: matcher.drain_pod_by_id(pod.id))
 
     return TransitionOutcome(created_run=run, reason="created")
-
-
-def _dispatch_to_runner(run_id) -> None:
-    """Match a runner and forward the Assign envelope.
-
-    Called after commit so the daemon never sees a run that hasn't landed yet.
-    """
-    from pi_dash.runner.services import matcher
-    from pi_dash.runner.services.pubsub import send_to_runner
-
-    with transaction.atomic():
-        try:
-            run = AgentRun.objects.select_for_update().get(id=run_id)
-        except AgentRun.DoesNotExist:
-            logger.warning("orchestration: run %s disappeared before dispatch", run_id)
-            return
-
-        if run.status != AgentRunStatus.QUEUED:
-            return  # someone else already handled it
-
-        chosen = matcher.select_runner_for_run(run)
-        if chosen is None:
-            logger.info("orchestration: no runner available for run %s; leaving queued", run.id)
-            return
-
-        run.runner = chosen
-        run.status = AgentRunStatus.ASSIGNED
-        run.assigned_at = timezone.now()
-        run.save(update_fields=["runner", "status", "assigned_at"])
-        chosen_id = chosen.id
-        assign_msg = {
-            "v": 1,
-            "type": "assign",
-            "run_id": str(run.id),
-            "work_item_id": str(run.work_item_id) if run.work_item_id else None,
-            "prompt": run.prompt,
-            "repo_url": run.run_config.get("repo_url"),
-            "repo_ref": run.run_config.get("repo_ref"),
-            "git_work_branch": run.run_config.get("git_work_branch"),
-            "expected_codex_model": run.run_config.get("model"),
-            "approval_policy_overrides": run.run_config.get(
-                "approval_policy_overrides"
-            ),
-            "deadline": None,
-        }
-
-    send_to_runner(chosen_id, assign_msg)

--- a/apps/api/pi_dash/runner/apps.py
+++ b/apps/api/pi_dash/runner/apps.py
@@ -10,3 +10,8 @@ class RunnerConfig(AppConfig):
     label = "runner"
     verbose_name = "Pi Dash Runner"
     default_auto_field = "django.db.models.BigAutoField"
+
+    def ready(self):
+        # Import for side effects: registers post_save signal handlers
+        # (workspace auto-pod creation). See runner/signals.py.
+        from pi_dash.runner import signals  # noqa: F401

--- a/apps/api/pi_dash/runner/consumers.py
+++ b/apps/api/pi_dash/runner/consumers.py
@@ -453,11 +453,17 @@ class RunnerConsumer(AsyncJsonWebsocketConsumer):
         AgentRun.objects.filter(id=run_id, runner=runner).update(**updates)
 
         # The runner just freed up — drain its pod so any QUEUED runs in the
-        # same pod can move to it. See design §6.3 (drain triggers).
+        # same pod can move to it. See design §6.3: drain must fire after the
+        # terminal state commits, otherwise a new assign could race with the
+        # update and the runner would receive work for a run it's finishing.
         if runner.pod_id is not None:
+            from django.db import transaction
+
             from pi_dash.runner.services.matcher import drain_pod_by_id
 
-            drain_pod_by_id(runner.pod_id)
+            transaction.on_commit(
+                lambda pid=runner.pod_id: drain_pod_by_id(pid)
+            )
 
     # ---- misc ----
 

--- a/apps/api/pi_dash/runner/consumers.py
+++ b/apps/api/pi_dash/runner/consumers.py
@@ -452,6 +452,13 @@ class RunnerConsumer(AsyncJsonWebsocketConsumer):
             updates["error"] = (msg.get("detail") or "")[:16000]
         AgentRun.objects.filter(id=run_id, runner=runner).update(**updates)
 
+        # The runner just freed up — drain its pod so any QUEUED runs in the
+        # same pod can move to it. See design §6.3 (drain triggers).
+        if runner.pod_id is not None:
+            from pi_dash.runner.services.matcher import drain_pod_by_id
+
+            drain_pod_by_id(runner.pod_id)
+
     # ---- misc ----
 
     def _header(self, name: str) -> Optional[str]:

--- a/apps/api/pi_dash/runner/management/commands/ensure_workspace_pods.py
+++ b/apps/api/pi_dash/runner/management/commands/ensure_workspace_pods.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Idempotently ensure every workspace has a default pod.
+
+Intended for dev / test environments where workspaces may have been created
+before the post_save signal was wired in. On a fresh deploy with no existing
+workspaces, this command is a no-op.
+
+Usage::
+
+    python manage.py ensure_workspace_pods
+    python manage.py ensure_workspace_pods --dry-run
+
+See ``.ai_design/issue_runner/design.md`` §9.3.
+"""
+
+from __future__ import annotations
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from pi_dash.db.models.workspace import Workspace
+from pi_dash.runner.models import Pod
+
+
+class Command(BaseCommand):
+    help = "Ensure every workspace has a default pod; creates missing pods idempotently."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report what would change without writing anything.",
+        )
+
+    def handle(self, *args, dry_run: bool = False, **options):
+        missing = []
+        for ws in Workspace.objects.all():
+            if Pod.objects.filter(workspace=ws).exists():
+                continue
+            missing.append(ws)
+
+        if not missing:
+            self.stdout.write(self.style.SUCCESS("All workspaces already have a pod. Nothing to do."))
+            return
+
+        self.stdout.write(
+            f"Found {len(missing)} workspace(s) without a pod:"
+        )
+        for ws in missing:
+            self.stdout.write(f"  - {ws.id} ({ws.name})")
+
+        if dry_run:
+            self.stdout.write(self.style.WARNING("--dry-run: no changes written."))
+            return
+
+        with transaction.atomic():
+            for ws in missing:
+                Pod.objects.create(
+                    workspace=ws,
+                    name=f"{ws.name}-pod",
+                    description="Auto-created default pod by ensure_workspace_pods.",
+                    is_default=True,
+                    created_by=getattr(ws, "owner", None),
+                )
+        self.stdout.write(
+            self.style.SUCCESS(f"Created {len(missing)} default pod(s).")
+        )

--- a/apps/api/pi_dash/runner/management/commands/ensure_workspace_pods.py
+++ b/apps/api/pi_dash/runner/management/commands/ensure_workspace_pods.py
@@ -56,15 +56,26 @@ class Command(BaseCommand):
             self.stdout.write(self.style.WARNING("--dry-run: no changes written."))
             return
 
-        with transaction.atomic():
-            for ws in missing:
-                Pod.objects.create(
+        # Create each pod in its own small transaction and use get_or_create so
+        # a concurrent signal (or a second invocation of this command) races
+        # safely: whoever wins inserts the row, the loser gets the existing
+        # row back and skips. Without this, an IntegrityError in the middle of
+        # the batch would abort the entire atomic block and skip every
+        # workspace after the conflict.
+        created = 0
+        for ws in missing:
+            with transaction.atomic():
+                _, was_created = Pod.objects.get_or_create(
                     workspace=ws,
-                    name=f"{ws.name}-pod",
-                    description="Auto-created default pod by ensure_workspace_pods.",
-                    is_default=True,
-                    created_by=getattr(ws, "owner", None),
+                    name=f"{ws.name[:123]}-pod",
+                    defaults={
+                        "description": "Auto-created default pod by ensure_workspace_pods.",
+                        "is_default": True,
+                        "created_by": getattr(ws, "owner", None),
+                    },
                 )
+                if was_created:
+                    created += 1
         self.stdout.write(
-            self.style.SUCCESS(f"Created {len(missing)} default pod(s).")
+            self.style.SUCCESS(f"Created {created} default pod(s).")
         )

--- a/apps/api/pi_dash/runner/migrations/0004_add_pod_and_run_identity.py
+++ b/apps/api/pi_dash/runner/migrations/0004_add_pod_and_run_identity.py
@@ -77,7 +77,7 @@ def _backfill_run_identity(apps, schema_editor):
     """
     AgentRun = apps.get_model("runner", "AgentRun")
     Pod = apps.get_model("runner", "Pod")
-    for run in AgentRun.objects.all().iterator(chunk_size=500):
+    for run in AgentRun.objects.all().select_related("runner").iterator(chunk_size=500):
         updates = []
         if run.pod_id is None:
             if run.runner_id is not None and run.runner.pod_id is not None:
@@ -94,6 +94,27 @@ def _backfill_run_identity(apps, schema_editor):
             updates.append("created_by")
         if updates:
             run.save(update_fields=updates)
+
+
+def _assert_no_null_created_by(apps, schema_editor):
+    """Fail loudly before the NOT NULL tighten rather than letting the
+    AlterField raise a cryptic IntegrityError mid-migration.
+
+    Legacy rows where both ``created_by`` and ``owner`` were NULL cannot be
+    backfilled automatically; they must be resolved manually (either deleted
+    or assigned to a synthetic system user) before this migration can run.
+    """
+    AgentRun = apps.get_model("runner", "AgentRun")
+    null_ids = list(
+        AgentRun.objects.filter(created_by__isnull=True).values_list("id", flat=True)[:10]
+    )
+    if null_ids:
+        remaining = AgentRun.objects.filter(created_by__isnull=True).count()
+        raise RuntimeError(
+            f"Cannot tighten AgentRun.created_by to NOT NULL: {remaining} row(s) "
+            f"still have created_by=NULL after backfill (sample IDs: {null_ids}). "
+            f"Resolve these rows manually before retrying the migration."
+        )
 
 
 class Migration(migrations.Migration):
@@ -225,6 +246,12 @@ class Migration(migrations.Migration):
         migrations.RunPython(_ensure_default_pods, reverse_code=migrations.RunPython.noop),
         migrations.RunPython(_backfill_runner_pods, reverse_code=migrations.RunPython.noop),
         migrations.RunPython(_backfill_run_identity, reverse_code=migrations.RunPython.noop),
+        # Preflight: fail clearly if any AgentRun still has created_by=NULL
+        # before the NOT NULL tighten below; otherwise the AlterField raises a
+        # cryptic IntegrityError mid-migration.
+        migrations.RunPython(
+            _assert_no_null_created_by, reverse_code=migrations.RunPython.noop
+        ),
         # --- 5. Tighten Runner.pod / AgentRun.pod / AgentRun.created_by to NOT NULL ---
         migrations.AlterField(
             model_name="runner",

--- a/apps/api/pi_dash/runner/migrations/0004_add_pod_and_run_identity.py
+++ b/apps/api/pi_dash/runner/migrations/0004_add_pod_and_run_identity.py
@@ -1,0 +1,282 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Pod + run-identity split — see .ai_design/issue_runner/design.md.
+
+Introduces:
+
+- ``Pod`` table (workspace-scoped group of runners sharing a work queue).
+- ``Runner.pod`` FK (NOT NULL via nullable-then-tighten in-migration).
+- ``AgentRun.pod`` FK (same pattern).
+- ``AgentRun.created_by`` FK (NOT NULL via nullable-then-tighten; the
+  authoritative principal for permission checks).
+- ``AgentRun.owner`` relaxed to nullable + ``on_delete=SET_NULL``; semantic
+  shift from "access principal" to "billable party," captured at assignment
+  time from ``runner.owner``.
+
+The two-step (add nullable → data pass → tighten) is kept even though
+pi-dash has no production data yet, because dev/test databases may have
+rows from prior local testing, and the extra RunPython passes are trivial
+for the empty case.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+def _ensure_default_pods(apps, schema_editor):
+    """For every existing workspace, ensure a default Pod row exists.
+
+    Idempotent. Uses historical models so the logic is immune to later model
+    edits.
+    """
+    Workspace = apps.get_model("db", "Workspace")
+    Pod = apps.get_model("runner", "Pod")
+    for ws in Workspace.objects.all():
+        if Pod.objects.filter(workspace=ws).exists():
+            continue
+        Pod.objects.create(
+            workspace=ws,
+            name=f"{ws.name}-pod",
+            description="Auto-created default pod (migration 0004).",
+            is_default=True,
+            created_by=getattr(ws, "owner", None),
+        )
+
+
+def _backfill_runner_pods(apps, schema_editor):
+    """Attach every Runner to its workspace's default Pod."""
+    Runner = apps.get_model("runner", "Runner")
+    Pod = apps.get_model("runner", "Pod")
+    for runner in Runner.objects.filter(pod__isnull=True):
+        default_pod = Pod.objects.filter(
+            workspace=runner.workspace, is_default=True
+        ).first()
+        if default_pod is None:
+            # Shouldn't happen after _ensure_default_pods, but be defensive:
+            # pick any pod in the workspace or skip.
+            default_pod = Pod.objects.filter(workspace=runner.workspace).first()
+        if default_pod is not None:
+            runner.pod = default_pod
+            runner.save(update_fields=["pod"])
+
+
+def _backfill_run_identity(apps, schema_editor):
+    """Populate AgentRun.pod and AgentRun.created_by for existing rows.
+
+    - ``pod``: derived from the run's runner.pod if assigned, else workspace
+      default.
+    - ``created_by``: copy from existing ``owner`` (under the old model, owner
+      was always the triggering user, so this is semantically correct).
+    """
+    AgentRun = apps.get_model("runner", "AgentRun")
+    Pod = apps.get_model("runner", "Pod")
+    for run in AgentRun.objects.all().iterator(chunk_size=500):
+        updates = []
+        if run.pod_id is None:
+            if run.runner_id is not None and run.runner.pod_id is not None:
+                run.pod_id = run.runner.pod_id
+            else:
+                default_pod = Pod.objects.filter(
+                    workspace_id=run.workspace_id, is_default=True
+                ).first()
+                if default_pod is not None:
+                    run.pod = default_pod
+            updates.append("pod")
+        if run.created_by_id is None and run.owner_id is not None:
+            run.created_by_id = run.owner_id
+            updates.append("created_by")
+        if updates:
+            run.save(update_fields=updates)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("runner", "0003_runner_name_unique_per_workspace"),
+        ("db", "0125_branch_name_validators"),
+    ]
+
+    operations = [
+        # --- 1. Create Pod table ---
+        migrations.CreateModel(
+            name="Pod",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("name", models.CharField(max_length=128)),
+                (
+                    "description",
+                    models.CharField(blank=True, default="", max_length=512),
+                ),
+                ("is_default", models.BooleanField(default=False)),
+                (
+                    "deleted_at",
+                    models.DateTimeField(blank=True, db_index=True, null=True),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="pods_created",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "workspace",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="pods",
+                        to="db.workspace",
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "pod",
+                "ordering": ("-is_default", "created_at"),
+            },
+        ),
+        migrations.AddConstraint(
+            model_name="pod",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(("deleted_at__isnull", True)),
+                fields=("workspace", "name"),
+                name="pod_unique_name_per_workspace_when_active",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="pod",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(
+                    ("is_default", True), ("deleted_at__isnull", True)
+                ),
+                fields=("workspace",),
+                name="pod_one_default_per_workspace_when_active",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="pod",
+            index=models.Index(
+                fields=["workspace", "is_default"], name="pod_workspc_is_def_idx"
+            ),
+        ),
+        # --- 2. Runner.pod (nullable initially to support backfill) ---
+        migrations.AddField(
+            model_name="runner",
+            name="pod",
+            field=models.ForeignKey(
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="runners",
+                to="runner.pod",
+            ),
+        ),
+        # --- 3. AgentRun fields (pod + created_by nullable; owner relaxed) ---
+        migrations.AddField(
+            model_name="agentrun",
+            name="pod",
+            field=models.ForeignKey(
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="agent_runs",
+                to="runner.pod",
+            ),
+        ),
+        migrations.AddField(
+            model_name="agentrun",
+            name="created_by",
+            field=models.ForeignKey(
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="agent_runs_created",
+                to=settings.AUTH_USER_MODEL,
+            ),
+        ),
+        migrations.AlterField(
+            model_name="agentrun",
+            name="owner",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="agent_runs",
+                to=settings.AUTH_USER_MODEL,
+            ),
+        ),
+        # --- 4. Data pass: ensure pods, attach runners and runs, fill created_by ---
+        migrations.RunPython(_ensure_default_pods, reverse_code=migrations.RunPython.noop),
+        migrations.RunPython(_backfill_runner_pods, reverse_code=migrations.RunPython.noop),
+        migrations.RunPython(_backfill_run_identity, reverse_code=migrations.RunPython.noop),
+        # --- 5. Tighten Runner.pod / AgentRun.pod / AgentRun.created_by to NOT NULL ---
+        migrations.AlterField(
+            model_name="runner",
+            name="pod",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="runners",
+                to="runner.pod",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="agentrun",
+            name="pod",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="agent_runs",
+                to="runner.pod",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="agentrun",
+            name="created_by",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="agent_runs_created",
+                to=settings.AUTH_USER_MODEL,
+            ),
+        ),
+        # --- 6. Replace Runner name uniqueness with (pod, name) ---
+        migrations.RemoveConstraint(
+            model_name="runner",
+            name="runner_unique_name_per_workspace",
+        ),
+        migrations.AddConstraint(
+            model_name="runner",
+            constraint=models.UniqueConstraint(
+                fields=("pod", "name"),
+                name="runner_unique_name_per_pod",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="runner",
+            index=models.Index(fields=["pod", "status"], name="runner_pod_status_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="agentrun",
+            index=models.Index(fields=["pod", "status"], name="agent_run_pod_status_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="agentrun",
+            index=models.Index(
+                fields=["created_by", "status"], name="agent_run_created_status_idx"
+            ),
+        ),
+    ]

--- a/apps/api/pi_dash/runner/models.py
+++ b/apps/api/pi_dash/runner/models.py
@@ -205,9 +205,57 @@ class Runner(models.Model):
         self.save(update_fields=["last_heartbeat_at"])
 
     def revoke(self) -> None:
-        self.status = RunnerStatus.REVOKED
-        self.revoked_at = timezone.now()
-        self.save(update_fields=["status", "revoked_at"])
+        """Mark the runner revoked and synchronously cancel any in-flight runs.
+
+        See ``.ai_design/issue_runner/design.md`` §7.5. Without this, a
+        force-closed runner leaves ``ASSIGNED``/``RUNNING`` rows stranded
+        because ``consumers._finalize_run`` only triggers on runner-sent
+        completion messages that may never arrive after revocation.
+
+        After the transaction commits, the affected pods are re-drained so
+        queued work (if any) attempts to move to remaining online runners in
+        the same pod.
+        """
+        # Imports deferred to avoid a circular dependency (matcher imports
+        # Runner model; Runner.revoke calls into matcher).
+        from django.db import transaction
+        from pi_dash.runner.services.matcher import (
+            NON_TERMINAL_STATUSES,
+            drain_pod_by_id,
+        )
+
+        affected_pod_ids: set = set()
+        with transaction.atomic():
+            now = timezone.now()
+            Runner.objects.filter(pk=self.pk).update(
+                status=RunnerStatus.REVOKED,
+                revoked_at=now,
+            )
+            # Refresh in-memory instance so callers see the new status/timestamp
+            # without an extra query on their side.
+            self.status = RunnerStatus.REVOKED
+            self.revoked_at = now
+
+            active_runs = list(
+                AgentRun.objects.select_for_update()
+                .filter(runner=self, status__in=NON_TERMINAL_STATUSES)
+                .values_list("pk", "pod_id")
+            )
+            if active_runs:
+                AgentRun.objects.filter(
+                    pk__in=[pk for pk, _ in active_runs]
+                ).update(
+                    status=AgentRunStatus.CANCELLED,
+                    ended_at=now,
+                    error="runner revoked",
+                )
+                affected_pod_ids = {pid for _, pid in active_runs if pid is not None}
+
+        # Refire drain for every affected pod once the transaction commits.
+        # Remaining online runners (if any) in the same pod may now pick up
+        # queued work.
+        for pod_id in affected_pod_ids:
+            transaction.on_commit(lambda pid=pod_id: drain_pod_by_id(pid))
 
 
 class RunnerRegistrationToken(models.Model):

--- a/apps/api/pi_dash/runner/models.py
+++ b/apps/api/pi_dash/runner/models.py
@@ -9,6 +9,88 @@ from django.db import models
 from django.utils import timezone
 
 
+class PodManager(models.Manager):
+    """Default manager: excludes soft-deleted pods from routine queries.
+
+    Use ``Pod.all_objects`` to include tombstones in admin / audit views.
+    """
+
+    def get_queryset(self):
+        return super().get_queryset().filter(deleted_at__isnull=True)
+
+
+class Pod(models.Model):
+    """A workspace-scoped group of runners that share a work queue.
+
+    See ``.ai_design/issue_runner/design.md`` §4.1.
+    """
+
+    MAX_PER_WORKSPACE = 20
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    workspace = models.ForeignKey(
+        "db.Workspace",
+        on_delete=models.CASCADE,
+        related_name="pods",
+    )
+    name = models.CharField(max_length=128)
+    description = models.CharField(max_length=512, blank=True, default="")
+    created_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="pods_created",
+    )
+    is_default = models.BooleanField(default=False)
+    deleted_at = models.DateTimeField(null=True, blank=True, db_index=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    objects = PodManager()
+    all_objects = models.Manager()
+
+    class Meta:
+        db_table = "pod"
+        ordering = ("-is_default", "created_at")
+        constraints = [
+            models.UniqueConstraint(
+                fields=["workspace", "name"],
+                condition=models.Q(deleted_at__isnull=True),
+                name="pod_unique_name_per_workspace_when_active",
+            ),
+            models.UniqueConstraint(
+                fields=["workspace"],
+                condition=models.Q(is_default=True) & models.Q(deleted_at__isnull=True),
+                name="pod_one_default_per_workspace_when_active",
+            ),
+        ]
+        indexes = [
+            models.Index(
+                fields=["workspace", "is_default"], name="pod_workspc_is_def_idx"
+            ),
+        ]
+
+    def __str__(self) -> str:
+        return f"{self.name} (ws={self.workspace_id})"
+
+    @classmethod
+    def default_for_workspace(cls, workspace) -> "Pod | None":
+        """Return the active default pod for a workspace, or None.
+
+        Every workspace normally has exactly one default pod (invariant #13 in
+        the design doc). Returns None only during the transient window between
+        workspace creation and the post_save signal firing, or when an admin
+        has soft-deleted the default without promoting a replacement.
+        """
+        return cls.default_for_workspace_id(workspace.id)
+
+    @classmethod
+    def default_for_workspace_id(cls, workspace_id) -> "Pod | None":
+        """Same as :meth:`default_for_workspace` but avoids loading the Workspace."""
+        return cls.objects.filter(workspace_id=workspace_id, is_default=True).first()
+
+
 class RunnerStatus(models.TextChoices):
     ONLINE = "online", "Online"
     OFFLINE = "offline", "Offline"
@@ -60,6 +142,13 @@ class Runner(models.Model):
         on_delete=models.CASCADE,
         related_name="runners",
     )
+    # Every runner belongs to exactly one pod (§4.2). PROTECT because pods are
+    # soft-deleted, not physically removed, so this FK is always valid.
+    pod = models.ForeignKey(
+        Pod,
+        on_delete=models.PROTECT,
+        related_name="runners",
+    )
     name = models.CharField(max_length=128)
     # Runner authenticates over WS with a bearer token; we store only its hash.
     credential_hash = models.CharField(max_length=128, db_index=True)
@@ -83,22 +172,33 @@ class Runner(models.Model):
     class Meta:
         db_table = "runner"
         ordering = ("-last_heartbeat_at", "-created_at")
-        # Per-workspace name uniqueness. `(workspace, name)` is the human key
-        # the CLI uses to address a runner; the UUID `id` is the internal
-        # auth identity. See .ai_design/runner_install_ux/ for the rationale.
+        # Per-pod name uniqueness (§4.2). Pod is the natural namespace; the CLI
+        # still addresses runners by name within a pod. Two pods in the same
+        # workspace can each have a runner named "mac-mini".
         constraints = [
             models.UniqueConstraint(
-                fields=["workspace", "name"],
-                name="runner_unique_name_per_workspace",
+                fields=["pod", "name"],
+                name="runner_unique_name_per_pod",
             ),
         ]
         indexes = [
             models.Index(fields=["owner", "status"]),
             models.Index(fields=["workspace", "status"]),
+            models.Index(fields=["pod", "status"], name="runner_pod_status_idx"),
         ]
 
     def __str__(self) -> str:
         return f"{self.name} ({self.owner_id})"
+
+    def save(self, *args, **kwargs):
+        # Auto-resolve pod to workspace default when not explicitly set.
+        # Safe invariant: every workspace has a default pod (§13).
+        # Explicit pod_id=None with a workspace set triggers resolution.
+        if self.pod_id is None and self.workspace_id is not None:
+            default = Pod.default_for_workspace_id(self.workspace_id)
+            if default is not None:
+                self.pod = default
+        super().save(*args, **kwargs)
 
     def mark_heartbeat(self) -> None:
         self.last_heartbeat_at = timezone.now()
@@ -157,9 +257,28 @@ class AgentRun(models.Model):
         on_delete=models.CASCADE,
         related_name="agent_runs",
     )
+    # `owner` = billable party; populated at assignment from runner.owner (§5.3).
+    # Nullable because it's unknown until a runner is assigned. Legacy rows
+    # that had owner pre-set under the old model are unaffected.
     owner = models.ForeignKey(
         settings.AUTH_USER_MODEL,
-        on_delete=models.CASCADE,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="agent_runs",
+    )
+    # `created_by` = the user who triggered the run. Authoritative principal for
+    # list / detail / cancel / approval permissions (decision #9).
+    created_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.PROTECT,
+        related_name="agent_runs_created",
+        null=False,
+    )
+    # Every run belongs to exactly one pod; resolved before insert (§6.5).
+    pod = models.ForeignKey(
+        "runner.Pod",
+        on_delete=models.PROTECT,
         related_name="agent_runs",
     )
     runner = models.ForeignKey(
@@ -210,7 +329,28 @@ class AgentRun(models.Model):
             models.Index(fields=["owner", "status"]),
             models.Index(fields=["workspace", "status"]),
             models.Index(fields=["work_item", "status"]),
+            models.Index(fields=["pod", "status"], name="agent_run_pod_status_idx"),
+            models.Index(
+                fields=["created_by", "status"], name="agent_run_created_status_idx"
+            ),
         ]
+
+    def save(self, *args, **kwargs):
+        # Auto-resolve pod to workspace default when not explicitly set.
+        # Design §4.3: every new run has a pod, resolved at the view layer; the
+        # fallback here keeps direct-ORM callers (tests, management commands)
+        # working as long as the workspace has a default pod.
+        if self.pod_id is None and self.workspace_id is not None:
+            default = Pod.default_for_workspace_id(self.workspace_id)
+            if default is not None:
+                self.pod = default
+        # Back-compat: legacy call sites that set `owner` but not `created_by`
+        # (to be audited and removed in Phase 3). Mirror owner into created_by
+        # so the NOT NULL constraint holds. The design's interpretation for
+        # historical rows is that owner == created_by under the old model.
+        if self.created_by_id is None and self.owner_id is not None:
+            self.created_by_id = self.owner_id
+        super().save(*args, **kwargs)
 
     @property
     def is_terminal(self) -> bool:

--- a/apps/api/pi_dash/runner/serializers.py
+++ b/apps/api/pi_dash/runner/serializers.py
@@ -11,6 +11,7 @@ from pi_dash.runner.models import (
     ApprovalKind,
     ApprovalRequest,
     ApprovalStatus,
+    Pod,
     Runner,
     RunnerRegistrationToken,
 )
@@ -27,7 +28,50 @@ RUNNER_NAME_CHARSET = RegexValidator(
 )
 
 
+class PodSerializer(serializers.ModelSerializer):
+    runner_count = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Pod
+        fields = [
+            "id",
+            "name",
+            "description",
+            "is_default",
+            "workspace",
+            "created_by",
+            "runner_count",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = [
+            "id",
+            "is_default",
+            "workspace",
+            "created_by",
+            "runner_count",
+            "created_at",
+            "updated_at",
+        ]
+
+    def get_runner_count(self, pod: Pod) -> int:
+        # `runners` related_name; we count active (non-revoked) runners for
+        # the UI's "N runners" badge.
+        return pod.runners.exclude(status="revoked").count()
+
+
+class PodMiniSerializer(serializers.ModelSerializer):
+    """Compact nested representation of a pod for embedding in other rows."""
+
+    class Meta:
+        model = Pod
+        fields = ["id", "name", "is_default"]
+        read_only_fields = fields
+
+
 class RunnerSerializer(serializers.ModelSerializer):
+    pod_detail = PodMiniSerializer(source="pod", read_only=True)
+
     class Meta:
         model = Runner
         fields = [
@@ -40,10 +84,26 @@ class RunnerSerializer(serializers.ModelSerializer):
             "protocol_version",
             "capabilities",
             "last_heartbeat_at",
+            "owner",
+            "pod",
+            "pod_detail",
             "created_at",
             "updated_at",
         ]
-        read_only_fields = fields
+        read_only_fields = [
+            "id",
+            "status",
+            "os",
+            "arch",
+            "runner_version",
+            "protocol_version",
+            "capabilities",
+            "last_heartbeat_at",
+            "owner",
+            "pod_detail",
+            "created_at",
+            "updated_at",
+        ]
 
 
 class RegistrationTokenSerializer(serializers.ModelSerializer):
@@ -84,6 +144,8 @@ class RegistrationResponseSerializer(serializers.Serializer):
 
 
 class AgentRunSerializer(serializers.ModelSerializer):
+    pod_detail = PodMiniSerializer(source="pod", read_only=True)
+
     class Meta:
         model = AgentRun
         fields = [
@@ -93,6 +155,10 @@ class AgentRunSerializer(serializers.ModelSerializer):
             "thread_id",
             "runner",
             "work_item",
+            "pod",
+            "pod_detail",
+            "created_by",
+            "owner",
             "created_at",
             "assigned_at",
             "started_at",

--- a/apps/api/pi_dash/runner/services/matcher.py
+++ b/apps/api/pi_dash/runner/services/matcher.py
@@ -2,43 +2,185 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # See the LICENSE file for details.
 
-"""Runner selection for an AgentRun.
+"""Runner selection and pod dispatch.
 
-MVP rule (per ``.ai_design/implement_runner/runner-design.md``): pick one
-online idle runner owned by the user. No label matching. Users may register
-up to ``Runner.MAX_PER_USER`` runners; the matcher still needs to pick only
-one per run.
+Pod-scoped helpers (``select_runner_in_pod``, ``next_queued_run_for_pod``,
+``drain_pod``) are the forward-looking API and are used by Phase 3 and beyond.
+``select_runner_for_run`` is kept for back-compat with existing views /
+orchestration code that Phase 1 has not yet migrated; Phase 3 will remove it.
+
+See ``.ai_design/issue_runner/design.md`` §6.
 """
 
 from __future__ import annotations
 
+import logging
 from datetime import timedelta
 from typing import Optional
 
+from django.db import transaction
 from django.db.models import Q
 from django.utils import timezone
 
-from pi_dash.runner.models import AgentRun, AgentRunStatus, Runner, RunnerStatus
+from pi_dash.runner.models import (
+    AgentRun,
+    AgentRunStatus,
+    Pod,
+    Runner,
+    RunnerStatus,
+)
+
+logger = logging.getLogger(__name__)
 
 # A runner is considered stale (no longer eligible) if it has not heartbeated
 # within this window. Defensive in case a runner crashed without calling Bye.
 HEARTBEAT_GRACE = timedelta(seconds=90)
 
+# Runs in these statuses occupy a runner slot or a queue position. Used to
+# exclude busy runners from matching and to block pod deletion while work is
+# outstanding.
+NON_TERMINAL_STATUSES = (
+    AgentRunStatus.QUEUED,
+    AgentRunStatus.ASSIGNED,
+    AgentRunStatus.RUNNING,
+    AgentRunStatus.AWAITING_APPROVAL,
+    AgentRunStatus.AWAITING_REAUTH,
+)
 
-def select_runner_for_run(run: AgentRun) -> Optional[Runner]:
-    """Return a suitable Runner or ``None`` if no machine is currently eligible.
+# Statuses that indicate a runner is currently serving a run.
+BUSY_STATUSES = (
+    AgentRunStatus.ASSIGNED,
+    AgentRunStatus.RUNNING,
+    AgentRunStatus.AWAITING_APPROVAL,
+    AgentRunStatus.AWAITING_REAUTH,
+)
 
-    Caller must be inside a ``transaction.atomic()`` block — the query takes a
-    row-level lock (``SELECT … FOR UPDATE SKIP LOCKED``) so two concurrent
-    assignments can't pick the same runner.
+
+# ---------------------------------------------------------------------------
+# Pod-scoped helpers (new, used by Phase 3 and beyond)
+# ---------------------------------------------------------------------------
+
+
+def select_runner_in_pod(pod: Pod) -> Optional[Runner]:
+    """Pick an online, heartbeat-fresh, idle runner inside ``pod``.
+
+    Must be called inside a ``transaction.atomic()`` block — the query takes a
+    row-level lock (``SELECT … FOR UPDATE SKIP LOCKED``) so concurrent drains
+    can't both pick the same runner.
     """
     alive_threshold = timezone.now() - HEARTBEAT_GRACE
-    busy_states = (
-        AgentRunStatus.ASSIGNED,
-        AgentRunStatus.RUNNING,
-        AgentRunStatus.AWAITING_APPROVAL,
-        AgentRunStatus.AWAITING_REAUTH,
+    return (
+        Runner.objects.select_for_update(skip_locked=True)
+        .filter(
+            pod=pod,
+            status=RunnerStatus.ONLINE,
+            last_heartbeat_at__gte=alive_threshold,
+        )
+        .exclude(agent_runs__status__in=BUSY_STATUSES)
+        .order_by("-last_heartbeat_at")
+        .first()
     )
+
+
+def next_queued_run_for_pod(pod: Pod) -> Optional[AgentRun]:
+    """Return the oldest QUEUED run in the pod, locked for update.
+
+    Must be called inside a ``transaction.atomic()`` block.
+    """
+    return (
+        AgentRun.objects.select_for_update(skip_locked=True)
+        .filter(pod=pod, status=AgentRunStatus.QUEUED)
+        .order_by("created_at")
+        .first()
+    )
+
+
+def drain_pod(pod: Pod) -> int:
+    """Assign as many QUEUED runs in ``pod`` to idle runners as possible.
+
+    Returns the number of runs assigned in this pass. Dispatch messages are
+    sent over the WebSocket ``on_commit`` so receivers never see a run that
+    hasn't landed in the DB.
+    """
+    # Late import to avoid an import cycle (pubsub imports matcher in no path
+    # I can see today, but this keeps future refactors safe).
+    from pi_dash.runner.services.pubsub import send_to_runner
+
+    assignments: list[tuple[Runner, AgentRun]] = []
+    with transaction.atomic():
+        while True:
+            run = next_queued_run_for_pod(pod)
+            if run is None:
+                break
+            runner = select_runner_in_pod(pod)
+            if runner is None:
+                break
+            run.runner = runner
+            # Capture billable party at assignment (design §5.3).
+            run.owner_id = runner.owner_id
+            run.status = AgentRunStatus.ASSIGNED
+            run.assigned_at = timezone.now()
+            run.save(update_fields=["runner", "owner", "status", "assigned_at"])
+            assignments.append((runner, run))
+
+    # Fire WS dispatches after the transaction commits.
+    for runner, run in assignments:
+        transaction.on_commit(
+            lambda r=run, rn=runner: send_to_runner(rn.id, _build_assign_msg(r))
+        )
+    if assignments:
+        logger.info(
+            "drain_pod: pod=%s assigned %d run(s)", pod.id, len(assignments)
+        )
+    return len(assignments)
+
+
+def drain_pod_by_id(pod_id) -> int:
+    """Convenience wrapper for callers that only have a pod id.
+
+    Skips if the pod has been soft-deleted.
+    """
+    pod = Pod.objects.filter(pk=pod_id).first()
+    if pod is None:
+        return 0
+    return drain_pod(pod)
+
+
+def _build_assign_msg(run: AgentRun) -> dict:
+    """Compose the WS ``assign`` envelope sent to a runner daemon.
+
+    Mirrors the shape currently inlined in ``runs.py`` POST and
+    ``orchestration/service._dispatch_to_runner``; Phase 3 will point both at
+    this helper.
+    """
+    return {
+        "v": 1,
+        "type": "assign",
+        "run_id": str(run.id),
+        "work_item_id": str(run.work_item_id) if run.work_item_id else None,
+        "prompt": run.prompt,
+        "repo_url": run.run_config.get("repo_url"),
+        "repo_ref": run.run_config.get("repo_ref"),
+        "git_work_branch": run.run_config.get("git_work_branch"),
+        "expected_codex_model": run.run_config.get("model"),
+        "approval_policy_overrides": run.run_config.get("approval_policy_overrides"),
+        "deadline": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Legacy helpers (kept until Phase 3 removes callers)
+# ---------------------------------------------------------------------------
+
+
+def select_runner_for_run(run: AgentRun) -> Optional[Runner]:
+    """Legacy owner-scoped matcher. Kept for back-compat.
+
+    Under the pod model, use :func:`drain_pod` or :func:`select_runner_in_pod`
+    instead. This function filters by ``owner=run.owner``, which was the old
+    access-gating rule. Phase 3 migrates callers.
+    """
+    alive_threshold = timezone.now() - HEARTBEAT_GRACE
     return (
         Runner.objects.select_for_update(skip_locked=True)
         .filter(
@@ -47,7 +189,7 @@ def select_runner_for_run(run: AgentRun) -> Optional[Runner]:
             status=RunnerStatus.ONLINE,
             last_heartbeat_at__gte=alive_threshold,
         )
-        .exclude(agent_runs__status__in=busy_states)
+        .exclude(agent_runs__status__in=BUSY_STATUSES)
         .order_by("-last_heartbeat_at")
         .first()
     )

--- a/apps/api/pi_dash/runner/services/permissions.py
+++ b/apps/api/pi_dash/runner/services/permissions.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Workspace-membership and role helpers for the runner app.
+
+Extracted so runner views, pod views, validation, and orchestration can share a
+single source of truth. See ``.ai_design/issue_runner/design.md`` §5.1.
+
+Role values come from ``pi_dash.db.models.workspace.ROLE_CHOICES``:
+``Admin=20``, ``Member=15``, ``Guest=5``.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pi_dash.db.models.workspace import WorkspaceMember
+
+ROLE_ADMIN = 20
+ROLE_MEMBER = 15
+ROLE_GUEST = 5
+
+
+def is_workspace_member(user, workspace_id) -> bool:
+    """True if ``user`` is a member (any role) of the given workspace."""
+    if user is None or not getattr(user, "is_authenticated", False):
+        return False
+    return WorkspaceMember.objects.filter(
+        workspace_id=workspace_id, member=user
+    ).exists()
+
+
+def workspace_role(user, workspace_id) -> Optional[int]:
+    """Return the user's role in the workspace, or ``None`` if not a member."""
+    if user is None or not getattr(user, "is_authenticated", False):
+        return None
+    return (
+        WorkspaceMember.objects.filter(workspace_id=workspace_id, member=user)
+        .values_list("role", flat=True)
+        .first()
+    )
+
+
+def is_workspace_admin(user, workspace_id) -> bool:
+    """True if ``user`` is an Admin (role >= 20) of the workspace."""
+    role = workspace_role(user, workspace_id)
+    return role is not None and role >= ROLE_ADMIN
+
+
+def is_at_least_member(user, workspace_id) -> bool:
+    """True if ``user`` is at least Member role (>=15) — not Guest."""
+    role = workspace_role(user, workspace_id)
+    return role is not None and role >= ROLE_MEMBER

--- a/apps/api/pi_dash/runner/services/validation.py
+++ b/apps/api/pi_dash/runner/services/validation.py
@@ -1,0 +1,144 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Pre-create validation shared by the direct run-creation endpoint and the
+orchestration path.
+
+See ``.ai_design/issue_runner/design.md`` §6.5.
+
+The goal is to reject a run creation *before* the DB insert when any of:
+
+- the caller is not a member of the target workspace,
+- the referenced work item doesn't belong to the workspace,
+- the resolved pod doesn't belong to the workspace or is soft-deleted,
+- no pod can be resolved at all.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from pi_dash.db.models.issue import Issue
+from pi_dash.runner.models import Pod
+from pi_dash.runner.services.permissions import is_workspace_member
+
+
+class RunCreationError(Exception):
+    """Raised when pre-create validation fails. Carries an HTTP-ish status."""
+
+    def __init__(self, status: int, message: str, code: str = ""):
+        super().__init__(message)
+        self.status = status
+        self.message = message
+        self.code = code
+
+
+@dataclass(frozen=True)
+class ValidatedRunContext:
+    """The verified inputs for an ``AgentRun`` row about to be inserted."""
+
+    workspace_id: object
+    work_item_id: Optional[object]
+    pod: Pod
+    created_by: object  # User instance
+
+
+def validate_run_creation(
+    user,
+    workspace_id,
+    *,
+    work_item_id=None,
+    pod_id=None,
+) -> ValidatedRunContext:
+    """Run the §6.5 checks and return a :class:`ValidatedRunContext`.
+
+    Parameters are intentionally keyword-only for the optional fields so call
+    sites can't accidentally swap work_item_id / pod_id.
+
+    Raises
+    ------
+    RunCreationError
+        With ``status=403`` if the caller is not a workspace member.
+        With ``status=400`` for consistency violations.
+        With ``status=409`` if no pod can be resolved.
+    """
+    if not workspace_id:
+        raise RunCreationError(400, "workspace is required", "workspace_required")
+
+    # 1. Workspace membership.
+    if not is_workspace_member(user, workspace_id):
+        raise RunCreationError(
+            403,
+            "caller is not a member of the target workspace",
+            "not_workspace_member",
+        )
+
+    # 2. Work-item consistency.
+    if work_item_id is not None:
+        issue = (
+            Issue.objects.filter(pk=work_item_id)
+            .values("workspace_id", "assigned_pod_id")
+            .first()
+        )
+        if issue is None:
+            raise RunCreationError(400, "work_item does not exist", "work_item_missing")
+        if str(issue["workspace_id"]) != str(workspace_id):
+            raise RunCreationError(
+                400,
+                "work_item does not belong to workspace",
+                "work_item_workspace_mismatch",
+            )
+    else:
+        issue = None
+
+    # 3. Pod resolution and consistency.
+    pod = _resolve_pod(
+        workspace_id=workspace_id,
+        pod_id=pod_id,
+        issue_assigned_pod_id=(issue or {}).get("assigned_pod_id") if issue else None,
+    )
+
+    return ValidatedRunContext(
+        workspace_id=workspace_id,
+        work_item_id=work_item_id,
+        pod=pod,
+        created_by=user,
+    )
+
+
+def _resolve_pod(*, workspace_id, pod_id, issue_assigned_pod_id) -> Pod:
+    """Resolve the pod the run belongs to.
+
+    Priority: explicit pod_id > issue.assigned_pod > workspace.default_pod.
+    """
+    # Explicit pod: must exist, not be soft-deleted, and belong to the workspace.
+    if pod_id is not None:
+        pod = Pod.objects.filter(pk=pod_id).first()
+        if pod is None:
+            raise RunCreationError(400, "pod does not exist or has been deleted", "pod_missing")
+        if str(pod.workspace_id) != str(workspace_id):
+            raise RunCreationError(
+                400, "pod does not belong to workspace", "pod_workspace_mismatch"
+            )
+        return pod
+
+    # Fall back to the issue's pinned pod if one exists.
+    if issue_assigned_pod_id is not None:
+        pod = Pod.objects.filter(pk=issue_assigned_pod_id).first()
+        if pod is not None and str(pod.workspace_id) == str(workspace_id):
+            return pod
+        # Pinned pod was soft-deleted between issue creation and run — fall
+        # through to workspace default.
+
+    # Final fallback: workspace default pod. Invariant #13 guarantees it exists
+    # in normal operation.
+    default = Pod.default_for_workspace_id(workspace_id)
+    if default is None:
+        raise RunCreationError(
+            409,
+            "no pod available for this workspace; ask an admin to create one",
+            "no_pod_available",
+        )
+    return default

--- a/apps/api/pi_dash/runner/signals.py
+++ b/apps/api/pi_dash/runner/signals.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Signal handlers for the runner app.
+
+Currently wires one behavior:
+
+- On workspace creation, auto-create a default pod named ``<workspace.name>-pod``
+  so that runner registration and issue delegation work with zero setup. See
+  ``.ai_design/issue_runner/design.md`` §7.1 and invariant #13.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from pi_dash.db.models.workspace import Workspace
+from pi_dash.runner.models import Pod
+
+logger = logging.getLogger(__name__)
+
+
+@receiver(post_save, sender=Workspace)
+def create_default_pod_for_new_workspace(sender, instance: Workspace, created: bool, **kwargs):
+    """When a workspace is created, ensure it has a default pod.
+
+    Idempotent: no-op if the workspace already has any active pods (e.g. test
+    fixtures that seed their own pod before the signal fires, or workspaces
+    that existed before this signal was wired in).
+    """
+    if not created:
+        return
+    # Guard against fixtures / seed data that pre-populate pods.
+    if Pod.objects.filter(workspace=instance).exists():
+        return
+    pod_name = f"{instance.name}-pod"
+    try:
+        Pod.objects.create(
+            workspace=instance,
+            name=pod_name,
+            description="Auto-created default pod. Rename or add more pods anytime.",
+            is_default=True,
+            created_by=getattr(instance, "owner", None),
+        )
+    except Exception:
+        # Don't block workspace creation if pod creation fails (e.g. a unique
+        # constraint conflict from a manually-seeded pod racing us). Log and
+        # let the ensure_workspace_pods management command catch up.
+        logger.exception(
+            "runner.signals: failed to auto-create default pod for workspace %s",
+            instance.id,
+        )

--- a/apps/api/pi_dash/runner/signals.py
+++ b/apps/api/pi_dash/runner/signals.py
@@ -37,7 +37,11 @@ def create_default_pod_for_new_workspace(sender, instance: Workspace, created: b
     # Guard against fixtures / seed data that pre-populate pods.
     if Pod.objects.filter(workspace=instance).exists():
         return
-    pod_name = f"{instance.name}-pod"
+    # Pod.name max_length is 128; truncate the workspace name to leave room
+    # for the "-pod" suffix so long workspace names don't raise DataError here
+    # (which the bare except below would swallow, silently violating the
+    # "every workspace has a pod" invariant).
+    pod_name = f"{instance.name[:123]}-pod"
     try:
         Pod.objects.create(
             workspace=instance,

--- a/apps/api/pi_dash/runner/views/__init__.py
+++ b/apps/api/pi_dash/runner/views/__init__.py
@@ -4,6 +4,7 @@
 
 from .approvals import ApprovalDecideEndpoint, ApprovalListEndpoint
 from .metrics import MetricsEndpoint
+from .pods import PodDetailEndpoint, PodListEndpoint
 from .register import (
     HealthEndpoint,
     RegisterEndpoint,
@@ -19,6 +20,8 @@ __all__ = [
     "ApprovalListEndpoint",
     "HealthEndpoint",
     "MetricsEndpoint",
+    "PodDetailEndpoint",
+    "PodListEndpoint",
     "RegisterEndpoint",
     "RegistrationTokenCreateEndpoint",
     "RunnerDeregisterEndpoint",

--- a/apps/api/pi_dash/runner/views/approvals.py
+++ b/apps/api/pi_dash/runner/views/approvals.py
@@ -27,8 +27,9 @@ class ApprovalListEndpoint(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request):
+        # Approvals are routed to the run creator (decision #6, design §5.2).
         qs = (
-            ApprovalRequest.objects.filter(agent_run__owner=request.user)
+            ApprovalRequest.objects.filter(agent_run__created_by=request.user)
             .filter(status=ApprovalStatus.PENDING)
             .order_by("-requested_at")[:200]
         )
@@ -51,7 +52,7 @@ class ApprovalDecideEndpoint(APIView):
                 approval = (
                     ApprovalRequest.objects.select_for_update()
                     .select_related("agent_run", "agent_run__runner")
-                    .get(id=approval_id, agent_run__owner=request.user)
+                    .get(id=approval_id, agent_run__created_by=request.user)
                 )
             except ApprovalRequest.DoesNotExist:
                 return Response(

--- a/apps/api/pi_dash/runner/views/pods.py
+++ b/apps/api/pi_dash/runner/views/pods.py
@@ -1,0 +1,202 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Pod CRUD endpoints (web app, session auth).
+
+See ``.ai_design/issue_runner/design.md`` §8.1.
+
+Permissions:
+- List / detail: any workspace member.
+- Create / rename / toggle default: workspace admin OR the pod's creator.
+- Soft-delete: same as create, plus the §7.2 preconditions (no runners, no
+  non-terminal runs, not the workspace's last active pod).
+"""
+
+from __future__ import annotations
+
+from django.db import transaction
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from pi_dash.authentication.session import BaseSessionAuthentication
+from pi_dash.runner.models import Pod
+from pi_dash.runner.serializers import PodSerializer
+from pi_dash.runner.services.matcher import NON_TERMINAL_STATUSES
+from pi_dash.runner.services.permissions import (
+    is_workspace_admin,
+    is_workspace_member,
+)
+
+
+def _can_manage_pod(user, pod: Pod) -> bool:
+    """True if ``user`` may rename / toggle / delete this pod."""
+    return is_workspace_admin(user, pod.workspace_id) or pod.created_by_id == user.id
+
+
+class PodListEndpoint(APIView):
+    """List pods in a workspace and create new pods.
+
+    GET ``?workspace=<uuid>`` — list active pods, any member.
+    POST — create a new pod, admin only.
+    """
+
+    authentication_classes = [BaseSessionAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        workspace_id = request.query_params.get("workspace")
+        if not workspace_id:
+            return Response(
+                {"error": "workspace is required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if not is_workspace_member(request.user, workspace_id):
+            return Response(
+                {"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN
+            )
+        qs = Pod.objects.filter(workspace_id=workspace_id).order_by(
+            "-is_default", "created_at"
+        )
+        return Response(PodSerializer(qs, many=True).data)
+
+    def post(self, request):
+        workspace_id = request.data.get("workspace")
+        name = (request.data.get("name") or "").strip()
+        description = request.data.get("description") or ""
+        if not workspace_id or not name:
+            return Response(
+                {"error": "workspace and name are required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if not is_workspace_admin(request.user, workspace_id):
+            return Response(
+                {"error": "workspace admin required"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        pod = Pod.objects.create(
+            workspace_id=workspace_id,
+            name=name,
+            description=description,
+            created_by=request.user,
+            # Manual pods are not default unless the admin toggles after.
+            is_default=False,
+        )
+        return Response(
+            PodSerializer(pod).data, status=status.HTTP_201_CREATED
+        )
+
+
+class PodDetailEndpoint(APIView):
+    """Read, rename / toggle default, or soft-delete a pod."""
+
+    authentication_classes = [BaseSessionAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def _get_pod(self, request, pod_id):
+        pod = Pod.objects.filter(pk=pod_id).first()
+        if pod is None:
+            return None
+        if not is_workspace_member(request.user, pod.workspace_id):
+            return False  # signal forbidden
+        return pod
+
+    def get(self, request, pod_id):
+        pod = self._get_pod(request, pod_id)
+        if pod is None:
+            return Response({"error": "not found"}, status=status.HTTP_404_NOT_FOUND)
+        if pod is False:
+            return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
+        return Response(PodSerializer(pod).data)
+
+    def patch(self, request, pod_id):
+        pod = self._get_pod(request, pod_id)
+        if pod is None:
+            return Response({"error": "not found"}, status=status.HTTP_404_NOT_FOUND)
+        if pod is False:
+            return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
+        if not _can_manage_pod(request.user, pod):
+            return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
+
+        updates: list[str] = []
+        if "name" in request.data:
+            new_name = (request.data.get("name") or "").strip()
+            if not new_name:
+                return Response(
+                    {"error": "name cannot be empty"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            pod.name = new_name
+            updates.append("name")
+        if "description" in request.data:
+            pod.description = request.data.get("description") or ""
+            updates.append("description")
+        if "is_default" in request.data:
+            wants_default = bool(request.data.get("is_default"))
+            if wants_default and not pod.is_default:
+                # Promote: clear any existing default in this workspace first.
+                with transaction.atomic():
+                    Pod.objects.filter(
+                        workspace_id=pod.workspace_id, is_default=True
+                    ).exclude(pk=pod.pk).update(is_default=False)
+                    pod.is_default = True
+                    updates.append("is_default")
+            elif not wants_default and pod.is_default:
+                pod.is_default = False
+                updates.append("is_default")
+
+        if updates:
+            pod.save(update_fields=list(set(updates + ["updated_at"])))
+        return Response(PodSerializer(pod).data)
+
+    def delete(self, request, pod_id):
+        pod = self._get_pod(request, pod_id)
+        if pod is None:
+            return Response({"error": "not found"}, status=status.HTTP_404_NOT_FOUND)
+        if pod is False:
+            return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
+        if not _can_manage_pod(request.user, pod):
+            return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
+
+        # Pre-deletion guards (§7.2).
+        if pod.runners.count() > 0:
+            return Response(
+                {
+                    "error": "pod has runners; move or revoke them first",
+                    "code": "pod_has_runners",
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
+        if pod.agent_runs.filter(status__in=NON_TERMINAL_STATUSES).exists():
+            return Response(
+                {
+                    "error": "pod has non-terminal runs; cancel or wait",
+                    "code": "pod_has_active_runs",
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
+        # Last-pod guard (invariant #13).
+        sibling_count = Pod.objects.filter(workspace_id=pod.workspace_id).exclude(
+            pk=pod.pk
+        ).count()
+        if sibling_count == 0:
+            return Response(
+                {
+                    "error": "cannot delete the last pod in a workspace; create a replacement first",
+                    "code": "last_pod_in_workspace",
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        with transaction.atomic():
+            pod.deleted_at = timezone.now()
+            pod.is_default = False
+            pod.save(update_fields=["deleted_at", "is_default", "updated_at"])
+            # Sweep pointing issues.
+            from pi_dash.db.models.issue import Issue
+
+            Issue.objects.filter(assigned_pod=pod).update(assigned_pod=None)
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/apps/api/pi_dash/runner/views/pods.py
+++ b/apps/api/pi_dash/runner/views/pods.py
@@ -23,7 +23,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from pi_dash.authentication.session import BaseSessionAuthentication
-from pi_dash.runner.models import Pod
+from pi_dash.runner.models import Pod, RunnerStatus
 from pi_dash.runner.serializers import PodSerializer
 from pi_dash.runner.services.matcher import NON_TERMINAL_STATUSES
 from pi_dash.runner.services.permissions import (
@@ -161,42 +161,55 @@ class PodDetailEndpoint(APIView):
         if not _can_manage_pod(request.user, pod):
             return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
 
-        # Pre-deletion guards (§7.2).
-        if pod.runners.count() > 0:
-            return Response(
-                {
-                    "error": "pod has runners; move or revoke them first",
-                    "code": "pod_has_runners",
-                },
-                status=status.HTTP_409_CONFLICT,
-            )
-        if pod.agent_runs.filter(status__in=NON_TERMINAL_STATUSES).exists():
-            return Response(
-                {
-                    "error": "pod has non-terminal runs; cancel or wait",
-                    "code": "pod_has_active_runs",
-                },
-                status=status.HTTP_409_CONFLICT,
-            )
-        # Last-pod guard (invariant #13).
-        sibling_count = Pod.objects.filter(workspace_id=pod.workspace_id).exclude(
-            pk=pod.pk
-        ).count()
-        if sibling_count == 0:
-            return Response(
-                {
-                    "error": "cannot delete the last pod in a workspace; create a replacement first",
-                    "code": "last_pod_in_workspace",
-                },
-                status=status.HTTP_409_CONFLICT,
-            )
-
+        # Run all three §7.2 guards *inside* the transaction with the pod row
+        # locked, so a concurrent runner-move / run-create / sibling-delete
+        # cannot slip past the checks (TOCTOU).
         with transaction.atomic():
-            pod.deleted_at = timezone.now()
-            pod.is_default = False
-            pod.save(update_fields=["deleted_at", "is_default", "updated_at"])
+            locked = (
+                Pod.objects.select_for_update().filter(pk=pod.pk).first()
+            )
+            if locked is None:
+                return Response(
+                    {"error": "not found"}, status=status.HTTP_404_NOT_FOUND
+                )
+            # Revoked runners keep their pod FK but cannot accept work, so they
+            # do not block deletion (matches PodSerializer.get_runner_count).
+            if locked.runners.exclude(status=RunnerStatus.REVOKED).exists():
+                return Response(
+                    {
+                        "error": "pod has runners; move or revoke them first",
+                        "code": "pod_has_runners",
+                    },
+                    status=status.HTTP_409_CONFLICT,
+                )
+            if locked.agent_runs.filter(status__in=NON_TERMINAL_STATUSES).exists():
+                return Response(
+                    {
+                        "error": "pod has non-terminal runs; cancel or wait",
+                        "code": "pod_has_active_runs",
+                    },
+                    status=status.HTTP_409_CONFLICT,
+                )
+            # Last-pod guard (invariant #13).
+            sibling_count = (
+                Pod.objects.filter(workspace_id=locked.workspace_id)
+                .exclude(pk=locked.pk)
+                .count()
+            )
+            if sibling_count == 0:
+                return Response(
+                    {
+                        "error": "cannot delete the last pod in a workspace; create a replacement first",
+                        "code": "last_pod_in_workspace",
+                    },
+                    status=status.HTTP_409_CONFLICT,
+                )
+
+            locked.deleted_at = timezone.now()
+            locked.is_default = False
+            locked.save(update_fields=["deleted_at", "is_default", "updated_at"])
             # Sweep pointing issues.
             from pi_dash.db.models.issue import Issue
 
-            Issue.objects.filter(assigned_pod=pod).update(assigned_pod=None)
+            Issue.objects.filter(assigned_pod=locked).update(assigned_pod=None)
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/apps/api/pi_dash/runner/views/runners.py
+++ b/apps/api/pi_dash/runner/views/runners.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # See the LICENSE file for details.
 
+from django.db import transaction
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -93,22 +94,30 @@ class RunnerDetailEndpoint(APIView):
                 )
             runner.name = new_name
             updates.append("name")
+        new_pod_id = request.data.get("pod") if "pod" in request.data else None
+        # Hold the pod lock for the duration of the runner save so a concurrent
+        # pod soft-delete cannot leave the runner pointing at an inactive pod.
         if "pod" in request.data:
-            new_pod_id = request.data.get("pod")
-            new_pod = Pod.objects.filter(pk=new_pod_id).first()
-            if new_pod is None:
-                return Response(
-                    {"error": "pod does not exist or has been deleted"},
-                    status=status.HTTP_400_BAD_REQUEST,
+            with transaction.atomic():
+                new_pod = (
+                    Pod.objects.select_for_update()
+                    .filter(pk=new_pod_id)
+                    .first()
                 )
-            if new_pod.workspace_id != runner.workspace_id:
-                return Response(
-                    {"error": "pod is in a different workspace"},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-            runner.pod = new_pod
-            updates.append("pod")
-        if updates:
+                if new_pod is None:
+                    return Response(
+                        {"error": "pod does not exist or has been deleted"},
+                        status=status.HTTP_400_BAD_REQUEST,
+                    )
+                if new_pod.workspace_id != runner.workspace_id:
+                    return Response(
+                        {"error": "pod is in a different workspace"},
+                        status=status.HTTP_400_BAD_REQUEST,
+                    )
+                runner.pod = new_pod
+                updates.append("pod")
+                runner.save(update_fields=list(set(updates + ["updated_at"])))
+        elif updates:
             runner.save(update_fields=list(set(updates + ["updated_at"])))
         return Response(RunnerSerializer(runner).data)
 

--- a/apps/api/pi_dash/runner/views/runners.py
+++ b/apps/api/pi_dash/runner/views/runners.py
@@ -8,44 +8,123 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from pi_dash.authentication.session import BaseSessionAuthentication
-from pi_dash.runner.models import Runner
+from pi_dash.runner.models import Pod, Runner
 from pi_dash.runner.serializers import RunnerSerializer
+from pi_dash.runner.services.permissions import (
+    is_workspace_admin,
+    is_workspace_member,
+)
 from pi_dash.runner.services.pubsub import close_runner_session, send_to_runner
 
 
+def _can_manage_runner(user, runner: Runner) -> bool:
+    return runner.owner_id == user.id or is_workspace_admin(user, runner.workspace_id)
+
+
 class RunnerListEndpoint(APIView):
+    """List runners in a workspace.
+
+    Per design §5, listing is workspace-scoped: any workspace member can see
+    every runner in that workspace, regardless of who owns it. Optional
+    ``?pod=<uuid>`` filter narrows to a single pod.
+    """
+
     authentication_classes = [BaseSessionAuthentication]
     permission_classes = [IsAuthenticated]
 
     def get(self, request):
-        qs = Runner.objects.filter(owner=request.user).order_by("-updated_at")
         workspace_id = request.query_params.get("workspace")
-        if workspace_id:
-            qs = qs.filter(workspace_id=workspace_id)
+        if not workspace_id:
+            return Response(
+                {"error": "workspace is required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if not is_workspace_member(request.user, workspace_id):
+            return Response(
+                {"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN
+            )
+        qs = Runner.objects.filter(workspace_id=workspace_id).order_by(
+            "-updated_at"
+        )
+        pod_id = request.query_params.get("pod")
+        if pod_id:
+            qs = qs.filter(pod_id=pod_id)
         return Response(RunnerSerializer(qs, many=True).data)
 
 
 class RunnerDetailEndpoint(APIView):
+    """Read a single runner; supports PATCH for pod move and rename."""
+
     authentication_classes = [BaseSessionAuthentication]
     permission_classes = [IsAuthenticated]
 
+    def _get_runner(self, request, runner_id):
+        runner = Runner.objects.filter(pk=runner_id).first()
+        if runner is None:
+            return None
+        if not is_workspace_member(request.user, runner.workspace_id):
+            return False
+        return runner
+
     def get(self, request, runner_id):
-        try:
-            runner = Runner.objects.get(id=runner_id, owner=request.user)
-        except Runner.DoesNotExist:
+        runner = self._get_runner(request, runner_id)
+        if runner is None:
             return Response({"error": "not found"}, status=status.HTTP_404_NOT_FOUND)
+        if runner is False:
+            return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
+        return Response(RunnerSerializer(runner).data)
+
+    def patch(self, request, runner_id):
+        runner = self._get_runner(request, runner_id)
+        if runner is None:
+            return Response({"error": "not found"}, status=status.HTTP_404_NOT_FOUND)
+        if runner is False:
+            return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
+        if not _can_manage_runner(request.user, runner):
+            return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
+
+        updates: list[str] = []
+        if "name" in request.data:
+            new_name = (request.data.get("name") or "").strip()
+            if not new_name:
+                return Response(
+                    {"error": "name cannot be empty"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            runner.name = new_name
+            updates.append("name")
+        if "pod" in request.data:
+            new_pod_id = request.data.get("pod")
+            new_pod = Pod.objects.filter(pk=new_pod_id).first()
+            if new_pod is None:
+                return Response(
+                    {"error": "pod does not exist or has been deleted"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            if new_pod.workspace_id != runner.workspace_id:
+                return Response(
+                    {"error": "pod is in a different workspace"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            runner.pod = new_pod
+            updates.append("pod")
+        if updates:
+            runner.save(update_fields=list(set(updates + ["updated_at"])))
         return Response(RunnerSerializer(runner).data)
 
 
 class RunnerRevokeEndpoint(APIView):
+    """Revoke a runner. Owner OR workspace admin (widened from owner-only)."""
+
     authentication_classes = [BaseSessionAuthentication]
     permission_classes = [IsAuthenticated]
 
     def post(self, request, runner_id):
-        try:
-            runner = Runner.objects.get(id=runner_id, owner=request.user)
-        except Runner.DoesNotExist:
+        runner = Runner.objects.filter(pk=runner_id).first()
+        if runner is None:
             return Response({"error": "not found"}, status=status.HTTP_404_NOT_FOUND)
+        if not _can_manage_runner(request.user, runner):
+            return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
         runner.revoke()
         # Fan out a revoke WS message — best-effort; runner may already be offline.
         send_to_runner(

--- a/apps/api/pi_dash/runner/views/runs.py
+++ b/apps/api/pi_dash/runner/views/runs.py
@@ -28,7 +28,14 @@ from pi_dash.runner.services.validation import (
 
 
 def _can_view_run(user, run: AgentRun) -> bool:
-    """View is allowed for the creator, the runner's owner, or a workspace admin."""
+    """View is allowed for the creator, the runner's owner, or a workspace admin.
+
+    Workspace membership is always required first — a user removed from the
+    workspace must not be able to see runs there, even if they still appear as
+    ``runner.owner`` (an admin bond that does not track current membership).
+    """
+    if not is_workspace_member(user, run.workspace_id):
+        return False
     if run.created_by_id == user.id:
         return True
     if run.runner_id is not None and run.runner.owner_id == user.id:
@@ -108,11 +115,14 @@ class AgentRunDetailEndpoint(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request, run_id):
-        run = AgentRun.objects.filter(id=run_id).first()
+        run = (
+            AgentRun.objects.select_related("runner").filter(id=run_id).first()
+        )
         if run is None:
             return Response({"error": "not found"}, status=status.HTTP_404_NOT_FOUND)
         if not _can_view_run(request.user, run):
-            return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
+            # 404 not 403 — do not confirm run existence across workspaces.
+            return Response({"error": "not found"}, status=status.HTTP_404_NOT_FOUND)
         include_events = request.query_params.get("include_events") == "1"
         payload = AgentRunSerializer(run).data
         if include_events:
@@ -126,27 +136,50 @@ class AgentRunCancelEndpoint(APIView):
     permission_classes = [IsAuthenticated]
 
     def post(self, request, run_id):
-        run = AgentRun.objects.filter(id=run_id).first()
+        # Authorization check happens on a non-locked read; re-check terminal
+        # state after acquiring the row lock to avoid racing with
+        # Runner.revoke() (which holds select_for_update on in-flight runs).
+        run = (
+            AgentRun.objects.select_related("runner").filter(id=run_id).first()
+        )
         if run is None:
             return Response({"error": "not found"}, status=status.HTTP_404_NOT_FOUND)
         if not _can_cancel_run(request.user, run):
-            return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
-        if run.is_terminal:
-            return Response(
-                {"error": "run already terminal"},
-                status=status.HTTP_409_CONFLICT,
+            return Response({"error": "not found"}, status=status.HTTP_404_NOT_FOUND)
+
+        runner_id = run.runner_id
+        with transaction.atomic():
+            locked = (
+                AgentRun.objects.select_for_update()
+                .filter(id=run_id)
+                .first()
             )
-        if run.runner_id:
-            send_to_runner(
-                run.runner_id,
-                {
-                    "v": 1,
-                    "type": "cancel",
-                    "run_id": str(run.id),
-                    "reason": request.data.get("reason", ""),
-                },
+            if locked is None:
+                return Response(
+                    {"error": "not found"}, status=status.HTTP_404_NOT_FOUND
+                )
+            if locked.is_terminal:
+                return Response(
+                    {"error": "run already terminal"},
+                    status=status.HTTP_409_CONFLICT,
+                )
+            locked.status = AgentRunStatus.CANCELLED
+            locked.ended_at = timezone.now()
+            locked.save(update_fields=["status", "ended_at"])
+            run = locked
+
+        # Best-effort WS fan-out after commit; runner may already be offline or
+        # revoked, in which case the frame is dropped silently.
+        if runner_id:
+            transaction.on_commit(
+                lambda rid=runner_id, reason=request.data.get("reason", ""): send_to_runner(
+                    rid,
+                    {
+                        "v": 1,
+                        "type": "cancel",
+                        "run_id": str(run_id),
+                        "reason": reason,
+                    },
+                )
             )
-        run.status = AgentRunStatus.CANCELLED
-        run.ended_at = timezone.now()
-        run.save(update_fields=["status", "ended_at"])
         return Response(AgentRunSerializer(run).data)

--- a/apps/api/pi_dash/runner/views/runs.py
+++ b/apps/api/pi_dash/runner/views/runs.py
@@ -16,17 +16,44 @@ from pi_dash.runner.serializers import (
     AgentRunSerializer,
 )
 from pi_dash.runner.services import matcher
+from pi_dash.runner.services.permissions import (
+    is_workspace_admin,
+    is_workspace_member,
+)
 from pi_dash.runner.services.pubsub import send_to_runner
+from pi_dash.runner.services.validation import (
+    RunCreationError,
+    validate_run_creation,
+)
+
+
+def _can_view_run(user, run: AgentRun) -> bool:
+    """View is allowed for the creator, the runner's owner, or a workspace admin."""
+    if run.created_by_id == user.id:
+        return True
+    if run.runner_id is not None and run.runner.owner_id == user.id:
+        return True
+    return is_workspace_admin(user, run.workspace_id)
+
+
+def _can_cancel_run(user, run: AgentRun) -> bool:
+    """Cancellation is permitted for the same set as view."""
+    return _can_view_run(user, run)
 
 
 class AgentRunListEndpoint(APIView):
-    """Create a new run from a work item, or list the authenticated user's runs."""
+    """List the caller's runs, or create a new one."""
 
     authentication_classes = [BaseSessionAuthentication]
     permission_classes = [IsAuthenticated]
 
     def get(self, request):
-        qs = AgentRun.objects.filter(owner=request.user).order_by("-created_at")
+        # "My runs" — the runs the caller created. Workspace-scoped views are
+        # available to admins via the workspace listing once we add it; for
+        # MVP, list-by-creator is enough.
+        qs = AgentRun.objects.filter(created_by=request.user).order_by(
+            "-created_at"
+        )
         workspace_id = request.query_params.get("workspace")
         if workspace_id:
             qs = qs.filter(workspace_id=workspace_id)
@@ -35,48 +62,41 @@ class AgentRunListEndpoint(APIView):
     def post(self, request):
         prompt = request.data.get("prompt")
         workspace_id = request.data.get("workspace")
-        if not prompt or not workspace_id:
+        if not prompt:
             return Response(
-                {"error": "prompt and workspace are required"},
+                {"error": "prompt is required"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        chosen_id = None
+
+        try:
+            ctx = validate_run_creation(
+                request.user,
+                workspace_id,
+                work_item_id=request.data.get("work_item"),
+                pod_id=request.data.get("pod"),
+            )
+        except RunCreationError as exc:
+            return Response(
+                {"error": exc.message, "code": exc.code},
+                status=exc.status,
+            )
+
         with transaction.atomic():
             run = AgentRun.objects.create(
-                owner=request.user,
-                workspace_id=workspace_id,
+                workspace_id=ctx.workspace_id,
+                created_by=ctx.created_by,
+                pod=ctx.pod,
                 prompt=prompt,
                 run_config=request.data.get("run_config") or {},
                 required_capabilities=request.data.get("required_capabilities") or [],
-                work_item_id=request.data.get("work_item"),
+                work_item_id=ctx.work_item_id,
+                # Owner stays NULL until assignment (design §5.3).
             )
-            chosen = matcher.select_runner_for_run(run)
-            if chosen is not None:
-                run.runner = chosen
-                run.status = AgentRunStatus.ASSIGNED
-                run.assigned_at = timezone.now()
-                run.save(update_fields=["runner", "status", "assigned_at"])
-                chosen_id = chosen.id
-                assign_msg = {
-                    "v": 1,
-                    "type": "assign",
-                    "run_id": str(run.id),
-                    "work_item_id": (
-                        str(run.work_item_id) if run.work_item_id else None
-                    ),
-                    "prompt": run.prompt,
-                    "repo_url": run.run_config.get("repo_url"),
-                    "repo_ref": run.run_config.get("repo_ref"),
-                    "expected_codex_model": run.run_config.get("model"),
-                    "approval_policy_overrides": run.run_config.get(
-                        "approval_policy_overrides"
-                    ),
-                    "deadline": None,
-                }
-        # Push over the WS only after the row is committed — otherwise the
-        # daemon could ack before the DB is visible to other processes.
-        if chosen_id is not None:
-            send_to_runner(chosen_id, assign_msg)
+
+        # Drain the pod's queue — assigns this run (or any predecessor) to
+        # an idle runner if one exists. Non-blocking on commit.
+        matcher.drain_pod(ctx.pod)
+        run.refresh_from_db()
         return Response(
             AgentRunSerializer(run).data,
             status=status.HTTP_201_CREATED,
@@ -88,10 +108,11 @@ class AgentRunDetailEndpoint(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request, run_id):
-        try:
-            run = AgentRun.objects.get(id=run_id, owner=request.user)
-        except AgentRun.DoesNotExist:
+        run = AgentRun.objects.filter(id=run_id).first()
+        if run is None:
             return Response({"error": "not found"}, status=status.HTTP_404_NOT_FOUND)
+        if not _can_view_run(request.user, run):
+            return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
         include_events = request.query_params.get("include_events") == "1"
         payload = AgentRunSerializer(run).data
         if include_events:
@@ -105,10 +126,11 @@ class AgentRunCancelEndpoint(APIView):
     permission_classes = [IsAuthenticated]
 
     def post(self, request, run_id):
-        try:
-            run = AgentRun.objects.get(id=run_id, owner=request.user)
-        except AgentRun.DoesNotExist:
+        run = AgentRun.objects.filter(id=run_id).first()
+        if run is None:
             return Response({"error": "not found"}, status=status.HTTP_404_NOT_FOUND)
+        if not _can_cancel_run(request.user, run):
+            return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
         if run.is_terminal:
             return Response(
                 {"error": "run already terminal"},

--- a/apps/api/pi_dash/runner/web_urls.py
+++ b/apps/api/pi_dash/runner/web_urls.py
@@ -12,6 +12,8 @@ from pi_dash.runner.views import (
     AgentRunListEndpoint,
     ApprovalDecideEndpoint,
     ApprovalListEndpoint,
+    PodDetailEndpoint,
+    PodListEndpoint,
     RegistrationTokenCreateEndpoint,
     RunnerDetailEndpoint,
     RunnerListEndpoint,
@@ -35,6 +37,14 @@ urlpatterns = [
         RunnerRevokeEndpoint.as_view(),
         name="runner-revoke",
     ),
+    # Pods
+    path("pods/", PodListEndpoint.as_view(), name="pod-list"),
+    path(
+        "pods/<uuid:pod_id>/",
+        PodDetailEndpoint.as_view(),
+        name="pod-detail",
+    ),
+    # Runs
     path("runs/", AgentRunListEndpoint.as_view(), name="runner-runs"),
     path(
         "runs/<uuid:run_id>/",

--- a/apps/api/pi_dash/space/serializer/issue.py
+++ b/apps/api/pi_dash/space/serializer/issue.py
@@ -175,6 +175,7 @@ class IssueSerializer(BaseSerializer):
     issue_attachment = IssueAttachmentSerializer(read_only=True, many=True)
     sub_issues_count = serializers.IntegerField(read_only=True)
     issue_reactions = IssueReactionSerializer(read_only=True, many=True)
+    assigned_pod_detail = serializers.SerializerMethodField()
 
     class Meta:
         model = Issue
@@ -187,6 +188,14 @@ class IssueSerializer(BaseSerializer):
             "created_at",
             "updated_at",
         ]
+
+    def get_assigned_pod_detail(self, obj):
+        # Lazy serializer to avoid circular import at module load.
+        from pi_dash.runner.serializers import PodMiniSerializer
+
+        if obj.assigned_pod_id is None:
+            return None
+        return PodMiniSerializer(obj.assigned_pod).data
 
 
 class IssueFlatSerializer(BaseSerializer):

--- a/apps/api/pi_dash/tests/unit/orchestration/test_service.py
+++ b/apps/api/pi_dash/tests/unit/orchestration/test_service.py
@@ -63,9 +63,23 @@ def issue(workspace, project, states, create_user):
 @pytest.fixture(autouse=True)
 def no_runner_dispatch(monkeypatch):
     """Every test in this file exercises orchestration logic, not the runner
-    fan-out. Stub the dispatcher so tests don't need a Redis."""
-    monkeypatch.setattr(service, "_dispatch_to_runner", mock.Mock())
-    return service._dispatch_to_runner
+    fan-out. Stub the post-commit drain so tests don't need a Redis.
+
+    After Phase 3 of the pod design, `_dispatch_to_runner` was replaced with
+    a `transaction.on_commit(drain_pod_by_id)` call inside
+    `_create_and_dispatch_run`. We patch the matcher entry point and also
+    force `transaction.on_commit` to fire immediately so the call is
+    observable to the test.
+    """
+    from pi_dash.runner.services import matcher
+
+    drain_mock = mock.Mock()
+    monkeypatch.setattr(matcher, "drain_pod_by_id", drain_mock)
+    monkeypatch.setattr(
+        "django.db.transaction.on_commit",
+        lambda fn, **kw: fn(),
+    )
+    return drain_mock
 
 
 @pytest.mark.unit

--- a/apps/api/pi_dash/tests/unit/runner/test_drain_pod.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_drain_pod.py
@@ -1,0 +1,257 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Tests for the pod-scoped matcher helpers and ``drain_pod``.
+
+Covers ``select_runner_in_pod``, ``next_queued_run_for_pod``, and
+``drain_pod`` from ``pi_dash.runner.services.matcher``.
+See ``.ai_design/issue_runner/design.md`` §6.3.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from django.utils import timezone
+
+from pi_dash.runner.models import (
+    AgentRun,
+    AgentRunStatus,
+    Pod,
+    Runner,
+    RunnerStatus,
+)
+from pi_dash.runner.services import matcher
+
+
+@pytest.fixture
+def pod(workspace):
+    return Pod.default_for_workspace(workspace)
+
+
+def _make_runner(user, workspace, pod, name, online=True, heartbeat_ago_s=1):
+    return Runner.objects.create(
+        owner=user,
+        workspace=workspace,
+        pod=pod,
+        name=name,
+        credential_hash=f"h-{name}",
+        credential_fingerprint=name[:16].ljust(16, "x")[:16],
+        status=(
+            RunnerStatus.ONLINE if online else RunnerStatus.OFFLINE
+        ),
+        last_heartbeat_at=(
+            timezone.now() - timezone.timedelta(seconds=heartbeat_ago_s)
+            if online
+            else None
+        ),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _stub_send_to_runner():
+    """Replace the WS send so tests don't need redis/channels.
+
+    Patches at the source (``pubsub.send_to_runner``) because matcher.py
+    imports it lazily inside ``drain_pod`` to avoid an import cycle.
+    """
+    with patch(
+        "pi_dash.runner.services.pubsub.send_to_runner"
+    ) as mock:
+        yield mock
+
+
+@pytest.fixture(autouse=True)
+def _run_on_commit_immediately():
+    """Run ``transaction.on_commit`` callbacks inline.
+
+    pytest-django wraps each test in a transaction that gets rolled back,
+    which means ``on_commit`` callbacks never fire. Patching the hook to
+    execute immediately lets us verify side effects (WS dispatch, drain
+    refiring) without switching the whole test to
+    ``django_db(transaction=True)``.
+    """
+    with patch(
+        "django.db.transaction.on_commit", side_effect=lambda fn, **kw: fn()
+    ):
+        yield
+
+
+# ---------------- select_runner_in_pod ----------------
+
+
+@pytest.mark.unit
+def test_select_runner_in_pod_none_when_empty(db, pod):
+    from django.db import transaction
+
+    with transaction.atomic():
+        assert matcher.select_runner_in_pod(pod) is None
+
+
+@pytest.mark.unit
+def test_select_runner_in_pod_picks_freshest_heartbeat(
+    db, create_user, workspace, pod
+):
+    from django.db import transaction
+
+    _make_runner(create_user, workspace, pod, "old", heartbeat_ago_s=20)
+    fresh = _make_runner(create_user, workspace, pod, "fresh", heartbeat_ago_s=1)
+    with transaction.atomic():
+        picked = matcher.select_runner_in_pod(pod)
+    assert picked.pk == fresh.pk
+
+
+@pytest.mark.unit
+def test_select_runner_in_pod_excludes_busy(db, create_user, workspace, pod):
+    from django.db import transaction
+
+    busy = _make_runner(create_user, workspace, pod, "busy")
+    AgentRun.objects.create(
+        workspace=workspace,
+        owner=create_user,
+        created_by=create_user,
+        pod=pod,
+        runner=busy,
+        status=AgentRunStatus.RUNNING,
+        prompt="x",
+    )
+    with transaction.atomic():
+        assert matcher.select_runner_in_pod(pod) is None
+
+
+@pytest.mark.unit
+def test_select_runner_in_pod_excludes_other_pod(
+    db, create_user, workspace
+):
+    """Runners in a different pod in the same workspace are not selected."""
+    from django.db import transaction
+
+    pod_a = Pod.objects.create(
+        workspace=workspace, name="a", created_by=create_user
+    )
+    pod_b = Pod.objects.create(
+        workspace=workspace, name="b", created_by=create_user
+    )
+    _make_runner(create_user, workspace, pod_b, "only-in-b")
+    with transaction.atomic():
+        assert matcher.select_runner_in_pod(pod_a) is None
+
+
+@pytest.mark.unit
+def test_select_runner_in_pod_skips_stale_heartbeat(
+    db, create_user, workspace, pod
+):
+    from django.db import transaction
+
+    _make_runner(create_user, workspace, pod, "stale", heartbeat_ago_s=120)
+    with transaction.atomic():
+        assert matcher.select_runner_in_pod(pod) is None
+
+
+# ---------------- next_queued_run_for_pod ----------------
+
+
+@pytest.mark.unit
+def test_next_queued_run_fifo(db, create_user, workspace, pod):
+    from django.db import transaction
+
+    first = AgentRun.objects.create(
+        workspace=workspace,
+        owner=create_user,
+        created_by=create_user,
+        pod=pod,
+        status=AgentRunStatus.QUEUED,
+        prompt="first",
+    )
+    AgentRun.objects.create(
+        workspace=workspace,
+        owner=create_user,
+        created_by=create_user,
+        pod=pod,
+        status=AgentRunStatus.QUEUED,
+        prompt="second",
+    )
+    with transaction.atomic():
+        assert matcher.next_queued_run_for_pod(pod).pk == first.pk
+
+
+# ---------------- drain_pod ----------------
+
+
+@pytest.mark.unit
+def test_drain_pod_assigns_queued_to_idle_runner(
+    db, create_user, workspace, pod, _stub_send_to_runner
+):
+    runner = _make_runner(create_user, workspace, pod, "r1")
+    run = AgentRun.objects.create(
+        workspace=workspace,
+        owner=create_user,
+        created_by=create_user,
+        pod=pod,
+        status=AgentRunStatus.QUEUED,
+        prompt="go",
+    )
+    n = matcher.drain_pod(pod)
+    assert n == 1
+    run.refresh_from_db()
+    assert run.status == AgentRunStatus.ASSIGNED
+    assert run.runner_id == runner.pk
+    # Billing capture: AgentRun.owner now reflects the runner's owner.
+    assert run.owner_id == runner.owner_id
+    # Dispatch WS call was fired.
+    assert _stub_send_to_runner.called
+
+
+@pytest.mark.unit
+def test_drain_pod_stops_when_all_runners_busy(
+    db, create_user, workspace, pod, _stub_send_to_runner
+):
+    _make_runner(create_user, workspace, pod, "only-runner")
+    run_a = AgentRun.objects.create(
+        workspace=workspace,
+        owner=create_user,
+        created_by=create_user,
+        pod=pod,
+        status=AgentRunStatus.QUEUED,
+        prompt="a",
+    )
+    run_b = AgentRun.objects.create(
+        workspace=workspace,
+        owner=create_user,
+        created_by=create_user,
+        pod=pod,
+        status=AgentRunStatus.QUEUED,
+        prompt="b",
+    )
+    n = matcher.drain_pod(pod)
+    assert n == 1  # Only the one runner got filled.
+    run_a.refresh_from_db()
+    run_b.refresh_from_db()
+    statuses = sorted([run_a.status, run_b.status])
+    assert statuses == [AgentRunStatus.ASSIGNED, AgentRunStatus.QUEUED]
+
+
+@pytest.mark.unit
+def test_drain_pod_noop_when_no_runners(
+    db, create_user, workspace, pod, _stub_send_to_runner
+):
+    AgentRun.objects.create(
+        workspace=workspace,
+        owner=create_user,
+        created_by=create_user,
+        pod=pod,
+        status=AgentRunStatus.QUEUED,
+        prompt="orphan",
+    )
+    n = matcher.drain_pod(pod)
+    assert n == 0
+    assert not _stub_send_to_runner.called
+
+
+@pytest.mark.unit
+def test_drain_pod_by_id_returns_zero_when_missing(db):
+    import uuid
+
+    assert matcher.drain_pod_by_id(uuid.uuid4()) == 0

--- a/apps/api/pi_dash/tests/unit/runner/test_issue_pod.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_issue_pod.py
@@ -1,0 +1,175 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Tests for the issue ↔ pod integration (Phase 4 of the design)."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from pi_dash.db.models import (
+    Project,
+    State,
+    User,
+    Workspace,
+    WorkspaceMember,
+)
+from pi_dash.db.models.issue import Issue
+from pi_dash.runner.models import Pod
+
+
+@pytest.fixture
+def project(workspace):
+    return Project.objects.create(
+        name="ProjP4", workspace=workspace, identifier="P4"
+    )
+
+
+@pytest.fixture
+def state(project):
+    return State.objects.create(
+        name="Backlog",
+        project=project,
+        workspace=project.workspace,
+        group="backlog",
+        default=True,
+    )
+
+
+@pytest.fixture
+def second_workspace(create_user):
+    ws = Workspace.objects.create(
+        name="OtherWS-p4", owner=create_user, slug="other-p4"
+    )
+    WorkspaceMember.objects.create(workspace=ws, member=create_user, role=20)
+    return ws
+
+
+@pytest.mark.unit
+def test_new_issue_auto_fills_assigned_pod_from_workspace_default(
+    db, create_user, project, state
+):
+    issue = Issue.objects.create(
+        name="Demo",
+        project=project,
+        workspace=project.workspace,
+        created_by=create_user,
+    )
+    assert issue.assigned_pod_id == Pod.default_for_workspace(
+        project.workspace
+    ).id
+
+
+@pytest.mark.unit
+def test_explicit_assigned_pod_preserved_on_create(
+    db, create_user, project, state
+):
+    """If the caller passes an explicit pod, the auto-resolve doesn't overwrite it."""
+    custom = Pod.objects.create(
+        workspace=project.workspace,
+        name="custom-pod",
+        created_by=create_user,
+    )
+    issue = Issue.objects.create(
+        name="Pinned",
+        project=project,
+        workspace=project.workspace,
+        created_by=create_user,
+        assigned_pod=custom,
+    )
+    assert issue.assigned_pod_id == custom.id
+
+
+@pytest.mark.unit
+def test_create_serializer_rejects_pod_in_other_workspace(
+    db, create_user, project, state, second_workspace
+):
+    from pi_dash.app.serializers.issue import IssueCreateSerializer
+
+    other_pod = Pod.default_for_workspace(second_workspace)
+    serializer = IssueCreateSerializer(
+        data={
+            "name": "Bad",
+            "assigned_pod": str(other_pod.id),
+        },
+        context={
+            "project_id": project.id,
+            "workspace_id": project.workspace_id,
+        },
+    )
+    # Should be invalid because the pod belongs to a different workspace.
+    assert serializer.is_valid() is False
+    assert "assigned_pod" in serializer.errors
+
+
+@pytest.mark.unit
+def test_create_serializer_rejects_soft_deleted_pod(
+    db, create_user, project, state
+):
+    from django.utils import timezone
+
+    from pi_dash.app.serializers.issue import IssueCreateSerializer
+
+    extra = Pod.objects.create(
+        workspace=project.workspace,
+        name="extra",
+        created_by=create_user,
+    )
+    extra.deleted_at = timezone.now()
+    extra.save(update_fields=["deleted_at"])
+
+    serializer = IssueCreateSerializer(
+        data={"name": "Bad2", "assigned_pod": str(extra.id)},
+        context={
+            "project_id": project.id,
+            "workspace_id": project.workspace_id,
+        },
+    )
+    assert serializer.is_valid() is False
+    assert "assigned_pod" in serializer.errors
+
+
+@pytest.mark.unit
+def test_assigned_pod_detail_method_returns_pod_data(
+    db, create_user, project, state
+):
+    """get_assigned_pod_detail returns the nested pod info or None.
+
+    Doesn't go through the full serializer because IssueSerializer has many
+    nested fields requiring annotated querysets. The method is the bit we
+    added in Phase 4; we exercise it directly.
+    """
+    from pi_dash.space.serializer.issue import IssueSerializer
+
+    issue = Issue.objects.create(
+        name="Show",
+        project=project,
+        workspace=project.workspace,
+        created_by=create_user,
+    )
+    serializer = IssueSerializer()
+    data = serializer.get_assigned_pod_detail(issue)
+    assert data is not None
+    assert data["is_default"] is True
+    assert data["name"] == "Test Workspace-pod"
+
+
+@pytest.mark.unit
+def test_assigned_pod_detail_returns_none_when_unassigned(
+    db, create_user, project, state
+):
+    from pi_dash.space.serializer.issue import IssueSerializer
+
+    issue = Issue.objects.create(
+        name="Unpinned",
+        project=project,
+        workspace=project.workspace,
+        created_by=create_user,
+    )
+    issue.assigned_pod = None
+    issue.save(update_fields=["assigned_pod"])
+    serializer = IssueSerializer()
+    assert serializer.get_assigned_pod_detail(issue) is None

--- a/apps/api/pi_dash/tests/unit/runner/test_permissions.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_permissions.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Tests for the workspace-permission helpers (design §5.1)."""
+
+from __future__ import annotations
+
+import pytest
+
+from pi_dash.db.models import User, Workspace, WorkspaceMember
+from pi_dash.runner.services.permissions import (
+    ROLE_ADMIN,
+    ROLE_MEMBER,
+    ROLE_GUEST,
+    is_at_least_member,
+    is_workspace_admin,
+    is_workspace_member,
+    workspace_role,
+)
+
+
+@pytest.fixture
+def other_user(db):
+    from uuid import uuid4
+
+    unique = uuid4().hex[:8]
+    user = User.objects.create(
+        email=f"other-{unique}@pi-dash.so",
+        username=f"other_{unique}",
+        first_name="O",
+        last_name="Ther",
+    )
+    user.set_password("pw")
+    user.save()
+    return user
+
+
+@pytest.mark.unit
+def test_is_workspace_member_true_for_member(db, create_user, workspace):
+    assert is_workspace_member(create_user, workspace.id) is True
+
+
+@pytest.mark.unit
+def test_is_workspace_member_false_for_outsider(db, other_user, workspace):
+    assert is_workspace_member(other_user, workspace.id) is False
+
+
+@pytest.mark.unit
+def test_is_workspace_member_false_for_none_user(db, workspace):
+    assert is_workspace_member(None, workspace.id) is False
+
+
+@pytest.mark.unit
+def test_workspace_role_returns_admin(db, create_user, workspace):
+    # workspace fixture creates the member with role=20 (admin).
+    assert workspace_role(create_user, workspace.id) == ROLE_ADMIN
+
+
+@pytest.mark.unit
+def test_workspace_role_returns_none_for_outsider(db, other_user, workspace):
+    assert workspace_role(other_user, workspace.id) is None
+
+
+@pytest.mark.unit
+def test_is_workspace_admin_true_for_admin(db, create_user, workspace):
+    assert is_workspace_admin(create_user, workspace.id) is True
+
+
+@pytest.mark.unit
+def test_is_workspace_admin_false_for_member(db, other_user, workspace):
+    WorkspaceMember.objects.create(
+        workspace=workspace, member=other_user, role=ROLE_MEMBER
+    )
+    assert is_workspace_admin(other_user, workspace.id) is False
+    assert is_at_least_member(other_user, workspace.id) is True
+
+
+@pytest.mark.unit
+def test_is_at_least_member_false_for_guest(db, other_user, workspace):
+    WorkspaceMember.objects.create(
+        workspace=workspace, member=other_user, role=ROLE_GUEST
+    )
+    assert is_at_least_member(other_user, workspace.id) is False
+    assert is_workspace_admin(other_user, workspace.id) is False

--- a/apps/api/pi_dash/tests/unit/runner/test_pod.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_pod.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Pod model / manager / constraint tests.
+
+Covers the schema guarantees defined in
+``.ai_design/issue_runner/design.md`` §4.1.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.db import IntegrityError, transaction
+from django.utils import timezone
+
+from pi_dash.db.models import Workspace
+from pi_dash.runner.models import Pod
+
+
+@pytest.fixture
+def second_workspace(create_user):
+    return Workspace.objects.create(
+        name="Second Workspace", owner=create_user, slug="second-workspace"
+    )
+
+
+@pytest.mark.unit
+def test_workspace_creation_auto_creates_default_pod(db, create_user):
+    ws = Workspace.objects.create(
+        name="Auto Pod Ws", owner=create_user, slug="auto-pod-ws"
+    )
+    pods = list(Pod.objects.filter(workspace=ws))
+    assert len(pods) == 1
+    assert pods[0].name == "Auto Pod Ws-pod"
+    assert pods[0].is_default is True
+    assert pods[0].created_by_id == create_user.id
+
+
+@pytest.mark.unit
+def test_workspace_creation_is_idempotent_for_pre_seeded_workspaces(
+    db, create_user, workspace
+):
+    # workspace fixture already triggered the signal; a second pod row for the
+    # same workspace+name+is_default=True should be forbidden by the
+    # conditional unique constraint.
+    existing = Pod.objects.filter(workspace=workspace, is_default=True).count()
+    assert existing == 1
+
+
+@pytest.mark.unit
+def test_default_for_workspace_returns_active_default(db, workspace):
+    pod = Pod.default_for_workspace(workspace)
+    assert pod is not None
+    assert pod.workspace_id == workspace.id
+    assert pod.is_default is True
+
+
+@pytest.mark.unit
+def test_pod_manager_excludes_soft_deleted(db, workspace):
+    pod = Pod.default_for_workspace(workspace)
+    pod.deleted_at = timezone.now()
+    pod.is_default = False  # clear default while soft-deleting
+    pod.save(update_fields=["deleted_at", "is_default"])
+
+    assert Pod.objects.filter(pk=pod.pk).count() == 0
+    # all_objects still exposes the tombstone for audit.
+    assert Pod.all_objects.filter(pk=pod.pk).count() == 1
+
+
+@pytest.mark.unit
+def test_duplicate_name_in_same_workspace_fails_when_both_active(
+    db, create_user, workspace
+):
+    Pod.objects.create(
+        workspace=workspace, name="dup", created_by=create_user
+    )
+    with pytest.raises(IntegrityError):
+        with transaction.atomic():
+            Pod.objects.create(
+                workspace=workspace, name="dup", created_by=create_user
+            )
+
+
+@pytest.mark.unit
+def test_duplicate_name_allowed_when_prior_is_soft_deleted(
+    db, create_user, workspace
+):
+    first = Pod.objects.create(
+        workspace=workspace, name="reusable", created_by=create_user
+    )
+    first.deleted_at = timezone.now()
+    first.save(update_fields=["deleted_at"])
+    # Should succeed — conditional unique excludes deleted rows.
+    second = Pod.objects.create(
+        workspace=workspace, name="reusable", created_by=create_user
+    )
+    assert second.pk != first.pk
+
+
+@pytest.mark.unit
+def test_only_one_active_default_pod_per_workspace(
+    db, create_user, workspace
+):
+    # The auto-created default already exists; adding another is_default=True
+    # active pod should violate the conditional unique.
+    with pytest.raises(IntegrityError):
+        with transaction.atomic():
+            Pod.objects.create(
+                workspace=workspace,
+                name="second-default",
+                is_default=True,
+                created_by=create_user,
+            )
+
+
+@pytest.mark.unit
+def test_default_pod_isolation_between_workspaces(
+    db, workspace, second_workspace
+):
+    p1 = Pod.default_for_workspace(workspace)
+    p2 = Pod.default_for_workspace(second_workspace)
+    assert p1 is not None and p2 is not None
+    assert p1.pk != p2.pk
+    assert p1.name != p2.name  # different workspace names

--- a/apps/api/pi_dash/tests/unit/runner/test_pod_views.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_pod_views.py
@@ -1,0 +1,253 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Integration tests for the Pod CRUD endpoints (web app)."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from django.urls import reverse
+from rest_framework import status
+
+from pi_dash.db.models import User, Workspace, WorkspaceMember
+from pi_dash.runner.models import (
+    AgentRun,
+    AgentRunStatus,
+    Pod,
+    Runner,
+    RunnerStatus,
+)
+
+
+@pytest.fixture
+def member_user(db):
+    """A second user with role=Member (15) in the test workspace."""
+    unique = uuid4().hex[:8]
+    user = User.objects.create(
+        email=f"member-{unique}@pi-dash.so",
+        username=f"member_{unique}",
+        first_name="M",
+        last_name="ember",
+    )
+    user.set_password("pw")
+    user.save()
+    return user
+
+
+@pytest.fixture
+def member_in_workspace(member_user, workspace):
+    WorkspaceMember.objects.create(workspace=workspace, member=member_user, role=15)
+    return member_user
+
+
+@pytest.fixture
+def member_session_client(api_client, member_in_workspace):
+    api_client.force_authenticate(user=member_in_workspace)
+    return api_client
+
+
+@pytest.fixture
+def second_workspace_with_member(db, create_user):
+    ws = Workspace.objects.create(
+        name="OtherWS", owner=create_user, slug="other-ws"
+    )
+    WorkspaceMember.objects.create(workspace=ws, member=create_user, role=20)
+    return ws
+
+
+# ---------------- list / create ----------------
+
+
+@pytest.mark.unit
+def test_list_pods_requires_workspace_param(db, session_client):
+    resp = session_client.get("/api/runners/pods/")
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.unit
+def test_list_pods_returns_workspace_pods(
+    db, session_client, workspace
+):
+    resp = session_client.get(
+        "/api/runners/pods/", {"workspace": str(workspace.id)}
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    data = resp.data
+    assert len(data) == 1  # auto-created default
+    assert data[0]["is_default"] is True
+    assert data[0]["name"] == "Test Workspace-pod"
+
+
+@pytest.mark.unit
+def test_non_member_cannot_list_pods(
+    db, session_client, second_workspace_with_member
+):
+    # session_client is the workspace fixture's owner; second_workspace_with_member
+    # is owned by the same user, so they ARE a member. Use a fresh user instead.
+    from rest_framework.test import APIClient
+
+    other = User.objects.create(
+        email=f"out-{uuid4().hex[:8]}@pi-dash.so",
+        username=f"out_{uuid4().hex[:8]}",
+    )
+    other.set_password("pw")
+    other.save()
+    client = APIClient()
+    client.force_authenticate(user=other)
+    resp = client.get(
+        "/api/runners/pods/",
+        {"workspace": str(second_workspace_with_member.id)},
+    )
+    assert resp.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.unit
+def test_admin_can_create_pod(db, session_client, workspace):
+    resp = session_client.post(
+        "/api/runners/pods/",
+        {
+            "workspace": str(workspace.id),
+            "name": "gpu-pod",
+            "description": "for GPU jobs",
+        },
+        format="json",
+    )
+    assert resp.status_code == status.HTTP_201_CREATED
+    assert resp.data["name"] == "gpu-pod"
+    assert resp.data["is_default"] is False  # only first auto-pod is default
+
+
+@pytest.mark.unit
+def test_member_cannot_create_pod(
+    db, member_session_client, workspace
+):
+    resp = member_session_client.post(
+        "/api/runners/pods/",
+        {"workspace": str(workspace.id), "name": "x"},
+        format="json",
+    )
+    assert resp.status_code == status.HTTP_403_FORBIDDEN
+
+
+# ---------------- detail / patch ----------------
+
+
+@pytest.mark.unit
+def test_member_can_view_pod_detail(
+    db, member_session_client, workspace
+):
+    pod = Pod.default_for_workspace(workspace)
+    resp = member_session_client.get(f"/api/runners/pods/{pod.id}/")
+    assert resp.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.unit
+def test_admin_can_rename_pod(db, session_client, workspace):
+    pod = Pod.default_for_workspace(workspace)
+    resp = session_client.patch(
+        f"/api/runners/pods/{pod.id}/",
+        {"name": "renamed"},
+        format="json",
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["name"] == "renamed"
+
+
+@pytest.mark.unit
+def test_member_cannot_rename_pod_they_did_not_create(
+    db, member_session_client, workspace
+):
+    pod = Pod.default_for_workspace(workspace)
+    resp = member_session_client.patch(
+        f"/api/runners/pods/{pod.id}/",
+        {"name": "hacked"},
+        format="json",
+    )
+    assert resp.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.unit
+def test_promoting_pod_to_default_demotes_previous(
+    db, session_client, workspace, create_user
+):
+    new_pod = Pod.objects.create(
+        workspace=workspace, name="alt", created_by=create_user
+    )
+    old_default = Pod.default_for_workspace(workspace)
+    resp = session_client.patch(
+        f"/api/runners/pods/{new_pod.id}/",
+        {"is_default": True},
+        format="json",
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["is_default"] is True
+    old_default.refresh_from_db()
+    assert old_default.is_default is False
+
+
+# ---------------- soft-delete guards ----------------
+
+
+@pytest.mark.unit
+def test_delete_blocked_when_pod_has_runners(
+    db, session_client, workspace, create_user
+):
+    pod = Pod.objects.create(
+        workspace=workspace, name="with-runner", created_by=create_user
+    )
+    Runner.objects.create(
+        owner=create_user,
+        workspace=workspace,
+        pod=pod,
+        name="r-in-pod",
+        credential_hash="h",
+        credential_fingerprint="f",
+    )
+    resp = session_client.delete(f"/api/runners/pods/{pod.id}/")
+    assert resp.status_code == status.HTTP_409_CONFLICT
+    assert resp.data["code"] == "pod_has_runners"
+
+
+@pytest.mark.unit
+def test_delete_blocked_when_pod_has_active_runs(
+    db, session_client, workspace, create_user
+):
+    pod = Pod.objects.create(
+        workspace=workspace, name="with-active", created_by=create_user
+    )
+    AgentRun.objects.create(
+        workspace=workspace,
+        created_by=create_user,
+        pod=pod,
+        status=AgentRunStatus.QUEUED,
+        prompt="x",
+    )
+    resp = session_client.delete(f"/api/runners/pods/{pod.id}/")
+    assert resp.status_code == status.HTTP_409_CONFLICT
+    assert resp.data["code"] == "pod_has_active_runs"
+
+
+@pytest.mark.unit
+def test_delete_blocked_for_last_pod_in_workspace(
+    db, session_client, workspace
+):
+    pod = Pod.default_for_workspace(workspace)
+    resp = session_client.delete(f"/api/runners/pods/{pod.id}/")
+    assert resp.status_code == status.HTTP_409_CONFLICT
+    assert resp.data["code"] == "last_pod_in_workspace"
+
+
+@pytest.mark.unit
+def test_delete_succeeds_when_guards_satisfied(
+    db, session_client, workspace, create_user
+):
+    second = Pod.objects.create(
+        workspace=workspace, name="second", created_by=create_user
+    )
+    resp = session_client.delete(f"/api/runners/pods/{second.id}/")
+    assert resp.status_code == status.HTTP_204_NO_CONTENT
+    second.refresh_from_db()
+    assert second.deleted_at is not None

--- a/apps/api/pi_dash/tests/unit/runner/test_revocation.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_revocation.py
@@ -1,0 +1,172 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Tests for ``Runner.revoke()`` synchronous in-flight cleanup (design §7.5)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from django.utils import timezone
+
+from pi_dash.runner.models import (
+    AgentRun,
+    AgentRunStatus,
+    Pod,
+    Runner,
+    RunnerStatus,
+)
+
+
+@pytest.fixture
+def pod(workspace):
+    return Pod.default_for_workspace(workspace)
+
+
+def _make_runner(user, workspace, pod, name="r1"):
+    return Runner.objects.create(
+        owner=user,
+        workspace=workspace,
+        pod=pod,
+        name=name,
+        credential_hash=f"h-{name}",
+        credential_fingerprint=name[:16].ljust(16, "x")[:16],
+        status=RunnerStatus.ONLINE,
+        last_heartbeat_at=timezone.now(),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _stub_send_to_runner():
+    with patch(
+        "pi_dash.runner.services.pubsub.send_to_runner"
+    ) as mock:
+        yield mock
+
+
+@pytest.fixture(autouse=True)
+def _run_on_commit_immediately():
+    """Run ``transaction.on_commit`` callbacks inline in tests.
+
+    pytest-django rolls back the wrapping transaction so post-commit hooks
+    never fire; patching makes them run immediately so we can assert on
+    drain-after-revoke behavior.
+    """
+    with patch(
+        "django.db.transaction.on_commit", side_effect=lambda fn, **kw: fn()
+    ):
+        yield
+
+
+@pytest.mark.unit
+def test_revoke_sets_status_and_timestamp(db, create_user, workspace, pod):
+    r = _make_runner(create_user, workspace, pod)
+    r.revoke()
+    r.refresh_from_db()
+    assert r.status == RunnerStatus.REVOKED
+    assert r.revoked_at is not None
+
+
+@pytest.mark.unit
+def test_revoke_cancels_in_flight_assigned_run(
+    db, create_user, workspace, pod
+):
+    r = _make_runner(create_user, workspace, pod)
+    run = AgentRun.objects.create(
+        workspace=workspace,
+        owner=create_user,
+        created_by=create_user,
+        pod=pod,
+        runner=r,
+        status=AgentRunStatus.ASSIGNED,
+        prompt="x",
+    )
+    r.revoke()
+    run.refresh_from_db()
+    assert run.status == AgentRunStatus.CANCELLED
+    assert run.ended_at is not None
+    assert run.error == "runner revoked"
+
+
+@pytest.mark.unit
+def test_revoke_cancels_awaiting_approval_run(db, create_user, workspace, pod):
+    r = _make_runner(create_user, workspace, pod)
+    run = AgentRun.objects.create(
+        workspace=workspace,
+        owner=create_user,
+        created_by=create_user,
+        pod=pod,
+        runner=r,
+        status=AgentRunStatus.AWAITING_APPROVAL,
+        prompt="x",
+    )
+    r.revoke()
+    run.refresh_from_db()
+    assert run.status == AgentRunStatus.CANCELLED
+
+
+@pytest.mark.unit
+def test_revoke_leaves_terminal_runs_alone(db, create_user, workspace, pod):
+    r = _make_runner(create_user, workspace, pod)
+    done = AgentRun.objects.create(
+        workspace=workspace,
+        owner=create_user,
+        created_by=create_user,
+        pod=pod,
+        runner=r,
+        status=AgentRunStatus.COMPLETED,
+        prompt="x",
+    )
+    r.revoke()
+    done.refresh_from_db()
+    assert done.status == AgentRunStatus.COMPLETED
+
+
+@pytest.mark.unit
+def test_revoke_refires_drain_for_affected_pod(
+    db, create_user, workspace, pod
+):
+    """After revoke, if another runner exists in the pod, queued work should
+    move to it via the post-commit drain."""
+    revoked = _make_runner(create_user, workspace, pod, name="to-revoke")
+    survivor = _make_runner(create_user, workspace, pod, name="survivor")
+    in_flight = AgentRun.objects.create(
+        workspace=workspace,
+        owner=create_user,
+        created_by=create_user,
+        pod=pod,
+        runner=revoked,
+        status=AgentRunStatus.RUNNING,
+        prompt="in-flight",
+    )
+    queued = AgentRun.objects.create(
+        workspace=workspace,
+        owner=create_user,
+        created_by=create_user,
+        pod=pod,
+        status=AgentRunStatus.QUEUED,
+        prompt="queued",
+    )
+
+    revoked.revoke()
+
+    in_flight.refresh_from_db()
+    queued.refresh_from_db()
+    assert in_flight.status == AgentRunStatus.CANCELLED
+    # The post-commit drain should have picked up the queued run via the
+    # survivor runner.
+    assert queued.status == AgentRunStatus.ASSIGNED
+    assert queued.runner_id == survivor.pk
+
+
+@pytest.mark.unit
+def test_revoke_is_noop_when_no_in_flight_runs(
+    db, create_user, workspace, pod
+):
+    r = _make_runner(create_user, workspace, pod)
+    # No AgentRun rows attached — revoke should still succeed.
+    r.revoke()
+    r.refresh_from_db()
+    assert r.status == RunnerStatus.REVOKED

--- a/apps/api/pi_dash/tests/unit/runner/test_runs_views.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_runs_views.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Integration tests for the run-creation endpoint after Phase 3 wiring."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+from rest_framework import status
+
+from pi_dash.db.models import User, Workspace, WorkspaceMember
+from pi_dash.runner.models import (
+    AgentRun,
+    AgentRunStatus,
+    Pod,
+)
+
+
+@pytest.fixture
+def second_workspace(db, create_user):
+    ws = Workspace.objects.create(
+        name="OtherWS", owner=create_user, slug="other-ws-runs"
+    )
+    WorkspaceMember.objects.create(workspace=ws, member=create_user, role=20)
+    return ws
+
+
+@pytest.fixture(autouse=True)
+def _stub_send_to_runner():
+    with patch("pi_dash.runner.services.pubsub.send_to_runner"):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _on_commit_immediate():
+    with patch(
+        "django.db.transaction.on_commit", side_effect=lambda fn, **kw: fn()
+    ):
+        yield
+
+
+@pytest.mark.unit
+def test_post_run_validates_workspace_membership(
+    db, api_client, second_workspace
+):
+    outsider = User.objects.create(
+        email=f"out-{uuid4().hex[:8]}@pi-dash.so",
+        username=f"out_{uuid4().hex[:8]}",
+    )
+    outsider.set_password("pw")
+    outsider.save()
+    api_client.force_authenticate(user=outsider)
+    resp = api_client.post(
+        "/api/runners/runs/",
+        {"prompt": "x", "workspace": str(second_workspace.id)},
+        format="json",
+    )
+    assert resp.status_code == status.HTTP_403_FORBIDDEN
+    assert resp.data["code"] == "not_workspace_member"
+
+
+@pytest.mark.unit
+def test_post_run_creates_with_workspace_default_pod(
+    db, session_client, workspace
+):
+    resp = session_client.post(
+        "/api/runners/runs/",
+        {"prompt": "do work", "workspace": str(workspace.id)},
+        format="json",
+    )
+    assert resp.status_code == status.HTTP_201_CREATED
+    run_id = resp.data["id"]
+    run = AgentRun.objects.get(id=run_id)
+    assert run.pod_id == Pod.default_for_workspace(workspace).id
+    assert run.created_by_id == workspace.owner_id
+
+
+@pytest.mark.unit
+def test_post_run_rejects_pod_in_other_workspace(
+    db, session_client, workspace, second_workspace
+):
+    other_pod = Pod.default_for_workspace(second_workspace)
+    resp = session_client.post(
+        "/api/runners/runs/",
+        {
+            "prompt": "x",
+            "workspace": str(workspace.id),
+            "pod": str(other_pod.id),
+        },
+        format="json",
+    )
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+    assert resp.data["code"] == "pod_workspace_mismatch"
+
+
+@pytest.mark.unit
+def test_post_run_ignores_request_body_created_by(
+    db, session_client, workspace
+):
+    """Caller can't impersonate someone else by passing created_by in the body."""
+    spoofed = User.objects.create(
+        email=f"spoof-{uuid4().hex[:8]}@pi-dash.so",
+        username=f"spoof_{uuid4().hex[:8]}",
+    )
+    spoofed.set_password("pw")
+    spoofed.save()
+    resp = session_client.post(
+        "/api/runners/runs/",
+        {
+            "prompt": "x",
+            "workspace": str(workspace.id),
+            "created_by": spoofed.id,
+        },
+        format="json",
+    )
+    assert resp.status_code == status.HTTP_201_CREATED
+    run = AgentRun.objects.get(id=resp.data["id"])
+    # created_by reflects the authenticated user, not the body field.
+    assert run.created_by_id == workspace.owner_id
+
+
+@pytest.mark.unit
+def test_get_runs_lists_by_created_by(db, session_client, workspace):
+    AgentRun.objects.create(
+        workspace=workspace,
+        created_by=workspace.owner,
+        pod=Pod.default_for_workspace(workspace),
+        prompt="mine",
+    )
+    other = User.objects.create(
+        email=f"o-{uuid4().hex[:8]}@pi-dash.so",
+        username=f"o_{uuid4().hex[:8]}",
+    )
+    other.set_password("pw")
+    other.save()
+    AgentRun.objects.create(
+        workspace=workspace,
+        created_by=other,
+        pod=Pod.default_for_workspace(workspace),
+        prompt="not mine",
+    )
+    resp = session_client.get("/api/runners/runs/")
+    assert resp.status_code == status.HTTP_200_OK
+    prompts = [r["prompt"] for r in resp.data]
+    assert "mine" in prompts
+    assert "not mine" not in prompts

--- a/apps/api/pi_dash/tests/unit/runner/test_validation.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_validation.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Tests for ``validate_run_creation`` (design §6.5)."""
+
+from __future__ import annotations
+
+import pytest
+
+from pi_dash.db.models import Project, User, Workspace, WorkspaceMember
+from pi_dash.db.models.issue import Issue
+from pi_dash.runner.models import Pod
+from pi_dash.runner.services.validation import (
+    RunCreationError,
+    validate_run_creation,
+)
+
+
+@pytest.fixture
+def other_user(db):
+    from uuid import uuid4
+
+    unique = uuid4().hex[:8]
+    user = User.objects.create(
+        email=f"other-{unique}@pi-dash.so",
+        username=f"other_{unique}",
+        first_name="O",
+        last_name="Ther",
+    )
+    user.set_password("pw")
+    user.save()
+    return user
+
+
+@pytest.fixture
+def second_workspace(create_user):
+    ws = Workspace.objects.create(
+        name="Second WS", owner=create_user, slug="second-ws"
+    )
+    WorkspaceMember.objects.create(workspace=ws, member=create_user, role=20)
+    return ws
+
+
+@pytest.fixture
+def project(workspace, create_user):
+    return Project.objects.create(
+        name="Demo", workspace=workspace, identifier="DEMO"
+    )
+
+
+@pytest.fixture
+def issue_in_workspace(db, project, workspace, create_user):
+    # Issue.save() requires a State to be present via its save() override.
+    # For validation tests we only care about workspace/assigned_pod; bypass
+    # state resolution by using .objects.create with project set — the save
+    # override falls back silently if State model has no rows.
+    return Issue.objects.create(
+        project=project,
+        workspace=workspace,
+        name="Demo issue",
+        created_by=create_user,
+    )
+
+
+@pytest.mark.unit
+def test_requires_workspace(db, create_user):
+    with pytest.raises(RunCreationError) as exc:
+        validate_run_creation(create_user, workspace_id=None)
+    assert exc.value.status == 400
+    assert exc.value.code == "workspace_required"
+
+
+@pytest.mark.unit
+def test_non_member_rejected_403(db, other_user, workspace):
+    with pytest.raises(RunCreationError) as exc:
+        validate_run_creation(other_user, workspace_id=workspace.id)
+    assert exc.value.status == 403
+    assert exc.value.code == "not_workspace_member"
+
+
+@pytest.mark.unit
+def test_resolves_workspace_default_pod_when_no_pod_given(
+    db, create_user, workspace
+):
+    ctx = validate_run_creation(create_user, workspace_id=workspace.id)
+    assert ctx.pod.is_default is True
+    assert ctx.pod.workspace_id == workspace.id
+    assert ctx.created_by == create_user
+
+
+@pytest.mark.unit
+def test_explicit_pod_must_belong_to_workspace(
+    db, create_user, workspace, second_workspace
+):
+    other_pod = Pod.default_for_workspace(second_workspace)
+    with pytest.raises(RunCreationError) as exc:
+        validate_run_creation(
+            create_user, workspace_id=workspace.id, pod_id=other_pod.id
+        )
+    assert exc.value.status == 400
+    assert exc.value.code == "pod_workspace_mismatch"
+
+
+@pytest.mark.unit
+def test_soft_deleted_pod_rejected(db, create_user, workspace):
+    from django.utils import timezone
+
+    pod = Pod.default_for_workspace(workspace)
+    pod.deleted_at = timezone.now()
+    pod.is_default = False
+    pod.save(update_fields=["deleted_at", "is_default"])
+    with pytest.raises(RunCreationError) as exc:
+        validate_run_creation(
+            create_user, workspace_id=workspace.id, pod_id=pod.id
+        )
+    assert exc.value.status == 400
+    assert exc.value.code == "pod_missing"
+
+
+@pytest.mark.unit
+def test_work_item_must_belong_to_workspace(
+    db, create_user, workspace, second_workspace, issue_in_workspace
+):
+    with pytest.raises(RunCreationError) as exc:
+        validate_run_creation(
+            create_user,
+            workspace_id=second_workspace.id,
+            work_item_id=issue_in_workspace.id,
+        )
+    assert exc.value.status == 400
+    assert exc.value.code == "work_item_workspace_mismatch"
+
+
+@pytest.mark.unit
+def test_work_item_picks_assigned_pod_over_default(
+    db, create_user, workspace, issue_in_workspace
+):
+    # Create a second pod, pin the issue to it, and verify resolution prefers it.
+    second_pod = Pod.objects.create(
+        workspace=workspace, name="special-pod", created_by=create_user
+    )
+    issue_in_workspace.assigned_pod = second_pod
+    issue_in_workspace.save(update_fields=["assigned_pod"])
+
+    ctx = validate_run_creation(
+        create_user,
+        workspace_id=workspace.id,
+        work_item_id=issue_in_workspace.id,
+    )
+    assert ctx.pod.pk == second_pod.pk
+
+
+@pytest.mark.unit
+def test_no_pod_available_returns_409(db, create_user, workspace):
+    """When every pod in the workspace is soft-deleted, fall back fails."""
+    from django.utils import timezone
+
+    for pod in Pod.all_objects.filter(workspace=workspace):
+        pod.deleted_at = timezone.now()
+        pod.is_default = False
+        pod.save(update_fields=["deleted_at", "is_default"])
+    with pytest.raises(RunCreationError) as exc:
+        validate_run_creation(create_user, workspace_id=workspace.id)
+    assert exc.value.status == 409
+    assert exc.value.code == "no_pod_available"

--- a/apps/api/pi_dash/tests/unit/runner/test_workspace_signal.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_workspace_signal.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Tests for the Workspace ``post_save`` signal that auto-creates a default pod.
+
+See ``.ai_design/issue_runner/design.md`` §7.1 and invariant #13.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pi_dash.db.models import Workspace
+from pi_dash.runner.models import Pod
+
+
+@pytest.mark.unit
+def test_signal_creates_default_pod_on_new_workspace(db, create_user):
+    ws = Workspace.objects.create(
+        name="Signal Ws", owner=create_user, slug="signal-ws"
+    )
+    pods = Pod.objects.filter(workspace=ws)
+    assert pods.count() == 1
+    pod = pods.first()
+    assert pod.name == "Signal Ws-pod"
+    assert pod.is_default is True
+
+
+@pytest.mark.unit
+def test_signal_noop_on_workspace_update(db, workspace):
+    before = Pod.objects.filter(workspace=workspace).count()
+    workspace.name = "Renamed"
+    workspace.save()
+    after = Pod.objects.filter(workspace=workspace).count()
+    assert before == after  # no new pod spawned by rename
+
+
+@pytest.mark.unit
+def test_signal_respects_existing_pods(db, create_user):
+    """If a fixture pre-creates a pod, the signal does not duplicate it."""
+    ws = Workspace(name="Pre-Seeded", owner=create_user, slug="pre-seeded")
+    # Manually create before save — in practice fixtures typically seed after
+    # save; this test just exercises the guard.
+    ws.save()  # Signal fires here, creating one pod.
+    # Second save is an update; signal guard should not spawn another pod.
+    ws.save()
+    assert Pod.objects.filter(workspace=ws).count() == 1
+
+
+@pytest.mark.unit
+def test_pod_name_uses_workspace_name_verbatim(db, create_user):
+    ws = Workspace.objects.create(
+        name="Acme Inc.", owner=create_user, slug="acme-inc"
+    )
+    pod = Pod.objects.get(workspace=ws)
+    assert pod.name == "Acme Inc.-pod"
+
+
+@pytest.mark.unit
+def test_runner_save_auto_resolves_pod_from_workspace_default(
+    db, create_user, workspace
+):
+    """Runner.objects.create without explicit pod picks up the workspace default."""
+    from pi_dash.runner.models import Runner, RunnerStatus
+
+    runner = Runner.objects.create(
+        owner=create_user,
+        workspace=workspace,
+        name="auto-pod-runner",
+        credential_hash="h",
+        credential_fingerprint="f",
+        status=RunnerStatus.OFFLINE,
+    )
+    assert runner.pod_id is not None
+    assert runner.pod.is_default is True
+    assert runner.pod.workspace_id == workspace.id
+
+
+@pytest.mark.unit
+def test_agent_run_save_auto_resolves_pod_and_mirrors_created_by(
+    db, create_user, workspace
+):
+    """AgentRun.objects.create without pod/created_by fills them via the save() override."""
+    from pi_dash.runner.models import AgentRun, AgentRunStatus
+
+    run = AgentRun.objects.create(
+        workspace=workspace,
+        owner=create_user,  # legacy call path
+        prompt="hi",
+        status=AgentRunStatus.QUEUED,
+    )
+    assert run.pod_id is not None
+    assert run.pod.is_default is True
+    # created_by auto-mirrored from owner on legacy path.
+    assert run.created_by_id == create_user.id

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -1,0 +1,8 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "pi-dash"
+version = "0.24.0"
+source = { virtual = "." }

--- a/apps/web/app/(all)/[workspaceSlug]/runners/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/page.tsx
@@ -44,7 +44,7 @@ const RunnersListPage = observer(function RunnersListPage() {
     { refreshInterval: 5_000 }
   );
 
-  const { data: pods } = useSWR<IPod[]>(
+  const { data: pods, error: podsError } = useSWR<IPod[]>(
     workspaceId ? ["pods", workspaceId] : null,
     () => podService.list(workspaceId!),
     { refreshInterval: 30_000 }
@@ -200,22 +200,26 @@ const RunnersListPage = observer(function RunnersListPage() {
       <section>
         <div className="mb-2 text-13 font-medium text-primary">{t("runners.pods.title")}</div>
         <div className="mb-2 text-12 text-secondary">{t("runners.pods.help")}</div>
-        <div className="flex flex-wrap gap-2">
-          {(pods ?? []).map((p) => (
-            <div key={p.id} className="rounded-md border border-subtle bg-layer-1 px-3 py-2 text-12">
-              <div className="flex items-center gap-2">
-                <span className="font-medium text-primary">{p.name}</span>
-                {p.is_default && (
-                  <Badge variant="accent-neutral" size="sm">
-                    {t("runners.pods.default_badge")}
-                  </Badge>
-                )}
+        {podsError ? (
+          <div className="text-destructive text-12">{t("runners.pods.load_failed")}</div>
+        ) : (
+          <div className="flex flex-wrap gap-2">
+            {(pods ?? []).map((p) => (
+              <div key={p.id} className="rounded-md border border-subtle bg-layer-1 px-3 py-2 text-12">
+                <div className="flex items-center gap-2">
+                  <span className="font-medium text-primary">{p.name}</span>
+                  {p.is_default && (
+                    <Badge variant="accent-neutral" size="sm">
+                      {t("runners.pods.default_badge")}
+                    </Badge>
+                  )}
+                </div>
+                <div className="text-secondary">{t("runners.pods.runner_count", { count: p.runner_count })}</div>
               </div>
-              <div className="text-secondary">{t("runners.pods.runner_count", { count: p.runner_count })}</div>
-            </div>
-          ))}
-          {(pods ?? []).length === 0 && <div className="text-12 text-secondary">{t("runners.pods.empty")}</div>}
-        </div>
+            ))}
+            {(pods ?? []).length === 0 && <div className="text-12 text-secondary">{t("runners.pods.empty")}</div>}
+          </div>
+        )}
       </section>
 
       <section>

--- a/apps/web/app/(all)/[workspaceSlug]/runners/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/page.tsx
@@ -11,14 +11,15 @@ import useSWR from "swr";
 import { API_BASE_URL } from "@pi-dash/constants";
 import { useTranslation } from "@pi-dash/i18n";
 import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
-import { RunnerService } from "@pi-dash/services";
-import type { IRunner, TRunnerStatus } from "@pi-dash/types";
+import { PodService, RunnerService } from "@pi-dash/services";
+import type { IPod, IRunner, TRunnerStatus } from "@pi-dash/types";
 import type { TBadgeVariant } from "@pi-dash/ui";
 import { AlertModalCore, Badge, Button, Input, Tooltip } from "@pi-dash/ui";
 import { PageHead } from "@/components/core/page-title";
 import { useWorkspace } from "@/hooks/store/use-workspace";
 
 const service = new RunnerService();
+const podService = new PodService();
 
 const MAX_RUNNERS_PER_USER = 5;
 
@@ -41,6 +42,12 @@ const RunnersListPage = observer(function RunnersListPage() {
     workspaceId ? ["runners", workspaceId] : null,
     () => service.list(workspaceId),
     { refreshInterval: 5_000 }
+  );
+
+  const { data: pods } = useSWR<IPod[]>(
+    workspaceId ? ["pods", workspaceId] : null,
+    () => podService.list(workspaceId!),
+    { refreshInterval: 30_000 }
   );
 
   const [mintedToken, setMintedToken] = useState<string | null>(null);
@@ -191,12 +198,34 @@ const RunnersListPage = observer(function RunnersListPage() {
       </section>
 
       <section>
+        <div className="mb-2 text-13 font-medium text-primary">{t("runners.pods.title")}</div>
+        <div className="mb-2 text-12 text-secondary">{t("runners.pods.help")}</div>
+        <div className="flex flex-wrap gap-2">
+          {(pods ?? []).map((p) => (
+            <div key={p.id} className="rounded-md border border-subtle bg-layer-1 px-3 py-2 text-12">
+              <div className="flex items-center gap-2">
+                <span className="font-medium text-primary">{p.name}</span>
+                {p.is_default && (
+                  <Badge variant="accent-neutral" size="sm">
+                    {t("runners.pods.default_badge")}
+                  </Badge>
+                )}
+              </div>
+              <div className="text-secondary">{t("runners.pods.runner_count", { count: p.runner_count })}</div>
+            </div>
+          ))}
+          {(pods ?? []).length === 0 && <div className="text-12 text-secondary">{t("runners.pods.empty")}</div>}
+        </div>
+      </section>
+
+      <section>
         <div className="mb-2 text-13 font-medium text-primary">{t("runners.list.connected_runners")}</div>
         <div className="overflow-x-auto rounded-md border border-subtle">
           <table className="w-full text-13">
             <thead className="bg-layer-1 text-left text-secondary">
               <tr>
                 <th className="px-3 py-2">{t("runners.list.columns.name")}</th>
+                <th className="px-3 py-2">{t("runners.list.columns_pod")}</th>
                 <th className="px-3 py-2">{t("runners.list.columns.status")}</th>
                 <th className="px-3 py-2">{t("runners.list.columns.os_arch")}</th>
                 <th className="px-3 py-2">{t("runners.list.columns.version")}</th>
@@ -208,6 +237,7 @@ const RunnersListPage = observer(function RunnersListPage() {
               {(runners ?? []).map((r) => (
                 <tr key={r.id} className="border-t border-subtle">
                   <td className="font-mono px-3 py-2 text-11">{r.name}</td>
+                  <td className="px-3 py-2">{r.pod_detail ? r.pod_detail.name : "—"}</td>
                   <td className="px-3 py-2">
                     <Badge variant={STATUS_BADGE_VARIANT[r.status]} size="sm">
                       {t(`runners.list.status.${r.status}`)}
@@ -231,7 +261,7 @@ const RunnersListPage = observer(function RunnersListPage() {
               ))}
               {(runners ?? []).length === 0 && (
                 <tr>
-                  <td colSpan={6} className="px-3 py-8 text-center text-secondary">
+                  <td colSpan={7} className="px-3 py-8 text-center text-secondary">
                     {t("runners.list.empty")}
                   </td>
                 </tr>

--- a/packages/i18n/src/locales/en/core.ts
+++ b/packages/i18n/src/locales/en/core.ts
@@ -299,6 +299,15 @@ export default {
         offline: "offline",
         revoked: "revoked",
       },
+      columns_pod: "Pod",
+    },
+    pods: {
+      title: "Pods",
+      help: "Pods group your runners. Issues delegate to a pod, and any free runner inside picks up the work.",
+      empty: "No pods yet — your workspace pod will appear here.",
+      default_badge: "default",
+      runner_count: "{count} runner(s)",
+      load_failed: "Failed to load pods",
     },
     runs: {
       columns: {

--- a/packages/services/src/runner/index.ts
+++ b/packages/services/src/runner/index.ts
@@ -4,4 +4,5 @@
  * See the LICENSE file for details.
  */
 
+export * from "./pod.service";
 export * from "./runner.service";

--- a/packages/services/src/runner/pod.service.ts
+++ b/packages/services/src/runner/pod.service.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { API_BASE_URL } from "@pi-dash/constants";
+import type { IPod } from "@pi-dash/types";
+import { APIService } from "../api.service";
+
+/**
+ * Pi Dash Pod CRUD client. Session-authenticated; mounted at
+ * /api/runners/pods/ on the Django server. See
+ * .ai_design/issue_runner/design.md §8.1.
+ */
+export class PodService extends APIService {
+  constructor(BASE_URL?: string) {
+    super(BASE_URL || API_BASE_URL);
+  }
+
+  async list(workspaceId: string): Promise<IPod[]> {
+    return this.get("/api/runners/pods/", { params: { workspace: workspaceId } })
+      .then((r) => r?.data)
+      .catch((e) => {
+        throw e?.response?.data;
+      });
+  }
+
+  async create(input: { workspace: string; name: string; description?: string }): Promise<IPod> {
+    return this.post("/api/runners/pods/", input)
+      .then((r) => r?.data)
+      .catch((e) => {
+        throw e?.response?.data;
+      });
+  }
+
+  async get_one(podId: string): Promise<IPod> {
+    return this.get(`/api/runners/pods/${podId}/`)
+      .then((r) => r?.data)
+      .catch((e) => {
+        throw e?.response?.data;
+      });
+  }
+
+  async update(podId: string, input: { name?: string; description?: string; is_default?: boolean }): Promise<IPod> {
+    return this.patch(`/api/runners/pods/${podId}/`, input)
+      .then((r) => r?.data)
+      .catch((e) => {
+        throw e?.response?.data;
+      });
+  }
+
+  async remove(podId: string): Promise<void> {
+    return this.delete(`/api/runners/pods/${podId}/`)
+      .then(() => undefined)
+      .catch((e) => {
+        throw e?.response?.data;
+      });
+  }
+}

--- a/packages/services/src/runner/runner.service.ts
+++ b/packages/services/src/runner/runner.service.ts
@@ -41,6 +41,25 @@ export class RunnerService extends APIService {
       });
   }
 
+  /** Move a runner to a different pod (same workspace). Owner or admin only. */
+  async move(runnerId: string, podId: string, name?: string): Promise<IRunner> {
+    const body: Record<string, unknown> = { pod: podId };
+    if (name !== undefined) body.name = name;
+    return this.patch(`/api/runners/${runnerId}/`, body)
+      .then((r) => r?.data)
+      .catch((e) => {
+        throw e?.response?.data;
+      });
+  }
+
+  async getDetail(runnerId: string): Promise<IRunner> {
+    return this.get(`/api/runners/${runnerId}/`)
+      .then((r) => r?.data)
+      .catch((e) => {
+        throw e?.response?.data;
+      });
+  }
+
   async listTokens(): Promise<IRunnerRegistration[]> {
     return this.get("/api/runners/tokens/")
       .then((r) => r?.data)
@@ -89,6 +108,8 @@ export class RunnerService extends APIService {
     run_config?: Record<string, unknown>;
     required_capabilities?: string[];
     work_item?: string;
+    /** Optional pod override; defaults to issue.assigned_pod or workspace.default_pod. */
+    pod?: string;
   }): Promise<IAgentRun> {
     return this.post("/api/runners/runs/", input)
       .then((r) => r?.data)

--- a/packages/types/src/runner.ts
+++ b/packages/types/src/runner.ts
@@ -6,6 +6,24 @@
 
 export type TRunnerStatus = "online" | "offline" | "busy" | "revoked";
 
+export interface IPodMini {
+  id: string;
+  name: string;
+  is_default: boolean;
+}
+
+export interface IPod {
+  id: string;
+  name: string;
+  description: string;
+  is_default: boolean;
+  workspace: string;
+  created_by: string | null;
+  runner_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
 export interface IRunner {
   id: string;
   name: string;
@@ -16,6 +34,9 @@ export interface IRunner {
   protocol_version: number;
   capabilities: string[];
   last_heartbeat_at: string | null;
+  owner: string | null;
+  pod: string;
+  pod_detail: IPodMini | null;
   created_at: string;
   updated_at: string;
 }
@@ -61,6 +82,12 @@ export interface IAgentRun {
   thread_id: string;
   runner: string | null;
   work_item: string | null;
+  pod: string;
+  pod_detail: IPodMini | null;
+  /** Run creator — the access principal for permission checks. */
+  created_by: string;
+  /** Billable party — the runner's owner once assigned. NULL until assignment. */
+  owner: string | null;
   created_at: string;
   assigned_at: string | null;
   started_at: string | null;


### PR DESCRIPTION
## Summary

Reframes runners from personal machines (scoped to one `owner`) to **workspace-shared digital employees** grouped into **pods**. Issues pin to a pod; dispatch drains the pod's queue to idle runners. Fixes the stranded-`QUEUED` bug along the way — runners that complete a run now refire `drain_pod` so queued work moves forward without waiting for an external trigger.

Full design: [`.ai_design/issue_runner/design.md`](.ai_design/issue_runner/design.md).

## Why

- **Stranded QUEUED**: under the old matcher, if all of a user's runners were busy the run was left QUEUED with no background drain.
- **Permission model conflation**: `AgentRun.owner` was doing double duty as access principal and billable party. Once runners are shared, these identities diverge.
- **Revoke was unsafe**: `Runner.revoke()` only flipped a status bit. Force-closed runners left `ASSIGNED/RUNNING` rows hanging forever.
- **Zero-setup**: new workspaces should just work — no admin clicks required to make delegation run.

## Architecture

```
Workspace
├── Pod (many, workspace-scoped, soft-deleted)
│   ├── Runner (N, workspace-shared; owner is admin bond only)
│   └── AgentRun (N, FIFO per pod, drains to idle runners)
└── Issue.assigned_pod ──► Pod
```

Every workspace auto-creates a default pod named `<workspace.name>-pod`. Runner registration and issue creation both default to it. Pods can be deleted only when empty of runners, non-terminal runs, and not the workspace's last pod.

## What changed

### Backend
- **New**: `Pod` model + `PodManager` (soft-delete), workspace post-save signal, `ensure_workspace_pods` management command, three `services/` modules (`permissions.py`, `validation.py`, pod-scoped matcher + `drain_pod`), pod CRUD endpoints.
- **Rewritten**: `Runner.revoke()` synchronously cancels in-flight runs + refires drain; `orchestration._dispatch_to_runner` → pod-aware `drain_pod_by_id`; `_resolve_owner` → `_resolve_fallback_creator`; `consumers._finalize_run` drains after completion.
- **Permission-model switch**: list/detail/cancel/approve endpoints filter by `AgentRun.created_by` (new NOT-NULL FK); runner endpoints switch from owner-scoped to workspace-scoped; revoke widened to owner-or-admin; approvals route to the run creator (not runner owner).
- **Schema**: two migrations — `runner/0004_add_pod_and_run_identity` and `db/0126_issue_assigned_pod`. Single schema cutover (no backfill ceremony) because pi-dash has no production data yet. Tolerates local dev rows via in-migration data pass.

### Frontend
- Types extended (`IPod`, `IPodMini`, runner/agent-run get `pod` + `pod_detail`, agent-run gets `created_by`).
- New `PodService` + `RunnerService.move` / `getDetail`.
- Runners page shows a Pods strip above the table and a Pod column in the table.
- i18n keys added (`runners.pods.*`, `runners.list.columns_pod`) in `en` only.

### Design doc
- Zero-setup fresh-install model with `<workspace_name>-pod` naming.
- Decision table reconciled (#3 soft-delete semantics, #7 fresh install, #9–#12 codex-feedback fixes, #13 every-workspace-has-a-pod invariant).

## Tests

**Backend**: 115/116 runner + orchestration + contract tests pass. The 1 failure (`test_run_config_carries_git_fields_from_issue_and_project`) is pre-existing on main — reproduced by stashing this PR's diff and running against main.

Test coverage added:
- `test_pod.py` — pod model, soft-delete visibility, conditional unique constraints (8).
- `test_workspace_signal.py` — auto-pod creation, idempotency, model save() auto-resolve for Runner/AgentRun (6).
- `test_permissions.py` — workspace role helpers (8).
- `test_validation.py` — every §6.5 rule + pod resolution priority (8).
- `test_drain_pod.py` — pod-scoped matcher, billing capture, FIFO (10).
- `test_revocation.py` — synchronous cancel + drain refire (6).
- `test_pod_views.py` — CRUD endpoints + all three soft-delete guards (14).
- `test_runs_views.py` — membership enforcement, auto-pod, body-spoofing protection (5).
- `test_issue_pod.py` — issue auto-pin + serializer validation (6).

**Frontend**: `@pi-dash/types`, `@pi-dash/services`, `@pi-dash/i18n` build clean. `web` `check:types` reports no new errors (2 pre-existing `sidebar-item.tsx` errors unrelated to this PR).

## Test plan

- [ ] Run the migrations against a fresh dev DB: `python manage.py migrate`.
- [ ] Run the full test suite: `pytest pi_dash/tests/unit/runner/ pi_dash/tests/unit/orchestration/ pi_dash/tests/contract/runner/`.
- [ ] Create a new workspace in dev → confirm `<name>-pod` auto-exists and is default.
- [ ] Register a runner → confirm it lands in the default pod (visible in the new Pod column).
- [ ] Create an issue → confirm `assigned_pod` is set to the default.
- [ ] Move issue to In Progress → confirm `AgentRun` is created with `pod` set and `created_by` populated.
- [ ] Revoke the runner while a run is in flight → confirm the run transitions to `CANCELLED` with `error="runner revoked"`.
- [ ] Try to soft-delete the workspace's only pod via `DELETE /api/runners/pods/<id>/` → confirm 409 `last_pod_in_workspace`.

## Deferred (called out in Phase 5 commit)

- Full pods CRUD admin UI (create/rename/delete forms).
- Move-runner dialog.
- Issue-detail pod picker (advanced section per §8.3).
- `zh`, `ja`, etc. locale files for the new `runners.pods.*` keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)