### PR TITLE
fix(runner): harden login-shell spawn against .bashrc cwd + locale drift

### DIFF
--- a/runner/src/claude_code/process.rs
+++ b/runner/src/claude_code/process.rs
@@ -54,8 +54,7 @@ impl ClaudeProcess {
         if let Some(model) = args.model {
             argv.extend(["--model", model]);
         }
-        let mut cmd = login_shell_command(args.binary, &argv);
-        cmd.current_dir(args.cwd);
+        let cmd = login_shell_command(args.binary, &argv, Some(args.cwd));
         Self::spawn_command(cmd).await
     }
 

--- a/runner/src/cli/doctor.rs
+++ b/runner/src/cli/doctor.rs
@@ -183,7 +183,7 @@ pub async fn execute(paths: &Paths) -> Result<Report> {
 /// reflects what the daemon will actually see at spawn time — not just
 /// whether the binary is on the caller's interactive `PATH`.
 async fn check_version(binary: &str) -> Result<String> {
-    let mut cmd = login_shell_command(binary, &["--version"]);
+    let mut cmd = login_shell_command(binary, &["--version"], None);
     cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
     let out = cmd.output().await?;
     if !out.status.success() {
@@ -202,7 +202,7 @@ async fn check_version(binary: &str) -> Result<String> {
 
 async fn check_codex_auth(binary: &str) -> Result<String> {
     // codex has `account` as a subcommand in newer releases; fall back to `whoami`.
-    let mut cmd = login_shell_command(binary, &["account", "status"]);
+    let mut cmd = login_shell_command(binary, &["account", "status"], None);
     cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
     let out = cmd.output().await.ok();
     if let Some(o) = out

--- a/runner/src/codex/app_server.rs
+++ b/runner/src/codex/app_server.rs
@@ -21,8 +21,7 @@ impl AppServer {
     pub async fn spawn(binary: &str, cwd: &Path) -> Result<Self> {
         // Route through a login bash so the agent binary is found via the
         // user's interactive PATH. See `util::shell::login_shell_command`.
-        let mut cmd = login_shell_command(binary, &["app-server"]);
-        cmd.current_dir(cwd);
+        let cmd = login_shell_command(binary, &["app-server"], Some(cwd));
         Self::spawn_command(cmd).await
     }
 

--- a/runner/src/util/shell.rs
+++ b/runner/src/util/shell.rs
@@ -15,30 +15,59 @@
 //! user's full interactive environment, and gives us the same PATH the
 //! operator sees in their terminal.
 //!
-//! The script we pass to `-c` is just `exec "$@"`: `exec` replaces bash
-//! with the target (so the spawned PID and any signals we deliver hit the
-//! agent, not a lingering shell), and `"$@"` preserves our structured argv
-//! with no shell re-parsing of agent flags.
+//! The script we pass to `-c` is:
+//!   `[ -n "${PIDASH_AGENT_CWD-}" ] && cd -- "$PIDASH_AGENT_CWD"; exec "$@"`
+//!
+//! Two things earn their keep there:
+//!   * `cd -- "$PIDASH_AGENT_CWD"` re-asserts the caller's requested cwd
+//!     *after* rc files have run. Without it, any `cd` statement in the
+//!     operator's `.bashrc` (surprisingly common — `cd ~/projects` at the
+//!     end of an rc file, or a tmux "open in default dir" hook) silently
+//!     overrides the `current_dir` that tokio set on the outer bash
+//!     process, and the agent starts in the wrong directory. The `--`
+//!     guards against cwd strings that start with a dash.
+//!   * `exec "$@"` replaces bash with the target (so the spawned PID and
+//!     any signals we deliver hit the agent, not a lingering shell) and
+//!     preserves our structured argv without shell re-parsing of agent
+//!     flags.
 //!
 //! Running an interactive bash without a controlling TTY makes bash emit
 //! two diagnostic lines to stderr during startup:
 //!   `bash: cannot set terminal process group (-1): Inappropriate ioctl for device`
 //!   `bash: no job control in this shell`
 //! Those lines are harmless (bash just can't install a foreground job
-//! group), but they're emitted before our `-c` script runs so they can't be
-//! silenced from inside the script. Callers should filter them out of any
-//! captured stderr via [`is_benign_login_shell_warning`].
+//! group), but they're emitted before our `-c` script runs so they can't
+//! be silenced from inside the script. Callers should filter them out of
+//! any captured stderr via [`is_benign_login_shell_warning`]. We also
+//! pin `LC_MESSAGES=C` on the spawned bash so those strings stay English
+//! regardless of the host locale — the filter is exact-match and would
+//! otherwise go stale under a non-C/non-English locale.
 
+use std::path::Path;
 use tokio::process::Command;
+
+const SHELL_SCRIPT: &str =
+    r#"[ -n "${PIDASH_AGENT_CWD-}" ] && cd -- "$PIDASH_AGENT_CWD"; exec "$@""#;
 
 /// Build a [`Command`] that runs `program args…` through a login+interactive
 /// bash. See the module docs for why `-i` is required alongside `-l`.
 ///
-/// The returned command still needs the caller's usual stdio / cwd /
+/// `cwd`, when `Some`, is both applied to the outer bash (via `current_dir`)
+/// and re-asserted inside the script after rc files run, so `.bashrc`'s
+/// `cd` side effects can't clobber the agent's starting directory.
+///
+/// The returned command still needs the caller's usual stdio and
 /// `kill_on_drop` wiring before being spawned.
-pub fn login_shell_command(program: &str, args: &[&str]) -> Command {
+pub fn login_shell_command(program: &str, args: &[&str], cwd: Option<&Path>) -> Command {
     let mut cmd = Command::new("bash");
-    cmd.arg("-ilc").arg(r#"exec "$@""#).arg("bash").arg(program);
+    // Pin the message locale so `is_benign_login_shell_warning` matches
+    // regardless of the operator's LANG / LC_ALL.
+    cmd.env("LC_MESSAGES", "C");
+    if let Some(cwd) = cwd {
+        cmd.current_dir(cwd);
+        cmd.env("PIDASH_AGENT_CWD", cwd.as_os_str());
+    }
+    cmd.arg("-ilc").arg(SHELL_SCRIPT).arg("bash").arg(program);
     cmd.args(args);
     cmd
 }
@@ -59,20 +88,28 @@ pub fn is_benign_login_shell_warning(line: &str) -> bool {
 mod tests {
     use super::*;
     use std::ffi::OsString;
+    use std::path::PathBuf;
 
     fn argv(cmd: &Command) -> Vec<OsString> {
         cmd.as_std().get_args().map(|a| a.to_os_string()).collect()
     }
 
+    fn env_value(cmd: &Command, key: &str) -> Option<OsString> {
+        cmd.as_std()
+            .get_envs()
+            .find(|(k, _)| *k == key)
+            .and_then(|(_, v)| v.map(|v| v.to_os_string()))
+    }
+
     #[test]
     fn wraps_program_and_args_in_login_bash() {
-        let cmd = login_shell_command("claude", &["--print", "--model", "sonnet-4"]);
+        let cmd = login_shell_command("claude", &["--print", "--model", "sonnet-4"], None);
         assert_eq!(cmd.as_std().get_program(), "bash");
         assert_eq!(
             argv(&cmd),
             vec![
                 OsString::from("-ilc"),
-                OsString::from(r#"exec "$@""#),
+                OsString::from(SHELL_SCRIPT),
                 OsString::from("bash"),
                 OsString::from("claude"),
                 OsString::from("--print"),
@@ -84,16 +121,41 @@ mod tests {
 
     #[test]
     fn no_args_produces_bare_invocation() {
-        let cmd = login_shell_command("codex", &[]);
+        let cmd = login_shell_command("codex", &[], None);
         assert_eq!(
             argv(&cmd),
             vec![
                 OsString::from("-ilc"),
-                OsString::from(r#"exec "$@""#),
+                OsString::from(SHELL_SCRIPT),
                 OsString::from("bash"),
                 OsString::from("codex"),
             ]
         );
+    }
+
+    #[test]
+    fn pins_lc_messages_to_c_for_stable_warning_strings() {
+        // The stderr filter is exact-match English; pinning LC_MESSAGES=C
+        // keeps it working under localized hosts.
+        let cmd = login_shell_command("claude", &[], None);
+        assert_eq!(env_value(&cmd, "LC_MESSAGES"), Some(OsString::from("C")));
+    }
+
+    #[test]
+    fn cwd_none_does_not_set_pidash_agent_cwd() {
+        let cmd = login_shell_command("claude", &["--version"], None);
+        assert_eq!(env_value(&cmd, "PIDASH_AGENT_CWD"), None);
+    }
+
+    #[test]
+    fn cwd_some_sets_both_current_dir_and_pidash_agent_cwd() {
+        let cwd = PathBuf::from("/tmp/pidash-workspace");
+        let cmd = login_shell_command("claude", &["--version"], Some(&cwd));
+        assert_eq!(
+            env_value(&cmd, "PIDASH_AGENT_CWD"),
+            Some(OsString::from("/tmp/pidash-workspace"))
+        );
+        assert_eq!(cmd.as_std().get_current_dir(), Some(Path::new(&cwd)));
     }
 
     #[test]
@@ -118,11 +180,12 @@ mod tests {
         // Prove bash's `exec "$@"` preserves our argv exactly and the child
         // actually runs. `printf '%s\n' "$@"` echoes each arg on its own
         // line — verifies ordering and that args with spaces / `=` are not
-        // split or re-parsed by the shell. stderr is merged into stdout so
-        // the test passes regardless of whether bash emits its no-tty
-        // warnings (it does under `cargo test`, it doesn't under a tty).
-        let mut cmd =
-            login_shell_command("printf", &["%s\n", "first arg", "second-arg", "has=equal"]);
+        // split or re-parsed by the shell.
+        let mut cmd = login_shell_command(
+            "printf",
+            &["%s\n", "first arg", "second-arg", "has=equal"],
+            None,
+        );
         cmd.kill_on_drop(true);
         let out = cmd
             .output()
@@ -136,6 +199,66 @@ mod tests {
         assert_eq!(
             String::from_utf8_lossy(&out.stdout),
             "first arg\nsecond-arg\nhas=equal\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn agent_cwd_survives_bashrc_cd() {
+        // Regression: a `cd` in the operator's `.bashrc` used to silently
+        // override the cwd we set on the outer bash, because rc files run
+        // before `exec "$@"`. Build a throwaway HOME whose rc cds to `/`,
+        // ask the wrapper for a specific cwd, and confirm the target
+        // observes it via `pwd`.
+        let home = tempfile::tempdir().expect("tempdir for fake HOME");
+        let agent_cwd = tempfile::tempdir().expect("tempdir for agent cwd");
+
+        // `bash -l` reads the first of .bash_profile / .bash_login / .profile
+        // it finds; add one that sources .bashrc the way stock Ubuntu does.
+        std::fs::write(
+            home.path().join(".bash_profile"),
+            "[ -f \"$HOME/.bashrc\" ] && . \"$HOME/.bashrc\"\n",
+        )
+        .expect("write .bash_profile");
+        // And the .bashrc that would clobber cwd without our guard. No
+        // non-interactive guard: we *want* `-i` to run this file fully.
+        std::fs::write(home.path().join(".bashrc"), "cd /\n").expect("write .bashrc");
+
+        let mut cmd = login_shell_command("pwd", &[], Some(agent_cwd.path()));
+        cmd.env("HOME", home.path());
+        // Isolate the login bash from the developer's real environment so
+        // this test is deterministic on any box.
+        cmd.env_remove("BASH_ENV");
+        cmd.kill_on_drop(true);
+
+        let out = cmd.output().await.expect("spawn pwd through login shell");
+        assert!(
+            out.status.success(),
+            "pwd failed: stderr={}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        // Take the *last* non-empty stdout line. On Ubuntu hosts the
+        // system-wide `/etc/bash.bashrc` prints a sudo hint banner to
+        // stdout before our `-c` script runs, so `pwd`'s output lands on
+        // the final line rather than the only line.
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        let observed = stdout
+            .lines()
+            .map(str::trim)
+            .rfind(|l| !l.is_empty())
+            .unwrap_or("")
+            .to_string();
+        // macOS `TMPDIR` resolves through a symlinked /var → /private/var,
+        // so compare canonical paths rather than raw strings.
+        let expected = std::fs::canonicalize(agent_cwd.path()).expect("canonicalize expected");
+        let observed_canonical = std::fs::canonicalize(&observed).unwrap_or_else(|e| {
+            panic!(
+                "canonicalize observed={observed:?} failed: {e}; full stdout={stdout:?}; stderr={stderr:?}"
+            )
+        });
+        assert_eq!(
+            observed_canonical, expected,
+            ".bashrc's `cd /` leaked past our guard; pwd reported {observed}"
         );
     }
 }

--- a/runner/src/util/shell.rs
+++ b/runner/src/util/shell.rs
@@ -60,6 +60,10 @@ const SHELL_SCRIPT: &str =
 /// `kill_on_drop` wiring before being spawned.
 pub fn login_shell_command(program: &str, args: &[&str], cwd: Option<&Path>) -> Command {
     let mut cmd = Command::new("bash");
+    // `LC_ALL` overrides every more-specific locale category, so drop it
+    // first; otherwise `LC_MESSAGES=C` would be ignored when the parent
+    // environment exports `LC_ALL=...`.
+    cmd.env_remove("LC_ALL");
     // Pin the message locale so `is_benign_login_shell_warning` matches
     // regardless of the operator's LANG / LC_ALL.
     cmd.env("LC_MESSAGES", "C");
@@ -139,6 +143,17 @@ mod tests {
         // keeps it working under localized hosts.
         let cmd = login_shell_command("claude", &[], None);
         assert_eq!(env_value(&cmd, "LC_MESSAGES"), Some(OsString::from("C")));
+    }
+
+    #[test]
+    fn removes_lc_all_so_lc_messages_takes_effect() {
+        let cmd = login_shell_command("claude", &[], None);
+        let lc_all = cmd
+            .as_std()
+            .get_envs()
+            .find(|(k, _)| *k == "LC_ALL")
+            .map(|(_, v)| v);
+        assert_eq!(lc_all, Some(None));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Post-merge follow-ups on #48 from a Codex review. Two fixes, both isolated to the shell-wrapper helper and its call sites.

### 1. `.bashrc` could silently override the agent's cwd

`bash -ilc` runs interactive startup files before our `-c` script exec's the target. If the operator's `.bashrc` contains a `cd` — `cd ~/projects` at the end of a rc file, a tmux/iTerm "open in default dir" hook, etc. — that `cd` wins over the `current_dir` tokio set on the outer bash, and the agent silently starts in the wrong directory.

Reproducer: synthetic HOME whose `.bashrc` is `cd /`. Pre-fix, `pwd` under the wrapper reports `/`. Post-fix it reports the requested cwd.

Fix: plumb an optional cwd through `login_shell_command`, set it on **both** `current_dir` and a dedicated `PIDASH_AGENT_CWD` env var, and make the `-c` script re-cd after rc files run:

```
[ -n "${PIDASH_AGENT_CWD-}" ] && cd -- "$PIDASH_AGENT_CWD"; exec "$@"
```

The `--` guards against cwd strings that start with a dash; the `-` in the parameter expansion keeps `set -u` callers safe if the var is unset.

### 2. Stderr filter was locale-fragile

`is_benign_login_shell_warning` matches the two bash TTY-less startup warnings by exact English string. bash uses gettext, so under a localized host (`LANG=fr_FR.UTF-8` etc.) those strings change and we would start logging them at `warn!` on every spawn. The Codex reviewer confirmed the code path but couldn't demonstrate runtime impact locally (their box only had C/English locales), so this is defence-in-depth.

Fix: `cmd.env("LC_MESSAGES", "C")` on the spawned bash — the filter's exact strings stay stable regardless of operator locale.

## API change

`login_shell_command(program, args)` gains a third parameter `cwd: Option<&Path>`:
- `ClaudeProcess::spawn` and `AppServer::spawn` pass `Some(cwd)` and drop their own `current_dir` call.
- `doctor::check_version` / `check_codex_auth` pass `None` — they do not care where `--version` runs.

## Test plan

- [x] `cargo fmt` / `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib` — 70 tests pass (up from 66; 4 new: LC_MESSAGES env pin, cwd-None variant, cwd-Some variant, and `agent_cwd_survives_bashrc_cd` end-to-end regression with a synthetic `cd /` rc)
- [x] `cargo test --tests` — 11 integration tests pass unchanged
- [x] Dev-box smoke: reinstalled, `pidash status` connected/idle, `pidash doctor` ✓ for claude
- [ ] Rerun the failing PIDASH-1 runner task end-to-end with this build

🤖 Generated with [Claude Code](https://claude.com/claude-code)
