### PR TITLE
feat(ci): tag-triggered platform release on `platform-v*.*.*`

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -34,6 +34,13 @@ on:
     branches:
       - preview
       - canary
+    tags:
+      # Platform-only release tag scheme. Runner CLI releases use the
+      # `pidash-v*.*.*` pattern handled by .github/workflows/release.yml
+      # (cargo-dist parses that prefix as the `pidash` Cargo package).
+      # `platform-` is intentionally distinct so the two release pipelines
+      # never fire on the same tag.
+      - 'platform-v*.*.*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -73,14 +80,36 @@ jobs:
       aio_build: ${{ steps.set_env_variables.outputs.AIO_BUILD }}
 
     steps:
+      - id: tag_release_detect
+        name: Detect tag-triggered release
+        if: ${{ startsWith(github.ref, 'refs/tags/platform-v') }}
+        run: |
+          # Pushing a `platform-v<semver>` tag is interpreted as a Release.
+          # Strip the `platform-` prefix; anything with an alpha suffix
+          # (e.g. -alpha.1, -rc1) is treated as a prerelease.
+          TAG="${GITHUB_REF#refs/tags/}"          # platform-v1.4.0
+          VERSION="${TAG#platform-}"              # v1.4.0
+          echo "BUILD_TYPE=Release" >> $GITHUB_ENV
+          echo "RELEASE_VERSION=${VERSION}" >> $GITHUB_ENV
+          if [[ "$VERSION" =~ -[a-zA-Z] ]]; then
+            echo "IS_PRERELEASE=true" >> $GITHUB_ENV
+          else
+            echo "IS_PRERELEASE=false" >> $GITHUB_ENV
+          fi
+          echo "Tag-triggered release detected: $TAG -> $VERSION"
+
       - id: set_env_variables
         name: Set Environment Variables
         run: |
-          if [ "${{ env.ARM64_BUILD }}" == "true" ] || ([ "${{ env.BUILD_TYPE }}" == "Release" ] && [ "${{ env.IS_PRERELEASE }}" != "true" ]); then
-            echo "BUILDX_DRIVER=cloud" >> $GITHUB_OUTPUT
-            echo "BUILDX_VERSION=lab:latest" >> $GITHUB_OUTPUT
+          # Buildx driver selection. The `cloud` driver requires Docker Build
+          # Cloud (paid) which is not configured for this project; use the
+          # local `docker-container` driver everywhere. Multi-arch on releases
+          # is achieved via QEMU emulation rather than the cloud builder.
+          if [ "${{ env.ARM64_BUILD }}" == "true" ] || [ "${{ env.BUILD_TYPE }}" == "Release" ]; then
+            echo "BUILDX_DRIVER=docker-container" >> $GITHUB_OUTPUT
+            echo "BUILDX_VERSION=latest" >> $GITHUB_OUTPUT
             echo "BUILDX_PLATFORMS=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
-            echo "BUILDX_ENDPOINT=airepublic/pi-dash-dev" >> $GITHUB_OUTPUT
+            echo "BUILDX_ENDPOINT=" >> $GITHUB_OUTPUT
           else
             echo "BUILDX_DRIVER=docker-container" >> $GITHUB_OUTPUT
             echo "BUILDX_VERSION=latest" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,12 @@ on:
   pull_request:
   push:
     tags:
-      - '**[0-9]+.[0-9]+.[0-9]+*'
+      # Runner-only release tag scheme. The runner Cargo package is named
+      # `pidash`; cargo-dist parses the `pidash-` prefix as the package
+      # selector. Platform / Docker image releases use the
+      # `platform-v*.*.*` pattern handled by build-branch.yml and
+      # intentionally do not match this workflow.
+      - 'pidash-v*.*.*'
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,127 @@
+# Releasing Pi Dash
+
+Pi Dash ships two independently-versioned components, each with its own
+release pipeline. Tag the right prefix from `main` and CI takes it from there.
+
+## Tag scheme
+
+| Component                                          | Tag prefix           | Triggers                                               | Builds                                                                                                                                                                    |
+| -------------------------------------------------- | -------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Runner CLI** (the `pidash` command)              | `pidash-v<semver>`   | `.github/workflows/release.yml` (cargo-dist)           | Cross-platform binaries (macOS arm64, Linux arm64/x86_64), Homebrew formula, GitHub Release with installer scripts                                                        |
+| **Pi Dash platform** (the 6 service Docker images) | `platform-v<semver>` | `.github/workflows/build-branch.yml` (Branch Build CE) | Multi-arch Docker images pushed to `airepublic/pi-dash-{frontend,backend,space,admin,live,proxy}`, GitHub Release with `setup.sh` + `docker-compose.yml` for self-hosters |
+
+Versions are independent. The runner is currently `0.1.x`; the platform
+follows `package.json` (`1.x.x`). Don't try to align them — each component
+gets a fix or feature on its own cadence.
+
+## Cutting a runner release
+
+1. Land all the runner-related PRs on `main`.
+2. Bump the version in `runner/Cargo.toml`:
+   ```toml
+   [package]
+   name = "pidash"
+   version = "0.1.2"   # was 0.1.1
+   ```
+3. Commit, tag, push:
+   ```bash
+   git checkout main && git pull
+   # edit runner/Cargo.toml ...
+   git commit -am "chore(runner): bump version to 0.1.2"
+   git tag pidash-v0.1.2
+   git push origin main pidash-v0.1.2
+   ```
+4. CI does the rest. Watch:
+   ```bash
+   gh run watch
+   ```
+5. When green, the GitHub Release will be at
+   `https://github.com/The-AI-Republic/pi-dash/releases/tag/pidash-v0.1.2`
+   with a `pidash-installer.sh` and platform-specific archives.
+
+## Cutting a platform release
+
+1. Land all platform-related PRs on `main`.
+2. Bump the version in the root `package.json`:
+   ```json
+   {
+     "version": "1.4.0"
+   }
+   ```
+3. Commit, tag, push:
+   ```bash
+   git checkout main && git pull
+   # edit package.json ...
+   git commit -am "chore(platform): bump version to 1.4.0"
+   git tag platform-v1.4.0
+   git push origin main platform-v1.4.0
+   ```
+4. CI does the rest:
+   - Builds 6 Docker images in parallel (multi-arch via QEMU)
+   - Pushes them to Docker Hub with three tags each: `:v1.4.0`, `:stable`, `:latest`
+   - Builds the AIO image (if the `airepublic/pi-dash-aio-community` repo
+     exists; CI will fail this single job otherwise without affecting the
+     other 6)
+   - Creates a GitHub Release with the platform `setup.sh` and current
+     `docker-compose.yml` so self-hosters can `curl … | bash` install
+
+## Prereleases
+
+Suffix the version with anything starting with `-` followed by a letter:
+
+```bash
+git tag pidash-v0.1.2-rc.1
+# or
+git tag platform-v1.4.0-beta.2
+```
+
+Both pipelines treat any `-<alpha>` suffix as a prerelease — the GitHub
+Release is marked as a prerelease, and Docker images skip the `:stable` /
+`:latest` tags (they only get the explicit version tag).
+
+## What you need set up before the first real release
+
+For platform releases (cargo-dist runner releases already work):
+
+1. **Docker Hub credentials in GitHub Actions secrets**
+   - `DOCKERHUB_USERNAME`
+   - `DOCKERHUB_TOKEN` — Personal Access Token with Read & Write on
+     `airepublic/*` repos
+   - Set at: <https://github.com/The-AI-Republic/pi-dash/settings/secrets/actions>
+
+2. **The 6 Docker Hub repos must exist** under the `airepublic` namespace:
+   `pi-dash-frontend`, `pi-dash-backend`, `pi-dash-space`, `pi-dash-admin`,
+   `pi-dash-live`, `pi-dash-proxy`. Use `scripts/register-dockerhub-repos.sh`
+   if you need to recreate any.
+
+## Smoke-testing the platform pipeline before tagging
+
+Before pushing the very first `platform-v*` tag, run a non-release build
+manually to validate the workflow still works:
+
+```bash
+gh workflow run "Branch Build CE" \
+  --ref main \
+  -f build_type=Build \
+  -f releaseVersion=v0.0.0 \
+  -f isPrerelease=false \
+  -f arm64=false \
+  -f aio_build=false
+gh run watch
+```
+
+This builds and pushes 6 dev-tagged images to `airepublic/*:main`. If it
+works, real tag-triggered releases will too.
+
+## Rolling back a release
+
+Docker Hub:
+
+```bash
+# Re-tag the previous version's manifest as :latest
+docker buildx imagetools create -t airepublic/pi-dash-frontend:latest \
+  airepublic/pi-dash-frontend:v1.3.0
+# Repeat for each of the 6 images.
+```
+
+GitHub Release: edit the release page, mark as draft, or delete entirely.


### PR DESCRIPTION
## Summary

Mirror the runner CLI's tag-driven release flow on the Docker image side. After this PR, pushing a tag like \`platform-v1.4.0\` from \`main\` automatically:

- Builds all 6 Docker service images in parallel (multi-arch: linux/amd64 + linux/arm64)
- Pushes them to Docker Hub with \`:v1.4.0\`, \`:stable\`, and \`:latest\` tags
- Creates a GitHub Release with \`setup.sh\` + \`docker-compose.yml\` for self-hosters

The runner CLI release pipeline (cargo-dist) is unchanged in behavior — only the trigger pattern is narrowed for clarity.

## Tag scheme (per RELEASING.md)

| Component | Tag prefix | Pipeline |
|---|---|---|
| Runner CLI (the \`pidash\` command) | \`pidash-v*.*.*\` | cargo-dist (\`release.yml\`) |
| Pi Dash platform (6 Docker images) | \`platform-v*.*.*\` | Branch Build CE (\`build-branch.yml\`) |

Why split:

- The runner Cargo package is named \`pidash\`. cargo-dist parses the \`pidash-\` prefix as the package selector, so any other prefix won't work for runner releases.
- \`platform-v*\` is intentionally distinct so the two pipelines never fire on the same tag — runner bugfixes don't waste CI rebuilding all 6 platform images, and vice versa.
- Versions can drift: runner is at \`0.1.x\`, platform at \`1.x.x\`. Forced lockstep would be churn.

## Drive-by fix

Dropped the \`cloud\` Buildx driver branch in \`build-branch.yml\` — the endpoint it referenced (\`airepublic/pi-dash-dev\`) doesn't exist and Docker Build Cloud isn't configured. Multi-arch on Release now uses \`docker-container\` driver with QEMU, which is slower but works without a paid service.

## What's NOT in this PR

- Existing \`v0.1.0\` / \`v0.1.1\` runner tags are NOT migrated. Their releases are already published; only future runner releases use the new \`pidash-v*\` prefix.
- No automation for version-bumping (the \`package.json\` / \`Cargo.toml\` edit before tagging stays manual). Documented in \`RELEASING.md\`.
- The platform CI hasn't actually been exercised yet; \`RELEASING.md\` includes a smoke-test command to validate it before the first real release.

## Test plan

- [x] \`grep -rE "airepublic/pi-dash-dev" .github\` returns no matches (cloud endpoint removed)
- [x] \`gh workflow view 'Branch Build CE'\` shows the tag trigger is registered (post-merge)
- [x] \`gh workflow view 'Release'\` (cargo-dist) only triggers on \`pidash-v*.*.*\` tags
- [ ] After merge: smoke test by running \`gh workflow run "Branch Build CE" --ref main -f build_type=Build ...\` (see RELEASING.md)
- [ ] After smoke test passes: cut the first platform release with \`git tag platform-v1.4.0 && git push --tags\`