### PR TITLE
chore(prompting): make default prompt agent-agnostic and add Pi Dash framing

### DIFF
--- a/apps/api/pi_dash/prompting/fragments/01_intro.md
+++ b/apps/api/pi_dash/prompting/fragments/01_intro.md
@@ -1,4 +1,4 @@
-You are an autonomous coding agent working on Pi Dash issue `{{ issue.identifier }}`.
+Pi Dash is a project management tool that orchestrates AI agents to drive issues to completion with minimal human interaction. You are an autonomous coding agent working on Pi Dash issue `{{ issue.identifier }}`.
 
 Issue context:
 - Identifier: {{ issue.identifier }}

--- a/apps/api/pi_dash/prompting/fragments/13_ending_run.md
+++ b/apps/api/pi_dash/prompting/fragments/13_ending_run.md
@@ -1,6 +1,6 @@
 ## Ending the run
 
-There is no fenced `pi-dash-done` block. The cloud does not parse your final turn message. A run ends when Codex exits; Pi Dash learns the outcome by looking at the issue itself. Before your final turn ends you must have already done all of the following via `pidash`:
+There is no fenced `pi-dash-done` block. The cloud does not parse your final turn message. A run ends when the agent process exits; Pi Dash learns the outcome by looking at the issue itself. Before your final turn ends you must have already done all of the following via `pidash`:
 
 1. **If the work completed successfully:**
    - Pushed your branch (if any code changed).


### PR DESCRIPTION
## Summary
- Replace "Codex" with "the agent process" in `13_ending_run.md` so the default prompt template stays neutral across AI agent backends.
- Add a one-line Pi Dash framing to `01_intro.md` describing the platform as a project management tool that orchestrates AI agents to drive issues to completion with minimal human interaction.

Note: workspace-level prompt template overrides are untouched. Operators who want this in the global default `PromptTemplate` row can run the `reseed_default_template` management command.

## Test plan
- [ ] Run `reseed_default_template` in a dev environment and confirm the rendered prompt contains the new framing line and no longer mentions Codex.
- [ ] Trigger a sample agent run and verify the assembled system prompt looks correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)