### PR TITLE
chore(docs): use privacy_security@airepublic.com for vuln disclosures

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Feel free to ask questions, report bugs, participate in discussions, share ideas
 
 If you discover a security vulnerability in Pi Dash, please report it responsibly instead of opening a public issue. See [SECURITY.md](./SECURITY.md) for more info.
 
-To disclose any security issues, please email us at [security@airepublic.com](mailto:security@airepublic.com).
+To disclose any security issues, please email us at [privacy_security@airepublic.com](mailto:privacy_security@airepublic.com).
 
 ## 🤝 Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,10 @@
 # Security policy
+
 This document outlines the security protocols and vulnerability reporting guidelines for the Pi Dash project. Ensuring the security of our systems is a top priority, and while we work diligently to maintain robust protection, vulnerabilities may still occur. We highly value the community’s role in identifying and reporting security concerns to uphold the integrity of our systems and safeguard our users.
 
 ## Reporting a vulnerability
-If you have identified a security vulnerability, submit your findings to [security@airepublic.com](mailto:security@airepublic.com). 
+
+If you have identified a security vulnerability, submit your findings to [privacy_security@airepublic.com](mailto:privacy_security@airepublic.com).
 Ensure your report includes all relevant information needed for us to reproduce and assess the issue. Include the IP address or URL of the affected system.
 
 To ensure a responsible and effective disclosure process, please adhere to the following:
@@ -13,6 +15,7 @@ To ensure a responsible and effective disclosure process, please adhere to the f
 - Do not engage in physical security attacks, social engineering, distributed denial of service (DDoS) attacks, spam campaigns, or attacks on third-party applications as part of your vulnerability testing.
 
 ## Out of scope
+
 While we appreciate all efforts to assist in improving our security, please note that the following types of vulnerabilities are considered out of scope:
 
 - Vulnerabilities requiring man-in-the-middle (MITM) attacks or physical access to a user’s device.
@@ -26,14 +29,14 @@ While we appreciate all efforts to assist in improving our security, please note
 At Pi Dash, we are committed to maintaining transparent and collaborative communication throughout the vulnerability resolution process. Here's what you can expect from us:
 
 - **Response Time** <br/>
-We will acknowledge receipt of your vulnerability report within three business days and provide an estimated timeline for resolution.
+  We will acknowledge receipt of your vulnerability report within three business days and provide an estimated timeline for resolution.
 - **Legal Protection** <br/>
-We will not initiate legal action against you for reporting vulnerabilities, provided you adhere to the reporting guidelines.
+  We will not initiate legal action against you for reporting vulnerabilities, provided you adhere to the reporting guidelines.
 - **Confidentiality** <br/>
-Your report will be treated with confidentiality. We will not disclose your personal information to third parties without your consent.
+  Your report will be treated with confidentiality. We will not disclose your personal information to third parties without your consent.
 - **Recognition** <br/>
-With your permission, we are happy to publicly acknowledge your contribution to improving our security once the issue is resolved.
+  With your permission, we are happy to publicly acknowledge your contribution to improving our security once the issue is resolved.
 - **Timely Resolution** <br/>
-We are committed to working closely with you throughout the resolution process, providing timely updates as necessary. Our goal is to address all reported vulnerabilities swiftly, and we will actively engage with you to coordinate a responsible disclosure once the issue is fully resolved.
+  We are committed to working closely with you throughout the resolution process, providing timely updates as necessary. Our goal is to address all reported vulnerabilities swiftly, and we will actively engage with you to coordinate a responsible disclosure once the issue is fully resolved.
 
 We appreciate your help in ensuring the security of our platform. Your contributions are crucial to protecting our users and maintaining a secure environment. Thank you for working with us to keep Pi Dash safe.


### PR DESCRIPTION
## Summary

The security disclosure address in \`SECURITY.md\` and \`README.md\` was a placeholder set to \`security@airepublic.com\`. The mailbox actually monitored for security reports is \`privacy_security@airepublic.com\`. Update both files to point at the real address so vulnerability reports don't land in a black hole.

## Files changed

- \`SECURITY.md:5\`
- \`README.md:161\`

## Test plan

- [x] \`grep -rn "security@airepublic"\` returns no remaining references