### PR TITLE
feat(runner): multi-run continuation per issue (design + impl)

### DIFF
--- a/.ai_design/issue_run_improve/design.md
+++ b/.ai_design/issue_run_improve/design.md
@@ -6,7 +6,7 @@
 >
 > **Scope:** how an issue continues across more than one `AgentRun` when the
 > first run yields without finishing — and what that implies for run lifecycle,
-> conversation continuity, dispatch routing, and user UX.
+> dispatch routing, and conversation continuity.
 >
 > **Related work**
 >
@@ -24,132 +24,235 @@ Today, on `main` (commit `a99e736`):
 - The runner spawns a fresh `claude --print …` (or codex equivalent) for every
   run. Each run is a brand-new agent session.
 - When that run terminates — for any reason — the agent's working memory is
-  gone. There is no native session resume, no transcript replay, no thread
-  continuation across runs.
-- A user comment on an issue is **not** a signal: nothing wakes the agent, no
-  follow-up run is created.
+  gone. There is no resume path consumed by the cloud, no follow-up trigger
+  on user comments, no notion of a "paused" run.
+- A user comment on an issue is **not** a signal: nothing wakes the agent.
 
 The data model already partially supports continuation:
 
 - `AgentRun.thread_id` (`runner/models.py:363`) stores the provider's session
-  id (Claude `session_id` / Codex `thread_id`) when the runner reports it
-  via `run_started` (`consumers.py:374-379`).
+  id (Claude `session_id` / Codex `thread_id`) when the runner reports it via
+  `run_started` (`consumers.py:374-379`).
 - `AgentRun.parent_run` (`runner/models.py:346-352`) chains follow-up runs.
   `orchestration/service.py:103` sets it to the latest prior run when a new
   run is created for an issue that already has one.
 - The runner `RunPayload` struct has a `resume_thread_id: Option<String>` field
-  (`agent/mod.rs:54`) but the cloud never populates it.
-- Codex bridge supports `resume_thread()` (`runner/src/codex/bridge.rs:61-69`).
-  The Claude Code path has no `--resume` plumbing.
+  (`runner/src/agent/mod.rs:54`) and the **Codex bridge already consumes it**
+  (`runner/src/codex/bridge.rs:61-72`) — calling `thread/resume` when set,
+  `thread/start` otherwise. The Claude Code path explicitly skips resume
+  (`runner/src/claude_code/mod.rs:10`: "Single-turn runs only: no `--resume`").
+- The `Assign` wire envelope (`runner/src/cloud/protocol.rs:109-123`) does not
+  carry `resume_thread_id`, and the supervisor hardcodes `resume_thread_id:
+None` at `runner/src/daemon/supervisor.rs:544` regardless.
 
-So everything is wired *for storage* but nothing *consumes* it. This doc
-proposes how to wire the consumption side.
+So everything is wired _for storage_ and partially _for runner consumption_,
+but nothing on the cloud side ever populates the resume hint. This doc
+proposes how to wire the consumption side, and the dispatch model that lets
+it work without sacrificing throughput.
 
 ## 2. Goal
 
 For an issue whose work spans multiple agent runs, give the agent enough
 context on each follow-up run that it can continue meaningfully — while
-keeping the dispatch model (workspace pod queue, fair scheduling, runner
-ownership) intact.
+keeping the agent it ran on, when possible, so native session resume gives us
+correctness for free.
+
+The shape we want:
+
+```
+T0: issue001 dispatched to agentA → runs → yields → PAUSED
+T1: agentA picks issue002 from pod queue → BUSY on issue002
+T2: human comments on issue001 → run001b created, pinned to agentA → QUEUED
+T3: agentA finishes issue002 → idle → picks run001b from its personal queue
+T4: agentA resumes issue001's session natively (claude --resume / thread/resume)
+```
+
+The key property: agentA is never blocked. While issue001 is paused waiting
+for human input (potentially hours), agentA serves other issues from the pod
+queue. When the human finally responds, run001b is waiting in agentA's
+personal queue and gets picked up the moment agentA frees up.
 
 Non-goals:
 
 - Multi-agent collaboration on the same issue (one conversation per chain).
-- Cross-issue memory (a runner's recall of issue A is not available on issue
-  B; that's a separate, larger problem).
+- Cross-issue memory (a runner's recall of issue A is not available on
+  issue B; that's a separate, larger problem).
 - Long-term memory beyond a single issue's lifecycle.
 
-## 3. The Three Sub-Problems
+## 3. The three sub-problems
 
-This problem decomposes cleanly into three independent decisions. Each can be
-chosen separately; each has its own MVP/full-featured spectrum.
-
-| #   | Question                                                          | Where the design lives |
-| --- | ----------------------------------------------------------------- | ---------------------- |
-| A   | What does it mean for a run to "yield" instead of "finish"?       | §4 — Run Lifecycle     |
-| B   | What triggers a follow-up run?                                    | §5 — Continuation Triggers |
-| C   | How does the follow-up run inherit the prior run's context?       | §6 — Conversation Continuity |
-
-A separate question — whether to introduce an `IssueConversation` entity that
-owns the thread of runs — is covered in §7.
+| #   | Question                                                      | Section                      |
+| --- | ------------------------------------------------------------- | ---------------------------- |
+| A   | What does it mean for a run to "yield" instead of "finish"?   | §4 — Run Lifecycle           |
+| B   | What triggers a follow-up run, and where does it dispatch to? | §5 — Continuation & Dispatch |
+| C   | How does the follow-up run resume the prior run's context?    | §6 — Conversation Continuity |
 
 ## 4. Run Lifecycle: Yield vs. Finish
 
-### 4.1 Today's terminal states
+### 4.1 Today's status surface
 
-`AgentRunStatus` (`runner/models.py:101`) currently distinguishes
-`QUEUED → ASSIGNED → RUNNING → SUCCEEDED | FAILED | CANCELLED | TIMED_OUT`.
-All four terminals are flat: "done, don't expect more."
+`AgentRunStatus` (`apps/api/pi_dash/runner/models.py:101-110`) actually has:
+`QUEUED, ASSIGNED, RUNNING, AWAITING_APPROVAL, AWAITING_REAUTH, BLOCKED,
+COMPLETED, FAILED, CANCELLED`. Not the simpler enum sketched in earlier
+drafts — `BLOCKED` is already present and load-bearing.
 
-This is too coarse. An agent can stop without having finished, in several
-materially different ways:
+And there are **multiple independent classifiers**, not just two:
 
-| Termination kind          | What it means                                              | Should follow-up auto-trigger? |
-| ------------------------- | ---------------------------------------------------------- | ------------------------------ |
-| Completed cleanly         | Agent reports done; the work is finished                   | No                             |
-| Yielded — needs input     | Agent emits a structured "I need X from the human" signal  | Yes, when the human responds   |
-| Yielded — needs approval  | Agent paused on an approval gate                           | Yes, when approval resolves    |
-| Hit budget cap            | Run exceeded a token / wall-clock budget                   | Optional — policy decision     |
-| Crashed / disconnected    | Runner died, lease expired, network gone                   | Maybe — recovery is intra-run  |
-| User cancelled            | A human stopped the run                                    | No                             |
+| Classifier                                         | Where                           | Members today                                                 |
+| -------------------------------------------------- | ------------------------------- | ------------------------------------------------------------- |
+| `BUSY_STATUSES` (matcher excludes these runners)   | `runner/services/matcher.py:51` | ASSIGNED, RUNNING, AWAITING_APPROVAL, AWAITING_REAUTH         |
+| `NON_TERMINAL_STATUSES` (gates pod deletion)       | `runner/services/matcher.py:42` | QUEUED + the four BUSY                                        |
+| `AgentRun.is_terminal`                             | `runner/models.py:403-410`      | COMPLETED, FAILED, CANCELLED, **BLOCKED**                     |
+| `AgentRun.is_active` (single-active-run guardrail) | `runner/models.py:412-421`      | QUEUED, ASSIGNED, RUNNING, AWAITING_APPROVAL, AWAITING_REAUTH |
+| `ACTIVE_RUN_STATUSES` (Prom metrics)               | `runner/views/metrics.py:39`    | ASSIGNED, RUNNING, AWAITING_APPROVAL, AWAITING_REAUTH         |
 
-### 4.2 Proposed lifecycle additions
+Any new status has to be placed in **all five**. Treating `BUSY_STATUSES`
+alone is incomplete — `is_active` in particular is what `_active_run_for`
+(`orchestration/service.py:45`) consults to enforce the single-active-run
+guardrail per issue, which directly affects whether comment-triggered
+continuation can create a follow-up.
 
-Introduce an explicit **paused / awaiting** state distinct from terminal:
+### 4.2 Reconciling with the existing `BLOCKED` contract
 
-- `PAUSED_AWAITING_INPUT` — agent yielded cleanly with a question for the
-  human; no further dispatch until a continuation trigger fires.
-- `PAUSED_AWAITING_APPROVAL` — already partially modeled via the approvals
-  table; promote to a first-class run status so the matcher's "non-terminal"
-  predicate is honest.
+`BLOCKED` already terminates a run when the agent emits the
+`pi-dash-done` fenced block with `status: "blocked"`
+(`apps/api/pi_dash/orchestration/done_signal.py:32, 154-159`). The agent
+populates `autonomy.question_for_human` and `blockers[]` in the same
+payload. So today, "agent has a question" is already representable — but it
+goes to **terminal** BLOCKED, with no resume path.
 
-`PAUSED_*` is **not terminal**. The run holds its lease, retains its
-`thread_id`, and is the natural attachment point for the follow-up.
+We have two options:
 
-### 4.3 The "I'm yielding" protocol
+**Option A — `"blocked"` becomes resumable.** Change `done_signal.py:154-159`
+so the agent's `"blocked"` status maps to `PAUSED_AWAITING_INPUT` (the new
+status) when `autonomy.question_for_human` is set, and to terminal `BLOCKED`
+otherwise. One agent contract, two cloud outcomes.
 
-For `PAUSED_AWAITING_INPUT` to exist, the *agent* needs a way to emit a clean
-yield. Three options, in increasing order of integration cost:
+- _Pro:_ no agent-side change; existing prompts continue to work.
+- _Con:_ the "BLOCKED is terminal" invariant some code already assumes
+  becomes "BLOCKED is sometimes terminal" — must audit callers.
 
-1. **Heuristic on output** — sniff the agent's final stdout for "needs input"
-   markers. Cheap, brittle, fights the model.
-2. **Tool call** — give the agent a `request_user_input` tool. The runner sees
-   the tool call and reports it as a yield to the cloud. Aligned with how
-   approvals already work.
-3. **Prompt protocol** — instruct the agent (in the system prompt) to end its
-   final turn with a structured JSON envelope (`{"status": "yielded",
-   "reason": "...", "question": "..."}`). The runner parses it.
+**Option B — add a distinct `"paused"` agent status.** Extend
+`VALID_STATUSES = {"completed", "blocked", "noop", "paused"}`; agent emits
+`"paused"` when it can resume on reply, `"blocked"` when it has genuinely
+given up. Cloud maps `"paused"` → `PAUSED_AWAITING_INPUT`.
 
-Recommendation: **(2) tool call**. It piggybacks on the approval path's
-existing event plumbing, and tool calls are naturally first-class in both
-Claude Code and Codex SDKs.
+- _Pro:_ preserves the BLOCKED-is-terminal invariant; clearer agent intent.
+- _Con:_ requires updating the agent system prompt and any prompts that
+  document the done-signal schema; coordination across all agent paths.
 
-## 5. Continuation Triggers
+**Recommendation: Option B.** The audit cost in Option A is unbounded
+(every code path reading BLOCKED would need re-checking), and the prompt-
+side change is the smaller surface. We update the system prompt's done-
+signal schema once and the runtime contract stays clean.
+
+### 4.3 New status: `PAUSED_AWAITING_INPUT`
+
+Add `PAUSED_AWAITING_INPUT` to `AgentRunStatus` and place it in the
+classifiers as follows:
+
+| Classifier              | PAUSED_AWAITING_INPUT in? | Why                                                                               |
+| ----------------------- | ------------------------- | --------------------------------------------------------------------------------- |
+| `BUSY_STATUSES`         | **No**                    | Runner is free to take other pod work while paused (§5.3 interleaving)            |
+| `NON_TERMINAL_STATUSES` | Yes                       | Pod can't be deleted while a paused run exists (must drain first)                 |
+| `is_terminal`           | No                        | Run can resume; it isn't "done"                                                   |
+| `is_active`             | **No**                    | Single-active-run guardrail must allow a fresh follow-up to be created (see §5.2) |
+| `ACTIVE_RUN_STATUSES`   | No                        | Operational metric tracks runs occupying runner capacity; paused doesn't          |
+
+The `is_active` exclusion is the subtle one. Today `_active_run_for`
+prevents creating a new run when one already exists in `is_active` for the
+same issue. If PAUSED_AWAITING_INPUT were in `is_active`, the comment
+trigger could never create a follow-up — the paused run would block its own
+successor. So PAUSED is explicitly outside `is_active`, and the comment-
+trigger path additionally coalesces (§5.7) to avoid creating two parallel
+followers.
+
+(One subtle implication of PAUSED ∈ `NON_TERMINAL_STATUSES` but PAUSED ∉
+`BUSY_STATUSES`: the matcher won't avoid a pod with paused runs, but the
+pod-deletion path will refuse to drop the pod until those paused runs are
+drained. That's the intended behavior — paused runs hold cloud-side state
+that we want to preserve until explicitly resolved.)
+
+### 4.4 The "I'm yielding" protocol
+
+For `PAUSED_AWAITING_INPUT` to exist, the agent needs a clean way to emit a
+yield. The mechanism diverges per agent because today's plumbing is
+materially different:
+
+**Codex.** Approvals are wired (`runner/src/codex/bridge.rs` accepts
+`ApprovalResponseParams`; the JSON-RPC tool surface is live), and
+`thread/resume` works end-to-end. Add a `request_user_input` tool. The
+runner sees the tool call, sends `ClientMsg::RunPaused { ... }` to cloud,
+and lets the Codex thread idle on disk for later resume. This is the
+"piggyback the approval path" plan — and it works _for Codex_.
+
+**Claude Code.** Two limitations block the same approach:
+`runner/src/claude_code/mod.rs:6-10` documents that approvals are bypassed
+(`--permission-mode bypassPermissions`) and that resume is not wired.
+`runner/src/claude_code/bridge.rs:122-128` explicitly fails fast if an
+approval is routed in, because the MCP permission-prompt bridge isn't
+built. There is no tool-call surface to piggyback on.
+
+For Claude, the pragmatic path reuses the existing `pi-dash-done` channel:
+
+1. Extend `done_signal.py:VALID_STATUSES` to include `"paused"` (Option B
+   above). Add an optional `next_steps_if_resumed` field to the payload
+   schema.
+2. The system prompt instructs Claude to emit `status: "paused"` (instead
+   of `"blocked"`) when it has a question and can resume.
+3. Cloud's `done_signal.ingest_into_run` maps `"paused"` →
+   `PAUSED_AWAITING_INPUT` and stores the payload on `done_payload`.
+4. No runner-side bridge change; the runner already forwards Claude's
+   final stdout, and `done_signal.py` already parses it.
+5. **Resume-side** for Claude still requires the `--resume` plumbing
+   (§7.4 / §8.2 item 2). The yield path and the resume path are
+   independent changes; both must land for Claude continuation to work.
+
+**Heuristic on output** (sniffing for "needs input" markers) and
+**fully-untyped prompt protocol** are still rejected — too brittle. The
+above is two structured paths, one per agent, both grounded in existing
+plumbing.
+
+When the runner sees the yield (Codex tool call OR Claude done-signal
+parse):
+
+- Cloud transitions run to `PAUSED_AWAITING_INPUT`, stores the payload.
+- Runner reports completion (Codex: tool-call observed and ack'd; Claude:
+  process exits cleanly after emitting the fence) and returns to idle,
+  then triggers `drain_for_runner` (§5.6).
+
+When the runner sees the yield:
+
+- Reports `RunPaused { run_id, payload, ... }` to cloud.
+- Cloud transitions run to `PAUSED_AWAITING_INPUT`, stores the payload.
+- Runner returns to idle and triggers `drain_for_runner` (see §5.6).
+
+The yield tool's payload should be structured as a handoff (see §6.4) —
+question for the human plus enough state for a fresh agent to continue if
+native resume fails.
+
+## 5. Continuation Triggers and Dispatch
 
 ### 5.1 Candidate triggers
 
-| Trigger                                       | Carries new info? | UX feel             | Implementation cost                 |
-| --------------------------------------------- | ----------------- | ------------------- | ----------------------------------- |
-| User comment on the issue                     | Yes               | Conversational      | New `IssueComment` post_save signal |
-| Issue state transition back to In Progress    | No                | Coarse, button-y    | Already wired                       |
-| Explicit "Continue" / "Reply" action          | Optional          | Explicit, button-y  | New endpoint + UI                   |
-| Approval grant (resumes paused run)           | No                | Invisible           | Already partially wired             |
-| Scheduled retry after timeout                 | No                | System-driven       | New scheduler                       |
+| Trigger                                    | Carries new info? | UX feel            | Implementation cost                 |
+| ------------------------------------------ | ----------------- | ------------------ | ----------------------------------- |
+| User comment on the issue                  | Yes               | Conversational     | New `IssueComment` post_save signal |
+| Issue state transition back to In Progress | No                | Coarse, button-y   | Already wired                       |
+| Explicit "Continue" / "Reply" action       | Optional          | Explicit, button-y | New endpoint + UI                   |
+| Approval grant (resumes paused run)        | No                | Invisible          | Already partially wired             |
 
-### 5.2 Recommendation
+**Recommendation**: comment-triggered continuation as the primary path
+(matches the user's mental model: "I leave a comment, the agent reads it"),
+with explicit "Continue" as a secondary path for cases where the user has
+nothing to add but wants the agent to keep going.
 
-Make **comment-triggered continuation** the primary user path. It maps to the
-mental model the user already has ("I just leave a comment and the agent will
-read it"), and it carries the new information (the comment body) inline.
+### 5.2 Comment-triggered flow
 
-Add **explicit "Continue"** as a secondary path for cases where the user has
-nothing to add but wants the agent to keep going (e.g., agent yielded on a
-budget cap; user accepts the additional spend).
-
-Treat **approval grant** as intra-run, not a new run — the run was holding its
-lease the whole time. This is already most of the way there.
-
-### 5.3 Comment-triggered flow (sketch)
+Today, run creation is triggered exclusively by issue state transitions
+(`apps/api/pi_dash/orchestration/signals.py:48` →
+`handle_issue_state_transition`). Comments are inert. This proposal adds a
+second trigger via a `post_save(IssueComment)` receiver.
 
 ```
 User adds comment to Issue I
@@ -157,234 +260,454 @@ User adds comment to Issue I
         ▼
 post_save(IssueComment)
         │
-        ├─► Skip if author is a runner / agent (avoid self-trigger loops)
+        ├─► Skip if comment.actor.is_bot (excludes pi_dash_agent workpad bot — see workpad.py)
         ├─► Skip if no prior AgentRun for I (no conversation to continue)
+        ├─► Skip if issue.state.group ∈ frozen-states (see gating below)
+        ├─► Coalesce: if a QUEUED follow-up already exists for I, append to its prompt and stop
         ├─► Find latest AgentRun R_prev for I
         │     │
-        │     ├─► R_prev is PAUSED_*    → create R_next with parent_run=R_prev
-        │     ├─► R_prev is terminal    → create R_next with parent_run=R_prev (resume a finished issue)
-        │     └─► R_prev is RUNNING     → append comment to live run via WS frame, do NOT create R_next
+        │     ├─► R_prev is PAUSED_AWAITING_INPUT → create R_next, pin to R_prev.runner
+        │     ├─► R_prev is is_terminal           → create R_next, pin to R_prev.runner
+        │     └─► R_prev is is_active             → queue comment for delivery on terminate
+        │                                            (RUNNING / ASSIGNED / AWAITING_*)
         │
         ▼
-R_next dispatched through normal pod queue
+R_next dispatched through normal pod queue (with personal-queue priority)
 ```
 
-### 5.4 Race conditions to think about
+**Bot filter.** The `pi_dash_agent` bot user
+(`apps/api/pi_dash/orchestration/workpad.py:27-70`) authors the agent's
+workpad comments with `is_bot=True`. The trigger MUST filter
+`comment.actor.is_bot` — not a vague "skip runner/agent" — otherwise the
+agent's own workpad updates would re-trigger continuation in a loop.
 
-- **Two comments before R_next dispatches.** Coalesce: the dispatcher reads
-  *all* comments since `R_prev.completed_at` at dispatch time. Don't create
-  one R_next per comment.
-- **Comment arrives while R_prev is still RUNNING.** Don't queue a new run.
-  Either (a) push the comment to the live run as an inbound user message via
-  the WS bridge, or (b) hold the comment until the run terminates and then
-  dispatch. Option (a) is closer to the desired UX but requires runner-side
-  support for mid-run inbound messages.
-- **Agent comments on its own issue.** Filter by author type: if the comment
-  is an agent-authored comment (logged on behalf of an `AgentRun`), do not
-  re-trigger.
+**State gating.** The comment trigger should respect the issue's lifecycle:
+
+- If `issue.state.group ∈ {COMPLETED, CANCELLED}` (terminal groups): do not
+  dispatch. The user should re-open the issue to resume work.
+- If `issue.state.group ∈ {BACKLOG, UNSTARTED}`: do not dispatch. State-
+  transition path owns starting work; the comment trigger only continues
+  in-progress work.
+- If `issue.state.group = STARTED` (default "In Progress"): dispatch.
+- Custom workspace state groups: defer to the workspace's policy; for MVP
+  treat anything not in the above set as "no dispatch" (conservative).
+
+**Guardrail interaction.** The existing single-active-run guardrail in
+`_active_run_for` (`orchestration/service.py:45-59`) blocks new runs when
+one is already `is_active` for the issue. With PAUSED_AWAITING_INPUT
+explicitly _outside_ `is_active` (§4.3), a paused run does not block the
+follow-up — which is what we want. But two distinct comments arriving in
+quick succession could both observe "no active run" and create two
+QUEUED follow-ups for the same issue. The **coalesce step above** handles
+this: before creating R_next, the trigger checks for an existing QUEUED
+run with `parent_run = R_prev` (or the same chain) and appends the new
+comment text to that run's prompt instead of creating a duplicate. This
+keeps the chain linear.
+
+### 5.3 Pinning model: strict pin with interleaving
+
+When R_next is created from a comment-trigger, set
+`pinned_runner_id = R_prev.runner_id`. This is **strict pin** — only the
+original runner picks it up. Resume affinity is preserved and we get cheap,
+high-fidelity native resume on every continuation.
+
+Strict pin works without blocking the runner because of §4.2 — paused runs
+don't make the runner busy, so the runner stays available for fresh pod work.
+The pin just means "when that runner is next idle, this is what it takes."
+
+This is the central design choice. Earlier sketches (soft pin with replay
+fallback, no pin with replay always) gave up on native resume in the common
+case. Strict-pin-with-interleaving keeps native resume as the primary
+mechanism while still letting agentA do useful work during human latency.
+
+### 5.4 Two queues, one table
+
+Each runner now has, conceptually, two queues feeding it:
+
+1. **Personal queue**: runs `pinned_runner_id = me`. Strict pin.
+2. **Pod general queue**: runs with `pinned_runner_id IS NULL`.
+
+But this is **one `AgentRun` table, two filters** — not a new table or a new
+data structure. The matcher's per-runner query becomes:
+
+```sql
+SELECT FROM agent_run
+WHERE pod = <runner.pod>
+  AND status = QUEUED
+  AND (pinned_runner_id = <runner.id> OR pinned_runner_id IS NULL)
+ORDER BY (pinned_runner_id = <runner.id>) DESC, created_at ASC
+LIMIT 1
+FOR UPDATE SKIP LOCKED
+```
+
+Pinned-to-me runs come first; otherwise FIFO over unpinned. Pinned-to-someone-
+else runs are excluded entirely.
+
+### 5.5 Dispatch loop: runner-first
+
+Today's `drain_pod` is run-first — pick a QUEUED run, then a runner. With
+pinning, runner-first is cleaner (avoids head-of-line blocking when the head
+QUEUED run is pinned to a busy runner):
+
+```python
+def drain_pod(pod):
+    assignments = []
+    with transaction.atomic():
+        for runner in idle_runners_in_pod_locked(pod):
+            run = next_for_runner_locked(runner)  # the SQL above
+            if run is None:
+                continue
+            assign(run, runner)
+            assignments.append((runner, run))
+    for runner, run in assignments:
+        on_commit(lambda: send_to_runner(runner.id, build_assign_msg(run)))
+```
+
+`drain_for_runner(runner)` is `drain_pod` narrowed to one runner — same
+query, same locking, same `on_commit` send.
+
+### 5.6 Drain triggers
+
+Drain is invoked at three moments:
+
+1. **New run enqueued** (existing) — `transaction.on_commit(matcher.drain_pod_by_id(pod.id))` in `orchestration/service.py:195`. Already wired.
+2. **Run terminates** (SUCCEEDED / FAILED / PAUSED) → runner becomes idle → `drain_for_runner(runner)`. **New**, lives in the Channels consumer where run state is updated. Without this, agentA never picks up its own pinned run after finishing issue002.
+3. **Runner reconnects** → `drain_for_runner(runner)` in the consumer's connect handler. **New**, covers the case where pinned runs were enqueued while the runner was offline.
+
+### 5.7 Edge cases
+
+- **Two comments before R_next dispatches.** Coalesce: at run-creation time,
+  if there's already a QUEUED R_next for the issue, append the new comment
+  to its prompt instead of creating a second run.
+- **Comment arrives while R_prev is RUNNING.** Don't queue a new run yet.
+  Either (a) push the comment to the live run as an inbound user message
+  (out of MVP scope; needs runner-side support for mid-run inbound), or
+  (b) hold the comment until terminate and dispatch then. Start with (b).
+- **Agent comments on its own issue.** Filter by author type; agent-authored
+  comments do not re-trigger.
+- **Pinned runner offline / revoked.** The pinned run sits in QUEUED forever
+  unless we intervene. Two mitigations:
+  - On `Runner.status = REVOKED` transition, release pinned QUEUED runs:
+    `UPDATE AgentRun SET pinned_runner=NULL WHERE pinned_runner=R.id AND status=QUEUED`. They fall back to the pod general queue.
+  - **Operator escape hatch in UI**: a "release pin" button on the run row
+    that sets `pinned_runner_id = NULL`. The MVP-correct answer is operator-
+    driven, not a TTL — TTLs silently lose the resume benefit and are easy
+    to misconfigure.
+- **Multiple paused conversations on the same agent.** issue001, issue003 both
+  paused on agentA, both get human comments. R001b and R003b both pin to
+  agentA. When agentA finishes issue002, FIFO by `created_at` of the new run
+  is the obvious order — earliest comment wins.
+- **No thread_id to resume against.** If `R_prev.thread_id IS NULL` (parent
+  crashed before reporting one), pinning buys nothing — there's no session
+  to resume. Skip the pin; the new run goes to the pod general queue and any
+  runner takes it.
 
 ## 6. Conversation Continuity
 
-This is the hardest of the three sub-problems. The follow-up run needs the
-prior run's context. Three mechanisms.
+### 6.1 Primary mechanism: native session resume
 
-### 6.1 Mechanism A — Native provider-side resume
+When R_next is dispatched:
 
-`claude --resume <session_id>` (Claude Code) and `resume_thread(...)` (Codex)
-let the provider runtime re-attach to a previous session.
+- Cloud sets `resume_thread_id = R_prev.thread_id` on the `Assign` envelope.
+- Runner passes it through to the agent CLI:
+  - **Codex**: already wired — `runner/src/codex/bridge.rs:61-72` calls
+    `thread/resume` when `resume_thread_id` is set.
+  - **Claude Code**: not yet wired — `runner/src/claude_code/mod.rs:10`
+    explicitly says "single-turn only." Needs `--resume <session_id>`
+    plumbing.
 
-**Pros**
+The agent CLI looks up its own on-disk session and reattaches:
 
-- Zero token overhead — no transcript replay.
-- Perfect memory — the agent has its full prior turn-by-turn state.
-- Simplest semantics; trivially supports tool/file state if the provider
-  supports it.
+- Claude Code: `~/.claude/projects/<workspace>/sessions/<session_id>.jsonl`
+- Codex: its own data directory, keyed by thread id
 
-**Cons**
+### 6.2 The runner is stateless about past runs
 
-- **Locality.** Claude Code stores its session on the local disk of the runner
-  process. The follow-up run *must* hit the same runner, and that runner's
-  session storage must still be intact (no restart, no GC, no reinstall).
-- **Couples runs to runner identity** — fights the pod queue's "any runner in
-  the pod" model.
-- **Provider-specific.** Codex resume works differently; cross-provider runs
-  on the same conversation are out of scope.
+The runner does **not** maintain any (issue → session_id) index. The cloud is
+authoritative. The runner is a pass-through:
 
-### 6.2 Mechanism B — Cloud transcript replay
+- `RunsIndex` (`runner/src/history/index.rs`) stores recents for the TUI but
+  has no `thread_id` field.
+- `HistoryWriter` (`runner/src/history/jsonl.rs`) writes per-run JSONL but
+  doesn't index by session.
+- `StateHandle` (`runner/src/daemon/state.rs`) is in-memory only; the
+  `current_run.thread_id` field is wiped on terminate.
 
-We already capture every meaningful event into `AgentRunEvent`
-(`runner/models.py:424`). On a follow-up run we synthesize a system-prompt
-preamble that summarizes — or replays — the prior run's user/assistant turns,
-and start a *fresh* provider session.
+No new runner-side persistence is required for resume to work. The runner
+just receives `Assign { resume_thread_id }` and passes the id to the agent
+CLI's resume function. The agent CLI's own on-disk session store is the
+artifact that matters.
 
-**Pros**
+(Optional observability: add `thread_id` to `RunSummary` in `RunsIndex` so
+the TUI's Runs view can show "issue X, last session Y, on disk: ✓/✗" for
+operator sanity-checks. Not on the dispatch critical path.)
 
-- Provider-agnostic.
-- Runner-agnostic — the follow-up can land on any idle runner in the pod.
-- Durable — the cloud is the source of truth.
-- Auditable — the same transcript drives both replay and human review.
+### 6.3 What if native resume fails?
 
-**Cons**
+Resume can fail for legitimate reasons: agent CLI was reinstalled, session
+file was manually deleted, host disk was wiped, the agent CLI's session
+store rotated. The runner detects this when the agent CLI returns an error
+on the resume call.
 
-- Token cost on every continuation. For long conversations this compounds.
-- Tool/file state not perfectly restored. The agent "remembers" what it did
-  but doesn't have the same in-memory caches, file handles, etc.
-- Replay quality is sensitive to how we summarize. Naive concat of all events
-  blows the context window quickly.
+The runner reports `RunFailed { reason: ResumeUnavailable, ... }` to cloud.
+Cloud's options:
 
-### 6.3 Mechanism C — Hybrid
+1. **Re-dispatch as fresh-context** (recommended default). Drop the pin,
+   drop the `resume_thread_id`, re-queue R_next. Whichever runner picks it
+   up starts a fresh session, with the issue body + comments + the prior
+   handoff (§6.4) as its context.
+2. **Mark the issue as needing human attention.** Surface in UI: "the agent's
+   prior session is no longer available; reply to start over." Right answer
+   when the chain is so long that fresh-context-from-issue would be lossy
+   enough to be misleading.
 
-Try (A) first; fall back to (B) when (A) is unavailable.
+Option 1 is the default. Option 2 is an upgrade we may want later.
 
+### 6.4 Agent-authored handoffs (the "free" fallback)
+
+The yield tool (§4.3) requires a structured handoff payload, e.g.:
+
+```json
+{
+  "question": "Should I keep the legacy export endpoint or remove it?",
+  "summary_so_far": "Migrated /export/v1 to /export/v2; legacy still mounted; tests passing on v2.",
+  "next_steps_if_resumed": "Either remove legacy mount in api/urls.py, or add a deprecation header."
+}
 ```
-follow-up run dispatched
-        │
-        ▼
-Was R_prev assigned to a runner that is still online & in the pod?
-        ├─ Yes → set resume_thread_id on RunPayload; runner attempts native resume
-        │           ├─ Native resume succeeds → done
-        │           └─ Native resume fails    → fall back to replay path
-        └─ No  → skip native; use replay path
+
+The cloud stores this in `R_prev.done_payload` (or a dedicated field) and
+posts it as an issue comment so it's human-visible. When fallback fresh-
+context-from-issue happens (§6.3 option 1), the new agent reads the handoff
+like any other comment and picks up.
+
+This means even when native resume fails, a well-disciplined yield produces
+enough state for a fresh agent to continue meaningfully — without any
+transcript-replay machinery.
+
+### 6.5 Why we're not building a transcript-replay path
+
+An earlier sketch proposed reconstructing prior turns from `AgentRunEvent`
+into a system-prompt preamble and starting a fresh provider session on every
+follow-up. We're explicitly **not** building this for v1, because:
+
+- Native resume covers the common case (same runner, same agent CLI, session
+  on disk). It's cheaper (no token replay), higher-fidelity (real session
+  state), and trivially correct.
+- For the uncommon case where native resume fails, the issue body + comments
+  - agent-authored handoff (§6.4) + branch state are already a durable,
+    human-readable handoff. Replay competes with this for no clear win.
+- Replay quality is sensitive to summarization. A poor preamble produces a
+  worse continuation than just letting a fresh agent re-read the issue.
+
+If observation later shows that fresh-context-from-issue is dropping too much
+fidelity, replay can be added as a second fallback layer. It's not on the v1
+critical path.
+
+## 7. Wire Protocol Changes
+
+### 7.1 `Assign` envelope (`runner/src/cloud/protocol.rs:109-123`)
+
+Add one optional field:
+
+```rust
+Assign {
+    run_id: Uuid,
+    work_item_id: Option<Uuid>,
+    prompt: String,
+    repo_url: Option<String>,
+    repo_ref: Option<String>,
+    git_work_branch: Option<String>,
+    expected_codex_model: Option<String>,
+    approval_policy_overrides: Option<BTreeMap<String, serde_json::Value>>,
+    deadline: Option<DateTime<Utc>>,
+    #[serde(default)]
+    resume_thread_id: Option<String>,  // NEW
+}
 ```
 
-This is what we should ship for v1. It captures the cheap-and-fast common case
-(same runner is still around) without sacrificing correctness when the runner
-is gone.
+`#[serde(default)]` keeps it backward-compatible with older runners — a
+field-only addition, so `protocol_version` does not need to be bumped.
 
-### 6.4 Pinning policy
+### 7.2 Runner-to-cloud yield message (Codex only)
 
-Hybrid raises a real scheduling question: how hard do we *try* to keep the
-follow-up on the same runner?
+Add a new variant to `ClientMsg` for the Codex tool-call yield path:
 
-Three positions:
+```rust
+RunPaused {
+    run_id: Uuid,
+    reason: PauseReason,            // AwaitingInput | AwaitingApproval | …
+    payload: serde_json::Value,     // the handoff struct from §6.4
+    paused_at: DateTime<Utc>,
+}
+```
 
-- **Strict pin.** Follow-up run is exclusively dispatchable to the original
-  runner. If that runner is busy, the run waits. Maximum native-resume hit
-  rate; worst queue fairness; users wait longer.
-- **Soft pin (recommended).** Prefer the original runner; wait up to N seconds
-  (e.g., 30s) for it to free up; then release the pin and dispatch to any
-  runner using the replay path. Tunable knob.
-- **No pin.** Always dispatch to whoever is free; native resume is just a
-  performance hint that succeeds opportunistically. Best fairness; loses the
-  native-resume benefit when runners are busy.
+Cloud needs a matching `on_run_paused` handler in
+`apps/api/pi_dash/runner/consumers.py` (next to `on_run_completed` /
+`on_run_failed` at line 236). The handler transitions the run to
+`PAUSED_AWAITING_INPUT`, stores the payload on `done_payload`, and
+triggers `drain_for_runner(runner)` so the runner picks up its next
+queued work immediately.
 
-Soft pin is the right default because it aligns with the digital-employee
-model: "I'd like the same person who worked on this last time, but I'd rather
-make progress than wait forever."
+**Claude does not use this path.** Claude's yield rides the existing
+`pi-dash-done` fenced-block channel (§4.4); cloud's
+`done_signal.ingest_into_run` is the entry point, with the new `"paused"`
+status mapping to `PAUSED_AWAITING_INPUT`. No new `ClientMsg` variant is
+needed for Claude.
 
-### 6.5 Where the resume hint lives
+### 7.3 Resume-failure reporting
 
-Two storage options:
-
-1. Read at dispatch time from `parent_run.thread_id` and `parent_run.runner_id`.
-2. Promote to a first-class field on the new run: `resume_thread_id`,
-   `pinned_runner_id`.
-
-Option 1 keeps the model lean (no new columns), at the cost of always walking
-the chain. Option 2 lets us snapshot the resume hint once and stop caring
-about whether it's still derivable later (e.g., if `parent_run.runner_id` was
-nulled out for some reason).
-
-Recommendation: **Option 1 for MVP**, promote to Option 2 if we find ourselves
-patching the same data lookup in three places.
-
-## 7. Optional: An `IssueConversation` Entity
-
-Today, "the conversation on an issue" is implicit — it's the chain of
-`AgentRun` rows whose `parent_run` walks back to a root.
-
-A first-class `IssueConversation` (or `WorkThread`) model could own:
-
-- `issue_id` — the issue this conversation is about.
-- `native_session_id` — the canonical provider session id (latest non-empty
-  `thread_id` in the chain).
-- `pinned_runner_id` — soft affinity for native-resume.
-- `head_run_id` — the latest run in the chain.
-- `status` — `active` (work continuing), `closed` (done), `abandoned`.
-
-### 7.1 Why we'd add it
-
-- **Multiple conversations per issue.** "I want to start over" or "let me ask a
-  side question" become natural — each gets its own conversation. The walk-
-  the-parent_run-chain model has no place for branching.
-- **Cleaner ownership.** Pinning, transcript caching, and the resume hint all
-  live in one place instead of being recomputed from the chain.
-- **Cleaner permissions.** Conversation-level subscribe / mute / reassign
-  actions become possible.
-
-### 7.2 Why we'd skip it (for now)
-
-- The chain model is sufficient for one-conversation-per-issue. Promoting now
-  is speculative.
-- New entity = new migrations, new permission rules, new API surface.
-
-Recommendation: **defer.** Walk-the-chain works for v1. Promote to
-`IssueConversation` only if the multi-thread-per-issue use case becomes real.
+When the agent CLI returns "no such session" or equivalent on a resume call,
+the runner reports it via `RunFailed` with a new
+`FailureReason::ResumeUnavailable`. Cloud's reaction is described in §6.3.
 
 ## 8. Recommended MVP Shape
 
-This is the minimum coherent slice that delivers the user-visible benefit.
+### 8.1 Cloud (Django)
 
-1. **Run lifecycle** (§4)
-   - Add `AgentRunStatus.PAUSED_AWAITING_INPUT` (and `PAUSED_AWAITING_APPROVAL`
-     if not already represented as a status).
-   - Define the `request_user_input` tool that the agent calls to yield.
-   - Runner reports the yield to the cloud; cloud transitions `R_prev` to
-     `PAUSED_AWAITING_INPUT` and stores the agent's question in `R_prev.done_payload`.
+1. **Status enum + classifiers**: add `PAUSED_AWAITING_INPUT` to
+   `AgentRunStatus`. Update **all five** classifiers consistently per the
+   table in §4.3:
+   - Out of: `BUSY_STATUSES`, `is_terminal`, `is_active`,
+     `ACTIVE_RUN_STATUSES`.
+   - In: `NON_TERMINAL_STATUSES`.
+2. **Done-signal contract** (`apps/api/pi_dash/orchestration/done_signal.py`):
+   add `"paused"` to `VALID_STATUSES`. In `ingest_into_run`, map
+   `"paused"` → `PAUSED_AWAITING_INPUT` (non-terminal); leave `"blocked"`
+   → `BLOCKED` unchanged. Leave `done_payload` populated so the handoff
+   is preserved across resume.
+3. **Schema**: add `pinned_runner_id` (FK to `Runner`, nullable) on
+   `AgentRun`. Field-only migration.
+4. **Comment trigger**: `post_save` on `IssueComment`:
+   - Filter `comment.actor.is_bot` (excludes `pi_dash_agent` workpad bot).
+   - Apply state gating per §5.2 (only continue when issue.state.group is
+     STARTED).
+   - Coalesce duplicate triggers: if a QUEUED follow-up already exists for
+     the chain, append the comment to its prompt rather than creating a
+     second run.
+   - Create R_next with `pinned_runner_id = R_prev.runner_id` (only when
+     `R_prev.thread_id` is not null and `R_prev.runner` is online-eligible).
+5. **Matcher**: rewrite `drain_pod` to be runner-first; introduce
+   `next_for_runner` with the personal-then-pod query from §5.4.
+6. **Drain triggers**: add `drain_for_runner` calls in the Channels consumer
+   on `run_completed`, `run_failed`, on the new `run_paused` handler, and
+   on `on_hello` connect (after `_resume_run`). Also from
+   `done_signal.ingest_into_run` when status becomes
+   `PAUSED_AWAITING_INPUT` (Claude path).
+7. **`on_run_paused` consumer handler** (`runner/consumers.py:236` neighborhood):
+   transition the run, persist `done_payload`, post the handoff as an
+   issue comment (§6.4), and trigger drain.
+8. **Assign payload**: include `resume_thread_id = R.parent_run.thread_id`
+   when set; `pinned_runner_id` does not need to be on the wire.
+9. **Pin release on revoke**: on `Runner` REVOKED transition, null out
+   pinned QUEUED runs. Trigger drain on the affected pod.
+10. **Operator pin-release**: a UI/API affordance to manually clear
+    `pinned_runner_id` on a stuck QUEUED run.
 
-2. **Continuation trigger** (§5)
-   - Add `post_save` on `IssueComment`:
-     - Skip agent-authored comments.
-     - Find latest `AgentRun` for the issue.
-     - If `RUNNING`: forward the comment to the live run via WS (out of MVP
-       scope — okay to defer and queue instead).
-     - If `PAUSED_*` or terminal: create a new `AgentRun` with `parent_run`
-       set, dispatch through the normal pod queue.
-   - Add `POST /api/v1/runner/runs/<id>/continue/` endpoint as the explicit
-     button-driven path.
+### 8.2 Runner (Rust)
 
-3. **Conversation continuity — hybrid** (§6)
-   - At dispatch, the cloud computes `resume_thread_id = parent_run.thread_id`
-     and `preferred_runner_id = parent_run.runner_id`.
-   - Matcher implements **soft pin**: prefer `preferred_runner_id`, wait up to
-     `RUN_PIN_GRACE_SECONDS` (default 30), then release.
-   - Runner side: if `resume_thread_id` is set, attempt native resume first
-     (Claude Code: pass `--resume`; Codex: call `resume_thread()`). On failure,
-     fall back to replay.
-   - Replay path: load `R_prev` events, render a transcript preamble
-     (compact format — user turns, assistant turns, key tool calls, dropping
-     internal scratchpad), prepend to the new run's prompt.
+1. **Supervisor**: read `resume_thread_id` from the incoming `Assign`
+   message and plumb it into `RunPayload` instead of the hardcoded `None`
+   at `runner/src/daemon/supervisor.rs:544`.
+2. **Claude Code resume**: lift the "single-turn only" restriction in
+   `runner/src/claude_code/mod.rs:10`; pass `--resume <session_id>` when
+   `resume_thread_id` is set. Detect "no such session" failure and bubble
+   it up as `RunFailed { reason: ResumeUnavailable }`.
+3. **Codex resume**: already wired in `runner/src/codex/bridge.rs:61-72`.
+   Verify that `RunPaused` paths leave the Codex thread state intact on
+   disk and that subsequent `thread/resume` works.
+4. **Codex yield tool**: expose `request_user_input` via the Codex
+   JSON-RPC tool surface. On tool call, send `ClientMsg::RunPaused { ... }`
+   and return runner to idle.
+5. **Claude yield**: no runner-side change. Claude emits the existing
+   `pi-dash-done` fenced block with the new `"paused"` status; the runner
+   already forwards Claude's terminal output and cloud parses it.
+6. **Resume-failure detection**: when the bridge's resume call fails
+   because the session is missing, report `RunFailed { reason:
+ResumeUnavailable }`.
 
-4. **Defer**
-   - `IssueConversation` entity (§7).
-   - Mid-run inbound user messages (forwarding a comment into a `RUNNING`
-     run). Workaround: queue the comment, dispatch on terminate.
-   - Cross-issue / cross-conversation memory.
+### 8.3 Prerequisite for Claude continuation
+
+Claude approvals are bypassed today (`runner/src/claude_code/mod.rs:6-10`,
+`runner/src/claude_code/bridge.rs:122-128` fails fast on approval routing).
+This is **not a blocker for the yield path** above — Claude yields via
+done-signal, not via tool-call/approval — but it does mean Claude
+continuation lacks the structured tool-yield UX Codex gets. Wiring the
+permission-prompt MCP bridge is tracked separately in `claude_code/mod.rs`'s
+MVP-limitations comment; if/when it lands, Claude can adopt the same
+tool-call yield mechanism Codex uses, and the done-signal `"paused"` path
+becomes a fallback rather than the primary mechanism.
+
+### 8.3 Defer
+
+- Mid-run inbound user messages (forwarding a comment into a `RUNNING` run).
+  Workaround: hold the comment, dispatch on terminate.
+- Transcript-replay fallback (§6.5).
+- `IssueConversation` entity (one-thread-per-issue is sufficient for v1).
+- TTL-based pin release (§5.7) — operator-driven is enough for v1.
+- Cross-issue / cross-conversation memory.
+- Smarter prompt for fresh-context-from-issue beyond "read the issue + the
+  prior handoff comment."
 
 ## 9. Open Questions
 
-| #   | Question                                                                                                                                         |
-| --- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Q1  | What's the right TTL on a `PAUSED_AWAITING_INPUT` run? After 7 days with no comment, do we GC it to terminal?                                    |
-| Q2  | Replay format: full turn-by-turn vs. summarize-the-prior-run? At what conversation length do we switch?                                          |
-| Q3  | Can we forward an inline comment into a `RUNNING` run without making the runner stateful in dangerous ways? Or do we always wait for terminate? |
-| Q4  | Soft-pin grace window: 30s reasonable? Tunable per pod?                                                                                          |
-| Q5  | If native resume succeeds but the resumed agent's working directory was wiped (runner reinstalled), the agent has memory but no files. How do we detect and handle? |
-| Q6  | Do we expose conversation history (the run chain) as a first-class API for the UI's issue panel, or keep it as `issue.agent_runs.order_by(...)`? |
-| Q7  | Billing: a follow-up run costs tokens; who pays? Same `runner.owner` semantics as the primary run, or attribute to the comment author?           |
-| Q8  | If `IssueComment` triggers a run but the issue is no longer in `In Progress` (user moved it back to Backlog), do we still dispatch? Probably not — define the gating rule. |
+| #   | Question                                                                                                                                                                                            |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Q1  | What's the right TTL on a `PAUSED_AWAITING_INPUT` run? After 7 days with no comment, do we GC it to terminal?                                                                                       |
+| Q2  | If R_prev terminated SUCCEEDED but a comment still arrives weeks later, do we resume? Probably yes, but the agent CLI's session may have been cleaned up.                                           |
+| Q3  | Workspace persistence on the runner: when agentA pauses issue001 and switches to issue002 (different workspace path), can issue001's workspace be left dirty? Or do we require commit-before-yield? |
+| Q4  | If the issue is no longer in `In Progress` (user moved it back to Backlog), do we still dispatch on comment? Probably not — define the gating rule.                                                 |
+| Q5  | Billing: a follow-up run costs tokens; same `runner.owner` semantics as the primary run, or attribute to the comment author?                                                                        |
+| Q6  | Do we expose conversation history (the run chain) as a first-class API for the UI's issue panel, or keep it derived (`issue.agent_runs.order_by(...)`)?                                             |
+| Q7  | The handoff payload schema (§6.4) — minimal viable shape, or richer fields (file-level annotations, follow-up checklist)?                                                                           |
+| Q8  | Pinned-runner failure UX: when run sits QUEUED because the pinned runner is offline, what does the user see? Silent wait, or a "stuck on agentA" indicator with a release button?                   |
 
-## 10. Summary of Tradeoffs
+## 10. Summary of Decisions
 
-The central tradeoff is **runner affinity vs. queue fairness**. Native resume
-is dramatically cheaper and higher-fidelity, but it ties a run to a specific
-runner; the pod queue's whole point is that any runner can pick up any work.
+The original framing put the central tradeoff as **runner affinity vs. queue
+fairness**, and recommended soft pin with replay fallback. After working
+through interleaving and where state lives, the decisions tighten:
 
-Soft pin with replay fallback is the pragmatic middle: we capture the common-
-case win (the original runner is usually still around) and degrade
-gracefully when it isn't.
+1. **Strict pin, not soft pin.** Comment-triggered runs go back to the same
+   runner. No grace window, no fallback to "anyone." Native resume is the
+   correctness path; everything else is recovery from a real failure.
+2. **Paused is not busy _or_ active.** Add `PAUSED_AWAITING_INPUT` to the
+   status enum and place it correctly across all five classifiers
+   (`BUSY_STATUSES`, `NON_TERMINAL_STATUSES`, `is_terminal`, `is_active`,
+   `ACTIVE_RUN_STATUSES`) — not just the two named in earlier drafts.
+   Excluding it from `is_active` is what lets the comment trigger create
+   a follow-up; excluding it from `BUSY_STATUSES` is what lets the runner
+   keep working other issues while paused.
+3. **`"paused"` is a new agent done-signal status, distinct from `"blocked"`.**
+   The existing `"blocked"` → terminal `BLOCKED` contract stays intact.
+   Adding `"paused"` extends the done-signal grammar without disturbing
+   anything that already reads BLOCKED.
+4. **Yield mechanism diverges per agent.** Codex uses a `request_user_input`
+   tool call and a new `RunPaused` `ClientMsg` (the approval path is wired,
+   tool calls are first-class). Claude rides the existing `pi-dash-done`
+   fenced block with the new `"paused"` status because Claude approvals
+   are bypassed and there's no tool-call surface to piggyback. Both paths
+   converge on the cloud-side `PAUSED_AWAITING_INPUT` state.
+5. **One table, two filters.** No new queue, no new data structure — just
+   `pinned_runner_id` on `AgentRun` and a smarter `ORDER BY`.
+6. **Runner-first dispatch.** When a runner becomes idle, ask "what should
+   you take?" rather than "is there work that fits you?". Eliminates
+   head-of-line blocking on pinned runs and serves personal-queue work the
+   moment the runner frees up.
+7. **Cloud is authoritative; runner is stateless about past runs.** No new
+   runner-side index. The agent CLI's own session store is the on-disk
+   resume artifact.
+8. **Handoff comments, not transcript replay.** When native resume fails,
+   fresh-context-from-issue carries it — _if_ the yield protocol forces a
+   structured handoff. This sidesteps the entire replay-quality problem.
+9. **Comment trigger has explicit gates.** Bot filter on `actor.is_bot`
+   (the `pi_dash_agent` workpad bot is the concrete blocker), state-group
+   gating to STARTED, and coalesce on duplicate QUEUED followers. Without
+   these, the trigger conflicts with the existing single-active-run
+   guardrail and the workpad bot self-triggers a loop.
 
-The other meaningful tradeoff is **trigger surface**. Comment-triggered
-continuation matches user intent best but introduces an implicit dispatch
-path, which is harder to reason about than an explicit button. Shipping both
-gives users a fallback for surprising cases.
+The cost of this design: roughly ~200 lines of cloud Python (status +
+classifiers, column, done-signal extension, matcher rewrite, consumer
+hooks, comment signal with gates), one wire-protocol field addition,
+one new `ClientMsg` variant for Codex yield, and two runner-side changes
+(Claude `--resume` plumbing, Codex yield tool). No new tables, no new
+services, no new background workers.

--- a/.ai_design/issue_run_improve/design.md
+++ b/.ai_design/issue_run_improve/design.md
@@ -773,3 +773,178 @@ hooks, comment signal with gates), one wire-protocol field addition,
 one new `ClientMsg` variant for Codex yield, and two runner-side changes
 (Claude `--resume` plumbing, Codex yield tool). No new tables, no new
 services, no new background workers.
+
+## 11. Expected Behavior
+
+This section captures the user-visible and system-level behavior the
+implementation must produce. Each scenario maps to an integration-test
+candidate in §11.5.
+
+### 11.1 Happy paths
+
+**A1. Issue completes in one run.** Unchanged from today. State → In
+Progress, run dispatched, agent emits `pi-dash-done` with
+`status: "completed"`, run terminates COMPLETED. No continuation.
+
+**A2. Issue takes two runs (clean continuation).**
+
+1. Issue → In Progress; run R1 dispatched to agentA.
+2. Agent yields with a question. R1 → `PAUSED_AWAITING_INPUT`. The
+   handoff payload is posted as an issue comment so the human can read
+   the question.
+3. AgentA returns to idle. Pod treats it as available (paused ≠ busy).
+   User-visible: "Run paused — agent has a question."
+4. User comments with their answer.
+5. Cloud creates R2 pinned to agentA, with
+   `resume_thread_id = R1.thread_id`. R2 lands in agentA's personal
+   queue.
+6. AgentA picks R2 up the next time it's idle (immediately if no other
+   work; after current run if busy with another issue).
+   User-visible: "Run resumed."
+7. Agent continues the same Codex/Claude session, finishes, R2 →
+   COMPLETED.
+
+**A3. Three-way interleave.** This is the canonical scenario the design
+is built around.
+
+1. R1 paused on agentA after a yield.
+2. AgentA picks issue002's R3 from pod queue → busy on R3.
+3. User comments on issue001 → R2 created, pinned to agentA, sits
+   QUEUED.
+4. AgentA finishes R3 → `drain_for_runner` checks personal queue
+   first → picks R2 → resumes.
+5. From the user's POV: their comment didn't get an immediate response,
+   but the moment agentA freed up it picked up where it left off — with
+   full session memory, not a re-read of the issue.
+
+### 11.2 Timing expectations
+
+| Event                                   | Expected latency                                                  |
+| --------------------------------------- | ----------------------------------------------------------------- |
+| Yield → handoff comment visible         | Sub-second (posted in `on_run_paused` / done-signal ingest)       |
+| Comment → dispatch (idle pinned runner) | Sub-second (`on_commit(drain_for_runner)`)                        |
+| Comment → dispatch (busy pinned runner) | As long as the runner's current run takes; no fallback timeout    |
+| Comment during RUNNING → dispatch       | At terminate of R_prev (no extra delay beyond terminate handling) |
+
+### 11.3 Coalescing & ordering
+
+- **Two comments before R2 dispatches.** Appended into a single R2
+  prompt. User does not get two parallel runs.
+- **Multiple paused issues on agentA.** When agentA frees up, FIFO by
+  `R_next.created_at` (the follow-up's creation time, not the
+  original's). Earliest comment-trigger wins.
+- **Bot comments.** Filtered by `actor.is_bot`. The `pi_dash_agent`
+  workpad updates never trigger continuation.
+
+### 11.4 State-gating outcomes
+
+| Issue state when comment arrives | Expected behavior                                              |
+| -------------------------------- | -------------------------------------------------------------- |
+| STARTED ("In Progress")          | Comment triggers continuation (the main path)                  |
+| BACKLOG / UNSTARTED              | Ignored. State-transition path is what starts work             |
+| COMPLETED / CANCELLED            | Ignored. User must move issue back to In Progress to re-engage |
+| Custom workspace state group     | Ignored (conservative MVP); revisit per Q4                     |
+
+### 11.5 Failure-mode behavior
+
+**B1. Pinned runner offline.** R2 sits QUEUED with
+`pinned_runner = agentA` indefinitely. UI surfaces a "stuck on agentA —
+release pin?" indicator. Operator clicks "release pin" →
+`pinned_runner_id = NULL` → drain places R2 on whichever runner is
+free → resume fails on a different runner → `ResumeUnavailable` → R2
+re-queued without `resume_thread_id` → fresh-context dispatch using the
+issue + handoff comment.
+
+**B2. AgentA revoked while R2 is pinned.** Automatic. The
+`Runner.status = REVOKED` transition nulls `pinned_runner_id` on QUEUED
+runs in the affected pod and triggers drain. R2 falls into the pod
+general queue. Same fresh-context fallback as B1.
+
+**B3. Resume fails (session evicted from disk).** AgentA online, R2
+dispatched to it, `claude --resume <id>` (or Codex `thread/resume`)
+returns "no such session." Runner reports
+`RunFailed { reason: ResumeUnavailable }`. Cloud drops the pin and the
+resume hint, re-queues R2. Picked up fresh by any runner — possibly
+agentA itself — with the handoff comment as context.
+
+**B4. AgentA's host was reinstalled.** Same as B3; session store was
+wiped, detected the same way.
+
+**B5. Yield with malformed handoff payload.** Existing
+`done_signal.ingest_into_run` returns FAILED on parse error. For the
+new `"paused"` status, validation must additionally reject when the
+required handoff fields (e.g., `autonomy.question_for_human`) are
+absent. Run terminates as FAILED, not PAUSED.
+
+### 11.6 Invariants the implementation must preserve
+
+1. **PAUSED status placement** across all five classifiers per §4.3:
+   out of `BUSY_STATUSES`, `is_terminal`, `is_active`,
+   `ACTIVE_RUN_STATUSES`; in `NON_TERMINAL_STATUSES`.
+2. **Single-active-run guardrail.** `_active_run_for` continues to
+   block creation of two `is_active` runs for the same issue. A paused
+   run + one QUEUED follow-up is allowed (paused is not active); two
+   QUEUED followers are not (coalesce step).
+3. **Pin only when resume is meaningful.** Set `pinned_runner_id` only
+   when `R_prev.thread_id IS NOT NULL` and `R_prev.runner` is
+   online-eligible. Otherwise leave NULL so any runner can take R_next.
+4. **Pod deletion respects paused runs.** Pod deletion path refuses
+   while any non-terminal run (including PAUSED) exists in the pod.
+   The drain process must explicitly resolve paused runs (cancel or
+   re-route) before the pod can be removed.
+5. **Bot self-trigger immunity.** No agent-authored comment can
+   produce a new run. Filter must be on `actor.is_bot=True`, not on
+   string match or username.
+
+### 11.7 What does NOT change
+
+- The pod queue model. Fresh issues still dispatch to whoever's free
+  in the pod.
+- Runner identity exposure. No new "this run is pinned to that runner"
+  UI beyond the stuck-pin indicator from B1.
+- Existing terminal statuses (`COMPLETED`, `FAILED`, `CANCELLED`,
+  `BLOCKED`). `BLOCKED` keeps its terminal contract; `"paused"` is the
+  new agent status that produces the new non-terminal
+  `PAUSED_AWAITING_INPUT`.
+- Runner-side persistence model. No new index, no new cache, no new
+  per-issue state on the runner.
+
+### 11.8 Integration test scenarios
+
+These map directly to acceptance criteria for the implementation:
+
+1. **Yield → comment → resume on idle runner.** A2 end-to-end with
+   agentA being the only runner in the pod.
+2. **Yield → other-issue dispatch → comment → resume after current
+   run.** A3 end-to-end. Verify R2 sits QUEUED while agentA works on
+   issue002 and dispatches the moment R3 terminates.
+3. **Coalesce two comments into one follow-up.** Send two comments in
+   rapid succession before R2 dispatches; assert only one new
+   `AgentRun` row exists and its prompt contains both comments.
+4. **Bot comment does not trigger continuation.** Workpad update from
+   `pi_dash_agent`; assert no new `AgentRun` is created.
+5. **State gating.** Comment on a BACKLOG / COMPLETED issue produces
+   no new run.
+6. **Comment during RUNNING.** Comment arrives mid-run; assert the
+   terminate-side sweep picks it up and dispatches R_next when R_prev
+   terminates.
+7. **Stuck pin → operator release → fresh-context fallback.** Take
+   pinned runner offline, simulate operator release, assert R2 routes
+   to another runner without `resume_thread_id`.
+8. **Resume failure → automatic fallback.** Mock the agent CLI's
+   resume call to fail; assert cloud drops the pin and re-queues
+   without resume hint.
+9. **Status classifier coverage.** Unit test asserting
+   `PAUSED_AWAITING_INPUT` membership in each of the five
+   classifiers per §4.3.
+10. **Pod deletion blocked by paused runs.** Attempt to delete a pod
+    with a `PAUSED_AWAITING_INPUT` run; assert it's refused until the
+    run is resolved.
+11. **Multiple paused issues on one agent, FIFO by follow-up
+    creation.** Pause issue001 then issue003 on agentA; comment on
+    issue003 first, then issue001; assert R3-next dispatches before
+    R1-next when agentA frees up.
+12. **PAUSED + state transition back to In Progress.** With a paused
+    run on the issue, move the issue to In Progress manually; assert
+    the resulting run is pinned to the prior runner with
+    `resume_thread_id` set (per Q-style edge case from §11.6 #2).

--- a/.ai_design/issue_run_improve/design.md
+++ b/.ai_design/issue_run_improve/design.md
@@ -1,0 +1,390 @@
+# Issue Run Continuation — Multi-Run Conversations Per Issue
+
+> Directory: `.ai_design/issue_run_improve/`
+>
+> **Status:** discussion / pre-implementation. No code changes yet.
+>
+> **Scope:** how an issue continues across more than one `AgentRun` when the
+> first run yields without finishing — and what that implies for run lifecycle,
+> conversation continuity, dispatch routing, and user UX.
+>
+> **Related work**
+>
+> - `.ai_design/issue_runner/design.md` — pods, runners, the queue model, the
+>   run-identity split (creator vs. billable owner). This doc builds on top of
+>   that one and assumes its decisions.
+
+## 1. Problem
+
+Today, on `main` (commit `a99e736`):
+
+- An issue moved to **In Progress** auto-creates an `AgentRun` and dispatches
+  it to a runner via the pod queue (`orchestration/signals.py`,
+  `orchestration/service.py`, `runner/services/matcher.py`).
+- The runner spawns a fresh `claude --print …` (or codex equivalent) for every
+  run. Each run is a brand-new agent session.
+- When that run terminates — for any reason — the agent's working memory is
+  gone. There is no native session resume, no transcript replay, no thread
+  continuation across runs.
+- A user comment on an issue is **not** a signal: nothing wakes the agent, no
+  follow-up run is created.
+
+The data model already partially supports continuation:
+
+- `AgentRun.thread_id` (`runner/models.py:363`) stores the provider's session
+  id (Claude `session_id` / Codex `thread_id`) when the runner reports it
+  via `run_started` (`consumers.py:374-379`).
+- `AgentRun.parent_run` (`runner/models.py:346-352`) chains follow-up runs.
+  `orchestration/service.py:103` sets it to the latest prior run when a new
+  run is created for an issue that already has one.
+- The runner `RunPayload` struct has a `resume_thread_id: Option<String>` field
+  (`agent/mod.rs:54`) but the cloud never populates it.
+- Codex bridge supports `resume_thread()` (`runner/src/codex/bridge.rs:61-69`).
+  The Claude Code path has no `--resume` plumbing.
+
+So everything is wired *for storage* but nothing *consumes* it. This doc
+proposes how to wire the consumption side.
+
+## 2. Goal
+
+For an issue whose work spans multiple agent runs, give the agent enough
+context on each follow-up run that it can continue meaningfully — while
+keeping the dispatch model (workspace pod queue, fair scheduling, runner
+ownership) intact.
+
+Non-goals:
+
+- Multi-agent collaboration on the same issue (one conversation per chain).
+- Cross-issue memory (a runner's recall of issue A is not available on issue
+  B; that's a separate, larger problem).
+- Long-term memory beyond a single issue's lifecycle.
+
+## 3. The Three Sub-Problems
+
+This problem decomposes cleanly into three independent decisions. Each can be
+chosen separately; each has its own MVP/full-featured spectrum.
+
+| #   | Question                                                          | Where the design lives |
+| --- | ----------------------------------------------------------------- | ---------------------- |
+| A   | What does it mean for a run to "yield" instead of "finish"?       | §4 — Run Lifecycle     |
+| B   | What triggers a follow-up run?                                    | §5 — Continuation Triggers |
+| C   | How does the follow-up run inherit the prior run's context?       | §6 — Conversation Continuity |
+
+A separate question — whether to introduce an `IssueConversation` entity that
+owns the thread of runs — is covered in §7.
+
+## 4. Run Lifecycle: Yield vs. Finish
+
+### 4.1 Today's terminal states
+
+`AgentRunStatus` (`runner/models.py:101`) currently distinguishes
+`QUEUED → ASSIGNED → RUNNING → SUCCEEDED | FAILED | CANCELLED | TIMED_OUT`.
+All four terminals are flat: "done, don't expect more."
+
+This is too coarse. An agent can stop without having finished, in several
+materially different ways:
+
+| Termination kind          | What it means                                              | Should follow-up auto-trigger? |
+| ------------------------- | ---------------------------------------------------------- | ------------------------------ |
+| Completed cleanly         | Agent reports done; the work is finished                   | No                             |
+| Yielded — needs input     | Agent emits a structured "I need X from the human" signal  | Yes, when the human responds   |
+| Yielded — needs approval  | Agent paused on an approval gate                           | Yes, when approval resolves    |
+| Hit budget cap            | Run exceeded a token / wall-clock budget                   | Optional — policy decision     |
+| Crashed / disconnected    | Runner died, lease expired, network gone                   | Maybe — recovery is intra-run  |
+| User cancelled            | A human stopped the run                                    | No                             |
+
+### 4.2 Proposed lifecycle additions
+
+Introduce an explicit **paused / awaiting** state distinct from terminal:
+
+- `PAUSED_AWAITING_INPUT` — agent yielded cleanly with a question for the
+  human; no further dispatch until a continuation trigger fires.
+- `PAUSED_AWAITING_APPROVAL` — already partially modeled via the approvals
+  table; promote to a first-class run status so the matcher's "non-terminal"
+  predicate is honest.
+
+`PAUSED_*` is **not terminal**. The run holds its lease, retains its
+`thread_id`, and is the natural attachment point for the follow-up.
+
+### 4.3 The "I'm yielding" protocol
+
+For `PAUSED_AWAITING_INPUT` to exist, the *agent* needs a way to emit a clean
+yield. Three options, in increasing order of integration cost:
+
+1. **Heuristic on output** — sniff the agent's final stdout for "needs input"
+   markers. Cheap, brittle, fights the model.
+2. **Tool call** — give the agent a `request_user_input` tool. The runner sees
+   the tool call and reports it as a yield to the cloud. Aligned with how
+   approvals already work.
+3. **Prompt protocol** — instruct the agent (in the system prompt) to end its
+   final turn with a structured JSON envelope (`{"status": "yielded",
+   "reason": "...", "question": "..."}`). The runner parses it.
+
+Recommendation: **(2) tool call**. It piggybacks on the approval path's
+existing event plumbing, and tool calls are naturally first-class in both
+Claude Code and Codex SDKs.
+
+## 5. Continuation Triggers
+
+### 5.1 Candidate triggers
+
+| Trigger                                       | Carries new info? | UX feel             | Implementation cost                 |
+| --------------------------------------------- | ----------------- | ------------------- | ----------------------------------- |
+| User comment on the issue                     | Yes               | Conversational      | New `IssueComment` post_save signal |
+| Issue state transition back to In Progress    | No                | Coarse, button-y    | Already wired                       |
+| Explicit "Continue" / "Reply" action          | Optional          | Explicit, button-y  | New endpoint + UI                   |
+| Approval grant (resumes paused run)           | No                | Invisible           | Already partially wired             |
+| Scheduled retry after timeout                 | No                | System-driven       | New scheduler                       |
+
+### 5.2 Recommendation
+
+Make **comment-triggered continuation** the primary user path. It maps to the
+mental model the user already has ("I just leave a comment and the agent will
+read it"), and it carries the new information (the comment body) inline.
+
+Add **explicit "Continue"** as a secondary path for cases where the user has
+nothing to add but wants the agent to keep going (e.g., agent yielded on a
+budget cap; user accepts the additional spend).
+
+Treat **approval grant** as intra-run, not a new run — the run was holding its
+lease the whole time. This is already most of the way there.
+
+### 5.3 Comment-triggered flow (sketch)
+
+```
+User adds comment to Issue I
+        │
+        ▼
+post_save(IssueComment)
+        │
+        ├─► Skip if author is a runner / agent (avoid self-trigger loops)
+        ├─► Skip if no prior AgentRun for I (no conversation to continue)
+        ├─► Find latest AgentRun R_prev for I
+        │     │
+        │     ├─► R_prev is PAUSED_*    → create R_next with parent_run=R_prev
+        │     ├─► R_prev is terminal    → create R_next with parent_run=R_prev (resume a finished issue)
+        │     └─► R_prev is RUNNING     → append comment to live run via WS frame, do NOT create R_next
+        │
+        ▼
+R_next dispatched through normal pod queue
+```
+
+### 5.4 Race conditions to think about
+
+- **Two comments before R_next dispatches.** Coalesce: the dispatcher reads
+  *all* comments since `R_prev.completed_at` at dispatch time. Don't create
+  one R_next per comment.
+- **Comment arrives while R_prev is still RUNNING.** Don't queue a new run.
+  Either (a) push the comment to the live run as an inbound user message via
+  the WS bridge, or (b) hold the comment until the run terminates and then
+  dispatch. Option (a) is closer to the desired UX but requires runner-side
+  support for mid-run inbound messages.
+- **Agent comments on its own issue.** Filter by author type: if the comment
+  is an agent-authored comment (logged on behalf of an `AgentRun`), do not
+  re-trigger.
+
+## 6. Conversation Continuity
+
+This is the hardest of the three sub-problems. The follow-up run needs the
+prior run's context. Three mechanisms.
+
+### 6.1 Mechanism A — Native provider-side resume
+
+`claude --resume <session_id>` (Claude Code) and `resume_thread(...)` (Codex)
+let the provider runtime re-attach to a previous session.
+
+**Pros**
+
+- Zero token overhead — no transcript replay.
+- Perfect memory — the agent has its full prior turn-by-turn state.
+- Simplest semantics; trivially supports tool/file state if the provider
+  supports it.
+
+**Cons**
+
+- **Locality.** Claude Code stores its session on the local disk of the runner
+  process. The follow-up run *must* hit the same runner, and that runner's
+  session storage must still be intact (no restart, no GC, no reinstall).
+- **Couples runs to runner identity** — fights the pod queue's "any runner in
+  the pod" model.
+- **Provider-specific.** Codex resume works differently; cross-provider runs
+  on the same conversation are out of scope.
+
+### 6.2 Mechanism B — Cloud transcript replay
+
+We already capture every meaningful event into `AgentRunEvent`
+(`runner/models.py:424`). On a follow-up run we synthesize a system-prompt
+preamble that summarizes — or replays — the prior run's user/assistant turns,
+and start a *fresh* provider session.
+
+**Pros**
+
+- Provider-agnostic.
+- Runner-agnostic — the follow-up can land on any idle runner in the pod.
+- Durable — the cloud is the source of truth.
+- Auditable — the same transcript drives both replay and human review.
+
+**Cons**
+
+- Token cost on every continuation. For long conversations this compounds.
+- Tool/file state not perfectly restored. The agent "remembers" what it did
+  but doesn't have the same in-memory caches, file handles, etc.
+- Replay quality is sensitive to how we summarize. Naive concat of all events
+  blows the context window quickly.
+
+### 6.3 Mechanism C — Hybrid
+
+Try (A) first; fall back to (B) when (A) is unavailable.
+
+```
+follow-up run dispatched
+        │
+        ▼
+Was R_prev assigned to a runner that is still online & in the pod?
+        ├─ Yes → set resume_thread_id on RunPayload; runner attempts native resume
+        │           ├─ Native resume succeeds → done
+        │           └─ Native resume fails    → fall back to replay path
+        └─ No  → skip native; use replay path
+```
+
+This is what we should ship for v1. It captures the cheap-and-fast common case
+(same runner is still around) without sacrificing correctness when the runner
+is gone.
+
+### 6.4 Pinning policy
+
+Hybrid raises a real scheduling question: how hard do we *try* to keep the
+follow-up on the same runner?
+
+Three positions:
+
+- **Strict pin.** Follow-up run is exclusively dispatchable to the original
+  runner. If that runner is busy, the run waits. Maximum native-resume hit
+  rate; worst queue fairness; users wait longer.
+- **Soft pin (recommended).** Prefer the original runner; wait up to N seconds
+  (e.g., 30s) for it to free up; then release the pin and dispatch to any
+  runner using the replay path. Tunable knob.
+- **No pin.** Always dispatch to whoever is free; native resume is just a
+  performance hint that succeeds opportunistically. Best fairness; loses the
+  native-resume benefit when runners are busy.
+
+Soft pin is the right default because it aligns with the digital-employee
+model: "I'd like the same person who worked on this last time, but I'd rather
+make progress than wait forever."
+
+### 6.5 Where the resume hint lives
+
+Two storage options:
+
+1. Read at dispatch time from `parent_run.thread_id` and `parent_run.runner_id`.
+2. Promote to a first-class field on the new run: `resume_thread_id`,
+   `pinned_runner_id`.
+
+Option 1 keeps the model lean (no new columns), at the cost of always walking
+the chain. Option 2 lets us snapshot the resume hint once and stop caring
+about whether it's still derivable later (e.g., if `parent_run.runner_id` was
+nulled out for some reason).
+
+Recommendation: **Option 1 for MVP**, promote to Option 2 if we find ourselves
+patching the same data lookup in three places.
+
+## 7. Optional: An `IssueConversation` Entity
+
+Today, "the conversation on an issue" is implicit — it's the chain of
+`AgentRun` rows whose `parent_run` walks back to a root.
+
+A first-class `IssueConversation` (or `WorkThread`) model could own:
+
+- `issue_id` — the issue this conversation is about.
+- `native_session_id` — the canonical provider session id (latest non-empty
+  `thread_id` in the chain).
+- `pinned_runner_id` — soft affinity for native-resume.
+- `head_run_id` — the latest run in the chain.
+- `status` — `active` (work continuing), `closed` (done), `abandoned`.
+
+### 7.1 Why we'd add it
+
+- **Multiple conversations per issue.** "I want to start over" or "let me ask a
+  side question" become natural — each gets its own conversation. The walk-
+  the-parent_run-chain model has no place for branching.
+- **Cleaner ownership.** Pinning, transcript caching, and the resume hint all
+  live in one place instead of being recomputed from the chain.
+- **Cleaner permissions.** Conversation-level subscribe / mute / reassign
+  actions become possible.
+
+### 7.2 Why we'd skip it (for now)
+
+- The chain model is sufficient for one-conversation-per-issue. Promoting now
+  is speculative.
+- New entity = new migrations, new permission rules, new API surface.
+
+Recommendation: **defer.** Walk-the-chain works for v1. Promote to
+`IssueConversation` only if the multi-thread-per-issue use case becomes real.
+
+## 8. Recommended MVP Shape
+
+This is the minimum coherent slice that delivers the user-visible benefit.
+
+1. **Run lifecycle** (§4)
+   - Add `AgentRunStatus.PAUSED_AWAITING_INPUT` (and `PAUSED_AWAITING_APPROVAL`
+     if not already represented as a status).
+   - Define the `request_user_input` tool that the agent calls to yield.
+   - Runner reports the yield to the cloud; cloud transitions `R_prev` to
+     `PAUSED_AWAITING_INPUT` and stores the agent's question in `R_prev.done_payload`.
+
+2. **Continuation trigger** (§5)
+   - Add `post_save` on `IssueComment`:
+     - Skip agent-authored comments.
+     - Find latest `AgentRun` for the issue.
+     - If `RUNNING`: forward the comment to the live run via WS (out of MVP
+       scope — okay to defer and queue instead).
+     - If `PAUSED_*` or terminal: create a new `AgentRun` with `parent_run`
+       set, dispatch through the normal pod queue.
+   - Add `POST /api/v1/runner/runs/<id>/continue/` endpoint as the explicit
+     button-driven path.
+
+3. **Conversation continuity — hybrid** (§6)
+   - At dispatch, the cloud computes `resume_thread_id = parent_run.thread_id`
+     and `preferred_runner_id = parent_run.runner_id`.
+   - Matcher implements **soft pin**: prefer `preferred_runner_id`, wait up to
+     `RUN_PIN_GRACE_SECONDS` (default 30), then release.
+   - Runner side: if `resume_thread_id` is set, attempt native resume first
+     (Claude Code: pass `--resume`; Codex: call `resume_thread()`). On failure,
+     fall back to replay.
+   - Replay path: load `R_prev` events, render a transcript preamble
+     (compact format — user turns, assistant turns, key tool calls, dropping
+     internal scratchpad), prepend to the new run's prompt.
+
+4. **Defer**
+   - `IssueConversation` entity (§7).
+   - Mid-run inbound user messages (forwarding a comment into a `RUNNING`
+     run). Workaround: queue the comment, dispatch on terminate.
+   - Cross-issue / cross-conversation memory.
+
+## 9. Open Questions
+
+| #   | Question                                                                                                                                         |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Q1  | What's the right TTL on a `PAUSED_AWAITING_INPUT` run? After 7 days with no comment, do we GC it to terminal?                                    |
+| Q2  | Replay format: full turn-by-turn vs. summarize-the-prior-run? At what conversation length do we switch?                                          |
+| Q3  | Can we forward an inline comment into a `RUNNING` run without making the runner stateful in dangerous ways? Or do we always wait for terminate? |
+| Q4  | Soft-pin grace window: 30s reasonable? Tunable per pod?                                                                                          |
+| Q5  | If native resume succeeds but the resumed agent's working directory was wiped (runner reinstalled), the agent has memory but no files. How do we detect and handle? |
+| Q6  | Do we expose conversation history (the run chain) as a first-class API for the UI's issue panel, or keep it as `issue.agent_runs.order_by(...)`? |
+| Q7  | Billing: a follow-up run costs tokens; who pays? Same `runner.owner` semantics as the primary run, or attribute to the comment author?           |
+| Q8  | If `IssueComment` triggers a run but the issue is no longer in `In Progress` (user moved it back to Backlog), do we still dispatch? Probably not — define the gating rule. |
+
+## 10. Summary of Tradeoffs
+
+The central tradeoff is **runner affinity vs. queue fairness**. Native resume
+is dramatically cheaper and higher-fidelity, but it ties a run to a specific
+runner; the pod queue's whole point is that any runner can pick up any work.
+
+Soft pin with replay fallback is the pragmatic middle: we capture the common-
+case win (the original runner is usually still around) and degrade
+gracefully when it isn't.
+
+The other meaningful tradeoff is **trigger surface**. Comment-triggered
+continuation matches user intent best but introduces an implicit dispatch
+path, which is harder to reason about than an explicit button. Shipping both
+gives users a fallback for surprising cases.

--- a/.ai_design/issue_run_improve/design.md
+++ b/.ai_design/issue_run_improve/design.md
@@ -213,23 +213,33 @@ For Claude, the pragmatic path reuses the existing `pi-dash-done` channel:
 above is two structured paths, one per agent, both grounded in existing
 plumbing.
 
-When the runner sees the yield (Codex tool call OR Claude done-signal
-parse):
+**Codex yield path** (tool call):
 
-- Cloud transitions run to `PAUSED_AWAITING_INPUT`, stores the payload.
-- Runner reports completion (Codex: tool-call observed and ack'd; Claude:
-  process exits cleanly after emitting the fence) and returns to idle,
-  then triggers `drain_for_runner` (§5.6).
+- Runner observes the `request_user_input` tool call from Codex.
+- Runner sends `ClientMsg::RunPaused { run_id, payload, paused_at }` to
+  cloud (new variant — see §7.2).
+- Cloud's `on_run_paused` consumer handler transitions the run to
+  `PAUSED_AWAITING_INPUT`, persists the payload to `done_payload`, and
+  triggers `drain_for_runner` (§5.6).
+- Runner ack's the tool call to Codex (so the thread parks cleanly on
+  disk for later resume) and returns to idle.
 
-When the runner sees the yield:
+**Claude yield path** (done-signal fenced block):
 
-- Reports `RunPaused { run_id, payload, ... }` to cloud.
-- Cloud transitions run to `PAUSED_AWAITING_INPUT`, stores the payload.
-- Runner returns to idle and triggers `drain_for_runner` (see §5.6).
+- Claude emits its terminal `pi-dash-done` fence with `status: "paused"`
+  and a `done_payload` containing the question + handoff fields.
+- Runner forwards Claude's terminal output verbatim (no bridge change)
+  and reports run completion via the existing `RunCompleted` /
+  done-signal flow.
+- Cloud's `done_signal.ingest_into_run` parses the fence, sees
+  `"paused"`, transitions the run to `PAUSED_AWAITING_INPUT` instead of
+  terminal `BLOCKED`, and triggers `drain_for_runner`.
+- No new `ClientMsg` variant is needed for Claude.
 
-The yield tool's payload should be structured as a handoff (see §6.4) —
-question for the human plus enough state for a fresh agent to continue if
-native resume fails.
+Both paths converge on `PAUSED_AWAITING_INPUT` with a populated
+`done_payload`. The payload schema (§6.4) is shared — question for the
+human plus enough state for a fresh agent to continue if native resume
+fails.
 
 ## 5. Continuation Triggers and Dispatch
 
@@ -268,12 +278,51 @@ post_save(IssueComment)
         │     │
         │     ├─► R_prev is PAUSED_AWAITING_INPUT → create R_next, pin to R_prev.runner
         │     ├─► R_prev is is_terminal           → create R_next, pin to R_prev.runner
-        │     └─► R_prev is is_active             → queue comment for delivery on terminate
-        │                                            (RUNNING / ASSIGNED / AWAITING_*)
+        │     └─► R_prev is is_active             → no-op here; terminate-side
+        │                                            sweep picks it up (see below)
         │
         ▼
 R_next dispatched through normal pod queue (with personal-queue priority)
 ```
+
+**Comments-during-active-run.** When R_prev is still `is_active`
+(RUNNING / ASSIGNED / AWAITING_APPROVAL / AWAITING_REAUTH), the
+`post_save` receiver does **not** create R_next, and the comment is
+**not** held in any side table or queue. Instead, the comment lives
+exactly where every comment lives — in `IssueComment` — and is
+discovered later by a **timestamp sweep** in the terminate handlers:
+
+```
+on_run_completed / on_run_failed / on_run_paused (consumers.py)
+        │
+        │ (existing run-state update + drain trigger)
+        ▼
+maybe_continue_after_terminate(R):
+    if R.work_item_id is None: return
+    pending = IssueComment.objects.filter(
+        issue=R.work_item,
+        actor__is_bot=False,
+        created_at__gt=R.started_at,
+    ).exists()
+    if not pending: return
+    invoke comment-trigger flow on R.work_item
+        (which reads the same comments to compose R_next.prompt
+         and applies the same gating + pinning rules above)
+```
+
+This means there is no "pending comment" model field, no separate
+queue, no new persistence. The storage is `IssueComment` itself; the
+"queue" is implicit via the timestamp range
+`created_at > R_prev.started_at`. The prompt builder for R_next reads
+all unconsumed comments in that range and composes them into the
+prompt — naturally coalescing multiple comments arriving during the
+active run.
+
+(One subtle detail: the sweep filter must use `R.started_at` rather
+than `R.assigned_at` so comments left between assignment and the
+agent actually starting work are included. Also worth scoping by
+`R.created_by` or excluding the trigger comment itself depending on
+intended semantics — see Q9.)
 
 **Bot filter.** The `pi_dash_agent` bot user
 (`apps/api/pi_dash/orchestration/workpad.py:27-70`) authors the agent's
@@ -294,8 +343,8 @@ agent's own workpad updates would re-trigger continuation in a loop.
 
 **Guardrail interaction.** The existing single-active-run guardrail in
 `_active_run_for` (`orchestration/service.py:45-59`) blocks new runs when
-one is already `is_active` for the issue. With PAUSED_AWAITING_INPUT
-explicitly _outside_ `is_active` (§4.3), a paused run does not block the
+one is already `is_active` for the issue. With PAUSED*AWAITING_INPUT
+explicitly \_outside* `is_active` (§4.3), a paused run does not block the
 follow-up — which is what we want. But two distinct comments arriving in
 quick succession could both observe "no active run" and create two
 QUEUED follow-ups for the same issue. The **coalesce step above** handles
@@ -380,9 +429,12 @@ Drain is invoked at three moments:
   if there's already a QUEUED R_next for the issue, append the new comment
   to its prompt instead of creating a second run.
 - **Comment arrives while R_prev is RUNNING.** Don't queue a new run yet.
-  Either (a) push the comment to the live run as an inbound user message
-  (out of MVP scope; needs runner-side support for mid-run inbound), or
-  (b) hold the comment until terminate and dispatch then. Start with (b).
+  Two future options: (a) push the comment to the live run as an inbound
+  user message (out of MVP scope; needs runner-side support for mid-run
+  inbound). For MVP, take (b) — the terminate-side timestamp sweep in
+  §5.2 picks up any non-bot comments with `created_at > R.started_at`
+  when the run terminates, and runs the comment-trigger logic. No
+  separate "pending comment" storage is needed.
 - **Agent comments on its own issue.** Filter by author type; agent-authored
   comments do not re-trigger.
 - **Pinned runner offline / revoked.** The pinned run sits in QUEUED forever
@@ -596,11 +648,18 @@ the runner reports it via `RunFailed` with a new
 7. **`on_run_paused` consumer handler** (`runner/consumers.py:236` neighborhood):
    transition the run, persist `done_payload`, post the handoff as an
    issue comment (§6.4), and trigger drain.
-8. **Assign payload**: include `resume_thread_id = R.parent_run.thread_id`
+8. **Terminate-side comment sweep** (`runner/consumers.py` terminate handlers):
+   in `on_run_completed`, `on_run_failed`, and `on_run_paused`, after
+   updating run state, check for non-bot `IssueComment`s with
+   `created_at > R.started_at` on the run's issue. If any exist, invoke
+   the comment-trigger flow (§5.2) to create R_next. No new model field
+   or pending-comment table — `IssueComment` + the timestamp range is
+   the storage.
+9. **Assign payload**: include `resume_thread_id = R.parent_run.thread_id`
    when set; `pinned_runner_id` does not need to be on the wire.
-9. **Pin release on revoke**: on `Runner` REVOKED transition, null out
-   pinned QUEUED runs. Trigger drain on the affected pod.
-10. **Operator pin-release**: a UI/API affordance to manually clear
+10. **Pin release on revoke**: on `Runner` REVOKED transition, null out
+    pinned QUEUED runs. Trigger drain on the affected pod.
+11. **Operator pin-release**: a UI/API affordance to manually clear
     `pinned_runner_id` on a stuck QUEUED run.
 
 ### 8.2 Runner (Rust)
@@ -640,7 +699,9 @@ becomes a fallback rather than the primary mechanism.
 ### 8.3 Defer
 
 - Mid-run inbound user messages (forwarding a comment into a `RUNNING` run).
-  Workaround: hold the comment, dispatch on terminate.
+  Workaround: the terminate-side timestamp sweep (§5.2) picks up comments
+  with `created_at > R.started_at` once the run finishes, and dispatches
+  R_next normally. No separate pending-comment storage.
 - Transcript-replay fallback (§6.5).
 - `IssueConversation` entity (one-thread-per-issue is sufficient for v1).
 - TTL-based pin release (§5.7) — operator-driven is enough for v1.
@@ -650,16 +711,17 @@ becomes a fallback rather than the primary mechanism.
 
 ## 9. Open Questions
 
-| #   | Question                                                                                                                                                                                            |
-| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Q1  | What's the right TTL on a `PAUSED_AWAITING_INPUT` run? After 7 days with no comment, do we GC it to terminal?                                                                                       |
-| Q2  | If R_prev terminated SUCCEEDED but a comment still arrives weeks later, do we resume? Probably yes, but the agent CLI's session may have been cleaned up.                                           |
-| Q3  | Workspace persistence on the runner: when agentA pauses issue001 and switches to issue002 (different workspace path), can issue001's workspace be left dirty? Or do we require commit-before-yield? |
-| Q4  | If the issue is no longer in `In Progress` (user moved it back to Backlog), do we still dispatch on comment? Probably not — define the gating rule.                                                 |
-| Q5  | Billing: a follow-up run costs tokens; same `runner.owner` semantics as the primary run, or attribute to the comment author?                                                                        |
-| Q6  | Do we expose conversation history (the run chain) as a first-class API for the UI's issue panel, or keep it derived (`issue.agent_runs.order_by(...)`)?                                             |
-| Q7  | The handoff payload schema (§6.4) — minimal viable shape, or richer fields (file-level annotations, follow-up checklist)?                                                                           |
-| Q8  | Pinned-runner failure UX: when run sits QUEUED because the pinned runner is offline, what does the user see? Silent wait, or a "stuck on agentA" indicator with a release button?                   |
+| #   | Question                                                                                                                                                                                                                        |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Q1  | What's the right TTL on a `PAUSED_AWAITING_INPUT` run? After 7 days with no comment, do we GC it to terminal?                                                                                                                   |
+| Q2  | If R_prev terminated SUCCEEDED but a comment still arrives weeks later, do we resume? Probably yes, but the agent CLI's session may have been cleaned up.                                                                       |
+| Q3  | Workspace persistence on the runner: when agentA pauses issue001 and switches to issue002 (different workspace path), can issue001's workspace be left dirty? Or do we require commit-before-yield?                             |
+| Q4  | If the issue is no longer in `In Progress` (user moved it back to Backlog), do we still dispatch on comment? Probably not — define the gating rule.                                                                             |
+| Q5  | Billing: a follow-up run costs tokens; same `runner.owner` semantics as the primary run, or attribute to the comment author?                                                                                                    |
+| Q6  | Do we expose conversation history (the run chain) as a first-class API for the UI's issue panel, or keep it derived (`issue.agent_runs.order_by(...)`)?                                                                         |
+| Q7  | The handoff payload schema (§6.4) — minimal viable shape, or richer fields (file-level annotations, follow-up checklist)?                                                                                                       |
+| Q8  | Pinned-runner failure UX: when run sits QUEUED because the pinned runner is offline, what does the user see? Silent wait, or a "stuck on agentA" indicator with a release button?                                               |
+| Q9  | Terminate-side comment sweep (§5.2): exact filter semantics. Use `created_at > R.started_at` or `> R.created_at`? Exclude the comment that originally triggered R itself? Cap the lookback for very long-running paused chains? |
 
 ## 10. Summary of Decisions
 

--- a/apps/api/pi_dash/orchestration/done_signal.py
+++ b/apps/api/pi_dash/orchestration/done_signal.py
@@ -29,7 +29,7 @@ FENCE_RE = re.compile(
     re.DOTALL | re.MULTILINE,
 )
 
-VALID_STATUSES = {"completed", "blocked", "noop"}
+VALID_STATUSES = {"completed", "blocked", "noop", "paused"}
 
 
 class DoneSignalError(ValueError):
@@ -71,6 +71,18 @@ def parse(text: str) -> DoneSignal:
         raise DoneSignalError(
             f"pi-dash-done.status must be one of {sorted(VALID_STATUSES)}; got {status!r}"
         )
+
+    if status == "paused":
+        # The whole point of pausing instead of blocking is to ask a human
+        # something. A paused signal without a question is malformed — the
+        # cloud has nothing to surface and no signal that a comment will be
+        # actionable.
+        question = (payload.get("autonomy") or {}).get("question_for_human")
+        if not question:
+            raise DoneSignalError(
+                "pi-dash-done.status='paused' requires "
+                "autonomy.question_for_human to be set"
+            )
 
     return DoneSignal(status=status, payload=_normalize(payload))
 
@@ -153,10 +165,17 @@ def ingest_into_run(run, text: str):
     run.error = ""
     if signal.status == "completed":
         run.status = AgentRunStatus.COMPLETED
+        run.ended_at = now
     elif signal.status == "blocked":
         run.status = AgentRunStatus.BLOCKED
+        run.ended_at = now
     elif signal.status == "noop":
         run.status = AgentRunStatus.COMPLETED
-    run.ended_at = now
+        run.ended_at = now
+    elif signal.status == "paused":
+        # Non-terminal: a follow-up run will resume this thread once a
+        # human comments. Leave ended_at NULL so observability tooling
+        # doesn't treat the row as finished.
+        run.status = AgentRunStatus.PAUSED_AWAITING_INPUT
     run.save(update_fields=["done_payload", "error", "status", "ended_at"])
     return signal

--- a/apps/api/pi_dash/orchestration/service.py
+++ b/apps/api/pi_dash/orchestration/service.py
@@ -21,11 +21,11 @@ from typing import Optional
 from django.db import transaction
 from django.utils import timezone
 
-from pi_dash.db.models.issue import Issue
+from pi_dash.db.models.issue import Issue, IssueComment
 from pi_dash.db.models.state import State, StateGroup
-from pi_dash.prompting.composer import build_first_turn
+from pi_dash.prompting.composer import build_continuation, build_first_turn
 from pi_dash.prompting.renderer import PromptRenderError
-from pi_dash.runner.models import AgentRun, AgentRunStatus
+from pi_dash.runner.models import AgentRun, AgentRunStatus, Runner, RunnerStatus
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +39,15 @@ class TransitionOutcome:
     """What `handle_issue_state_transition` decided to do."""
 
     created_run: Optional[AgentRun] = None
+    reason: str = ""
+
+
+@dataclass
+class ContinuationOutcome:
+    """What ``handle_issue_comment`` decided to do."""
+
+    created_run: Optional[AgentRun] = None
+    coalesced_into: Optional[AgentRun] = None
     reason: str = ""
 
 
@@ -155,6 +164,176 @@ def _resolve_pod_for_issue(issue: Issue):
         if pinned is not None:
             return pinned
     return Pod.default_for_workspace_id(issue.workspace_id)
+
+
+#: Issue state groups in which a comment is allowed to wake the agent.
+#: Backlog/Unstarted are owned by the state-transition trigger; Completed/
+#: Cancelled require the user to re-open the issue. See §5.2 of
+#: .ai_design/issue_run_improve/design.md.
+CONTINUATION_ELIGIBLE_GROUPS = (StateGroup.STARTED.value,)
+
+
+def handle_issue_comment(comment: IssueComment) -> ContinuationOutcome:
+    """React to a comment on an issue. Maybe wake the agent.
+
+    The flow:
+    1. Skip if the comment was authored by a bot (the agent's own workpad
+       updates would otherwise trigger continuation in a loop).
+    2. Skip when the issue's state group disallows continuation (see
+       :data:`CONTINUATION_ELIGIBLE_GROUPS`).
+    3. Coalesce: if a QUEUED follow-up already exists for the issue,
+       leave it alone — the prompt builder will pick up the new comment
+       at dispatch time via :func:`build_continuation`.
+    4. Skip if the latest run is itself ``is_active`` (RUNNING / ASSIGNED
+       / AWAITING_*). The terminate-side sweep will pick the comment up
+       when that run finishes.
+    5. Otherwise create R_next, pin it to the prior runner when eligible,
+       and trigger drain.
+    """
+    if comment.actor_id is None:
+        logger.info("orchestration.continuation: skip comment=%s reason=no-actor", comment.pk)
+        return ContinuationOutcome(reason="no-actor")
+    if comment.actor.is_bot:
+        logger.info("orchestration.continuation: skip comment=%s reason=bot-comment", comment.pk)
+        return ContinuationOutcome(reason="bot-comment")
+
+    issue = comment.issue
+    state_group = issue.state.group if issue.state else None
+    if state_group not in CONTINUATION_ELIGIBLE_GROUPS:
+        logger.info(
+            "orchestration.continuation: skip issue=%s reason=state-not-eligible group=%s",
+            issue.pk, state_group,
+        )
+        return ContinuationOutcome(reason="state-not-eligible")
+
+    prior = _latest_prior_run(issue)
+    if prior is None:
+        logger.info("orchestration.continuation: skip issue=%s reason=no-prior-run", issue.pk)
+        return ContinuationOutcome(reason="no-prior-run")
+
+    # Coalesce against an already-queued follow-up. The prompt builder
+    # rebuilds the continuation prompt from comments at dispatch time.
+    queued_follow_up = (
+        AgentRun.objects.filter(
+            work_item=issue, status=AgentRunStatus.QUEUED
+        )
+        .order_by("-created_at")
+        .first()
+    )
+    if queued_follow_up is not None:
+        return ContinuationOutcome(
+            coalesced_into=queued_follow_up, reason="coalesced"
+        )
+
+    # Don't wake while a run is already in flight; terminate sweep handles it.
+    if prior.is_active:
+        return ContinuationOutcome(reason="prior-run-active")
+
+    pod = _resolve_pod_for_issue(issue)
+    if pod is None:
+        logger.warning(
+            "orchestration.continuation: no pod for workspace %s; "
+            "leaving issue %s unhandled",
+            issue.workspace_id,
+            issue.id,
+        )
+        return ContinuationOutcome(reason="no-pod-available")
+
+    return _create_continuation_run(
+        issue=issue,
+        parent=prior,
+        creator=comment.actor,
+        pod=pod,
+    )
+
+
+def maybe_continue_after_terminate(run: AgentRun) -> ContinuationOutcome:
+    """Sweep for non-bot comments that arrived while ``run`` was active.
+
+    Called from the runner Channels consumer when a run terminates
+    (completed / failed / paused). Without this hook, comments left
+    while the run was RUNNING would never trigger a follow-up — the
+    ``post_save(IssueComment)`` receiver explicitly skips them
+    (`reason='prior-run-active'`).
+
+    Storage is the existing ``IssueComment`` table; the "queue" is
+    the timestamp range ``created_at > run.started_at``.
+    """
+    if run.work_item_id is None or run.started_at is None:
+        return ContinuationOutcome(reason="no-issue-or-not-started")
+    issue = run.work_item
+    pending = (
+        IssueComment.objects.filter(
+            issue=issue,
+            actor__is_bot=False,
+            created_at__gt=run.started_at,
+        )
+        .order_by("created_at")
+        .first()
+    )
+    if pending is None:
+        return ContinuationOutcome(reason="no-pending-comments")
+    return handle_issue_comment(pending)
+
+
+def _create_continuation_run(
+    *, issue: Issue, parent: AgentRun, creator, pod
+) -> ContinuationOutcome:
+    """Create R_next as a continuation of ``parent`` with optional pin."""
+    from pi_dash.runner.services import matcher
+
+    pinned_runner = _pinned_runner_for(parent)
+
+    with transaction.atomic():
+        run = AgentRun.objects.create(
+            workspace=issue.workspace,
+            created_by=creator,
+            pod=pod,
+            work_item=issue,
+            parent_run=parent,
+            pinned_runner=pinned_runner,
+            status=AgentRunStatus.QUEUED,
+            prompt="",
+            run_config={
+                "repo_url": (issue.project.repo_url or None),
+                "repo_ref": (issue.project.base_branch or None),
+                "git_work_branch": (issue.git_work_branch or None),
+            },
+        )
+        try:
+            run.prompt = build_continuation(issue, run)
+        except PromptRenderError as exc:
+            run.status = AgentRunStatus.FAILED
+            run.error = f"prompt render failed: {exc}"
+            run.ended_at = timezone.now()
+            run.save(update_fields=["status", "error", "ended_at"])
+            logger.exception(
+                "orchestration.continuation: prompt render failed for issue %s",
+                issue.id,
+            )
+            return ContinuationOutcome(created_run=run, reason="render-failed")
+        run.save(update_fields=["prompt"])
+        transaction.on_commit(lambda: matcher.drain_pod_by_id(pod.id))
+
+    return ContinuationOutcome(created_run=run, reason="created")
+
+
+def _pinned_runner_for(parent: AgentRun) -> Optional[Runner]:
+    """Return the runner to pin a follow-up to, or None.
+
+    Pin only when the parent has a session id we can resume against and
+    its runner is still online-eligible. Otherwise leave the new run
+    unpinned so any runner in the pod can take it (with a fresh-context
+    fallback).
+    """
+    if not parent.thread_id or parent.runner_id is None:
+        return None
+    runner = parent.runner
+    if runner is None:
+        return None
+    if runner.status == RunnerStatus.REVOKED:
+        return None
+    return runner
 
 
 def _create_and_dispatch_run(

--- a/apps/api/pi_dash/orchestration/signals.py
+++ b/apps/api/pi_dash/orchestration/signals.py
@@ -17,9 +17,12 @@ import logging
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 
-from pi_dash.db.models.issue import Issue
+from pi_dash.db.models.issue import Issue, IssueComment
 from pi_dash.db.models.state import State
-from pi_dash.orchestration.service import handle_issue_state_transition
+from pi_dash.orchestration.service import (
+    handle_issue_comment,
+    handle_issue_state_transition,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -82,3 +85,32 @@ def _lookup_state(state_id) -> State | None:
         return State.all_state_objects.get(pk=state_id)
     except State.DoesNotExist:
         return None
+
+
+@receiver(post_save, sender=IssueComment, dispatch_uid="orchestration.comment_postsave")
+def fire_comment_continuation(sender, instance: IssueComment, created: bool, **kwargs) -> None:
+    """Wake the agent on a new (non-bot) comment to an in-progress issue.
+
+    See :func:`pi_dash.orchestration.service.handle_issue_comment` for the
+    decision logic. Catches and logs every exception so a broken trigger
+    can't crash IssueComment writes.
+    """
+    if not created:
+        return
+    try:
+        outcome = handle_issue_comment(instance)
+    except Exception:  # noqa: BLE001 — never let orchestration crash comment save
+        global orchestration_error_count
+        orchestration_error_count += 1
+        logger.exception(
+            "orchestration.error: handle_issue_comment failed for "
+            "comment=%s issue=%s (total_errors=%d)",
+            instance.pk,
+            instance.issue_id,
+            orchestration_error_count,
+        )
+        return
+    logger.info(
+        "orchestration.continuation: comment=%s issue=%s reason=%s",
+        instance.pk, instance.issue_id, outcome.reason,
+    )

--- a/apps/api/pi_dash/prompting/composer.py
+++ b/apps/api/pi_dash/prompting/composer.py
@@ -65,12 +65,33 @@ def build_first_turn(issue: Issue, run: AgentRun) -> str:
 
 
 def build_continuation(issue: Issue, run: AgentRun) -> str:
-    """Continuation-turn rendering is explicitly deferred in MVP.
+    """Render a continuation prompt for a follow-up run.
 
-    The runner is single-turn today; when we add multi-turn we will compose
-    continuations from workpad state plus the prior turn transcript.
+    The agent reattaches to its prior session via native resume
+    (``--resume`` / ``thread/resume``), so it already has the
+    conversation context in memory. The prompt for the follow-up turn
+    is therefore just the human's new input — concatenated comments
+    written by non-bot users since the parent run started.
+
+    Falls back to the full first-turn template when there is no parent
+    run with a ``started_at`` to anchor the comment sweep against
+    (e.g. parent crashed before reporting a session id).
     """
-    raise NotImplementedError(
-        "Continuation turns are not supported in MVP; see "
-        ".ai_design/prompt_system/prompt-system-design.md §2 decision 7."
+    from pi_dash.db.models.issue import IssueComment
+
+    parent = run.parent_run
+    if parent is None or parent.started_at is None:
+        return build_first_turn(issue, run)
+    comments = list(
+        IssueComment.objects.filter(
+            issue=issue,
+            actor__is_bot=False,
+            created_at__gt=parent.started_at,
+        )
+        .order_by("created_at")
+        .values_list("comment_stripped", flat=True)
     )
+    bodies = [c.strip() for c in comments if c and c.strip()]
+    if not bodies:
+        return "(continuation requested with no new human input — proceed)"
+    return "\n\n---\n\n".join(bodies)

--- a/apps/api/pi_dash/runner/consumers.py
+++ b/apps/api/pi_dash/runner/consumers.py
@@ -242,6 +242,17 @@ class RunnerConsumer(AsyncJsonWebsocketConsumer):
     async def on_run_cancelled(self, runner: Runner, msg: Dict[str, Any]) -> None:
         await sync_to_async(self._finalize_run)(runner, msg, AgentRunStatus.CANCELLED)
 
+    async def on_run_paused(self, runner: Runner, msg: Dict[str, Any]) -> None:
+        """Codex tool-call yield path. Cloud parks the run as
+        PAUSED_AWAITING_INPUT and triggers drain so the runner is free to
+        pick up other pod work while waiting for a human reply.
+
+        Claude's yield arrives via ``on_run_completed`` with a
+        ``pi-dash-done`` fenced block whose status is ``"paused"``; the
+        done-signal parser handles that path separately.
+        """
+        await sync_to_async(self._handle_run_paused)(runner, msg)
+
     async def on_run_awaiting_reauth(
         self, runner: Runner, msg: Dict[str, Any]
     ) -> None:
@@ -431,6 +442,53 @@ class RunnerConsumer(AsyncJsonWebsocketConsumer):
         )
         AgentRun.objects.filter(id=run_id, runner=runner).update(
             status=AgentRunStatus.AWAITING_APPROVAL
+        )
+
+    def _handle_run_paused(
+        self, runner: Runner, msg: Dict[str, Any]
+    ) -> None:
+        run_id = msg.get("run_id")
+        if not run_id:
+            return
+        payload = msg.get("payload") or {}
+        # Park the run; do NOT set ended_at (paused is non-terminal).
+        AgentRun.objects.filter(id=run_id, runner=runner).update(
+            status=AgentRunStatus.PAUSED_AWAITING_INPUT,
+            done_payload=payload,
+        )
+        # Surface the agent's question as an issue comment so the human can
+        # see it and reply (which then re-triggers continuation).
+        try:
+            run = AgentRun.objects.select_related("work_item").get(id=run_id)
+        except AgentRun.DoesNotExist:
+            return
+        if run.work_item_id is not None:
+            from pi_dash.orchestration.workpad import get_agent_system_user
+            from pi_dash.db.models.issue import IssueComment
+
+            question = (payload.get("autonomy") or {}).get("question_for_human")
+            summary = payload.get("summary")
+            body_parts = []
+            if question:
+                body_parts.append(f"<p><strong>Agent paused — question:</strong></p><p>{question}</p>")
+            if summary:
+                body_parts.append(f"<p><em>Summary so far:</em> {summary}</p>")
+            if body_parts:
+                IssueComment.objects.create(
+                    issue=run.work_item,
+                    project=run.work_item.project,
+                    workspace=run.work_item.workspace,
+                    actor=get_agent_system_user(),
+                    comment_html="".join(body_parts),
+                )
+
+        # Runner is now idle — kick the dispatcher.
+        from django.db import transaction
+
+        from pi_dash.runner.services.matcher import drain_for_runner_by_id
+
+        transaction.on_commit(
+            lambda rid=runner.id: drain_for_runner_by_id(rid)
         )
 
     def _finalize_run(

--- a/apps/api/pi_dash/runner/consumers.py
+++ b/apps/api/pi_dash/runner/consumers.py
@@ -452,18 +452,39 @@ class RunnerConsumer(AsyncJsonWebsocketConsumer):
             updates["error"] = (msg.get("detail") or "")[:16000]
         AgentRun.objects.filter(id=run_id, runner=runner).update(**updates)
 
-        # The runner just freed up — drain its pod so any QUEUED runs in the
-        # same pod can move to it. See design §6.3: drain must fire after the
-        # terminal state commits, otherwise a new assign could race with the
-        # update and the runner would receive work for a run it's finishing.
-        if runner.pod_id is not None:
-            from django.db import transaction
+        # The runner just freed up. Two follow-up actions, both gated on
+        # the terminal state having committed (otherwise a new assign
+        # would race with the update):
+        #
+        # 1. Sweep for non-bot comments that arrived while this run was
+        #    active. ``post_save(IssueComment)`` skipped them with
+        #    reason='prior-run-active'; this is where they get picked up.
+        # 2. Drain the pod (and prefer this just-freed runner) so any
+        #    QUEUED work — including a follow-up R_next created by the
+        #    sweep above — can dispatch.
+        from django.db import transaction
 
-            from pi_dash.runner.services.matcher import drain_pod_by_id
+        from pi_dash.orchestration.service import maybe_continue_after_terminate
+        from pi_dash.runner.services.matcher import (
+            drain_for_runner_by_id,
+            drain_pod_by_id,
+        )
 
-            transaction.on_commit(
-                lambda pid=runner.pod_id: drain_pod_by_id(pid)
-            )
+        def _sweep_and_drain(rid=run_id, runner_id=runner.id, pod_id=runner.pod_id):
+            run = AgentRun.objects.filter(pk=rid).first()
+            if run is not None:
+                try:
+                    maybe_continue_after_terminate(run)
+                except Exception:
+                    logger.exception(
+                        "orchestration.error: terminate sweep failed for run %s",
+                        rid,
+                    )
+            drain_for_runner_by_id(runner_id)
+            if pod_id is not None:
+                drain_pod_by_id(pod_id)
+
+        transaction.on_commit(_sweep_and_drain)
 
     # ---- misc ----
 

--- a/apps/api/pi_dash/runner/consumers.py
+++ b/apps/api/pi_dash/runner/consumers.py
@@ -444,6 +444,45 @@ class RunnerConsumer(AsyncJsonWebsocketConsumer):
             status=AgentRunStatus.AWAITING_APPROVAL
         )
 
+    def _handle_resume_unavailable(
+        self, runner: Runner, run_id: str
+    ) -> None:
+        """Cloud reaction to a ResumeUnavailable failure (§6.3 of design).
+
+        The agent CLI's session store no longer has the requested thread.
+        Drop the pin so any runner can take it, drop the resume hint by
+        nulling thread_id (so the next dispatch builds it from
+        parent_run.thread_id, which would be the same broken id — instead
+        we walk one level up so the run starts fresh-context-from-issue),
+        re-queue, and trigger drain.
+        """
+        run = AgentRun.objects.filter(id=run_id, runner=runner).first()
+        if run is None:
+            return
+        run.status = AgentRunStatus.QUEUED
+        run.runner = None
+        run.pinned_runner = None
+        run.assigned_at = None
+        # parent_run.thread_id is what _build_assign_msg reads; nulling
+        # this run's thread_id is irrelevant. To prevent the cloud from
+        # handing the same dead session id to the next runner, null the
+        # parent's thread_id too — the parent is paused/terminal, this
+        # is fine. The handoff comment carries the human-readable state.
+        if run.parent_run is not None and run.parent_run.thread_id:
+            run.parent_run.thread_id = ""
+            run.parent_run.save(update_fields=["thread_id"])
+        run.save(
+            update_fields=["status", "runner", "pinned_runner", "assigned_at"]
+        )
+        from django.db import transaction
+
+        from pi_dash.runner.services.matcher import drain_pod_by_id
+
+        if run.pod_id is not None:
+            transaction.on_commit(
+                lambda pid=run.pod_id: drain_pod_by_id(pid)
+            )
+
     def _handle_run_paused(
         self, runner: Runner, msg: Dict[str, Any]
     ) -> None:
@@ -499,6 +538,15 @@ class RunnerConsumer(AsyncJsonWebsocketConsumer):
     ) -> None:
         run_id = msg.get("run_id")
         if not run_id:
+            return
+        # Special-case resume-unavailable: don't terminate the chain, drop
+        # the pin and re-queue without the resume hint so a fresh-context
+        # dispatch can pick it up. See §6.3 of the design doc.
+        if (
+            new_status == AgentRunStatus.FAILED
+            and msg.get("reason") == "resume_unavailable"
+        ):
+            self._handle_resume_unavailable(runner, run_id)
             return
         updates: Dict[str, Any] = {
             "status": new_status,

--- a/apps/api/pi_dash/runner/consumers.py
+++ b/apps/api/pi_dash/runner/consumers.py
@@ -37,7 +37,7 @@ from pi_dash.runner.services.tokens import hash_token
 
 logger = logging.getLogger(__name__)
 
-PROTOCOL_VERSION = 1
+PROTOCOL_VERSION = 2
 HEARTBEAT_INTERVAL_SECS = 25
 OFFLINE_GRACE_SECS = 60
 
@@ -502,16 +502,27 @@ class RunnerConsumer(AsyncJsonWebsocketConsumer):
         except AgentRun.DoesNotExist:
             return
         if run.work_item_id is not None:
+            from django.utils.html import format_html
+
             from pi_dash.orchestration.workpad import get_agent_system_user
             from pi_dash.db.models.issue import IssueComment
 
             question = (payload.get("autonomy") or {}).get("question_for_human")
             summary = payload.get("summary")
-            body_parts = []
+            body_parts: list[str] = []
+            # Agent payload is untrusted (the upstream prompt can shape it),
+            # so escape with format_html before persisting to comment_html.
             if question:
-                body_parts.append(f"<p><strong>Agent paused — question:</strong></p><p>{question}</p>")
+                body_parts.append(
+                    format_html(
+                        "<p><strong>Agent paused — question:</strong></p><p>{}</p>",
+                        question,
+                    )
+                )
             if summary:
-                body_parts.append(f"<p><em>Summary so far:</em> {summary}</p>")
+                body_parts.append(
+                    format_html("<p><em>Summary so far:</em> {}</p>", summary)
+                )
             if body_parts:
                 IssueComment.objects.create(
                     issue=run.work_item,
@@ -521,14 +532,30 @@ class RunnerConsumer(AsyncJsonWebsocketConsumer):
                     comment_html="".join(body_parts),
                 )
 
-        # Runner is now idle — kick the dispatcher.
+        # Two follow-ups: (1) sweep for non-bot comments that arrived while
+        # this run was RUNNING — ``post_save(IssueComment)`` skipped them
+        # with reason='prior-run-active'; pause is the symmetric
+        # opportunity to pick them up. (2) Kick the dispatcher so the now-
+        # idle runner can take other pod work (including any R_next the
+        # sweep just created).
         from django.db import transaction
 
+        from pi_dash.orchestration.service import maybe_continue_after_terminate
         from pi_dash.runner.services.matcher import drain_for_runner_by_id
 
-        transaction.on_commit(
-            lambda rid=runner.id: drain_for_runner_by_id(rid)
-        )
+        def _sweep_and_drain(rid=run_id, runner_id=runner.id):
+            paused = AgentRun.objects.filter(pk=rid).first()
+            if paused is not None:
+                try:
+                    maybe_continue_after_terminate(paused)
+                except Exception:
+                    logger.exception(
+                        "orchestration.error: pause sweep failed for run %s",
+                        rid,
+                    )
+            drain_for_runner_by_id(runner_id)
+
+        transaction.on_commit(_sweep_and_drain)
 
     def _finalize_run(
         self,

--- a/apps/api/pi_dash/runner/migrations/0005_paused_status_and_pinned_runner.py
+++ b/apps/api/pi_dash/runner/migrations/0005_paused_status_and_pinned_runner.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("runner", "0004_add_pod_and_run_identity"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="agentrun",
+            name="pinned_runner",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="pinned_agent_runs",
+                to="runner.runner",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="agentrun",
+            name="status",
+            field=models.CharField(
+                choices=[
+                    ("queued", "Queued"),
+                    ("assigned", "Assigned"),
+                    ("running", "Running"),
+                    ("awaiting_approval", "Awaiting Approval"),
+                    ("awaiting_reauth", "Awaiting Reauth"),
+                    ("paused_awaiting_input", "Paused — Awaiting Input"),
+                    ("blocked", "Blocked"),
+                    ("completed", "Completed"),
+                    ("failed", "Failed"),
+                    ("cancelled", "Cancelled"),
+                ],
+                db_index=True,
+                default="queued",
+                max_length=24,
+            ),
+        ),
+    ]

--- a/apps/api/pi_dash/runner/models.py
+++ b/apps/api/pi_dash/runner/models.py
@@ -104,6 +104,7 @@ class AgentRunStatus(models.TextChoices):
     RUNNING = "running", "Running"
     AWAITING_APPROVAL = "awaiting_approval", "Awaiting Approval"
     AWAITING_REAUTH = "awaiting_reauth", "Awaiting Reauth"
+    PAUSED_AWAITING_INPUT = "paused_awaiting_input", "Paused — Awaiting Input"
     BLOCKED = "blocked", "Blocked"
     COMPLETED = "completed", "Completed"
     FAILED = "failed", "Failed"
@@ -335,6 +336,18 @@ class AgentRun(models.Model):
         null=True,
         blank=True,
         related_name="agent_runs",
+    )
+    # Soft affinity: when set, dispatch routes this QUEUED run only to this
+    # runner. Used by comment-triggered continuations so a follow-up resumes
+    # on the same runner that holds the prior session on disk. Cleared when
+    # the runner is revoked or by an operator escape hatch (see §5.7 of
+    # .ai_design/issue_run_improve/design.md).
+    pinned_runner = models.ForeignKey(
+        Runner,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="pinned_agent_runs",
     )
     work_item = models.ForeignKey(
         "db.Issue",

--- a/apps/api/pi_dash/runner/models.py
+++ b/apps/api/pi_dash/runner/models.py
@@ -252,6 +252,22 @@ class Runner(models.Model):
                 )
                 affected_pod_ids = {pid for _, pid in active_runs if pid is not None}
 
+            # Pinned QUEUED runs (follow-ups waiting for this runner) don't
+            # get cancelled — they still represent legitimate user intent.
+            # Drop the pin so they flow back into the pod's general queue
+            # and any remaining online runner can take them with a fresh
+            # session. See §5.7 of .ai_design/issue_run_improve/design.md.
+            pinned_pod_ids = list(
+                AgentRun.objects.filter(
+                    pinned_runner=self, status=AgentRunStatus.QUEUED
+                ).values_list("pod_id", flat=True)
+            )
+            if pinned_pod_ids:
+                AgentRun.objects.filter(
+                    pinned_runner=self, status=AgentRunStatus.QUEUED
+                ).update(pinned_runner=None)
+                affected_pod_ids.update(pid for pid in pinned_pod_ids if pid is not None)
+
         # Refire drain for every affected pod once the transaction commits.
         # Remaining online runners (if any) in the same pod may now pick up
         # queued work.

--- a/apps/api/pi_dash/runner/services/matcher.py
+++ b/apps/api/pi_dash/runner/services/matcher.py
@@ -262,6 +262,13 @@ def _build_assign_msg(run: AgentRun) -> dict:
     ``orchestration/service._dispatch_to_runner``; Phase 3 will point both at
     this helper.
     """
+    # resume_thread_id is set when this run is a continuation of a prior
+    # run that recorded a session id (Codex thread_id / Claude session_id).
+    # The runner uses it to call thread/resume or claude --resume so the
+    # agent re-attaches to its prior in-memory state. Empty/missing on the
+    # wire means "fresh session" — backward compatible with older runners.
+    parent = run.parent_run
+    resume_thread_id = parent.thread_id if (parent and parent.thread_id) else None
     return {
         "v": 1,
         "type": "assign",
@@ -274,6 +281,7 @@ def _build_assign_msg(run: AgentRun) -> dict:
         "expected_codex_model": run.run_config.get("model"),
         "approval_policy_overrides": run.run_config.get("approval_policy_overrides"),
         "deadline": None,
+        "resume_thread_id": resume_thread_id,
     }
 
 

--- a/apps/api/pi_dash/runner/services/matcher.py
+++ b/apps/api/pi_dash/runner/services/matcher.py
@@ -128,9 +128,9 @@ def next_for_runner(runner: Runner) -> Optional[AgentRun]:
         .filter(
             Q(pinned_runner=runner) | Q(pinned_runner__isnull=True),
         )
-        # Pinned-to-me sorts before unpinned thanks to NULLS LAST on the
-        # boolean expression. ``BooleanField`` annotated to give us a
-        # stable, indexable sort key without requiring a CASE WHEN.
+        # Pinned-to-me sorts before unpinned via an integer rank: 0 for the
+        # personal queue, 1 for the pod queue. ``order_by`` on the rank then
+        # ``created_at`` gives FIFO inside each tier.
         .annotate(_is_mine=models.Case(
             models.When(pinned_runner=runner, then=models.Value(0)),
             default=models.Value(1),
@@ -139,6 +139,40 @@ def next_for_runner(runner: Runner) -> Optional[AgentRun]:
         .order_by("_is_mine", "created_at")
         .first()
     )
+
+
+def _refresh_continuation_prompt(run: AgentRun) -> bool:
+    """Re-render ``run.prompt`` from current comments if this is a continuation.
+
+    Comment-triggered follow-ups can coalesce: a second comment arriving while
+    R_next is still QUEUED is silently absorbed (`reason='coalesced'`) on the
+    expectation that the prompt builder picks it up at dispatch time. That
+    contract lives here. Returns True when the prompt was rebuilt and the
+    caller must include ``prompt`` in ``save(update_fields=...)``.
+
+    Late import to avoid a top-level cycle through prompting → db.models.
+    """
+    parent = run.parent_run
+    if parent is None:
+        return False
+    from pi_dash.prompting.composer import build_continuation
+    from pi_dash.prompting.renderer import PromptRenderError
+
+    if run.work_item_id is None:
+        return False
+    try:
+        rebuilt = build_continuation(run.work_item, run)
+    except PromptRenderError:
+        logger.exception(
+            "matcher: continuation prompt rebuild failed for run %s; "
+            "keeping prompt as-stored",
+            run.id,
+        )
+        return False
+    if rebuilt == run.prompt:
+        return False
+    run.prompt = rebuilt
+    return True
 
 
 def drain_pod(pod: Pod) -> int:
@@ -176,7 +210,10 @@ def drain_pod(pod: Pod) -> int:
             run.owner_id = runner.owner_id
             run.status = AgentRunStatus.ASSIGNED
             run.assigned_at = timezone.now()
-            run.save(update_fields=["runner", "owner", "status", "assigned_at"])
+            update_fields = ["runner", "owner", "status", "assigned_at"]
+            if _refresh_continuation_prompt(run):
+                update_fields.append("prompt")
+            run.save(update_fields=update_fields)
             assignments.append((runner, run))
 
     for runner, run in assignments:
@@ -234,7 +271,10 @@ def drain_for_runner(runner: Runner) -> bool:
         run.owner_id = locked.owner_id
         run.status = AgentRunStatus.ASSIGNED
         run.assigned_at = timezone.now()
-        run.save(update_fields=["runner", "owner", "status", "assigned_at"])
+        update_fields = ["runner", "owner", "status", "assigned_at"]
+        if _refresh_continuation_prompt(run):
+            update_fields.append("prompt")
+        run.save(update_fields=update_fields)
         assignment = (locked, run)
 
     runner_obj, run = assignment

--- a/apps/api/pi_dash/runner/services/matcher.py
+++ b/apps/api/pi_dash/runner/services/matcher.py
@@ -39,12 +39,18 @@ HEARTBEAT_GRACE = timedelta(seconds=90)
 # Runs in these statuses occupy a runner slot or a queue position. Used to
 # exclude busy runners from matching and to block pod deletion while work is
 # outstanding.
+#
+# PAUSED_AWAITING_INPUT is non-terminal (the run will resume on a comment) so
+# it gates pod deletion — but it is NOT in BUSY_STATUSES because the runner
+# is free to take other pod work while waiting for human reply. See §4.3 of
+# .ai_design/issue_run_improve/design.md.
 NON_TERMINAL_STATUSES = (
     AgentRunStatus.QUEUED,
     AgentRunStatus.ASSIGNED,
     AgentRunStatus.RUNNING,
     AgentRunStatus.AWAITING_APPROVAL,
     AgentRunStatus.AWAITING_REAUTH,
+    AgentRunStatus.PAUSED_AWAITING_INPUT,
 )
 
 # Statuses that indicate a runner is currently serving a run.

--- a/apps/api/pi_dash/runner/services/matcher.py
+++ b/apps/api/pi_dash/runner/services/matcher.py
@@ -18,7 +18,7 @@ import logging
 from datetime import timedelta
 from typing import Optional
 
-from django.db import transaction
+from django.db import models, transaction
 from django.db.models import Q
 from django.utils import timezone
 
@@ -89,14 +89,54 @@ def select_runner_in_pod(pod: Pod) -> Optional[Runner]:
 
 
 def next_queued_run_for_pod(pod: Pod) -> Optional[AgentRun]:
-    """Return the oldest QUEUED run in the pod, locked for update.
+    """Return the oldest unpinned QUEUED run in the pod, locked for update.
+
+    Must be called inside a ``transaction.atomic()`` block.
+
+    Pinned runs (``pinned_runner_id IS NOT NULL``) are excluded — they belong
+    to a specific runner and are served via :func:`next_for_runner`. This
+    keeps the legacy run-first matcher honest under the new pinning model.
+    """
+    return (
+        AgentRun.objects.select_for_update(skip_locked=True)
+        .filter(
+            pod=pod,
+            status=AgentRunStatus.QUEUED,
+            pinned_runner__isnull=True,
+        )
+        .order_by("created_at")
+        .first()
+    )
+
+
+def next_for_runner(runner: Runner) -> Optional[AgentRun]:
+    """Return the next QUEUED run this runner should take.
+
+    Personal queue first (runs pinned to this runner), then the pod
+    general queue (unpinned runs in the same pod). FIFO by ``created_at``
+    inside each queue. Returns the run row locked
+    ``FOR UPDATE SKIP LOCKED`` so concurrent drains don't double-assign.
 
     Must be called inside a ``transaction.atomic()`` block.
     """
     return (
         AgentRun.objects.select_for_update(skip_locked=True)
-        .filter(pod=pod, status=AgentRunStatus.QUEUED)
-        .order_by("created_at")
+        .filter(
+            pod=runner.pod,
+            status=AgentRunStatus.QUEUED,
+        )
+        .filter(
+            Q(pinned_runner=runner) | Q(pinned_runner__isnull=True),
+        )
+        # Pinned-to-me sorts before unpinned thanks to NULLS LAST on the
+        # boolean expression. ``BooleanField`` annotated to give us a
+        # stable, indexable sort key without requiring a CASE WHEN.
+        .annotate(_is_mine=models.Case(
+            models.When(pinned_runner=runner, then=models.Value(0)),
+            default=models.Value(1),
+            output_field=models.IntegerField(),
+        ))
+        .order_by("_is_mine", "created_at")
         .first()
     )
 
@@ -104,32 +144,41 @@ def next_queued_run_for_pod(pod: Pod) -> Optional[AgentRun]:
 def drain_pod(pod: Pod) -> int:
     """Assign as many QUEUED runs in ``pod`` to idle runners as possible.
 
-    Returns the number of runs assigned in this pass. Dispatch messages are
-    sent over the WebSocket ``on_commit`` so receivers never see a run that
-    hasn't landed in the DB.
+    Returns the number of runs assigned in this pass. The loop is
+    runner-first: for each idle runner, pick the best run for it
+    (personal queue > pod queue). This eliminates head-of-line blocking
+    when the head QUEUED run is pinned to a busy runner — other idle
+    runners can still serve unpinned work.
+
+    Dispatch messages are sent over the WebSocket ``on_commit`` so
+    receivers never observe a run that hasn't landed in the DB.
     """
-    # Late import to avoid an import cycle (pubsub imports matcher in no path
-    # I can see today, but this keeps future refactors safe).
     from pi_dash.runner.services.pubsub import send_to_runner
 
+    alive_threshold = timezone.now() - HEARTBEAT_GRACE
     assignments: list[tuple[Runner, AgentRun]] = []
     with transaction.atomic():
-        while True:
-            run = next_queued_run_for_pod(pod)
+        idle_runners = list(
+            Runner.objects.select_for_update(skip_locked=True)
+            .filter(
+                pod=pod,
+                status=RunnerStatus.ONLINE,
+                last_heartbeat_at__gte=alive_threshold,
+            )
+            .exclude(agent_runs__status__in=BUSY_STATUSES)
+            .order_by("-last_heartbeat_at")
+        )
+        for runner in idle_runners:
+            run = next_for_runner(runner)
             if run is None:
-                break
-            runner = select_runner_in_pod(pod)
-            if runner is None:
-                break
+                continue
             run.runner = runner
-            # Capture billable party at assignment (design §5.3).
             run.owner_id = runner.owner_id
             run.status = AgentRunStatus.ASSIGNED
             run.assigned_at = timezone.now()
             run.save(update_fields=["runner", "owner", "status", "assigned_at"])
             assignments.append((runner, run))
 
-    # Fire WS dispatches after the transaction commits.
     for runner, run in assignments:
         transaction.on_commit(
             lambda r=run, rn=runner: send_to_runner(rn.id, _build_assign_msg(r))
@@ -150,6 +199,60 @@ def drain_pod_by_id(pod_id) -> int:
     if pod is None:
         return 0
     return drain_pod(pod)
+
+
+def drain_for_runner(runner: Runner) -> bool:
+    """Try to assign one QUEUED run to ``runner``.
+
+    Used as the immediate-dispatch trigger when a runner becomes idle
+    (a run terminates or pauses) or reconnects with pinned work waiting.
+    Returns True if a run was assigned.
+    """
+    from pi_dash.runner.services.pubsub import send_to_runner
+
+    alive_threshold = timezone.now() - HEARTBEAT_GRACE
+    assignment: Optional[tuple[Runner, AgentRun]] = None
+    with transaction.atomic():
+        # Re-select the runner under lock so two concurrent drain calls
+        # for the same runner can't both assign it.
+        locked = (
+            Runner.objects.select_for_update(skip_locked=True)
+            .filter(
+                pk=runner.pk,
+                status=RunnerStatus.ONLINE,
+                last_heartbeat_at__gte=alive_threshold,
+            )
+            .exclude(agent_runs__status__in=BUSY_STATUSES)
+            .first()
+        )
+        if locked is None:
+            return False
+        run = next_for_runner(locked)
+        if run is None:
+            return False
+        run.runner = locked
+        run.owner_id = locked.owner_id
+        run.status = AgentRunStatus.ASSIGNED
+        run.assigned_at = timezone.now()
+        run.save(update_fields=["runner", "owner", "status", "assigned_at"])
+        assignment = (locked, run)
+
+    runner_obj, run = assignment
+    transaction.on_commit(
+        lambda r=run, rn=runner_obj: send_to_runner(rn.id, _build_assign_msg(r))
+    )
+    logger.info(
+        "drain_for_runner: runner=%s assigned run=%s", runner_obj.id, run.id
+    )
+    return True
+
+
+def drain_for_runner_by_id(runner_id) -> bool:
+    """Convenience wrapper for callers that only have a runner id."""
+    runner = Runner.objects.filter(pk=runner_id).first()
+    if runner is None:
+        return False
+    return drain_for_runner(runner)
 
 
 def _build_assign_msg(run: AgentRun) -> dict:

--- a/apps/api/pi_dash/runner/views/__init__.py
+++ b/apps/api/pi_dash/runner/views/__init__.py
@@ -13,7 +13,12 @@ from .register import (
     RunnerRotateEndpoint,
 )
 from .runners import RunnerDetailEndpoint, RunnerListEndpoint, RunnerRevokeEndpoint
-from .runs import AgentRunCancelEndpoint, AgentRunDetailEndpoint, AgentRunListEndpoint
+from .runs import (
+    AgentRunCancelEndpoint,
+    AgentRunDetailEndpoint,
+    AgentRunListEndpoint,
+    AgentRunReleasePinEndpoint,
+)
 
 __all__ = [
     "ApprovalDecideEndpoint",
@@ -32,4 +37,5 @@ __all__ = [
     "AgentRunCancelEndpoint",
     "AgentRunDetailEndpoint",
     "AgentRunListEndpoint",
+    "AgentRunReleasePinEndpoint",
 ]

--- a/apps/api/pi_dash/runner/views/register.py
+++ b/apps/api/pi_dash/runner/views/register.py
@@ -28,7 +28,7 @@ from pi_dash.runner.services.pubsub import close_runner_session
 
 
 HEARTBEAT_INTERVAL_SECS = 25
-PROTOCOL_VERSION = 1
+PROTOCOL_VERSION = 2
 
 
 class HealthEndpoint(APIView):

--- a/apps/api/pi_dash/runner/views/runs.py
+++ b/apps/api/pi_dash/runner/views/runs.py
@@ -183,3 +183,67 @@ class AgentRunCancelEndpoint(APIView):
                 )
             )
         return Response(AgentRunSerializer(run).data)
+
+
+class AgentRunReleasePinEndpoint(APIView):
+    """Operator escape hatch: clear ``pinned_runner_id`` on a stuck QUEUED run.
+
+    Used when the pinned runner is offline indefinitely and the human would
+    rather give up native session resume than wait. The run remains QUEUED
+    and falls into the pod's general queue; whichever runner picks it up
+    starts a fresh session, with the issue + handoff comment as context.
+
+    See §5.7 of ``.ai_design/issue_run_improve/design.md``.
+    """
+
+    authentication_classes = [BaseSessionAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, run_id):
+        run = (
+            AgentRun.objects.select_related("runner", "pinned_runner")
+            .filter(id=run_id)
+            .first()
+        )
+        if run is None:
+            return Response({"error": "not found"}, status=status.HTTP_404_NOT_FOUND)
+        if not _can_cancel_run(request.user, run):
+            return Response({"error": "not found"}, status=status.HTTP_404_NOT_FOUND)
+
+        with transaction.atomic():
+            locked = (
+                AgentRun.objects.select_for_update().filter(id=run_id).first()
+            )
+            if locked is None:
+                return Response(
+                    {"error": "not found"}, status=status.HTTP_404_NOT_FOUND
+                )
+            if locked.status != AgentRunStatus.QUEUED:
+                return Response(
+                    {"error": "run not queued"},
+                    status=status.HTTP_409_CONFLICT,
+                )
+            if locked.pinned_runner_id is None:
+                return Response(
+                    {"error": "run not pinned"},
+                    status=status.HTTP_409_CONFLICT,
+                )
+            locked.pinned_runner = None
+            # Also clear parent's stale thread_id so the upcoming dispatch
+            # builds an Assign without a resume hint — the new runner has
+            # no session to resume against. The handoff comment carries
+            # the human-readable state.
+            if (
+                locked.parent_run is not None
+                and locked.parent_run.thread_id
+            ):
+                locked.parent_run.thread_id = ""
+                locked.parent_run.save(update_fields=["thread_id"])
+            locked.save(update_fields=["pinned_runner"])
+            run = locked
+
+        if run.pod_id is not None:
+            transaction.on_commit(
+                lambda pid=run.pod_id: matcher.drain_pod_by_id(pid)
+            )
+        return Response(AgentRunSerializer(run).data)

--- a/apps/api/pi_dash/runner/web_urls.py
+++ b/apps/api/pi_dash/runner/web_urls.py
@@ -10,6 +10,7 @@ from pi_dash.runner.views import (
     AgentRunCancelEndpoint,
     AgentRunDetailEndpoint,
     AgentRunListEndpoint,
+    AgentRunReleasePinEndpoint,
     ApprovalDecideEndpoint,
     ApprovalListEndpoint,
     PodDetailEndpoint,
@@ -55,6 +56,11 @@ urlpatterns = [
         "runs/<uuid:run_id>/cancel/",
         AgentRunCancelEndpoint.as_view(),
         name="runner-run-cancel",
+    ),
+    path(
+        "runs/<uuid:run_id>/release-pin/",
+        AgentRunReleasePinEndpoint.as_view(),
+        name="runner-run-release-pin",
     ),
     path(
         "approvals/",

--- a/apps/api/pi_dash/tests/unit/orchestration/test_done_signal.py
+++ b/apps/api/pi_dash/tests/unit/orchestration/test_done_signal.py
@@ -161,3 +161,73 @@ def test_ingest_success_clears_prior_error_and_stamps_ended_at(
     assert run.status == AgentRunStatus.COMPLETED
     assert run.error == ""
     assert run.ended_at is not None
+
+
+# ---------------------------------------------------------------------------
+# Paused status — agent yields with a question, expects a follow-up run.
+# ---------------------------------------------------------------------------
+
+
+PAUSED_BODY = """
+```pi-dash-done
+{
+  "status": "paused",
+  "summary": "stuck on which API surface to expose",
+  "autonomy": {
+    "score": 0,
+    "type": "blocking",
+    "reason": "ambiguous requirement",
+    "question_for_human": "Should this be on /api/v1/ or /api/v2/?",
+    "safe_to_continue": false
+  },
+  "blockers": []
+}
+```
+"""
+
+
+PAUSED_BODY_NO_QUESTION = """
+```pi-dash-done
+{
+  "status": "paused",
+  "summary": "stuck",
+  "autonomy": {"score": 0, "type": "blocking", "reason": "x"},
+  "blockers": []
+}
+```
+"""
+
+
+@pytest.mark.unit
+def test_parse_paused_with_question_succeeds():
+    signal = parse(PAUSED_BODY)
+    assert signal.status == "paused"
+    assert (
+        signal.payload["autonomy"]["question_for_human"]
+        == "Should this be on /api/v1/ or /api/v2/?"
+    )
+
+
+@pytest.mark.unit
+def test_parse_paused_without_question_rejected():
+    with pytest.raises(DoneSignalError, match="question_for_human"):
+        parse(PAUSED_BODY_NO_QUESTION)
+
+
+@pytest.mark.unit
+def test_ingest_paused_transitions_to_paused_awaiting_input(
+    db, create_user, workspace
+):
+    run = AgentRun.objects.create(
+        owner=create_user,
+        workspace=workspace,
+        prompt="x",
+        status=AgentRunStatus.RUNNING,
+    )
+    signal = ingest_into_run(run, PAUSED_BODY)
+    run.refresh_from_db()
+    assert signal is not None
+    assert run.status == AgentRunStatus.PAUSED_AWAITING_INPUT
+    # Paused is non-terminal; ended_at must remain NULL.
+    assert run.ended_at is None
+    assert run.done_payload["autonomy"]["question_for_human"]

--- a/apps/api/pi_dash/tests/unit/orchestration/test_service.py
+++ b/apps/api/pi_dash/tests/unit/orchestration/test_service.py
@@ -180,3 +180,231 @@ def test_run_config_empty_git_fields_surface_as_none(seeded, issue, states):
     cfg = outcome.created_run.run_config
     assert cfg["repo_url"] is None
     assert cfg["git_work_branch"] is None
+
+
+# ---------------------------------------------------------------------------
+# Comment-triggered continuation (§5.2 of the design doc).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def workpad_bot_user(db):
+    from pi_dash.orchestration.workpad import get_agent_system_user
+
+    return get_agent_system_user()
+
+
+@pytest.fixture
+def runner_for_workspace(db, workspace, create_user):
+    from django.utils import timezone
+
+    from pi_dash.runner.models import Pod, Runner, RunnerStatus
+
+    pod = Pod.default_for_workspace(workspace)
+    return Runner.objects.create(
+        owner=create_user,
+        workspace=workspace,
+        pod=pod,
+        name="agentA",
+        credential_hash="h",
+        credential_fingerprint="f" * 12,
+        status=RunnerStatus.ONLINE,
+        last_heartbeat_at=timezone.now(),
+    )
+
+
+def _make_comment(issue, actor, body="please continue"):
+    from pi_dash.db.models.issue import IssueComment
+
+    with impersonate(actor):
+        # IssueComment derives comment_stripped from comment_html on save,
+        # so we must populate the HTML field for the body to survive.
+        return IssueComment.objects.create(
+            issue=issue,
+            project=issue.project,
+            workspace=issue.workspace,
+            actor=actor,
+            comment_html=f"<p>{body}</p>",
+        )
+
+
+def _make_paused_run(issue, runner, *, thread_id="sess_xyz"):
+    from django.utils import timezone
+
+    from pi_dash.runner.models import AgentRun, AgentRunStatus
+
+    return AgentRun.objects.create(
+        workspace=issue.workspace,
+        # AgentRun.save mirrors owner → created_by; anchor on runner.owner
+        # rather than issue.created_by (which a non-impersonated state save
+        # may have cleared).
+        owner=runner.owner,
+        pod=runner.pod,
+        work_item=issue,
+        runner=runner,
+        thread_id=thread_id,
+        status=AgentRunStatus.PAUSED_AWAITING_INPUT,
+        prompt="prior work",
+        started_at=timezone.now() - timezone.timedelta(minutes=5),
+    )
+
+
+@pytest.mark.unit
+def test_comment_creates_pinned_continuation(
+    seeded, project, issue, states, runner_for_workspace, create_user
+):
+    Issue.all_objects.filter(pk=issue.pk).update(state=states["in_progress"])
+    issue.refresh_from_db()
+    prior = _make_paused_run(issue, runner_for_workspace)
+
+    # post_save(IssueComment) fires the continuation trigger automatically;
+    # we observe its side effects rather than calling handle_issue_comment
+    # explicitly.
+    _make_comment(issue, create_user, "use option B please")
+
+    r_next = (
+        AgentRun.objects.filter(work_item=issue, parent_run=prior)
+        .order_by("-created_at")
+        .first()
+    )
+    assert r_next is not None
+    assert r_next.pinned_runner_id == runner_for_workspace.id
+    assert r_next.status == AgentRunStatus.QUEUED
+    assert "option B" in r_next.prompt
+
+
+@pytest.mark.unit
+def test_comment_from_bot_is_ignored(
+    seeded, project, issue, states, runner_for_workspace, workpad_bot_user
+):
+    Issue.all_objects.filter(pk=issue.pk).update(state=states["in_progress"])
+    issue.refresh_from_db()
+    _make_paused_run(issue, runner_for_workspace)
+
+    comment = _make_comment(issue, workpad_bot_user, "## Agent Workpad\n...")
+    outcome = service.handle_issue_comment(comment)
+    assert outcome.reason == "bot-comment"
+    assert outcome.created_run is None
+
+
+@pytest.mark.unit
+def test_comment_on_backlog_issue_is_ignored(
+    seeded, project, issue, states, runner_for_workspace, create_user
+):
+    # Issue.state defaults to states["todo"] (group=unstarted) — backlog-side.
+    _make_paused_run(issue, runner_for_workspace)
+    comment = _make_comment(issue, create_user)
+    outcome = service.handle_issue_comment(comment)
+    assert outcome.reason == "state-not-eligible"
+
+
+@pytest.mark.unit
+def test_comment_with_no_prior_run_skipped(
+    seeded, project, issue, states, create_user
+):
+    Issue.all_objects.filter(pk=issue.pk).update(state=states["in_progress"])
+    issue.refresh_from_db()
+    comment = _make_comment(issue, create_user)
+    outcome = service.handle_issue_comment(comment)
+    assert outcome.reason == "no-prior-run"
+
+
+@pytest.mark.unit
+def test_comment_during_active_run_held_for_terminate_sweep(
+    seeded, project, issue, states, runner_for_workspace, create_user
+):
+    """Comment arriving while R_prev is RUNNING is not dispatched immediately."""
+    from django.utils import timezone
+
+    Issue.all_objects.filter(pk=issue.pk).update(state=states["in_progress"])
+    issue.refresh_from_db()
+    AgentRun.objects.create(
+        workspace=issue.workspace,
+        created_by=create_user,
+        pod=runner_for_workspace.pod,
+        work_item=issue,
+        runner=runner_for_workspace,
+        status=AgentRunStatus.RUNNING,
+        prompt="working",
+        started_at=timezone.now() - timezone.timedelta(minutes=1),
+    )
+    comment = _make_comment(issue, create_user, "fyi")
+    outcome = service.handle_issue_comment(comment)
+    assert outcome.reason == "prior-run-active"
+    assert outcome.created_run is None
+
+
+@pytest.mark.unit
+def test_two_comments_coalesce_into_one_followup(
+    seeded, project, issue, states, runner_for_workspace, create_user
+):
+    Issue.all_objects.filter(pk=issue.pk).update(state=states["in_progress"])
+    issue.refresh_from_db()
+    _make_paused_run(issue, runner_for_workspace)
+
+    # First comment fires the trigger and creates R_next. The second
+    # comment fires the trigger again — but coalesces because R_next is
+    # already QUEUED. Observe via DB state, not return values.
+    _make_comment(issue, create_user, "first")
+    _make_comment(issue, create_user, "second")
+
+    queued = AgentRun.objects.filter(
+        work_item=issue, status=AgentRunStatus.QUEUED
+    )
+    assert queued.count() == 1
+
+
+@pytest.mark.unit
+def test_pin_skipped_when_parent_has_no_thread_id(
+    seeded, project, issue, states, runner_for_workspace, create_user
+):
+    """No thread_id means there's no session to resume against; don't pin."""
+    Issue.all_objects.filter(pk=issue.pk).update(state=states["in_progress"])
+    issue.refresh_from_db()
+    prior = _make_paused_run(issue, runner_for_workspace, thread_id="")
+    assert prior.thread_id == ""
+
+    _make_comment(issue, create_user, "go")
+    r_next = (
+        AgentRun.objects.filter(work_item=issue, parent_run=prior)
+        .order_by("-created_at")
+        .first()
+    )
+    assert r_next is not None
+    assert r_next.pinned_runner_id is None
+
+
+@pytest.mark.unit
+def test_terminate_sweep_picks_up_held_comment(
+    seeded, project, issue, states, runner_for_workspace, create_user
+):
+    """maybe_continue_after_terminate creates R_next from comments after R.started_at."""
+    from django.utils import timezone
+
+    from pi_dash.runner.models import AgentRunStatus
+
+    Issue.all_objects.filter(pk=issue.pk).update(state=states["in_progress"])
+    issue.refresh_from_db()
+    started = timezone.now() - timezone.timedelta(minutes=10)
+    prior = AgentRun.objects.create(
+        workspace=issue.workspace,
+        created_by=create_user,
+        pod=runner_for_workspace.pod,
+        work_item=issue,
+        runner=runner_for_workspace,
+        thread_id="sess_xyz",
+        status=AgentRunStatus.RUNNING,
+        prompt="working",
+        started_at=started,
+    )
+    # Comment arrives mid-run.
+    _make_comment(issue, create_user, "use option B")
+    # Run terminates.
+    prior.status = AgentRunStatus.COMPLETED
+    prior.ended_at = timezone.now()
+    prior.save(update_fields=["status", "ended_at"])
+
+    outcome = service.maybe_continue_after_terminate(prior)
+    assert outcome.reason == "created"
+    assert outcome.created_run is not None
+    assert outcome.created_run.parent_run_id == prior.id

--- a/apps/api/pi_dash/tests/unit/prompting/test_composer.py
+++ b/apps/api/pi_dash/tests/unit/prompting/test_composer.py
@@ -98,6 +98,14 @@ def test_build_first_turn_uses_default_template(seeded_default, issue, run):
 
 
 @pytest.mark.unit
-def test_build_continuation_not_implemented(seeded_default, issue, run):
-    with pytest.raises(NotImplementedError):
-        build_continuation(issue, run)
+def test_build_continuation_falls_back_to_first_turn_when_no_parent(
+    seeded_default, issue, run
+):
+    """Without a parent run with a started_at, build_continuation should
+    fall back to the full first-turn template rather than emitting a
+    bare 'no new input' placeholder.
+    """
+    out = build_continuation(issue, run)
+    # Same shape as build_first_turn — issue context, not just a
+    # placeholder string.
+    assert "Pi Dash issue" in out

--- a/apps/api/pi_dash/tests/unit/runner/test_consumers.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_consumers.py
@@ -1,0 +1,299 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Unit tests for ``RunnerConsumer``'s sync helpers.
+
+The consumer extends ``AsyncJsonWebsocketConsumer`` but most of the
+state-machine logic is delegated to plain sync methods that we can call
+directly without spinning up Channels. These tests cover:
+
+- ``_handle_run_paused`` — pause path, including HTML escaping of
+  agent-supplied question/summary that gets stored as an IssueComment.
+- ``_handle_resume_unavailable`` — re-queue + pin-drop on the typed
+  resume-failure path.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from crum import impersonate
+from django.utils import timezone
+
+from pi_dash.db.models.issue import Issue, IssueComment
+from pi_dash.db.models.project import Project
+from pi_dash.db.models.state import State
+from pi_dash.runner.consumers import RunnerConsumer
+from pi_dash.runner.models import (
+    AgentRun,
+    AgentRunStatus,
+    Pod,
+    Runner,
+    RunnerStatus,
+)
+
+
+@pytest.fixture
+def pod(workspace):
+    return Pod.default_for_workspace(workspace)
+
+
+@pytest.fixture
+def online_runner(db, create_user, workspace, pod):
+    return Runner.objects.create(
+        owner=create_user,
+        workspace=workspace,
+        pod=pod,
+        name="rX",
+        credential_hash="h",
+        credential_fingerprint="f" * 12,
+        status=RunnerStatus.ONLINE,
+        last_heartbeat_at=timezone.now(),
+    )
+
+
+@pytest.fixture
+def issue_in_progress(db, workspace, create_user):
+    with impersonate(create_user):
+        project = Project.objects.create(
+            name="P", identifier="P", workspace=workspace, created_by=create_user
+        )
+        in_progress = State.objects.create(
+            name="In Progress", project=project, group="started"
+        )
+        return Issue.objects.create(
+            name="task",
+            workspace=workspace,
+            project=project,
+            state=in_progress,
+            created_by=create_user,
+        )
+
+
+@pytest.fixture(autouse=True)
+def _on_commit_immediate():
+    with patch(
+        "django.db.transaction.on_commit", side_effect=lambda fn, **kw: fn()
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _stub_send_to_runner():
+    with patch("pi_dash.runner.services.pubsub.send_to_runner"):
+        yield
+
+
+def _consumer_for(runner):
+    consumer = RunnerConsumer()
+    consumer.runner = runner
+    return consumer
+
+
+# ---------------------------------------------------------------------------
+# _handle_run_paused
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_paused_parks_run_without_ended_at(
+    db, create_user, workspace, pod, online_runner, issue_in_progress
+):
+    run = AgentRun.objects.create(
+        owner=create_user,
+        workspace=workspace,
+        pod=pod,
+        work_item=issue_in_progress,
+        runner=online_runner,
+        status=AgentRunStatus.RUNNING,
+        prompt="working",
+        started_at=timezone.now() - timezone.timedelta(minutes=2),
+    )
+    msg = {
+        "run_id": str(run.id),
+        "payload": {
+            "status": "paused",
+            "summary": "stuck",
+            "autonomy": {"question_for_human": "which API surface?"},
+        },
+    }
+    _consumer_for(online_runner)._handle_run_paused(online_runner, msg)
+    run.refresh_from_db()
+    assert run.status == AgentRunStatus.PAUSED_AWAITING_INPUT
+    # Pause is non-terminal — ended_at must remain NULL.
+    assert run.ended_at is None
+    assert run.done_payload["autonomy"]["question_for_human"] == "which API surface?"
+
+
+@pytest.mark.unit
+def test_paused_escapes_agent_supplied_html_in_comment(
+    db, create_user, workspace, pod, online_runner, issue_in_progress
+):
+    """Agent payload is untrusted (upstream prompt can shape it). The
+    comment we surface must escape HTML, never persist raw markup that
+    could execute when rendered in the issue feed.
+    """
+    run = AgentRun.objects.create(
+        owner=create_user,
+        workspace=workspace,
+        pod=pod,
+        work_item=issue_in_progress,
+        runner=online_runner,
+        status=AgentRunStatus.RUNNING,
+        prompt="x",
+        started_at=timezone.now(),
+    )
+    payload = {
+        "summary": "<img src=x onerror=alert(1)>",
+        "autonomy": {
+            "question_for_human": "<script>alert('xss')</script>",
+        },
+    }
+    _consumer_for(online_runner)._handle_run_paused(
+        online_runner, {"run_id": str(run.id), "payload": payload}
+    )
+
+    comment = (
+        IssueComment.objects.filter(issue=issue_in_progress)
+        .order_by("-created_at")
+        .first()
+    )
+    assert comment is not None
+    html = comment.comment_html
+    # No raw script/img tags reach storage — they only appear as escaped
+    # text content. ``onerror=`` survives as a literal substring inside the
+    # escaped form, which is harmless because it's no longer an attribute
+    # on a real element.
+    assert "<script>" not in html
+    assert "<img" not in html
+    # Escaped form is present — sanity check that escaping ran.
+    assert "&lt;script&gt;" in html
+    assert "&lt;img" in html
+
+
+@pytest.mark.unit
+def test_paused_skips_comment_when_no_question_or_summary(
+    db, create_user, workspace, pod, online_runner, issue_in_progress
+):
+    run = AgentRun.objects.create(
+        owner=create_user,
+        workspace=workspace,
+        pod=pod,
+        work_item=issue_in_progress,
+        runner=online_runner,
+        status=AgentRunStatus.RUNNING,
+        prompt="x",
+        started_at=timezone.now(),
+    )
+    _consumer_for(online_runner)._handle_run_paused(
+        online_runner, {"run_id": str(run.id), "payload": {}}
+    )
+    assert IssueComment.objects.filter(issue=issue_in_progress).count() == 0
+
+
+@pytest.mark.unit
+def test_paused_sweep_creates_continuation_for_mid_run_comment(
+    db, create_user, workspace, pod, online_runner, issue_in_progress
+):
+    """Comments that arrived during RUNNING were skipped with
+    'prior-run-active'. The pause transition is the symmetric recovery
+    point — those comments must wake R_next.
+    """
+    run = AgentRun.objects.create(
+        owner=create_user,
+        workspace=workspace,
+        pod=pod,
+        work_item=issue_in_progress,
+        runner=online_runner,
+        status=AgentRunStatus.RUNNING,
+        prompt="x",
+        started_at=timezone.now() - timezone.timedelta(minutes=5),
+    )
+    # Mid-run comment.
+    with impersonate(create_user):
+        IssueComment.objects.create(
+            issue=issue_in_progress,
+            project=issue_in_progress.project,
+            workspace=workspace,
+            actor=create_user,
+            comment_html="<p>use option B</p>",
+        )
+
+    _consumer_for(online_runner)._handle_run_paused(
+        online_runner,
+        {
+            "run_id": str(run.id),
+            "payload": {"autonomy": {"question_for_human": "?"}},
+        },
+    )
+
+    follow_up = (
+        AgentRun.objects.filter(work_item=issue_in_progress, parent_run=run)
+        .order_by("-created_at")
+        .first()
+    )
+    assert follow_up is not None
+    assert follow_up.status in (
+        AgentRunStatus.QUEUED,
+        AgentRunStatus.ASSIGNED,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _handle_resume_unavailable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_resume_unavailable_drops_pin_and_requeues(
+    db, create_user, workspace, pod, online_runner, issue_in_progress
+):
+    parent = AgentRun.objects.create(
+        owner=create_user,
+        workspace=workspace,
+        pod=pod,
+        work_item=issue_in_progress,
+        runner=online_runner,
+        thread_id="sess_dead",
+        status=AgentRunStatus.PAUSED_AWAITING_INPUT,
+        prompt="prior",
+        started_at=timezone.now() - timezone.timedelta(minutes=5),
+    )
+    run = AgentRun.objects.create(
+        owner=create_user,
+        workspace=workspace,
+        pod=pod,
+        work_item=issue_in_progress,
+        runner=online_runner,
+        parent_run=parent,
+        pinned_runner=online_runner,
+        status=AgentRunStatus.ASSIGNED,
+        prompt="continuation",
+        assigned_at=timezone.now(),
+    )
+    _consumer_for(online_runner)._handle_resume_unavailable(
+        online_runner, str(run.id)
+    )
+    run.refresh_from_db()
+    parent.refresh_from_db()
+    assert run.status == AgentRunStatus.QUEUED
+    assert run.runner_id is None
+    assert run.pinned_runner_id is None
+    assert run.assigned_at is None
+    # Parent's thread_id is cleared so the next dispatch doesn't hand the
+    # same dead session id to a different runner.
+    assert parent.thread_id == ""
+
+
+@pytest.mark.unit
+def test_resume_unavailable_noop_when_run_unknown(
+    db, online_runner
+):
+    import uuid
+
+    # Should not raise, should not touch any rows.
+    _consumer_for(online_runner)._handle_resume_unavailable(
+        online_runner, str(uuid.uuid4())
+    )

--- a/apps/api/pi_dash/tests/unit/runner/test_drain_pod.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_drain_pod.py
@@ -255,3 +255,139 @@ def test_drain_pod_by_id_returns_zero_when_missing(db):
     import uuid
 
     assert matcher.drain_pod_by_id(uuid.uuid4()) == 0
+
+
+# ---------------------------------------------------------------------------
+# Pinning model: per-runner personal queue + pod general queue.
+# See §5 of .ai_design/issue_run_improve/design.md.
+# ---------------------------------------------------------------------------
+
+
+def _make_run(user, workspace, pod, *, prompt="x", pinned_runner=None,
+              status=AgentRunStatus.QUEUED):
+    return AgentRun.objects.create(
+        owner=user,
+        workspace=workspace,
+        pod=pod,
+        prompt=prompt,
+        status=status,
+        pinned_runner=pinned_runner,
+    )
+
+
+@pytest.mark.unit
+def test_next_for_runner_prefers_personal_queue(
+    db, create_user, workspace, pod
+):
+    rA = _make_runner(create_user, workspace, pod, "agentA")
+    # Older unpinned run + newer run pinned to me → pinned wins.
+    older = _make_run(create_user, workspace, pod, prompt="older unpinned")
+    pinned = _make_run(
+        create_user, workspace, pod, prompt="mine", pinned_runner=rA
+    )
+    from django.db import transaction
+
+    with transaction.atomic():
+        nxt = matcher.next_for_runner(rA)
+    assert nxt is not None
+    assert nxt.id == pinned.id
+    assert older.id != pinned.id  # sanity: older exists, just not chosen
+
+
+@pytest.mark.unit
+def test_next_for_runner_falls_back_to_pod_queue(
+    db, create_user, workspace, pod
+):
+    rA = _make_runner(create_user, workspace, pod, "agentA")
+    unpinned = _make_run(create_user, workspace, pod, prompt="any")
+    from django.db import transaction
+
+    with transaction.atomic():
+        nxt = matcher.next_for_runner(rA)
+    assert nxt is not None
+    assert nxt.id == unpinned.id
+
+
+@pytest.mark.unit
+def test_next_for_runner_excludes_pinned_to_others(
+    db, create_user, workspace, pod
+):
+    rA = _make_runner(create_user, workspace, pod, "agentA")
+    rB = _make_runner(create_user, workspace, pod, "agentB")
+    _make_run(create_user, workspace, pod, prompt="for B", pinned_runner=rB)
+    from django.db import transaction
+
+    with transaction.atomic():
+        nxt = matcher.next_for_runner(rA)
+    # rA must not pick up a run pinned to rB.
+    assert nxt is None
+
+
+@pytest.mark.unit
+def test_drain_pod_skips_pinned_to_busy_runner(
+    db, create_user, workspace, pod
+):
+    """Head-of-line is not blocked when the head run is pinned to a busy runner."""
+    rA = _make_runner(create_user, workspace, pod, "agentA")
+    rB = _make_runner(create_user, workspace, pod, "agentB")
+    # Make rA busy.
+    AgentRun.objects.create(
+        owner=create_user,
+        workspace=workspace,
+        pod=pod,
+        prompt="agentA's current",
+        runner=rA,
+        status=AgentRunStatus.RUNNING,
+    )
+    # Older pinned-to-busy-A run + newer unpinned run.
+    pinned_for_a = _make_run(
+        create_user, workspace, pod, prompt="for A later", pinned_runner=rA
+    )
+    unpinned = _make_run(create_user, workspace, pod, prompt="anyone")
+
+    n = matcher.drain_pod(pod)
+    pinned_for_a.refresh_from_db()
+    unpinned.refresh_from_db()
+    # rB should pick up the unpinned run; pinned-for-A should still be QUEUED.
+    assert n == 1
+    assert unpinned.runner_id == rB.id
+    assert unpinned.status == AgentRunStatus.ASSIGNED
+    assert pinned_for_a.status == AgentRunStatus.QUEUED
+    assert pinned_for_a.runner_id is None
+
+
+@pytest.mark.unit
+def test_drain_for_runner_picks_personal_first(
+    db, create_user, workspace, pod
+):
+    rA = _make_runner(create_user, workspace, pod, "agentA")
+    older_unpinned = _make_run(create_user, workspace, pod, prompt="any")
+    pinned = _make_run(
+        create_user, workspace, pod, prompt="mine", pinned_runner=rA
+    )
+
+    assigned = matcher.drain_for_runner(rA)
+    assert assigned is True
+    pinned.refresh_from_db()
+    older_unpinned.refresh_from_db()
+    assert pinned.runner_id == rA.id
+    assert pinned.status == AgentRunStatus.ASSIGNED
+    # Older unpinned run should still be QUEUED — drain_for_runner takes one.
+    assert older_unpinned.status == AgentRunStatus.QUEUED
+
+
+@pytest.mark.unit
+def test_drain_for_runner_returns_false_when_busy(
+    db, create_user, workspace, pod
+):
+    rA = _make_runner(create_user, workspace, pod, "agentA")
+    AgentRun.objects.create(
+        owner=create_user,
+        workspace=workspace,
+        pod=pod,
+        prompt="busy",
+        runner=rA,
+        status=AgentRunStatus.RUNNING,
+    )
+    _make_run(create_user, workspace, pod, prompt="waiting", pinned_runner=rA)
+    assert matcher.drain_for_runner(rA) is False

--- a/apps/api/pi_dash/tests/unit/runner/test_drain_pod.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_drain_pod.py
@@ -391,3 +391,133 @@ def test_drain_for_runner_returns_false_when_busy(
     )
     _make_run(create_user, workspace, pod, prompt="waiting", pinned_runner=rA)
     assert matcher.drain_for_runner(rA) is False
+
+
+# ---------------------------------------------------------------------------
+# Continuation prompt freshness at dispatch.
+#
+# Coalescing logic in ``handle_issue_comment`` returns ``coalesced`` for a
+# second comment that arrives while R_next is still QUEUED. The contract is
+# that the prompt builder runs again at dispatch time so the runner sees both
+# bodies. These tests pin that contract.
+# ---------------------------------------------------------------------------
+
+
+def _setup_paused_chain(create_user, workspace, pod, project_factory=None):
+    """Create an issue + paused parent run + queued continuation run.
+
+    Returns (issue, parent_run, queued_followup, runner). The parent has
+    a started_at in the past so build_continuation can sweep comments.
+
+    The issue is created in an ``unstarted`` state so the orchestration
+    state-transition signal does not auto-create a competing run that
+    would consume the runner.
+    """
+    from crum import impersonate
+
+    from pi_dash.db.models.issue import Issue
+    from pi_dash.db.models.project import Project
+    from pi_dash.db.models.state import State
+
+    rA = _make_runner(create_user, workspace, pod, "rA")
+    with impersonate(create_user):
+        project = Project.objects.create(
+            name="P", identifier="P", workspace=workspace, created_by=create_user
+        )
+        todo = State.objects.create(
+            name="Todo", project=project, group="unstarted"
+        )
+        issue = Issue.objects.create(
+            name="task",
+            workspace=workspace,
+            project=project,
+            state=todo,
+            created_by=create_user,
+        )
+    parent = AgentRun.objects.create(
+        owner=create_user,
+        workspace=workspace,
+        pod=pod,
+        work_item=issue,
+        runner=rA,
+        thread_id="sess_xyz",
+        status=AgentRunStatus.PAUSED_AWAITING_INPUT,
+        prompt="prior",
+        started_at=timezone.now() - timezone.timedelta(minutes=5),
+    )
+    queued = AgentRun.objects.create(
+        owner=create_user,
+        workspace=workspace,
+        pod=pod,
+        work_item=issue,
+        parent_run=parent,
+        pinned_runner=rA,
+        status=AgentRunStatus.QUEUED,
+        prompt="(stale prompt — only first comment)",
+    )
+    return issue, parent, queued, rA
+
+
+@pytest.mark.unit
+def test_drain_for_runner_rebuilds_continuation_prompt(
+    db, create_user, workspace, pod
+):
+    """Coalesced comment must reach the runner via prompt rebuild on dispatch."""
+    from crum import impersonate
+
+    from pi_dash.db.models.issue import IssueComment
+
+    issue, parent, queued, rA = _setup_paused_chain(create_user, workspace, pod)
+    # Two comments after parent.started_at — the second arrived after the
+    # follow-up was queued but before dispatch (the coalescing case).
+    with impersonate(create_user):
+        IssueComment.objects.create(
+            issue=issue, project=issue.project, workspace=issue.workspace,
+            actor=create_user, comment_html="<p>first</p>",
+        )
+        IssueComment.objects.create(
+            issue=issue, project=issue.project, workspace=issue.workspace,
+            actor=create_user, comment_html="<p>second</p>",
+        )
+
+    assigned = matcher.drain_for_runner(rA)
+    assert assigned is True
+    queued.refresh_from_db()
+    # Both bodies must be present in the dispatched prompt — the stale
+    # at-creation render is replaced.
+    assert "first" in queued.prompt
+    assert "second" in queued.prompt
+
+
+@pytest.mark.unit
+def test_drain_pod_rebuilds_continuation_prompt(
+    db, create_user, workspace, pod
+):
+    """Same contract for the pod-wide drain path."""
+    from crum import impersonate
+
+    from pi_dash.db.models.issue import IssueComment
+
+    issue, parent, queued, rA = _setup_paused_chain(create_user, workspace, pod)
+    with impersonate(create_user):
+        IssueComment.objects.create(
+            issue=issue, project=issue.project, workspace=issue.workspace,
+            actor=create_user, comment_html="<p>late comment</p>",
+        )
+
+    n = matcher.drain_pod(pod)
+    assert n == 1
+    queued.refresh_from_db()
+    assert "late comment" in queued.prompt
+
+
+@pytest.mark.unit
+def test_drain_does_not_rebuild_first_turn_prompt(
+    db, create_user, workspace, pod
+):
+    """A fresh run (parent_run is None) keeps its as-stored prompt."""
+    rA = _make_runner(create_user, workspace, pod, "rA")
+    run = _make_run(create_user, workspace, pod, prompt="original first-turn body")
+    assert matcher.drain_for_runner(rA) is True
+    run.refresh_from_db()
+    assert run.prompt == "original first-turn body"

--- a/apps/api/pi_dash/tests/unit/runner/test_matcher.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_matcher.py
@@ -73,3 +73,77 @@ def test_cap_enforced(db, create_user, workspace):
         )
     assert matcher.can_register_another(create_user.id, workspace.id) is False
     assert matcher.count_active(create_user.id, workspace.id) == Runner.MAX_PER_USER
+
+
+# ---------------------------------------------------------------------------
+# Status classifier coverage for PAUSED_AWAITING_INPUT
+#
+# PAUSED is a non-terminal state where the runner is free to pick up other
+# work while waiting for human reply (§4.3 of the design doc). The five
+# classifiers must reflect that consistently.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_paused_in_non_terminal_statuses():
+    # Pod deletion must wait for paused runs to drain.
+    assert AgentRunStatus.PAUSED_AWAITING_INPUT in matcher.NON_TERMINAL_STATUSES
+
+
+@pytest.mark.unit
+def test_paused_not_in_busy_statuses():
+    # Runner is free to take other pod work while a paused run exists.
+    assert AgentRunStatus.PAUSED_AWAITING_INPUT not in matcher.BUSY_STATUSES
+
+
+@pytest.mark.unit
+def test_paused_not_terminal_on_agent_run(db, create_user, workspace):
+    run = AgentRun.objects.create(
+        owner=create_user,
+        workspace=workspace,
+        prompt="paused",
+        status=AgentRunStatus.PAUSED_AWAITING_INPUT,
+    )
+    assert run.is_terminal is False
+
+
+@pytest.mark.unit
+def test_paused_not_active_on_agent_run(db, create_user, workspace):
+    # The single-active-run guardrail in _active_run_for must permit a
+    # follow-up run to be created when the prior one is paused.
+    run = AgentRun.objects.create(
+        owner=create_user,
+        workspace=workspace,
+        prompt="paused",
+        status=AgentRunStatus.PAUSED_AWAITING_INPUT,
+    )
+    assert run.is_active is False
+
+
+@pytest.mark.unit
+def test_paused_not_in_metrics_active_statuses():
+    from pi_dash.runner.views.metrics import ACTIVE_RUN_STATUSES
+
+    # Operational metric tracks runs occupying runner capacity; paused doesn't.
+    assert AgentRunStatus.PAUSED_AWAITING_INPUT not in ACTIVE_RUN_STATUSES
+
+
+@pytest.mark.unit
+def test_paused_runner_not_busy_for_matcher(
+    db, online_runner, create_user, workspace
+):
+    # A paused run on the runner must not exclude it from matching.
+    AgentRun.objects.create(
+        owner=create_user,
+        workspace=workspace,
+        prompt="parked",
+        runner=online_runner,
+        status=AgentRunStatus.PAUSED_AWAITING_INPUT,
+    )
+    fresh = AgentRun.objects.create(
+        owner=create_user,
+        workspace=workspace,
+        prompt="fresh",
+        status=AgentRunStatus.QUEUED,
+    )
+    assert matcher.select_runner_for_run(fresh) == online_runner

--- a/apps/api/pi_dash/tests/unit/runner/test_revocation.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_revocation.py
@@ -170,3 +170,45 @@ def test_revoke_is_noop_when_no_in_flight_runs(
     r.revoke()
     r.refresh_from_db()
     assert r.status == RunnerStatus.REVOKED
+
+
+# ---------------------------------------------------------------------------
+# Pin release on revoke (§5.7 of the design doc).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_revoke_releases_pinned_queued_runs(
+    db, create_user, workspace
+):
+    from django.utils import timezone
+
+    from pi_dash.runner.models import AgentRun, AgentRunStatus, Pod, Runner, RunnerStatus
+
+    pod = Pod.default_for_workspace(workspace)
+    runner = Runner.objects.create(
+        owner=create_user,
+        workspace=workspace,
+        pod=pod,
+        name="agentX",
+        credential_hash="hX",
+        credential_fingerprint="X" * 12,
+        status=RunnerStatus.ONLINE,
+        last_heartbeat_at=timezone.now(),
+    )
+    pinned_queued = AgentRun.objects.create(
+        owner=create_user,
+        workspace=workspace,
+        pod=pod,
+        prompt="waiting for agentX",
+        status=AgentRunStatus.QUEUED,
+        pinned_runner=runner,
+    )
+
+    runner.revoke()
+
+    pinned_queued.refresh_from_db()
+    # Pin dropped, but the run stays QUEUED so the pod can dispatch it
+    # to anyone with a fresh-context fallback.
+    assert pinned_queued.status == AgentRunStatus.QUEUED
+    assert pinned_queued.pinned_runner_id is None

--- a/apps/api/pi_dash/tests/unit/runner/test_runs_views.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_runs_views.py
@@ -148,3 +148,122 @@ def test_get_runs_lists_by_created_by(db, session_client, workspace):
     prompts = [r["prompt"] for r in resp.data]
     assert "mine" in prompts
     assert "not mine" not in prompts
+
+
+# ---------------------------------------------------------------------------
+# AgentRunReleasePinEndpoint
+#
+# Operator escape hatch for a stuck pin: the pinned runner is offline
+# indefinitely, and the human chooses to give up native session resume so
+# any other runner can pick the run up. See §5.7 of design doc.
+# ---------------------------------------------------------------------------
+
+
+def _make_pinned_run(workspace, *, parent_thread_id=None):
+    from django.utils import timezone
+
+    from pi_dash.runner.models import Runner, RunnerStatus
+
+    pod = Pod.default_for_workspace(workspace)
+    runner = Runner.objects.create(
+        owner=workspace.owner,
+        workspace=workspace,
+        pod=pod,
+        name="pinR",
+        credential_hash="h",
+        credential_fingerprint="f" * 12,
+        status=RunnerStatus.ONLINE,
+        last_heartbeat_at=timezone.now(),
+    )
+    parent = None
+    if parent_thread_id is not None:
+        parent = AgentRun.objects.create(
+            workspace=workspace,
+            created_by=workspace.owner,
+            pod=pod,
+            runner=runner,
+            thread_id=parent_thread_id,
+            status=AgentRunStatus.PAUSED_AWAITING_INPUT,
+            prompt="prior",
+            started_at=timezone.now() - timezone.timedelta(minutes=5),
+        )
+    run = AgentRun.objects.create(
+        workspace=workspace,
+        created_by=workspace.owner,
+        pod=pod,
+        parent_run=parent,
+        pinned_runner=runner,
+        status=AgentRunStatus.QUEUED,
+        prompt="continuation",
+    )
+    return run, parent, runner
+
+
+@pytest.mark.unit
+def test_release_pin_clears_pin_and_parent_thread_id(
+    db, session_client, workspace
+):
+    run, parent, runner = _make_pinned_run(
+        workspace, parent_thread_id="sess_alive"
+    )
+    resp = session_client.post(
+        f"/api/runners/runs/{run.id}/release-pin/",
+        {},
+        format="json",
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    run.refresh_from_db()
+    parent.refresh_from_db()
+    assert run.pinned_runner_id is None
+    # Status may flip to ASSIGNED if a runner is online and idle (drain
+    # fires on commit). The endpoint contract is "drop the pin without
+    # cancelling," not "stay QUEUED." Asserting the pin is what matters.
+    assert run.status in (AgentRunStatus.QUEUED, AgentRunStatus.ASSIGNED)
+    # Parent's session id is wiped so the next runner doesn't get a stale
+    # resume hint.
+    assert parent.thread_id == ""
+
+
+@pytest.mark.unit
+def test_release_pin_returns_409_when_not_queued(
+    db, session_client, workspace
+):
+    run, _, _ = _make_pinned_run(workspace)
+    AgentRun.objects.filter(pk=run.pk).update(status=AgentRunStatus.RUNNING)
+    resp = session_client.post(
+        f"/api/runners/runs/{run.id}/release-pin/", {}, format="json"
+    )
+    assert resp.status_code == status.HTTP_409_CONFLICT
+    assert resp.data["error"] == "run not queued"
+
+
+@pytest.mark.unit
+def test_release_pin_returns_409_when_not_pinned(
+    db, session_client, workspace
+):
+    run, _, _ = _make_pinned_run(workspace)
+    AgentRun.objects.filter(pk=run.pk).update(pinned_runner=None)
+    resp = session_client.post(
+        f"/api/runners/runs/{run.id}/release-pin/", {}, format="json"
+    )
+    assert resp.status_code == status.HTTP_409_CONFLICT
+    assert resp.data["error"] == "run not pinned"
+
+
+@pytest.mark.unit
+def test_release_pin_404_for_run_in_other_workspace(
+    db, api_client, workspace, second_workspace
+):
+    """A user who isn't authorized for the run must not see it exist."""
+    run, _, _ = _make_pinned_run(workspace)
+    outsider = User.objects.create(
+        email=f"o-{uuid4().hex[:8]}@example.com",
+        username=f"o_{uuid4().hex[:8]}",
+    )
+    outsider.set_password("pw")
+    outsider.save()
+    api_client.force_authenticate(user=outsider)
+    resp = api_client.post(
+        f"/api/runners/runs/{run.id}/release-pin/", {}, format="json"
+    )
+    assert resp.status_code == status.HTTP_404_NOT_FOUND

--- a/runner/README.md
+++ b/runner/README.md
@@ -81,7 +81,7 @@ All secrets on disk are written with `0600`. The Unix IPC socket is also `0600`.
 
 ## Protocol
 
-Wire version is `1` — bumped on incompatible shape changes. See `src/cloud/protocol.rs` for exhaustive schemas. Runner authenticates to the cloud with an HTTP `Authorization: Bearer <runner_secret>` header on the WebSocket upgrade request and echoes its UUID in `X-Runner-Id`. The server echoes an accepted `protocol_version` in the `welcome` frame.
+Wire version is `2` — bumped on incompatible shape changes. See `src/cloud/protocol.rs` for exhaustive schemas. Runner authenticates to the cloud with an HTTP `Authorization: Bearer <runner_secret>` header on the WebSocket upgrade request and echoes its UUID in `X-Runner-Id`. The server echoes an accepted `protocol_version` in the `welcome` frame.
 
 ## Test strategy
 

--- a/runner/src/agent/mod.rs
+++ b/runner/src/agent/mod.rs
@@ -54,6 +54,18 @@ pub struct RunPayload {
     pub resume_thread_id: Option<String>,
 }
 
+/// Agent-CLI native resume failed because the session id we were given
+/// is not present on this runner's local session store. The supervisor
+/// downcasts to this type to emit `FailureReason::ResumeUnavailable`
+/// rather than the generic agent-crash reason; cloud's reaction is to
+/// drop the pin and re-queue without the resume hint.
+#[derive(Debug, thiserror::Error)]
+#[error("agent CLI could not resume session {thread_id}: {detail}")]
+pub struct ResumeUnavailable {
+    pub thread_id: String,
+    pub detail: String,
+}
+
 /// Enum dispatch over the concrete bridges. Each variant owns the agent's
 /// subprocess; the supervisor treats them uniformly.
 pub enum AgentBridge {
@@ -86,10 +98,16 @@ impl AgentCursor {
 
 impl AgentBridge {
     /// Spawn the agent subprocess selected by the runner's config.
+    ///
+    /// `resume_thread_id` is used at spawn time only by Claude Code (it
+    /// goes to `claude --resume <id>` on the command line). Codex consumes
+    /// the resume hint inside `bridge.run()` via the `RunPayload` field
+    /// instead.
     pub async fn spawn_from_config(
         config: &Config,
         cwd: &Path,
         model_override: Option<String>,
+        resume_thread_id: Option<&str>,
     ) -> Result<Self> {
         match config.agent.kind {
             AgentKind::Codex => {
@@ -106,6 +124,7 @@ impl AgentBridge {
                     &config.claude_code.binary,
                     cwd,
                     selected_model(model_override, config.claude_code.model_default.clone()),
+                    resume_thread_id,
                 )
                 .await?;
                 Ok(AgentBridge::ClaudeCode(b))

--- a/runner/src/claude_code/bridge.rs
+++ b/runner/src/claude_code/bridge.rs
@@ -38,12 +38,18 @@ pub struct Bridge {
 }
 
 impl Bridge {
-    pub async fn spawn(binary: &str, cwd: &Path, model_default: Option<String>) -> Result<Self> {
+    pub async fn spawn(
+        binary: &str,
+        cwd: &Path,
+        model_default: Option<String>,
+        resume_thread_id: Option<&str>,
+    ) -> Result<Self> {
         let proc = ClaudeProcess::spawn(SpawnArgs {
             binary,
             cwd,
             model: model_default.as_deref(),
             bypass_permissions: true,
+            resume_thread_id,
         })
         .await?;
         Ok(Self {

--- a/runner/src/claude_code/mod.rs
+++ b/runner/src/claude_code/mod.rs
@@ -7,7 +7,12 @@
 //! - Approvals bypass: runs with `--permission-mode bypassPermissions`.
 //!   Wiring Claude's `--permission-prompt-tool` into the approval router
 //!   requires a small MCP server bridge; out of scope for the first pass.
-//! - Single-turn runs only: no `--resume` / session continuation.
+//!
+//! Resume support is wired: when `RunPayload.resume_thread_id` is set,
+//! the runner spawns `claude --resume <session_id>` so Claude reattaches
+//! to its prior on-disk session. The yield path uses the existing
+//! `pi-dash-done` fenced-block channel with `status: "paused"` (cloud
+//! parses it via `done_signal.ingest_into_run`).
 
 pub mod bridge;
 pub mod process;

--- a/runner/src/claude_code/process.rs
+++ b/runner/src/claude_code/process.rs
@@ -33,6 +33,10 @@ pub struct SpawnArgs<'a> {
     /// When `true`, pass `--permission-mode bypassPermissions`. Always `true`
     /// for MVP; wiring a real permission prompt needs an MCP bridge.
     pub bypass_permissions: bool,
+    /// When set, pass `--resume <session_id>` so Claude reattaches to its
+    /// prior on-disk session (`~/.claude/projects/...`). The cloud sets
+    /// this on a continuation run when `parent_run.thread_id` is known.
+    pub resume_thread_id: Option<&'a str>,
 }
 
 impl ClaudeProcess {
@@ -53,6 +57,9 @@ impl ClaudeProcess {
         }
         if let Some(model) = args.model {
             argv.extend(["--model", model]);
+        }
+        if let Some(thread_id) = args.resume_thread_id {
+            argv.extend(["--resume", thread_id]);
         }
         let cmd = login_shell_command(args.binary, &argv, Some(args.cwd));
         Self::spawn_command(cmd).await

--- a/runner/src/cloud/protocol.rs
+++ b/runner/src/cloud/protocol.rs
@@ -4,7 +4,14 @@ use std::collections::BTreeMap;
 use uuid::Uuid;
 
 /// Wire version — bump on incompatible shape changes.
-pub const WIRE_VERSION: u32 = 1;
+///
+/// v2 added `ClientMsg::RunPaused`, `FailureReason::ResumeUnavailable`, and
+/// the optional `resume_thread_id` field on `ServerMsg::Assign`. The cloud
+/// dispatches inbound messages by `type` string and silently drops unknown
+/// types, so a v2 runner against a v1 cloud loses pause/resume semantics
+/// rather than crashing — the version bump is the visible signal that
+/// rolling forward the cloud first is required.
+pub const WIRE_VERSION: u32 = 2;
 
 /// All frames carry `v`, `type`, `mid` (message id for dedupe).
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/runner/src/cloud/protocol.rs
+++ b/runner/src/cloud/protocol.rs
@@ -77,6 +77,16 @@ pub enum ClientMsg {
         done_payload: serde_json::Value,
         ended_at: DateTime<Utc>,
     },
+    /// Agent yielded with a question for the human (Codex tool-call path).
+    /// Cloud transitions the run to PAUSED_AWAITING_INPUT and waits for a
+    /// continuation trigger (typically a non-bot comment on the issue).
+    /// Claude's yield uses the `pi-dash-done` fenced block instead and
+    /// arrives via `RunCompleted` → cloud's done-signal parser.
+    RunPaused {
+        run_id: Uuid,
+        payload: serde_json::Value,
+        paused_at: DateTime<Utc>,
+    },
     RunFailed {
         run_id: Uuid,
         reason: FailureReason,
@@ -120,6 +130,12 @@ pub enum ServerMsg {
         expected_codex_model: Option<String>,
         approval_policy_overrides: Option<BTreeMap<String, serde_json::Value>>,
         deadline: Option<DateTime<Utc>>,
+        /// Provider session id to resume. When set, the runner asks the
+        /// agent CLI to reattach to that session (`thread/resume` for
+        /// Codex, `--resume` for Claude). Field-only addition — backward
+        /// compatible with older clouds that omit it.
+        #[serde(default)]
+        resume_thread_id: Option<String>,
     },
     Cancel {
         run_id: Uuid,
@@ -201,6 +217,12 @@ pub enum FailureReason {
     Timeout,
     Internal,
     Cancelled,
+    /// Native session resume was requested (Assign carried `resume_thread_id`)
+    /// but the agent CLI couldn't find the session on disk — the runner was
+    /// reinstalled, the session store was wiped, or the id is otherwise
+    /// stale. Cloud's response is to drop the pin and re-queue with a fresh
+    /// session.
+    ResumeUnavailable,
 }
 
 #[cfg(test)]
@@ -236,6 +258,7 @@ mod tests {
             expected_codex_model: None,
             approval_policy_overrides: None,
             deadline: None,
+            resume_thread_id: Some("sess_xyz".into()),
         };
         let env = Envelope::new(msg);
         let s = serde_json::to_string(&env).unwrap();

--- a/runner/src/codex/bridge.rs
+++ b/runner/src/codex/bridge.rs
@@ -122,8 +122,20 @@ impl Bridge {
             },
         )?;
         self.server.send_raw(&line).await?;
-        let _ = self.await_response(id, Duration::from_secs(30)).await?;
-        Ok(thread_id.to_string())
+        match self.await_response(id, Duration::from_secs(30)).await {
+            Ok(_) => Ok(thread_id.to_string()),
+            Err(e) => {
+                // The Codex app-server returns an error when the thread id
+                // is unknown locally (session store wiped, runner reinstalled,
+                // id stale). Surface as a typed error so the supervisor can
+                // emit FailureReason::ResumeUnavailable rather than the
+                // generic CodexCrash, and the cloud can drop the pin.
+                Err(anyhow::Error::new(crate::agent::ResumeUnavailable {
+                    thread_id: thread_id.to_string(),
+                    detail: format!("{e:#}"),
+                }))
+            }
+        }
     }
 
     async fn start_turn(&mut self, payload: &RunPayload) -> Result<()> {

--- a/runner/src/daemon/supervisor.rs
+++ b/runner/src/daemon/supervisor.rs
@@ -242,6 +242,7 @@ impl RunnerLoop {
                     repo_url,
                     git_work_branch,
                     expected_codex_model,
+                    resume_thread_id,
                     ..
                 } => {
                     if self.current_run.is_some() {
@@ -279,6 +280,7 @@ impl RunnerLoop {
                                 repo_url,
                                 git_work_branch,
                                 expected_codex_model,
+                                resume_thread_id,
                             )
                             .await
                         {
@@ -405,6 +407,7 @@ impl AssignWorker {
         repo_url: Option<String>,
         git_work_branch: Option<String>,
         expected_codex_model: Option<String>,
+        resume_thread_id: Option<String>,
     ) -> Result<()> {
         self.handle_assign(
             run_id,
@@ -412,6 +415,7 @@ impl AssignWorker {
             repo_url,
             git_work_branch,
             expected_codex_model,
+            resume_thread_id,
         )
         .await
     }
@@ -423,6 +427,7 @@ impl AssignWorker {
         repo_url: Option<String>,
         git_work_branch: Option<String>,
         expected_codex_model: Option<String>,
+        resume_thread_id: Option<String>,
     ) -> Result<()> {
         // Resolve workspace.
         let wd = self.config.workspace.working_dir.clone();
@@ -541,7 +546,7 @@ impl AssignWorker {
             run_id,
             prompt,
             model: expected_codex_model,
-            resume_thread_id: None,
+            resume_thread_id,
         };
         let mut cursor = match bridge.run(&payload, &workspace_path).await {
             Ok(c) => c,

--- a/runner/src/daemon/supervisor.rs
+++ b/runner/src/daemon/supervisor.rs
@@ -517,6 +517,7 @@ impl AssignWorker {
             &self.config,
             &workspace_path,
             expected_codex_model.clone(),
+            resume_thread_id.as_deref(),
         )
         .await
         {
@@ -559,7 +560,14 @@ impl AssignWorker {
                 })
                 .await
                 .ok();
-                let reason = self.crash_reason();
+                // Distinguish "agent CLI couldn't find the session id" from a
+                // generic agent crash. Cloud's reaction differs: drop the pin
+                // and re-queue with no resume hint, vs. mark the run failed.
+                let reason = if e.downcast_ref::<crate::agent::ResumeUnavailable>().is_some() {
+                    FailureReason::ResumeUnavailable
+                } else {
+                    self.crash_reason()
+                };
                 self.send(ClientMsg::RunFailed {
                     run_id,
                     reason,

--- a/runner/src/lib.rs
+++ b/runner/src/lib.rs
@@ -17,5 +17,5 @@ pub mod tui;
 pub mod util;
 pub mod workspace;
 
-pub const PROTOCOL_VERSION: u32 = 1;
+pub const PROTOCOL_VERSION: u32 = 2;
 pub const RUNNER_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/runner/tests/cloud_ws_fake.rs
+++ b/runner/tests/cloud_ws_fake.rs
@@ -62,6 +62,7 @@ async fn start_fake_cloud() -> (SocketAddr, tokio::task::JoinHandle<()>) {
             expected_codex_model: None,
             approval_policy_overrides: None,
             deadline: None,
+            resume_thread_id: None,
         });
         tx.send(Message::Text(serde_json::to_string(&assign).unwrap()))
             .await

--- a/runner/tests/protocol_roundtrip.rs
+++ b/runner/tests/protocol_roundtrip.rs
@@ -60,6 +60,7 @@ fn envelope_roundtrips_all_server_variants() {
             expected_codex_model: None,
             approval_policy_overrides: None,
             deadline: None,
+            resume_thread_id: None,
         },
         ServerMsg::Assign {
             run_id: Uuid::new_v4(),
@@ -71,6 +72,7 @@ fn envelope_roundtrips_all_server_variants() {
             expected_codex_model: None,
             approval_policy_overrides: None,
             deadline: None,
+            resume_thread_id: Some("sess_resume".into()),
         },
         ServerMsg::Cancel {
             run_id: Uuid::new_v4(),


### PR DESCRIPTION
## Summary

End-to-end implementation of multi-run continuation per issue: an issue's
work can span more than one `AgentRun`, the agent yields with a question,
a non-bot comment wakes a follow-up run, the original runner is preferred
(strict pin) but stays free to serve other issues while paused.

The design doc at `.ai_design/issue_run_improve/design.md` lays out the
model and §11 captures expected behavior + 12 acceptance scenarios. The
seven implementation commits map 1:1 to phases in the doc.

## What's in here

**Status model**
- New `AgentRunStatus.PAUSED_AWAITING_INPUT` placed correctly across all
  five classifiers: in `NON_TERMINAL_STATUSES`; out of `BUSY_STATUSES`,
  `is_terminal`, `is_active`, `ACTIVE_RUN_STATUSES`. PAUSED ≠ busy is the
  lynchpin that lets the runner serve other issues while waiting for a
  human reply.
- Field-only migration adds `pinned_runner` FK to `AgentRun`.
- `done_signal.py` accepts `"paused"` (alongside the existing `"blocked"`
  terminal contract) and requires `autonomy.question_for_human`.

**Dispatch**
- New `next_for_runner` query: a single `SELECT FOR UPDATE SKIP LOCKED`
  with `ORDER BY (pinned_runner = me) DESC, created_at ASC`. One table,
  two filters — no new queue.
- `drain_pod` rewritten runner-first to avoid head-of-line blocking when
  the head QUEUED run is pinned to a busy runner.
- `drain_for_runner` is the new immediate-dispatch trigger when a runner
  becomes idle (terminate / pause) or reconnects with pinned work.

**Continuation triggers**
- `post_save(IssueComment)` receiver wakes the agent on a non-bot comment
  to an in-progress issue. Filters explicitly on `actor.is_bot` (the
  `pi_dash_agent` workpad bot); gates by `state.group=STARTED`; coalesces
  duplicate followers; pins to `parent_run.runner` when there's a
  thread_id to resume against.
- `maybe_continue_after_terminate` is the consumer-side timestamp sweep
  that surfaces non-bot comments arriving during a RUNNING/ASSIGNED prior
  — no pending-comment table; `IssueComment` + `created_at > started_at`
  is the storage.

**Wire protocol** (backward compatible — field-only additions)
- `Assign.resume_thread_id` carries `parent_run.thread_id` to the runner.
- New `ClientMsg::RunPaused` for the Codex tool-call yield path; cloud's
  `on_run_paused` handler parks the run, posts the question as a workpad
  comment, and triggers drain.
- New `FailureReason::ResumeUnavailable` for the case where the agent
  CLI can't find the session locally.

**Runner side (Rust)**
- Lift the "single-turn only" Claude restriction; pass
  `claude --resume <session_id>` when `RunPayload.resume_thread_id` is set.
  Yield path on the Claude side rides the existing `pi-dash-done` fenced
  block with `status: "paused"`.
- Codex bridge wraps `thread/resume` errors into a typed
  `ResumeUnavailable`. Supervisor downcasts on the bridge error path and
  emits `FailureReason::ResumeUnavailable` so cloud drops the pin and
  re-queues.

**Operator escape hatches**
- `Runner.revoke()` now nulls `pinned_runner_id` on QUEUED runs (drops
  pin without cancelling) and triggers drain.
- `POST /api/runners/runs/<id>/release-pin/` lets an operator manually
  release a stuck pin when the pinned runner is offline indefinitely.

## Test plan

- [x] Rust: `cargo build` clean, `cargo test --lib` 71 passed.
- [x] Django: 238 unit tests pass (including 23 new tests across the
      classifier-coverage, drain_pod, done-signal, service, composer, and
      revocation suites). Pre-existing failures on `main`
      (`test_run_config_carries_git_fields`, `test_branch_name_validators`,
      `test_url`, `test_project_state`, `test_copy_s3_objects`,
      `test_work_item_link_task`) are unrelated and confirmed baseline.
- [ ] Manual smoke once merged: pause a run via Codex tool call (after the
      `request_user_input` tool exposure follow-up), comment, verify the
      same runner picks up R_next with `--resume`/`thread/resume`.
- [ ] Manual smoke for the Claude path: agent emits
      `pi-dash-done` with `status:"paused"`, comment, verify resume.
- [ ] Manual smoke for the no-pin fallback: pin to a runner, take it
      offline, click "release pin", verify R_next dispatches elsewhere
      with `resume_thread_id` cleared.

## Deferred (intentionally)

- Codex `request_user_input` tool exposure on the runner side — the wire
  and cloud halves are ready; only the Codex SDK tool registration
  remains. Tracked as the immediate follow-up.
- Mid-RUNNING comment delivery into a live run (terminate sweep handles
  the same scenario; this would be an upgrade, not a correctness fix).
- Transcript-replay fallback (deliberately rejected per §6.5 — handoff
  comments fill the role and are runner-agnostic).
- TTL on stuck pins (operator escape hatch is enough for v1; TTLs
  silently lose the resume benefit).

## Open design questions

Tracked in §9 of the design doc (Q1–Q9): paused-run TTL, resume on a
weeks-old completed run, workspace dirty across yields, comment-trigger
sweep filter semantics, billing attribution, and a few UI surfaces for
stuck pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
