### PR TITLE
docs: link AIO and compose deployment paths from top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,13 @@ pnpm dev
 5. Open your browser to http://localhost:3001/god-mode/ and register yourself as instance admin
 6. Open your browser to http://localhost:3000 and log in using the same credentials
 
-For production deployments, see the [`deployments/`](./deployments) directory for Docker Compose and Kubernetes configurations.
+#### Production deployment
+
+For real self-hosted deployments (not local development), pick the path that matches how much you want to manage yourself:
+
+- **[All-in-One Docker image](./deployments/aio/community/README.md)** — one container that bundles every Pi Dash service, managed by `supervisord` internally. Simplest path: a single `docker run` command. Best for demos, homelab setups, evaluation, and small teams. External Postgres / Redis / RabbitMQ / S3-compatible storage are still required.
+- **[Docker Compose / Swarm self-hosting](./deployments/cli/community/README.md)** — the full microservices stack (6 service containers + database + queue + storage). More configuration, but gives you independent scaling and rolling updates per service. Recommended for anything beyond evaluation.
+- **Kubernetes / Helm** — Helm chart publishing is planned but not yet shipped; see [`deployments/kubernetes/community/README.md`](./deployments/kubernetes/community/README.md).
 
 ### 2. Pi Dash CLI & Runner Daemon
 

--- a/deployments/cli/community/README.md
+++ b/deployments/cli/community/README.md
@@ -4,6 +4,14 @@ In this guide, we will walk you through the process of setting up a self-hosted 
 
 We will cover two main options for setting up your self-hosted environment: using a cloud server or using your desktop. For the cloud server, we will use an AWS EC2 instance. For the desktop, we will use Docker to create a local environment.
 
+> **Just want to try Pi Dash quickly?**
+> If you're evaluating Pi Dash or running it on a homelab / small VPS, the
+> [All-in-One Docker image](../aio/community/README.md) is a one-container
+> shortcut — single `docker run` command instead of docker-compose.
+> External Postgres / Redis / RabbitMQ / S3-compatible storage are still
+> required. Come back to this guide when you're ready for a full
+> production deployment with independent service scaling.
+
 Let's get started!
 
 ## Setting up Docker Environment


### PR DESCRIPTION
## Summary

The AIO deployment guide at \`deployments/aio/community/README.md\` is well-written but **unreachable** from the top-level README — a new visitor has to browse into the \`deployments/\` tree to discover it exists.

This PR adds two small cross-links so users know all three deployment paths (AIO, docker-compose/swarm, helm) exist.

## Changes

- **\`README.md\`** — replace the single-sentence \"see the deployments/ directory\" pointer with an explicit **Production deployment** subsection that names and links each path with a one-line positioning (AIO for demos/homelabs, compose for production, helm is WIP).
- **\`deployments/cli/community/README.md\`** — add a blockquote callout at the top cross-referencing AIO for users who just want a quick try.

No behavior change, no code changes. Docs only.

## Test plan

- [x] Render the top-level README on GitHub and confirm all three links resolve to the correct in-repo READMEs
- [x] Confirm no \`makeplane\`/\`pi-dash.so\`/other fictional references were reintroduced