### PR TITLE
chore(deps): bump deps to fix 13 Dependabot security alerts

### DIFF
--- a/apps/api/requirements/base.txt
+++ b/apps/api/requirements/base.txt
@@ -58,7 +58,7 @@ posthog==3.5.0
 # crypto
 cryptography==46.0.7
 # html validator
-lxml==6.0.0
+lxml==6.1.0
 # s3
 boto3==1.34.96
 # password validator
@@ -77,4 +77,4 @@ drf-spectacular==0.28.0
 # html sanitizer
 nh3==0.2.18
 # prompt templating (sandboxed)
-Jinja2==3.1.4
+Jinja2==3.1.6

--- a/package.json
+++ b/package.json
@@ -76,7 +76,10 @@
       "yaml@1": "1.10.3",
       "yaml@2": "2.8.3",
       "path-to-regexp": "0.1.13",
-      "defu": "6.1.5"
+      "defu": "6.1.5",
+      "follow-redirects": "1.16.0",
+      "postcss": "8.5.10",
+      "uuid": "14.0.0"
     },
     "onlyBuiltDependencies": [
       "@parcel/watcher",

--- a/packages/tailwind-config/package.json
+++ b/packages/tailwind-config/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@tailwindcss/postcss": "4.1.17",
-    "postcss": "8.5.6"
+    "postcss": "8.5.10"
   },
   "devDependencies": {
     "tailwindcss": "4.1.17"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,9 +78,6 @@ catalogs:
     tsdown:
       specifier: 0.16.0
       version: 0.16.0
-    uuid:
-      specifier: 13.0.0
-      version: 13.0.0
 
 overrides:
   express: 4.22.0
@@ -120,6 +117,9 @@ overrides:
   yaml@2: 2.8.3
   path-to-regexp: 0.1.13
   defu: 6.1.5
+  follow-redirects: 1.16.0
+  postcss: 8.5.10
+  uuid: 14.0.0
 
 importers:
 
@@ -228,8 +228,8 @@ importers:
         specifier: 'catalog:'
         version: 2.2.4(react@18.3.1)
       uuid:
-        specifier: 'catalog:'
-        version: 13.0.0
+        specifier: 14.0.0
+        version: 14.0.0
     devDependencies:
       '@pi-dash/tailwind-config':
         specifier: workspace:*
@@ -349,8 +349,8 @@ importers:
         specifier: ^0.34.3
         version: 0.34.3
       uuid:
-        specifier: 'catalog:'
-        version: 13.0.0
+        specifier: 14.0.0
+        version: 14.0.0
       ws:
         specifier: ^8.18.3
         version: 8.18.3
@@ -512,8 +512,8 @@ importers:
         specifier: 'catalog:'
         version: 2.2.4(react@18.3.1)
       uuid:
-        specifier: 'catalog:'
-        version: 13.0.0
+        specifier: 14.0.0
+        version: 14.0.0
     devDependencies:
       '@pi-dash/tailwind-config':
         specifier: workspace:*
@@ -714,8 +714,8 @@ importers:
         specifier: ^1.2.2
         version: 1.3.0(react@18.3.1)
       uuid:
-        specifier: 'catalog:'
-        version: 13.0.0
+        specifier: 14.0.0
+        version: 14.0.0
     devDependencies:
       '@pi-dash/tailwind-config':
         specifier: workspace:*
@@ -962,8 +962,8 @@ importers:
         specifier: ^0.8.10
         version: 0.8.10(@tiptap/core@2.26.3(@tiptap/pm@2.26.1))
       uuid:
-        specifier: 'catalog:'
-        version: 13.0.0
+        specifier: 14.0.0
+        version: 14.0.0
       y-indexeddb:
         specifier: ^9.0.12
         version: 9.0.12(yjs@13.6.27)
@@ -996,8 +996,8 @@ importers:
         specifier: 'catalog:'
         version: 18.3.1
       postcss:
-        specifier: ^8.4.38
-        version: 8.5.6
+        specifier: 8.5.10
+        version: 8.5.10
       tsdown:
         specifier: 'catalog:'
         version: 0.16.0(typescript@5.8.3)(unrun@0.2.34)
@@ -1226,8 +1226,8 @@ importers:
         specifier: 'catalog:'
         version: 6.0.8(mobx@6.12.0)
       uuid:
-        specifier: 'catalog:'
-        version: 13.0.0
+        specifier: 14.0.0
+        version: 14.0.0
       zod:
         specifier: ^3.22.2
         version: 3.25.76
@@ -1254,8 +1254,8 @@ importers:
         specifier: 4.1.17
         version: 4.1.17
       postcss:
-        specifier: 8.5.6
-        version: 8.5.6
+        specifier: 8.5.10
+        version: 8.5.10
     devDependencies:
       tailwindcss:
         specifier: 4.1.17
@@ -1416,13 +1416,13 @@ importers:
         version: 18.3.1
       autoprefixer:
         specifier: ^10.4.19
-        version: 10.4.21(postcss@8.5.6)
+        version: 10.4.21(postcss@8.5.10)
       postcss-cli:
         specifier: ^11.0.0
-        version: 11.0.1(jiti@2.6.1)(postcss@8.5.6)
+        version: 11.0.1(jiti@2.6.1)(postcss@8.5.10)
       postcss-nested:
         specifier: ^6.0.1
-        version: 6.2.0(postcss@8.5.6)
+        version: 6.2.0(postcss@8.5.10)
       storybook:
         specifier: 9.1.19
         version: 9.1.19(@testing-library/dom@10.4.0)(prettier@3.7.4)(vite@7.3.2(@types/node@22.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.43.1)(yaml@2.8.3))
@@ -1490,8 +1490,8 @@ importers:
         specifier: ^11.0.5
         version: 11.0.5
       uuid:
-        specifier: 'catalog:'
-        version: 13.0.0
+        specifier: 14.0.0
+        version: 14.0.0
     devDependencies:
       '@pi-dash/typescript-config':
         specifier: workspace:*
@@ -4734,7 +4734,7 @@ packages:
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: 8.5.10
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -5722,8 +5722,8 @@ packages:
   fn.name@1.1.0:
     resolution: {integrity: sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -6044,7 +6044,7 @@ packages:
     resolution: {integrity: sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: 8.5.10
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -7225,14 +7225,14 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
-      postcss: ^8.0.0
+      postcss: 8.5.10
 
   postcss-load-config@5.1.0:
     resolution: {integrity: sha512-G5AJ+IX0aD0dygOE0yFZQ/huFFMSNneyfp0e3/bT05a8OfPC5FUoZRPfGijUdGOJNMewJiwzcHJXFafFzeKFVA==}
     engines: {node: '>= 18'}
     peerDependencies:
       jiti: '>=1.21.0'
-      postcss: '>=8.0.9'
+      postcss: 8.5.10
       tsx: ^4.8.1
     peerDependenciesMeta:
       jiti:
@@ -7246,37 +7246,37 @@ packages:
     resolution: {integrity: sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: 8.5.10
 
   postcss-modules-local-by-default@4.2.0:
     resolution: {integrity: sha512-5kcJm/zk+GJDSfw+V/42fJ5fhjL5YbFDl8nVdXkJPLLW+Vf9mTD5Xe0wqIaDnLuL2U6cDNpTr+UQ+v2HWIBhzw==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: 8.5.10
 
   postcss-modules-scope@3.2.1:
     resolution: {integrity: sha512-m9jZstCVaqGjTAuny8MdgE88scJnCiQSlSrOWcTQgM2t32UBe+MUmFSO5t7VMSfAf/FJKImAxBav8ooCHJXCJA==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: 8.5.10
 
   postcss-modules-values@4.0.0:
     resolution: {integrity: sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: 8.5.10
 
   postcss-nested@6.2.0:
     resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
     engines: {node: '>=12.0'}
     peerDependencies:
-      postcss: ^8.2.14
+      postcss: 8.5.10
 
   postcss-reporter@7.1.0:
     resolution: {integrity: sha512-/eoEylGWyy6/DOiMP5lmFRdmDKThqgn7D6hP2dXKJI/0rJSO1ADFNngZfDzxL0YAxFvws+Rtpuji1YIHj4mySA==}
     engines: {node: '>=10'}
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: 8.5.10
 
   postcss-selector-parser@6.0.10:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
@@ -7293,8 +7293,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prettier@3.7.4:
@@ -8431,16 +8431,8 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
-  uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
-    hasBin: true
-
-  uuid@13.0.0:
-    resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
-    hasBin: true
-
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   uvu@0.5.6:
@@ -9195,7 +9187,7 @@ snapshots:
     dependencies:
       '@effect/platform': 0.94.1(effect@3.20.0)
       effect: 3.20.0
-      uuid: 11.1.0
+      uuid: 14.0.0
     optionalDependencies:
       ioredis: 5.7.0
 
@@ -9246,7 +9238,7 @@ snapshots:
       '@effect/experimental': 0.58.0(@effect/platform@0.94.1(effect@3.20.0))(effect@3.20.0)(ioredis@5.7.0)
       '@effect/platform': 0.94.1(effect@3.20.0)
       effect: 3.20.0
-      uuid: 11.1.0
+      uuid: 14.0.0
 
   '@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.1(effect@3.20.0))(effect@3.20.0)(ioredis@5.7.0))(@effect/platform@0.94.1(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.1(effect@3.20.0))(effect@3.20.0))(effect@3.20.0)':
     dependencies:
@@ -9459,7 +9451,7 @@ snapshots:
       kleur: 4.1.5
       lodash.debounce: 4.0.8
       redlock: 4.2.0
-      uuid: 11.1.0
+      uuid: 14.0.0
       y-protocols: 1.0.6(yjs@13.6.27)
       yjs: 13.6.27
     transitivePeerDependencies:
@@ -9485,7 +9477,7 @@ snapshots:
       async-lock: 1.4.1
       kleur: 4.1.5
       lib0: 0.2.114
-      uuid: 11.1.0
+      uuid: 14.0.0
       ws: 8.18.3
       y-protocols: 1.0.6(yjs@13.6.27)
       yjs: 13.6.27
@@ -10571,7 +10563,7 @@ snapshots:
       dequal: 2.0.3
       polished: 4.3.1
       storybook: 9.1.19(@testing-library/dom@10.4.0)(prettier@3.7.4)(vite@7.3.2(@types/node@22.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.43.1)(yaml@2.8.3))
-      uuid: 9.0.1
+      uuid: 14.0.0
 
   '@storybook/addon-backgrounds@8.6.14(storybook@9.1.19(@testing-library/dom@10.4.0)(prettier@3.7.4)(vite@7.3.2(@types/node@22.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.43.1)(yaml@2.8.3)))':
     dependencies:
@@ -11050,7 +11042,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.1.17
       '@tailwindcss/oxide': 4.1.17
-      postcss: 8.5.6
+      postcss: 8.5.10
       tailwindcss: 4.1.17
 
   '@tailwindcss/typography@0.5.19':
@@ -11970,14 +11962,14 @@ snapshots:
 
   attr-accept@2.2.5: {}
 
-  autoprefixer@10.4.21(postcss@8.5.6):
+  autoprefixer@10.4.21(postcss@8.5.10):
     dependencies:
       browserslist: 4.28.1
       caniuse-lite: 1.0.30001759
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.1
-      postcss: 8.5.6
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.7:
@@ -11986,7 +11978,7 @@ snapshots:
 
   axios@1.15.0:
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -12411,12 +12403,12 @@ snapshots:
 
   css-loader@6.11.0(webpack@5.104.1(@swc/core@1.13.5(@swc/helpers@0.5.17))):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.6)
-      postcss: 8.5.6
-      postcss-modules-extract-imports: 3.1.0(postcss@8.5.6)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.5.6)
-      postcss-modules-scope: 3.2.1(postcss@8.5.6)
-      postcss-modules-values: 4.0.0(postcss@8.5.6)
+      icss-utils: 5.1.0(postcss@8.5.10)
+      postcss: 8.5.10
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.10)
+      postcss-modules-local-by-default: 4.2.0(postcss@8.5.10)
+      postcss-modules-scope: 3.2.1(postcss@8.5.10)
+      postcss-modules-values: 4.0.0(postcss@8.5.10)
       postcss-value-parser: 4.2.0
       semver: 7.7.4
     optionalDependencies:
@@ -12991,7 +12983,7 @@ snapshots:
 
   fn.name@1.1.0: {}
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   fontfaceobserver@2.1.0: {}
 
@@ -13375,9 +13367,9 @@ snapshots:
       safer-buffer: 2.1.2
     optional: true
 
-  icss-utils@5.1.0(postcss@8.5.6):
+  icss-utils@5.1.0(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
 
   ieee754@1.2.1: {}
 
@@ -14775,15 +14767,15 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-cli@11.0.1(jiti@2.6.1)(postcss@8.5.6):
+  postcss-cli@11.0.1(jiti@2.6.1)(postcss@8.5.10):
     dependencies:
       chokidar: 3.6.0
       dependency-graph: 1.0.0
       fs-extra: 11.3.1
       picocolors: 1.1.1
-      postcss: 8.5.6
-      postcss-load-config: 5.1.0(jiti@2.6.1)(postcss@8.5.6)
-      postcss-reporter: 7.1.0(postcss@8.5.6)
+      postcss: 8.5.10
+      postcss-load-config: 5.1.0(jiti@2.6.1)(postcss@8.5.10)
+      postcss-reporter: 7.1.0(postcss@8.5.10)
       pretty-hrtime: 1.0.3
       read-cache: 1.0.0
       slash: 5.1.0
@@ -14793,44 +14785,44 @@ snapshots:
       - jiti
       - tsx
 
-  postcss-load-config@5.1.0(jiti@2.6.1)(postcss@8.5.6):
+  postcss-load-config@5.1.0(jiti@2.6.1)(postcss@8.5.10):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.8.3
     optionalDependencies:
       jiti: 2.6.1
-      postcss: 8.5.6
+      postcss: 8.5.10
 
-  postcss-modules-extract-imports@3.1.0(postcss@8.5.6):
+  postcss-modules-extract-imports@3.1.0(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
 
-  postcss-modules-local-by-default@4.2.0(postcss@8.5.6):
+  postcss-modules-local-by-default@4.2.0(postcss@8.5.10):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.6)
-      postcss: 8.5.6
+      icss-utils: 5.1.0(postcss@8.5.10)
+      postcss: 8.5.10
       postcss-selector-parser: 7.1.0
       postcss-value-parser: 4.2.0
 
-  postcss-modules-scope@3.2.1(postcss@8.5.6):
+  postcss-modules-scope@3.2.1(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
       postcss-selector-parser: 7.1.0
 
-  postcss-modules-values@4.0.0(postcss@8.5.6):
+  postcss-modules-values@4.0.0(postcss@8.5.10):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.6)
-      postcss: 8.5.6
+      icss-utils: 5.1.0(postcss@8.5.10)
+      postcss: 8.5.10
 
-  postcss-nested@6.2.0(postcss@8.5.6):
+  postcss-nested@6.2.0(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
       postcss-selector-parser: 6.1.2
 
-  postcss-reporter@7.1.0(postcss@8.5.6):
+  postcss-reporter@7.1.0(postcss@8.5.10):
     dependencies:
       picocolors: 1.1.1
-      postcss: 8.5.6
+      postcss: 8.5.10
       thenby: 1.3.4
 
   postcss-selector-parser@6.0.10:
@@ -14850,7 +14842,7 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.6:
+  postcss@8.5.10:
     dependencies:
       nanoid: 3.3.8
       picocolors: 1.1.1
@@ -15536,7 +15528,7 @@ snapshots:
       htmlparser2: 8.0.2
       is-plain-object: 5.0.0
       parse-srcset: 1.0.2
-      postcss: 8.5.6
+      postcss: 8.5.10
 
   saxes@6.0.0:
     dependencies:
@@ -16250,11 +16242,7 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
-  uuid@11.1.0: {}
-
-  uuid@13.0.0: {}
-
-  uuid@9.0.1: {}
+  uuid@14.0.0: {}
 
   uvu@0.5.6:
     dependencies:
@@ -16356,7 +16344,7 @@ snapshots:
       esbuild: 0.25.0
       fdir: 6.5.0(picomatch@2.3.2)
       picomatch: 2.3.2
-      postcss: 8.5.6
+      postcss: 8.5.10
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,7 +32,7 @@ catalog:
   swr: 2.2.4
   tsdown: 0.16.0
   typescript: 5.8.3
-  uuid: 13.0.0
+  uuid: 14.0.0
   vite: 7.3.2
 
 onlyBuiltDependencies:

--- a/runner/Cargo.lock
+++ b/runner/Cargo.lock
@@ -1466,9 +1466,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

Resolves 13 of 14 open Dependabot alerts across npm, pip, and cargo.

### npm (`pnpm-lock.yaml` + overrides)
- `postcss` 8.5.6 → 8.5.10 — XSS via unescaped `</style>` (alerts #14, #15)
- `uuid` catalog 13.0.0 → 14.0.0 + override — buffer bounds check in v3/v5/v6 when `buf` is provided (alert #8). The repo only uses `v4`, so the bug isn't exploitable in our code, but the lockfile-wide bump silences the alert.
- `follow-redirects` → 1.16.0 via override — auth header leak on cross-domain redirect (alert #1)

### pip (`apps/api/requirements/base.txt`)
- `Jinja2` 3.1.4 → 3.1.6 — sandbox breakouts (alerts #4, #5, #6, #9, #10, #11)
- `lxml` 6.0.0 → 6.1.0 — XXE in `iterparse()` / `ETCompatXMLParser()` default config (alerts #7, #12)

### cargo (`runner/Cargo.lock`)
- `rustls-webpki` 0.103.12 → 0.103.13 — DoS via panic on malformed CRL BIT STRING (alert #13)

### Skipped
- **Alert #2 (`lru` 0.12.5)** — Stacked Borrows soundness in `IterMut`, LOW severity. `lru` 0.12 is pinned transitively by `ratatui = "0.28"` via `^0.12.0`; only `ratatui` 0.30.0 drops the `lru` dependency entirely (0.28 → 0.30 is a major TUI refactor). Issue is a soundness concern under the Stacked Borrows aliasing model — not an exploitable vulnerability — so I recommend dismissing this alert as "tolerable risk" rather than rolling a major ratatui upgrade in a security-bump PR.

## Verification

- `pnpm check:types` — 28/28 workspace tasks pass
- `cargo test --no-run` — runner builds; tests compile

## Test plan

- [ ] CI passes (lint, types, build, tests)
- [ ] Verify `pnpm dev` and the runner still start cleanly post-merge
- [ ] After merge, dismiss alert #2 (lru) with rationale above