### PR TITLE
chore: remove unused apps/api/uv.lock to clear stale Dependabot alerts

### DIFF
--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -1,8 +1,0 @@
-version = 1
-revision = 3
-requires-python = ">=3.12"
-
-[[package]]
-name = "pi-dash"
-version = "0.24.0"
-source = { virtual = "." }


### PR DESCRIPTION
## Summary

Closes 4 of the 5 remaining Dependabot alerts after PR #58 by deleting an unused lockfile.

## Background

After PR #58 bumped the actual Python deps (\`apps/api/requirements/base.txt\`), 4 alerts remained \"open\" pointing at \`apps/api/uv.lock\`:

| Alert | Pkg | Severity |
|---|---|---|
| #12 | \`lxml\` | high |
| #9, #10 | \`jinja2\` | medium |
| #11 | \`Jinja2\` | medium |

Investigating, \`apps/api/uv.lock\` is a **128-byte stub** with no actual dependency entries:

\`\`\`toml
version = 1
revision = 3
requires-python = \">=3.12\"

[[package]]
name = \"pi-dash\"
version = \"0.24.0\"
source = { virtual = \".\" }
\`\`\`

It was added accidentally in PR #49. Confirmed unused:

- \`apps/api/Dockerfile.api\` and \`apps/api/Dockerfile.dev\` both install via \`pip install -r requirements/...txt\`
- \`pyproject.toml\` has no \`[project.dependencies]\` array
- \`grep -rE '\\\\buv\\\\b|uv\\\\.lock'\` finds zero references in the codebase

The Dependabot alerts are stale — they reference vulnerable versions that exist nowhere in the repo. Deleting the file lets Dependabot rescan and close them on its next run.

## Out of scope

The 5th remaining alert is **#2 \`lru\` (low severity)** in \`runner/Cargo.lock\`, a transitive dep through \`ratatui 0.28\` which pins \`lru = \"^0.12\"\`. Fixing requires bumping \`ratatui\` to 0.29+ — a minor TUI library upgrade with potential API breaking changes. Given the alert is Miri-detected stacked-borrows (no practical exploit), it'll be **dismissed with \`tolerable_risk\`** rather than fixed in this PR. Real fix lives in a future ratatui upgrade.

## Test plan

- [x] \`grep -rE 'uv\\\\b|uv\\\\.lock' apps/api/\` returns no functional references
- [x] \`apps/api/pyproject.toml\` confirmed not to declare any dependencies
- [ ] After merge: Dependabot will auto-close alerts #9, #10, #11, #12 on next scan (~24 hours)