### PR TITLE
fix(web): fall back to bundled cover URL when upload fails on project create

### DIFF
--- a/apps/web/ce/components/projects/create/root.tsx
+++ b/apps/web/ce/components/projects/create/root.tsx
@@ -84,9 +84,18 @@ export const CreateProjectForm = observer(function CreateProjectForm(props: TCre
           // form already defaults `cover_image_url` to a random static URL,
           // and that URL is renderable directly. Fall back to using it as
           // the project's `cover_image` instead of rejecting submission.
+          // A non-blocking warning toast surfaces the skipped upload so the
+          // user has a signal when the failure was actually fixable (auth
+          // expired, server rejected the file, etc.) rather than just a
+          // misconfigured local stack.
           console.warn("Cover upload failed; falling back to bundled static URL", error);
           formData.cover_image = coverImage;
           formData.cover_image_asset = null;
+          setToast({
+            type: TOAST_TYPE.WARNING,
+            title: t("warning"),
+            message: t("cover_image_upload_skipped"),
+          });
         }
       } else {
         formData.cover_image = coverImage;

--- a/apps/web/ce/components/projects/create/root.tsx
+++ b/apps/web/ce/components/projects/create/root.tsx
@@ -78,13 +78,15 @@ export const CreateProjectForm = observer(function CreateProjectForm(props: TCre
             isUserAsset: false,
           });
         } catch (error) {
-          console.error("Error uploading cover image:", error);
-          setToast({
-            type: TOAST_TYPE.ERROR,
-            title: t("toast.error"),
-            message: error instanceof Error ? error.message : "Failed to upload cover image",
-          });
-          return Promise.reject(error);
+          // Bundled static covers ship with the web bundle, so a flaky or
+          // misconfigured asset backend (e.g. MinIO unreachable from the
+          // browser) shouldn't block project creation — every new project
+          // form already defaults `cover_image_url` to a random static URL,
+          // and that URL is renderable directly. Fall back to using it as
+          // the project's `cover_image` instead of rejecting submission.
+          console.warn("Cover upload failed; falling back to bundled static URL", error);
+          formData.cover_image = coverImage;
+          formData.cover_image_asset = null;
         }
       } else {
         formData.cover_image = coverImage;
@@ -92,67 +94,65 @@ export const CreateProjectForm = observer(function CreateProjectForm(props: TCre
       }
     }
 
-    return createProject(workspaceSlug.toString(), formData)
-      .then(async (res) => {
-        if (uploadedAssetUrl) {
-          await updateCoverImageStatus(res.id, uploadedAssetUrl);
-          await updateProject(workspaceSlug.toString(), res.id, { cover_image_url: uploadedAssetUrl });
-        } else if (coverImage && coverImage.startsWith("http")) {
-          await updateCoverImageStatus(res.id, coverImage);
-          await updateProject(workspaceSlug.toString(), res.id, { cover_image_url: coverImage });
-        }
-        setToast({
-          type: TOAST_TYPE.SUCCESS,
-          title: t("success"),
-          message: t("project_created_successfully"),
-        });
+    try {
+      const res = await createProject(workspaceSlug.toString(), formData);
+      if (uploadedAssetUrl) {
+        await updateCoverImageStatus(res.id, uploadedAssetUrl);
+        await updateProject(workspaceSlug.toString(), res.id, { cover_image_url: uploadedAssetUrl });
+      } else if (coverImage && coverImage.startsWith("http")) {
+        await updateCoverImageStatus(res.id, coverImage);
+        await updateProject(workspaceSlug.toString(), res.id, { cover_image_url: coverImage });
+      }
+      setToast({
+        type: TOAST_TYPE.SUCCESS,
+        title: t("success"),
+        message: t("project_created_successfully"),
+      });
+      if (setToFavorite) {
+        handleAddToFavorites(res.id);
+      }
+      handleNextStep(res.id);
+    } catch (err) {
+      try {
+        // Handle the new error format where codes are nested in arrays under field names
+        const errorData = (err as { data?: Record<string, string[] | undefined> })?.data ?? {};
 
-        if (setToFavorite) {
-          handleAddToFavorites(res.id);
-        }
-        handleNextStep(res.id);
-      })
-      .catch((err) => {
-        try {
-          // Handle the new error format where codes are nested in arrays under field names
-          const errorData = err?.data ?? {};
+        const nameError = errorData.name?.includes("PROJECT_NAME_ALREADY_EXIST");
+        const identifierError = errorData?.identifier?.includes("PROJECT_IDENTIFIER_ALREADY_EXIST");
 
-          const nameError = errorData.name?.includes("PROJECT_NAME_ALREADY_EXIST");
-          const identifierError = errorData?.identifier?.includes("PROJECT_IDENTIFIER_ALREADY_EXIST");
-
-          if (nameError || identifierError) {
-            if (nameError) {
-              setToast({
-                type: TOAST_TYPE.ERROR,
-                title: t("toast.error"),
-                message: t("project_name_already_taken"),
-              });
-            }
-
-            if (identifierError) {
-              setToast({
-                type: TOAST_TYPE.ERROR,
-                title: t("toast.error"),
-                message: t("project_identifier_already_taken"),
-              });
-            }
-          } else {
+        if (nameError || identifierError) {
+          if (nameError) {
             setToast({
               type: TOAST_TYPE.ERROR,
               title: t("toast.error"),
-              message: t("something_went_wrong"),
+              message: t("project_name_already_taken"),
             });
           }
-        } catch (error) {
-          // Fallback error handling if the error processing fails
-          console.error("Error processing API error:", error);
+
+          if (identifierError) {
+            setToast({
+              type: TOAST_TYPE.ERROR,
+              title: t("toast.error"),
+              message: t("project_identifier_already_taken"),
+            });
+          }
+        } else {
           setToast({
             type: TOAST_TYPE.ERROR,
             title: t("toast.error"),
             message: t("something_went_wrong"),
           });
         }
-      });
+      } catch (error) {
+        // Fallback error handling if the error processing fails
+        console.error("Error processing API error:", error);
+        setToast({
+          type: TOAST_TYPE.ERROR,
+          title: t("toast.error"),
+          message: t("something_went_wrong"),
+        });
+      }
+    }
   };
 
   const handleClose = () => {

--- a/packages/i18n/src/locales/cs/translations.ts
+++ b/packages/i18n/src/locales/cs/translations.ts
@@ -210,6 +210,7 @@ export default {
   timezone: "Časové pásmo",
   avatar: "Profilový obrázek",
   cover_image: "Úvodní obrázek",
+  cover_image_upload_skipped: "Cover image upload skipped — using a default cover.",
   password: "Heslo",
   change_cover: "Změnit úvodní obrázek",
   language: "Jazyk",

--- a/packages/i18n/src/locales/de/translations.ts
+++ b/packages/i18n/src/locales/de/translations.ts
@@ -213,6 +213,7 @@ export default {
   timezone: "Zeitzone",
   avatar: "Profilbild",
   cover_image: "Titelbild",
+  cover_image_upload_skipped: "Cover image upload skipped — using a default cover.",
   password: "Passwort",
   change_cover: "Titelbild ändern",
   language: "Sprache",

--- a/packages/i18n/src/locales/en/translations.ts
+++ b/packages/i18n/src/locales/en/translations.ts
@@ -38,6 +38,7 @@ export default {
   timezone: "Timezone",
   avatar: "Avatar",
   cover_image: "Cover image",
+  cover_image_upload_skipped: "Cover image upload skipped — using a default cover.",
   password: "Password",
   change_cover: "Change cover",
   language: "Language",

--- a/packages/i18n/src/locales/es/translations.ts
+++ b/packages/i18n/src/locales/es/translations.ts
@@ -211,6 +211,7 @@ export default {
   timezone: "Zona horaria",
   avatar: "Avatar",
   cover_image: "Imagen de portada",
+  cover_image_upload_skipped: "Cover image upload skipped — using a default cover.",
   password: "Contraseña",
   change_cover: "Cambiar portada",
   language: "Idioma",

--- a/packages/i18n/src/locales/fr/translations.ts
+++ b/packages/i18n/src/locales/fr/translations.ts
@@ -211,6 +211,7 @@ export default {
   timezone: "Fuseau horaire",
   avatar: "Avatar",
   cover_image: "Image de couverture",
+  cover_image_upload_skipped: "Cover image upload skipped — using a default cover.",
   password: "Mot de passe",
   change_cover: "Changer la couverture",
   language: "Langue",

--- a/packages/i18n/src/locales/id/translations.ts
+++ b/packages/i18n/src/locales/id/translations.ts
@@ -211,6 +211,7 @@ export default {
   timezone: "Zona waktu",
   avatar: "Avatar",
   cover_image: "Gambar sampul",
+  cover_image_upload_skipped: "Cover image upload skipped — using a default cover.",
   password: "Kata sandi",
   change_cover: "Ganti sampul",
   language: "Bahasa",

--- a/packages/i18n/src/locales/it/translations.ts
+++ b/packages/i18n/src/locales/it/translations.ts
@@ -211,6 +211,7 @@ export default {
   timezone: "Fuso orario",
   avatar: "Avatar",
   cover_image: "Immagine di copertina",
+  cover_image_upload_skipped: "Cover image upload skipped — using a default cover.",
   password: "Password",
   change_cover: "Cambia copertina",
   language: "Lingua",

--- a/packages/i18n/src/locales/ja/translations.ts
+++ b/packages/i18n/src/locales/ja/translations.ts
@@ -210,6 +210,7 @@ export default {
   timezone: "タイムゾーン",
   avatar: "アバター",
   cover_image: "カバー画像",
+  cover_image_upload_skipped: "Cover image upload skipped — using a default cover.",
   password: "パスワード",
   change_cover: "カバーを変更",
   language: "言語",

--- a/packages/i18n/src/locales/ko/translations.ts
+++ b/packages/i18n/src/locales/ko/translations.ts
@@ -208,6 +208,7 @@ export default {
   timezone: "시간대",
   avatar: "아바타",
   cover_image: "커버 이미지",
+  cover_image_upload_skipped: "Cover image upload skipped — using a default cover.",
   password: "비밀번호",
   change_cover: "커버 변경",
   language: "언어",

--- a/packages/i18n/src/locales/pl/translations.ts
+++ b/packages/i18n/src/locales/pl/translations.ts
@@ -209,6 +209,7 @@ export default {
   timezone: "Strefa czasowa",
   avatar: "Zdjęcie profilowe",
   cover_image: "Obraz w tle",
+  cover_image_upload_skipped: "Cover image upload skipped — using a default cover.",
   password: "Hasło",
   change_cover: "Zmień obraz w tle",
   language: "Język",

--- a/packages/i18n/src/locales/pt-BR/translations.ts
+++ b/packages/i18n/src/locales/pt-BR/translations.ts
@@ -210,6 +210,7 @@ export default {
   timezone: "Fuso horário",
   avatar: "Avatar",
   cover_image: "Imagem de capa",
+  cover_image_upload_skipped: "Cover image upload skipped — using a default cover.",
   password: "Senha",
   change_cover: "Alterar capa",
   language: "Idioma",

--- a/packages/i18n/src/locales/ro/translations.ts
+++ b/packages/i18n/src/locales/ro/translations.ts
@@ -211,6 +211,7 @@ export default {
   timezone: "Fus orar",
   avatar: "Imagine de profil",
   cover_image: "Copertă",
+  cover_image_upload_skipped: "Cover image upload skipped — using a default cover.",
   password: "Parolă",
   change_cover: "Schimbă coperta",
   language: "Limbă",

--- a/packages/i18n/src/locales/ru/translations.ts
+++ b/packages/i18n/src/locales/ru/translations.ts
@@ -210,6 +210,7 @@ export default {
   timezone: "Часовой пояс",
   avatar: "Аватар",
   cover_image: "Обложка",
+  cover_image_upload_skipped: "Cover image upload skipped — using a default cover.",
   password: "Пароль",
   change_cover: "Изменить обложку",
   language: "Язык",

--- a/packages/i18n/src/locales/sk/translations.ts
+++ b/packages/i18n/src/locales/sk/translations.ts
@@ -210,6 +210,7 @@ export default {
   timezone: "Časové pásmo",
   avatar: "Profilový obrázok",
   cover_image: "Úvodný obrázok",
+  cover_image_upload_skipped: "Cover image upload skipped — using a default cover.",
   password: "Heslo",
   change_cover: "Zmeniť úvodný obrázok",
   language: "Jazyk",

--- a/packages/i18n/src/locales/tr-TR/translations.ts
+++ b/packages/i18n/src/locales/tr-TR/translations.ts
@@ -212,6 +212,7 @@ export default {
   timezone: "Saat dilimi",
   avatar: "Profil resmi",
   cover_image: "Kapak resmi",
+  cover_image_upload_skipped: "Cover image upload skipped — using a default cover.",
   password: "Şifre",
   change_cover: "Kapağı değiştir",
   language: "Dil",

--- a/packages/i18n/src/locales/ua/translations.ts
+++ b/packages/i18n/src/locales/ua/translations.ts
@@ -211,6 +211,7 @@ export default {
   timezone: "Часовий пояс",
   avatar: "Аватар",
   cover_image: "Обкладинка",
+  cover_image_upload_skipped: "Cover image upload skipped — using a default cover.",
   password: "Пароль",
   change_cover: "Змінити обкладинку",
   language: "Мова",

--- a/packages/i18n/src/locales/vi-VN/translations.ts
+++ b/packages/i18n/src/locales/vi-VN/translations.ts
@@ -211,6 +211,7 @@ export default {
   timezone: "Múi giờ",
   avatar: "Ảnh đại diện",
   cover_image: "Ảnh bìa",
+  cover_image_upload_skipped: "Cover image upload skipped — using a default cover.",
   password: "Mật khẩu",
   change_cover: "Thay đổi ảnh bìa",
   language: "Ngôn ngữ",

--- a/packages/i18n/src/locales/zh-CN/translations.ts
+++ b/packages/i18n/src/locales/zh-CN/translations.ts
@@ -208,6 +208,7 @@ export default {
   timezone: "时区",
   avatar: "头像",
   cover_image: "封面图片",
+  cover_image_upload_skipped: "Cover image upload skipped — using a default cover.",
   password: "密码",
   change_cover: "更改封面",
   language: "语言",

--- a/packages/i18n/src/locales/zh-TW/translations.ts
+++ b/packages/i18n/src/locales/zh-TW/translations.ts
@@ -208,6 +208,7 @@ export default {
   timezone: "時區",
   avatar: "大頭貼",
   cover_image: "封面圖片",
+  cover_image_upload_skipped: "Cover image upload skipped — using a default cover.",
   password: "密碼",
   change_cover: "更換封面",
   language: "語言",


### PR DESCRIPTION
## Summary

The create-project form pre-populates `cover_image_url` with a **random preset cover** from `STATIC_COVER_IMAGES` (29 bundled images) on form init. On submit, the flow tries to upload that bundled URL through `uploadCoverImage` to register it as a project asset. If the asset backend is unreachable from the **browser** — e.g. MinIO running in compose with no host port mapping, or any flaky/misconfigured storage path — the upload throws and the **entire submission is rejected**: the project is never created and the user sees only \`failed to upload cover image\`.

That asset-side failure shouldn't gate project creation. Bundled static covers ship inside the web bundle and are renderable directly via their bundle URL, so on upload failure we now fall back to assigning that URL to the project's `cover_image` field — mirroring the existing path the code already uses for non-static cover URLs (Unsplash, etc.) — and let create proceed.

## Behavior changes

- **Before**: cover upload throws → ❌ project not created, error toast.
- **After**: cover upload throws → ✅ project created with the bundled static URL as its cover, console-warn for debugging, no error toast.
- Real upload failures for **non-bundled** covers (user-provided file blobs, etc.) still go through the original non-static branch and surface to the user as before. This change only relaxes the failure mode for `local_static` covers, which by definition don't need the upload step to display.

## Drive-by refactor

Also converts the existing `createProject(...).then(...).catch(...)` chain inside the same `async onSubmit` to plain `await` + `try/catch`. No behavior change — same toasts fire on the same conditions. Needed because the new fallback (which removes the early `return Promise.reject(error)`) makes the file trip oxlint's prefer-await-to-then rule under \`--deny-warnings\`.

## Test plan
- [ ] \`pnpm --filter=web check:lint\` passes (no warning regression in the per-app budget)
- [ ] \`pnpm check:types\` passes
- [ ] Manual: create a project against a stack where MinIO/S3 is reachable → cover upload succeeds, project created with the uploaded asset (unchanged path)
- [ ] Manual: create a project against the multi-container compose stack (where MinIO has no host port mapping) → cover upload fails internally but the project is still created, and the project tile renders the bundled static cover
- [ ] Manual: pick an Unsplash cover → still uses Unsplash URL directly (non-static branch unchanged)
- [ ] Manual: trigger a duplicate project name → still surfaces the existing \`PROJECT_NAME_ALREADY_EXIST\` toast (refactored catch path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)