### PR TITLE
chore(runner): bump version to 0.1.1

### DIFF
--- a/runner/Cargo.lock
+++ b/runner/Cargo.lock
@@ -1086,7 +1086,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pidash"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pidash"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 rust-version = "1.93"
 description = "Pi Dash local runner: connects a dev machine to the Pi Dash cloud and drives Codex for assigned tasks."


### PR DESCRIPTION
## Summary

- Bump `runner/Cargo.toml` `version` from 0.1.0 to 0.1.1.
- Collects the following merged changes since v0.1.0:
  - #47 fix: stop overriding `XDG_RUNTIME_DIR` in unit/plist.
  - #48 fix: spawn agent binaries via login+interactive bash.
  - #49 feat: pods — workspace-shared runners with per-pod queue.
  - #50 fix: harden login-shell spawn against `.bashrc` cwd + locale drift.
- `Cargo.lock` regenerated via `cargo check -p pidash`.

Tagging `v0.1.1` on `main` immediately after merge will trigger the cargo-dist release workflow to publish signed binaries for macOS arm64, Linux arm64 (glibc), and Linux x86_64 (glibc) plus the installer shell script.

## Test plan

- [x] `cargo check` succeeds under the new version.
- [ ] After merge + tag, confirm the `Release` workflow run succeeds and the GitHub release `v0.1.1` has the expected three target artifacts + `pidash-installer.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)