### PR TITLE
refactor: rename IssueAgentSchedule to IssueAgentTicker

### DIFF
--- a/.ai_design/issue_ticking_system/design.md
+++ b/.ai_design/issue_ticking_system/design.md
@@ -140,7 +140,7 @@ When an issue enters that specific In Progress state:
 1. Immediate dispatch fires via the existing
    `_create_and_dispatch_run` path (today's behavior preserved —
    the user clicks In Progress, the agent starts immediately).
-2. Create or reset the `IssueAgentSchedule` row:
+2. Create or reset the `IssueAgentTicker` row:
    - `interval_seconds` = issue override if set, else project default
      (3h).
    - `max_ticks` = issue override if set, else project default (24).
@@ -299,10 +299,10 @@ process** (one scheduler instance) — running multiple beat workers
 duplicates the scan. This is standard Celery deployment hygiene.
 
 ```python
-def scan_due_schedules():
+def scan_due_tickers():
     """Fan out fire_tick tasks. The actual claim happens in fire_tick."""
     due_ids = list(
-        IssueAgentSchedule.objects
+        IssueAgentTicker.objects
         .filter(enabled=True, next_run_at__lte=timezone.now())
         .filter(Q(max_ticks=-1) | Q(tick_count__lt=F('max_ticks')))
         .order_by('next_run_at')
@@ -322,7 +322,7 @@ double-fire the same schedule:
 def fire_tick(sched_id):
     with transaction.atomic():
         sched = (
-            IssueAgentSchedule.objects
+            IssueAgentTicker.objects
             .select_for_update()
             .get(pk=sched_id)
         )
@@ -399,9 +399,9 @@ minute) would re-cluster every cycle.
 
 ## 7. Schema
 
-### 7.1 New model `IssueAgentSchedule`
+### 7.1 New model `IssueAgentTicker`
 
-Lives in `apps/api/pi_dash/db/models/issue_agent_schedule.py`
+Lives in `apps/api/pi_dash/db/models/issue_agent_ticker.py`
 (co-located with other issue-adjacent models — orchestration is a
 service layer with no `models.py` of its own). Migrations land in
 `apps/api/pi_dash/db/migrations/`.
@@ -424,7 +424,7 @@ created_at, updated_at
 ```
 
 Constraint: `issue` is unique. There is exactly one
-`IssueAgentSchedule` row per issue; arming, disarming, and changing
+`IssueAgentTicker` row per issue; arming, disarming, and changing
 overrides mutate that row in place rather than creating additional
 schedule rows.
 
@@ -462,7 +462,7 @@ agent integration from the project (different feature, out of
 scope for this design).
 
 When `agent_ticking_enabled = false` at the project level: arming
-logic creates the `IssueAgentSchedule` row but sets `enabled = false`
+logic creates the `IssueAgentTicker` row but sets `enabled = false`
 (so the scanner skips it). Re-enabling the project setting flips
 schedules back to `enabled = true` for issues currently in Started
 that don't have `user_disabled = true`.
@@ -518,7 +518,7 @@ New section "AI agent ticking":
 
 ### 8.3 Issue settings
 
-Per-issue overrides, written to `IssueAgentSchedule`:
+Per-issue overrides, written to `IssueAgentTicker`:
 
 | UI field                       | DB field           | Semantics                                                                                                                |
 | ------------------------------ | ------------------ | ------------------------------------------------------------------------------------------------------------------------ |
@@ -563,20 +563,20 @@ The following are **kept**:
 All v1 decisions are pinned below. Anything genuinely open lives in
 the §12 implementation plan as concrete tasks, not as ambiguity.
 
-| #   | Question                                                                                    | Decision                                                                                                                                                                                                                                                                                                                 |
-| --- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Q1  | Migration for existing In Progress issues — retroactive backfill?                           | **Yes.** Data migration (§12.1) iterates issues whose state is in `StateGroup.STARTED` AND named "In Progress" and creates an `IssueAgentSchedule` row for each, with `next_run_at = NOW() + project default interval + jitter` (so the first tick fires roughly an interval after deploy, not all at once on start-up). |
-| Q2  | "Paused" state — global template vs. per-workspace opt-in?                                  | **Global template.** Added to `seeds/data/states.json` (Backlog group) plus a one-time data migration that backfills every existing project that doesn't already have a "Paused" state. New projects pick it up via the existing seed path.                                                                              |
-| Q3  | Actor on system-driven In Progress → Paused transition?                                     | **The existing `pi_dash_agent` bot user** (`orchestration/workpad.py:get_agent_system_user()`). It already authors workpad comments; reusing it for the system-pause activity entry keeps a single "agent/system" actor in the activity feed. If we later need to distinguish, a separate bot user is a small addition.  |
-| Q4  | Custom Started-group state names — does ticking apply?                                      | **No, for v1.** Ticking inherits the same strictness as `_is_delegation_trigger`: only the state literally named "In Progress" arms or fires a schedule (see §4.2 and the name check in §6.1's `fire_tick`). Generalizing to "any STARTED state" is tracked outside this design.                                         |
-| Q5  | Quiet hours / business-hours awareness?                                                     | **Out of scope for v1.** Not blocking; can be added as an additional gate inside `fire_tick` later.                                                                                                                                                                                                                      |
-| Q6  | User **manually** moves issue to Paused while a run is `RUNNING` — cancel or let it finish? | **Let the run finish.** Schedule disarms immediately (no future ticks); the active run completes naturally; no auto-resume until the user explicitly moves the issue back to In Progress. Matches the deferred cap-hit behavior and avoids implicit cancellation semantics.                                              |
-| Q7  | UI for `max_ticks = -1` (infinite)?                                                         | **"No cap"** label plus the running tick count, e.g. `"42 ticks · no cap"`. Cap-hit copy in §8.1 only applies when `max_ticks > 0`.                                                                                                                                                                                      |
+| #   | Question                                                                                    | Decision                                                                                                                                                                                                                                                                                                                |
+| --- | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Q1  | Migration for existing In Progress issues — retroactive backfill?                           | **Yes.** Data migration (§12.1) iterates issues whose state is in `StateGroup.STARTED` AND named "In Progress" and creates an `IssueAgentTicker` row for each, with `next_run_at = NOW() + project default interval + jitter` (so the first tick fires roughly an interval after deploy, not all at once on start-up).  |
+| Q2  | "Paused" state — global template vs. per-workspace opt-in?                                  | **Global template.** Added to `seeds/data/states.json` (Backlog group) plus a one-time data migration that backfills every existing project that doesn't already have a "Paused" state. New projects pick it up via the existing seed path.                                                                             |
+| Q3  | Actor on system-driven In Progress → Paused transition?                                     | **The existing `pi_dash_agent` bot user** (`orchestration/workpad.py:get_agent_system_user()`). It already authors workpad comments; reusing it for the system-pause activity entry keeps a single "agent/system" actor in the activity feed. If we later need to distinguish, a separate bot user is a small addition. |
+| Q4  | Custom Started-group state names — does ticking apply?                                      | **No, for v1.** Ticking inherits the same strictness as `_is_delegation_trigger`: only the state literally named "In Progress" arms or fires a schedule (see §4.2 and the name check in §6.1's `fire_tick`). Generalizing to "any STARTED state" is tracked outside this design.                                        |
+| Q5  | Quiet hours / business-hours awareness?                                                     | **Out of scope for v1.** Not blocking; can be added as an additional gate inside `fire_tick` later.                                                                                                                                                                                                                     |
+| Q6  | User **manually** moves issue to Paused while a run is `RUNNING` — cancel or let it finish? | **Let the run finish.** Schedule disarms immediately (no future ticks); the active run completes naturally; no auto-resume until the user explicitly moves the issue back to In Progress. Matches the deferred cap-hit behavior and avoids implicit cancellation semantics.                                             |
+| Q7  | UI for `max_ticks = -1` (infinite)?                                                         | **"No cap"** label plus the running tick count, e.g. `"42 ticks · no cap"`. Cap-hit copy in §8.1 only applies when `max_ticks > 0`.                                                                                                                                                                                     |
 
 ## 11. Summary of decisions
 
 1. **Scanner-based periodic ticking.** Celery Beat runs every minute,
-   queries `IssueAgentSchedule`, fans out `fire_tick` tasks per due row.
+   queries `IssueAgentTicker`, fans out `fire_tick` tasks per due row.
 2. **Default 3h cadence, default 24-tick hard cap** (= 3 days at 3h
    cadence). Configurable at project + issue level. `-1` means
    infinite.
@@ -619,14 +619,14 @@ the §12 implementation plan as concrete tasks, not as ambiguity.
     single dispatch; the Paused → In Progress state transition
     arms the schedule but does not fire its own dispatch (§4.5).
     Avoids two-dispatch race against `_active_run_for`.
-15. **One schedule row per issue.** `IssueAgentSchedule.issue` is
+15. **One schedule row per issue.** `IssueAgentTicker.issue` is
     unique; override edits and arm/disarm events mutate the same row.
 16. **In Progress name strictness.** Ticking arms and fires only on
     the literal "In Progress" state name, mirroring
     `_is_delegation_trigger` in v1. Custom Started-group state names
     are deferred.
 17. **Schedule model lives in `db/`, not `orchestration/`.**
-    `apps/api/pi_dash/db/models/issue_agent_schedule.py`,
+    `apps/api/pi_dash/db/models/issue_agent_ticker.py`,
     migrations under `apps/api/pi_dash/db/migrations/`. Orchestration
     stays a service layer.
 
@@ -639,9 +639,9 @@ the §12 implementation plan as concrete tasks, not as ambiguity.
 Three migrations, in order, all under
 `apps/api/pi_dash/db/migrations/`:
 
-**M1 — schema.** `0NNN_issue_agent_schedule.py`
+**M1 — schema.** `0NNN_issue_agent_ticker.py`
 
-- `CreateModel(IssueAgentSchedule)` with the fields in §7.1.
+- `CreateModel(IssueAgentTicker)` with the fields in §7.1.
 - `AddField` × 3 on `Project`: `agent_default_interval_seconds`
   (int, default 10800), `agent_default_max_ticks` (int, default 24),
   `agent_ticking_enabled` (bool, default true).
@@ -664,7 +664,7 @@ Three migrations, in order, all under
   - Resolve each project's effective default interval.
   - For every Issue whose `state.group == STARTED` AND
     `state.name == "In Progress"`, `get_or_create` an
-    `IssueAgentSchedule` row with `next_run_at = NOW() +
+    `IssueAgentTicker` row with `next_run_at = NOW() +
 project_default_interval + jitter`, `tick_count = 0`,
     `enabled = NOT user_disabled`.
   - Setting `next_run_at = NOW() + interval + jitter` (not `NOW()`)
@@ -685,8 +685,8 @@ detail is in the lifecycle sections.
 #### orchestration/scheduling.py (new module)
 
 ```python
-def arm_schedule(issue: Issue, *, dispatch_immediate: bool = True) -> None:
-    """Create or reset the IssueAgentSchedule for an issue entering
+def arm_ticker(issue: Issue, *, dispatch_immediate: bool = True) -> None:
+    """Create or reset the IssueAgentTicker for an issue entering
     Started/In Progress.
 
     - dispatch_immediate=True (default): caller wants the immediate
@@ -699,12 +699,12 @@ def arm_schedule(issue: Issue, *, dispatch_immediate: bool = True) -> None:
     sets `enabled = false` when either suppresses ticks.
     """
 
-def disarm_schedule(issue: Issue) -> None:
+def disarm_ticker(issue: Issue) -> None:
     """Set enabled=false. Idempotent. Called when issue leaves
     Started, on cap hit, on terminal done-signal, and when the user
     toggles `user_disabled = true` mid-flight."""
 
-def reset_schedule_after_comment_and_run(issue: Issue) -> None:
+def reset_ticker_after_comment_and_run(issue: Issue) -> None:
     """Reset tick_count=0 and next_run_at = NOW() + interval + jitter.
     Called by the Comment & Run handler after the run is dispatched
     (§4.6 step 4). Uses select_for_update to serialize against
@@ -722,11 +722,11 @@ def dispatch_continuation_run(
     when the single-active-run guardrail blocks creation."""
 ```
 
-#### bgtasks/agent_schedule.py (new module)
+#### bgtasks/agent_ticker.py (new module)
 
 ```python
 @shared_task
-def scan_due_schedules() -> None:
+def scan_due_tickers() -> None:
     """Celery Beat target. Runs every minute. Fans out fire_tick
     tasks for due schedules. The actual claim happens inside
     fire_tick under select_for_update."""
@@ -743,8 +743,8 @@ Add to the existing `CELERY_BEAT_SCHEDULE` (in
 configured today):
 
 ```python
-"scan-due-agent-schedules": {
-    "task": "pi_dash.bgtasks.agent_schedule.scan_due_schedules",
+"scan-due-agent-tickers": {
+    "task": "pi_dash.bgtasks.agent_ticker.scan_due_tickers",
     "schedule": crontab(minute="*"),
 },
 ```
@@ -773,7 +773,7 @@ No new endpoints required. The existing
 `POST /api/runners/runs/` (consumed today by `apps/web/core/services/runner/agent-run.service.ts`)
 becomes the path Comment & Run hits; its server-side handler routes
 to `dispatch_continuation_run` plus
-`reset_schedule_after_comment_and_run`.
+`reset_ticker_after_comment_and_run`.
 
 The Paused-issue confirmation flow (§4.6) is client-side: the UI
 shows the dialog, then on Confirm makes three sequential calls in
@@ -784,7 +784,7 @@ this order:
    (existing endpoint; the state-transition handler arms the
    schedule with `dispatch_immediate=False` because the caller
    tags this transition as "comment-and-run-driven" — see
-   `arm_schedule` semantics above)
+   `arm_ticker` semantics above)
 3. `POST /api/runners/runs/` (Comment & Run dispatch)
 
 The state-transition handler needs a way to know "Comment & Run is
@@ -835,20 +835,20 @@ loses its `fire_comment_continuation` receiver entirely.
 Create `apps/api/pi_dash/tests/unit/orchestration/test_scheduling.py`
 covering:
 
-- `arm_schedule` honors `user_disabled` and project `agent_ticking_enabled`.
-- `arm_schedule(dispatch_immediate=False)` does not call into run dispatch.
-- `disarm_schedule` is idempotent.
-- `reset_schedule_after_comment_and_run` resets tick_count and
+- `arm_ticker` honors `user_disabled` and project `agent_ticking_enabled`.
+- `arm_ticker(dispatch_immediate=False)` does not call into run dispatch.
+- `disarm_ticker` is idempotent.
+- `reset_ticker_after_comment_and_run` resets tick_count and
   next_run_at; serializes against concurrent fire_tick.
 - `dispatch_continuation_run` resolves parent, creator, pod
   correctly and returns None when blocked by `_active_run_for`.
 - `maybe_apply_deferred_pause` only transitions when (schedule
   disarmed) AND (no active runs) AND (issue still in Started).
 
-Create `apps/api/pi_dash/tests/unit/bgtasks/test_agent_schedule.py`
+Create `apps/api/pi_dash/tests/unit/bgtasks/test_agent_ticker.py`
 covering:
 
-- `scan_due_schedules` selects only enabled, due, under-cap rows.
+- `scan_due_tickers` selects only enabled, due, under-cap rows.
 - `fire_tick` re-checks under lock and skips when conditions changed.
 - `fire_tick` increments tick_count and advances next_run_at.
 - `fire_tick` sets `enabled = false` on cap hit but does NOT auto-
@@ -876,17 +876,17 @@ Project field additions. No behavior change yet (no scanner, no
 auto-trigger removal). Easy to review.
 
 **PR B — orchestration scheduling primitives.**
-`orchestration/scheduling.py` with `arm_schedule`,
-`disarm_schedule`, `reset_schedule_after_comment_and_run`,
+`orchestration/scheduling.py` with `arm_ticker`,
+`disarm_ticker`, `reset_ticker_after_comment_and_run`,
 `dispatch_continuation_run`, `maybe_apply_deferred_pause`. Wire
-`arm_schedule` into the state-transition handler (called after the
-existing immediate dispatch). Wire `disarm_schedule` into the same
+`arm_ticker` into the state-transition handler (called after the
+existing immediate dispatch). Wire `disarm_ticker` into the same
 handler for Started → non-Started transitions. Tests for each.
 Comment auto-trigger and terminate sweep are still live; they just
 now coexist with the new schedule rows.
 
 **PR C — scanner + auto-trigger removal.**
-`bgtasks/agent_schedule.py` with `scan_due_schedules` and
+`bgtasks/agent_ticker.py` with `scan_due_tickers` and
 `fire_tick`. Beat schedule config. **Remove**:
 
 - `orchestration/signals.py:fire_comment_continuation` (the
@@ -919,7 +919,7 @@ A concrete trace. Cadence 3h, cap 24, no jitter shown for clarity.
 ```
 T=0     issue A → In Progress
         immediate dispatch: AgentRun A1 created, fired
-        IssueAgentSchedule(A): tick_count=0, next_run_at=T+3h
+        IssueAgentTicker(A): tick_count=0, next_run_at=T+3h
 T+15m   user adds plain comment. Schedule untouched. Agent unaware.
 T+30m   A1 emits paused (question), goes PAUSED_AWAITING_INPUT
         is_active(A) = false (PAUSED is not active)

--- a/.ai_design/issue_ticking_system/tasks.md
+++ b/.ai_design/issue_ticking_system/tasks.md
@@ -16,13 +16,13 @@ Goal:
 
 Scope:
 
-- add `IssueAgentSchedule` model in `apps/api/pi_dash/db/models/issue_agent_schedule.py` (fields per design §7.1)
+- add `IssueAgentTicker` model in `apps/api/pi_dash/db/models/issue_agent_ticker.py` (fields per design §7.1)
 - add three fields to `Project`: `agent_default_interval_seconds`, `agent_default_max_ticks`, `agent_ticking_enabled`
-- migration M1: `CreateModel(IssueAgentSchedule)` + `AddField × 3` on `Project`, plus the `(enabled, next_run_at)` index
+- migration M1: `CreateModel(IssueAgentTicker)` + `AddField × 3` on `Project`, plus the `(enabled, next_run_at)` index
 - update `apps/api/pi_dash/seeds/data/states.json` to include a `Paused` entry in the `backlog` group
 - migration M2: `RunPython` data migration backfilling a `Paused` state in every existing project that lacks one (idempotent)
-- migration M3: `RunPython` data migration backfilling `IssueAgentSchedule` rows for every issue currently in the literal "In Progress" state, with `next_run_at = NOW() + project_default_interval + jitter`
-- register `IssueAgentSchedule` in Django admin (read-only is fine; primarily for ops)
+- migration M3: `RunPython` data migration backfilling `IssueAgentTicker` rows for every issue currently in the literal "In Progress" state, with `next_run_at = NOW() + project_default_interval + jitter`
+- register `IssueAgentTicker` in Django admin (read-only is fine; primarily for ops)
 
 Why first:
 
@@ -38,15 +38,15 @@ Goal:
 Scope:
 
 - create `apps/api/pi_dash/orchestration/scheduling.py` with:
-  - `arm_schedule(issue, *, dispatch_immediate=True)`
-  - `disarm_schedule(issue)`
-  - `reset_schedule_after_comment_and_run(issue)`
+  - `arm_ticker(issue, *, dispatch_immediate=True)`
+  - `disarm_ticker(issue)`
+  - `reset_ticker_after_comment_and_run(issue)`
   - `dispatch_continuation_run(issue, *, triggered_by)`
   - `maybe_apply_deferred_pause(run)`
-- add `effective_interval()` and `effective_max_ticks()` model methods on `IssueAgentSchedule`
+- add `effective_interval()` and `effective_max_ticks()` model methods on `IssueAgentTicker`
 - add `jitter(interval_seconds)` helper
-- wire `arm_schedule` into `handle_issue_state_transition` after the existing immediate-dispatch path
-- wire `disarm_schedule` into the same handler for transitions out of Started
+- wire `arm_ticker` into `handle_issue_state_transition` after the existing immediate-dispatch path
+- wire `disarm_ticker` into the same handler for transitions out of Started
 - tests per design §12.3
 
 Why second:
@@ -62,16 +62,16 @@ Goal:
 
 Scope:
 
-- create `apps/api/pi_dash/bgtasks/agent_schedule.py` with:
-  - `scan_due_schedules` (Celery beat target; fans out `fire_tick` per due row)
+- create `apps/api/pi_dash/bgtasks/agent_ticker.py` with:
+  - `scan_due_tickers` (Celery beat target; fans out `fire_tick` per due row)
   - `fire_tick(sched_id)` (atomic claim + dispatch per design §6.1, including the literal "In Progress" name check)
-- add `CELERY_BEAT_SCHEDULE` entry: `scan-due-agent-schedules` runs `crontab(minute="*")`
+- add `CELERY_BEAT_SCHEDULE` entry: `scan-due-agent-tickers` runs `crontab(minute="*")`
 - verify Beat is deployed as a singleton (check `docker-compose-local.yml` and beat entrypoint)
 - remove `orchestration/signals.py:fire_comment_continuation` (the `post_save(IssueComment)` receiver)
 - remove `orchestration/service.py:maybe_continue_after_terminate`
 - replace the `transaction.on_commit(...)` calls to `maybe_continue_after_terminate` at `runner/consumers.py:550` (`_handle_run_paused`) and `:610` (`_finalize_run`) with calls to `maybe_apply_deferred_pause(run)`
 - delete or convert tests per design §12.3
-- add new test modules: `tests/unit/orchestration/test_scheduling.py`, `tests/unit/bgtasks/test_agent_schedule.py`
+- add new test modules: `tests/unit/orchestration/test_scheduling.py`, `tests/unit/bgtasks/test_agent_ticker.py`
 
 Why third:
 
@@ -93,7 +93,7 @@ Scope:
 - "no cap" label + running tick count when `max_ticks = -1`
 - project create / edit page: new "AI agent ticking" section with three controls (enabled, default cadence, max ticks)
 - issue settings: per-issue overrides for the same three fields (cadence, max ticks, "disable ticking for this issue")
-- server: route `POST /api/runners/runs/` through `dispatch_continuation_run(issue, triggered_by="comment_and_run")` + `reset_schedule_after_comment_and_run(issue)` in one transaction
+- server: route `POST /api/runners/runs/` through `dispatch_continuation_run(issue, triggered_by="comment_and_run")` + `reset_ticker_after_comment_and_run(issue)` in one transaction
 - server: when the state-transition view is invoked as part of a Comment & Run flow on a Paused issue, arm with `dispatch_immediate=False` so Comment & Run owns the single dispatch
 
 Why fourth:
@@ -123,35 +123,35 @@ Why optional:
 
 ### Schema + migrations
 
-- [ ] `apps/api/pi_dash/db/models/issue_agent_schedule.py` (new file): model class with fields per design §7.1
+- [ ] `apps/api/pi_dash/db/models/issue_agent_ticker.py` (new file): model class with fields per design §7.1
 - [ ] `apps/api/pi_dash/db/models/__init__.py`: export the new model
-- [ ] M1 migration: `CreateModel(IssueAgentSchedule)` + `AddField × 3` on `Project` + `Index(fields=['enabled', 'next_run_at'])`
+- [ ] M1 migration: `CreateModel(IssueAgentTicker)` + `AddField × 3` on `Project` + `Index(fields=['enabled', 'next_run_at'])`
 - [ ] Update `apps/api/pi_dash/seeds/data/states.json`: add `Paused` entry, `"group": "backlog"`, distinct color and sequence
 - [ ] M2 migration: `RunPython` backfilling `Paused` state for every existing project that lacks one. Idempotent — skip projects that already have it.
-- [ ] M3 migration: `RunPython` backfilling `IssueAgentSchedule` rows for issues currently in literal "In Progress" state. `next_run_at = NOW() + project_default_interval + jitter`, `tick_count = 0`, `enabled = NOT user_disabled`.
+- [ ] M3 migration: `RunPython` backfilling `IssueAgentTicker` rows for issues currently in literal "In Progress" state. `next_run_at = NOW() + project_default_interval + jitter`, `tick_count = 0`, `enabled = NOT user_disabled`.
 - [ ] Verify all three migrations are reversible (M1 drops the model + fields; M2/M3 delete the inserted rows)
 
 ### Orchestration scheduling primitives — `orchestration/scheduling.py`
 
-- [ ] `arm_schedule(issue, *, dispatch_immediate=True)` — idempotent; honors `user_disabled` and project `agent_ticking_enabled`; sets `enabled = false` when either suppresses ticks
-- [ ] `disarm_schedule(issue)` — idempotent; sets `enabled = false`
-- [ ] `reset_schedule_after_comment_and_run(issue)` — uses `select_for_update` to serialize against `fire_tick`; resets `tick_count = 0` and `next_run_at = NOW() + interval + jitter`
+- [ ] `arm_ticker(issue, *, dispatch_immediate=True)` — idempotent; honors `user_disabled` and project `agent_ticking_enabled`; sets `enabled = false` when either suppresses ticks
+- [ ] `disarm_ticker(issue)` — idempotent; sets `enabled = false`
+- [ ] `reset_ticker_after_comment_and_run(issue)` — uses `select_for_update` to serialize against `fire_tick`; resets `tick_count = 0` and `next_run_at = NOW() + interval + jitter`
 - [ ] `dispatch_continuation_run(issue, *, triggered_by)` — resolves parent (latest prior run), creator (system bot for ticks; comment author for Comment & Run), pod; calls `_create_continuation_run`; returns the created run or `None` when blocked by `_active_run_for`
 - [ ] `maybe_apply_deferred_pause(run)` — implements design §4.4.1: when schedule disarmed AND issue still in Started AND no other active runs, transition issue In Progress → Paused with the `pi_dash_agent` bot as actor
-- [ ] `IssueAgentSchedule.effective_interval()` and `effective_max_ticks()` model methods returning override-or-project-default
+- [ ] `IssueAgentTicker.effective_interval()` and `effective_max_ticks()` model methods returning override-or-project-default
 - [ ] `jitter(interval_seconds)` helper — uniform `random(0, interval × 0.1)`
 
 ### Wiring into existing orchestration
 
-- [ ] `handle_issue_state_transition` (`orchestration/service.py:88`): after the immediate-dispatch path, call `arm_schedule(issue, dispatch_immediate=True)`
-- [ ] `handle_issue_state_transition`: on transitions out of Started, call `disarm_schedule(issue)`
+- [ ] `handle_issue_state_transition` (`orchestration/service.py:88`): after the immediate-dispatch path, call `arm_ticker(issue, dispatch_immediate=True)`
+- [ ] `handle_issue_state_transition`: on transitions out of Started, call `disarm_ticker(issue)`
 - [ ] When the Comment & Run flow drives a Paused → In Progress transition, the view should arm with `dispatch_immediate=False` so Comment & Run owns the single dispatch
 
-### Background tasks — `bgtasks/agent_schedule.py`
+### Background tasks — `bgtasks/agent_ticker.py`
 
-- [ ] `scan_due_schedules` Celery Beat task: query enabled, due, under-cap rows; fan out `fire_tick.delay(sched_id)`
+- [ ] `scan_due_tickers` Celery Beat task: query enabled, due, under-cap rows; fan out `fire_tick.delay(sched_id)`
 - [ ] `fire_tick(sched_id)` Celery worker task: open transaction, `select_for_update` the row, re-check, advance `tick_count` + `next_run_at`, run In Progress name check, dispatch via `dispatch_continuation_run(issue, triggered_by="tick")`
-- [ ] Add `CELERY_BEAT_SCHEDULE` entry running `scan_due_schedules` every minute
+- [ ] Add `CELERY_BEAT_SCHEDULE` entry running `scan_due_tickers` every minute
 - [ ] Verify Beat is deployed as a singleton
 
 ### Removal of auto-trigger
@@ -162,7 +162,7 @@ Why optional:
 
 ### Comment & Run server flow
 
-- [ ] Server handler for `POST /api/runners/runs/` routes through `dispatch_continuation_run(issue, triggered_by="comment_and_run")` + `reset_schedule_after_comment_and_run(issue)` in a single transaction
+- [ ] Server handler for `POST /api/runners/runs/` routes through `dispatch_continuation_run(issue, triggered_by="comment_and_run")` + `reset_ticker_after_comment_and_run(issue)` in a single transaction
 - [ ] State-transition view detects "this transition is part of a Comment & Run on a Paused issue" (header / query flag / explicit endpoint) and arms with `dispatch_immediate=False`
 
 ### UI (apps/web)
@@ -191,23 +191,23 @@ In `apps/api/pi_dash/tests/unit/orchestration/test_service.py`:
 
 ### Delete
 
-- [ ] `test_comment_during_active_run_held_for_terminate_sweep` (line 313) — sweep is removed; replace with a tick-side equivalent in `test_agent_schedule.py`
+- [ ] `test_comment_during_active_run_held_for_terminate_sweep` (line 313) — sweep is removed; replace with a tick-side equivalent in `test_agent_ticker.py`
 - [ ] `test_two_comments_coalesce_into_one_followup` (line 338) — comments no longer create QUEUED follow-ups on their own
 - [ ] `test_terminate_sweep_picks_up_held_comment` (line 378) — sweep removed
 - [ ] Any test asserting on `orchestration_error_count` from the `fire_comment_continuation` signal receiver (the receiver is gone)
 
 ### New — `tests/unit/orchestration/test_scheduling.py`
 
-- [ ] `arm_schedule` honors `user_disabled` and project `agent_ticking_enabled`
-- [ ] `arm_schedule(dispatch_immediate=False)` does not call into run dispatch
-- [ ] `disarm_schedule` is idempotent
-- [ ] `reset_schedule_after_comment_and_run` resets `tick_count` and `next_run_at`; serializes against concurrent `fire_tick`
+- [ ] `arm_ticker` honors `user_disabled` and project `agent_ticking_enabled`
+- [ ] `arm_ticker(dispatch_immediate=False)` does not call into run dispatch
+- [ ] `disarm_ticker` is idempotent
+- [ ] `reset_ticker_after_comment_and_run` resets `tick_count` and `next_run_at`; serializes against concurrent `fire_tick`
 - [ ] `dispatch_continuation_run` resolves parent, creator, pod correctly and returns `None` when blocked by `_active_run_for`
 - [ ] `maybe_apply_deferred_pause` only transitions when (schedule disarmed) AND (no active runs) AND (issue still in Started)
 
-### New — `tests/unit/bgtasks/test_agent_schedule.py`
+### New — `tests/unit/bgtasks/test_agent_ticker.py`
 
-- [ ] `scan_due_schedules` selects only enabled, due, under-cap rows
+- [ ] `scan_due_tickers` selects only enabled, due, under-cap rows
 - [ ] `fire_tick` re-checks under lock and skips when conditions changed
 - [ ] `fire_tick` increments `tick_count` and advances `next_run_at`
 - [ ] `fire_tick` sets `enabled = false` on cap hit but does NOT auto-transition state (deferred pause)

--- a/apps/api/pi_dash/app/serializers/issue.py
+++ b/apps/api/pi_dash/app/serializers/issue.py
@@ -1020,35 +1020,35 @@ class IssueDetailSerializer(IssueSerializer):
     description_html = serializers.CharField()
     is_subscribed = serializers.BooleanField(read_only=True)
     is_intake = serializers.BooleanField(read_only=True)
-    agent_schedule = serializers.SerializerMethodField()
+    agent_ticker = serializers.SerializerMethodField()
 
     class Meta(IssueSerializer.Meta):
         fields = IssueSerializer.Meta.fields + [
             "description_html",
             "is_subscribed",
             "is_intake",
-            "agent_schedule",
+            "agent_ticker",
         ]
         read_only_fields = fields
 
-    def get_agent_schedule(self, obj):
-        """Surface the per-issue ticking schedule for the issue detail UI.
+    def get_agent_ticker(self, obj):
+        """Surface the per-issue continuation ticker for the issue detail UI.
 
-        Returns ``None`` when no schedule row exists yet (the issue has
+        Returns ``None`` when no ticker row exists yet (the issue has
         never been moved to In Progress). See
         ``.ai_design/issue_ticking_system/design.md`` §8.1.
         """
-        sched = getattr(obj, "agent_schedule", None)
-        if sched is None:
+        ticker = getattr(obj, "agent_ticker", None)
+        if ticker is None:
             return None
         return {
-            "enabled": sched.enabled,
-            "user_disabled": sched.user_disabled,
-            "tick_count": sched.tick_count,
-            "max_ticks": sched.effective_max_ticks(),
-            "interval_seconds": sched.effective_interval_seconds(),
-            "next_run_at": sched.next_run_at.isoformat() if sched.next_run_at else None,
-            "last_tick_at": sched.last_tick_at.isoformat() if sched.last_tick_at else None,
+            "enabled": ticker.enabled,
+            "user_disabled": ticker.user_disabled,
+            "tick_count": ticker.tick_count,
+            "max_ticks": ticker.effective_max_ticks(),
+            "interval_seconds": ticker.effective_interval_seconds(),
+            "next_run_at": ticker.next_run_at.isoformat() if ticker.next_run_at else None,
+            "last_tick_at": ticker.last_tick_at.isoformat() if ticker.last_tick_at else None,
         }
 
 

--- a/apps/api/pi_dash/bgtasks/agent_ticker.py
+++ b/apps/api/pi_dash/bgtasks/agent_ticker.py
@@ -2,12 +2,16 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # See the LICENSE file for details.
 
-"""Periodic agent ticking — scanner and per-schedule worker tasks.
+"""Per-issue agent ticking — scanner and per-ticker worker tasks.
 
-The scanner (``scan_due_schedules``) runs once a minute under Celery Beat
-and fans out one ``fire_tick`` task per due schedule row. ``fire_tick``
+The scanner (``scan_due_tickers``) runs once a minute under Celery Beat
+and fans out one ``fire_tick`` task per due ticker row. ``fire_tick``
 performs the atomic claim under ``select_for_update`` and dispatches the
 continuation run.
+
+Distinct from ``pi_dash.bgtasks.scheduler`` which fires user-authored
+project-level schedulers — this module is the per-issue continuation
+clock and is system-armed on state transitions, not user-installed.
 
 See ``.ai_design/issue_ticking_system/design.md`` §6 for the design and
 §11 (item 11) for the atomic-claim invariant.
@@ -27,17 +31,17 @@ from django.db.models import F, Q
 from django.db.models.functions import Coalesce
 from django.utils import timezone
 
-from pi_dash.db.models.issue_agent_schedule import (
+from pi_dash.db.models.issue_agent_ticker import (
     INFINITE_MAX_TICKS,
-    IssueAgentSchedule,
+    IssueAgentTicker,
 )
 
 logger = logging.getLogger("pi_dash.worker")
 
 
-@shared_task(name="pi_dash.bgtasks.agent_schedule.scan_due_schedules")
-def scan_due_schedules() -> int:
-    """Fan out ``fire_tick`` tasks for every due schedule row.
+@shared_task(name="pi_dash.bgtasks.agent_ticker.scan_due_tickers")
+def scan_due_tickers() -> int:
+    """Fan out ``fire_tick`` tasks for every due ticker row.
 
     The actual claim happens inside ``fire_tick`` under ``select_for_update``.
     Returns the number of fan-outs (mostly for logging / tests).
@@ -51,7 +55,7 @@ def scan_due_schedules() -> int:
         F("max_ticks"), F("issue__project__agent_default_max_ticks")
     )
     due_ids = list(
-        IssueAgentSchedule.objects.filter(
+        IssueAgentTicker.objects.filter(
             enabled=True,
             next_run_at__lte=now,
         )
@@ -60,19 +64,19 @@ def scan_due_schedules() -> int:
         .order_by("next_run_at")
         .values_list("id", flat=True)
     )
-    for sched_id in due_ids:
-        fire_tick.delay(str(sched_id))
+    for ticker_id in due_ids:
+        fire_tick.delay(str(ticker_id))
     if due_ids:
-        logger.info("agent_schedule.scan: dispatched %d fire_tick tasks", len(due_ids))
+        logger.info("agent_ticker.scan: dispatched %d fire_tick tasks", len(due_ids))
     return len(due_ids)
 
 
-@shared_task(name="pi_dash.bgtasks.agent_schedule.fire_tick")
-def fire_tick(sched_id: str) -> bool:
-    """Per-schedule worker. Atomically claims and dispatches.
+@shared_task(name="pi_dash.bgtasks.agent_ticker.fire_tick")
+def fire_tick(ticker_id: str) -> bool:
+    """Per-ticker worker. Atomically claims and dispatches.
 
     Returns ``True`` if a continuation run was dispatched, ``False`` if the
-    fire was skipped (race lost, schedule changed, no active In Progress
+    fire was skipped (race lost, ticker changed, no active In Progress
     state, run already in flight, etc.).
     """
     from pi_dash.orchestration.scheduling import (
@@ -82,31 +86,31 @@ def fire_tick(sched_id: str) -> bool:
     )
 
     with transaction.atomic():
-        sched = (
-            IssueAgentSchedule.objects.select_for_update(of=("self",))
+        ticker = (
+            IssueAgentTicker.objects.select_for_update(of=("self",))
             .select_related("issue", "issue__state", "issue__project")
-            .filter(pk=sched_id)
+            .filter(pk=ticker_id)
             .first()
         )
-        if sched is None:
+        if ticker is None:
             return False
 
         # Re-check after acquiring the lock — Comment & Run, another tick
         # firing on the same row, or a disarm could have moved things.
-        if not sched.enabled:
+        if not ticker.enabled:
             return False
         now = timezone.now()
-        if sched.next_run_at is None or sched.next_run_at > now:
+        if ticker.next_run_at is None or ticker.next_run_at > now:
             return False
 
-        cap = sched.effective_max_ticks()
-        if cap != INFINITE_MAX_TICKS and sched.tick_count >= cap:
+        cap = ticker.effective_max_ticks()
+        if cap != INFINITE_MAX_TICKS and ticker.tick_count >= cap:
             # Already at cap — disarm and bail.
-            sched.enabled = False
-            sched.save(update_fields=["enabled", "updated_at"])
+            ticker.enabled = False
+            ticker.save(update_fields=["enabled", "updated_at"])
             return False
 
-        issue = sched.issue
+        issue = ticker.issue
         # Mirror ``_is_delegation_trigger``: only the literally-named
         # "In Progress" state can tick in v1.
         if issue.state is None or issue.state.name != DELEGATION_STATE_NAME:
@@ -121,13 +125,13 @@ def fire_tick(sched_id: str) -> bool:
 
         if orchestration_service._active_run_for(issue) is not None:
             logger.info(
-                "agent_schedule.fire_tick: skip issue=%s reason=active-run-exists",
+                "agent_ticker.fire_tick: skip issue=%s reason=active-run-exists",
                 issue.pk,
             )
             return False
         if orchestration_service._latest_prior_run(issue) is None:
             logger.info(
-                "agent_schedule.fire_tick: skip issue=%s reason=no-prior-run",
+                "agent_ticker.fire_tick: skip issue=%s reason=no-prior-run",
                 issue.pk,
             )
             return False
@@ -137,29 +141,29 @@ def fire_tick(sched_id: str) -> bool:
         # None for a reason the pre-claim skips didn't catch (no-pod,
         # no-creator, race-inserted active run between the pre-check and
         # dispatch's own re-check). Without rollback the tick budget is
-        # silently burned and the schedule may auto-disarm at cap on a
+        # silently burned and the ticker may auto-disarm at cap on a
         # tick that never produced a run.
-        prev_tick_count = sched.tick_count
-        prev_next_run_at = sched.next_run_at
-        prev_enabled = sched.enabled
+        prev_tick_count = ticker.tick_count
+        prev_next_run_at = ticker.next_run_at
+        prev_enabled = ticker.enabled
 
-        sched.tick_count = sched.tick_count + 1
-        sched.last_tick_at = now
-        from pi_dash.db.models.issue_agent_schedule import jitter_seconds
+        ticker.tick_count = ticker.tick_count + 1
+        ticker.last_tick_at = now
+        from pi_dash.db.models.issue_agent_ticker import jitter_seconds
         from datetime import timedelta
 
-        interval = sched.effective_interval_seconds()
-        sched.next_run_at = now + timedelta(seconds=interval + jitter_seconds(interval))
+        interval = ticker.effective_interval_seconds()
+        ticker.next_run_at = now + timedelta(seconds=interval + jitter_seconds(interval))
 
         cap_hit_now = (
-            cap != INFINITE_MAX_TICKS and sched.tick_count >= cap
+            cap != INFINITE_MAX_TICKS and ticker.tick_count >= cap
         )
         if cap_hit_now:
             # Disarm immediately (no more fires); the In Progress → Paused
             # transition is deferred to the run-terminate hook (§4.4.1).
-            sched.enabled = False
+            ticker.enabled = False
 
-        sched.save(
+        ticker.save(
             update_fields=[
                 "tick_count",
                 "last_tick_at",
@@ -169,20 +173,20 @@ def fire_tick(sched_id: str) -> bool:
             ]
         )
 
-    # Dispatch outside the transaction so the schedule write is visible
-    # to other tx-bounded readers and so drain_pod_by_id (which is
-    # scheduled via transaction.on_commit inside _create_continuation_run)
-    # actually fires.
+    # Dispatch outside the transaction so the ticker write is visible to
+    # other tx-bounded readers and so drain_pod_by_id (which is scheduled
+    # via transaction.on_commit inside _create_continuation_run) actually
+    # fires.
     run = dispatch_continuation_run(issue, triggered_by=TRIGGER_TICK)
     if run is None:
-        # Dispatch failed post-claim — restore the schedule so the budget
+        # Dispatch failed post-claim — restore the ticker so the budget
         # isn't wasted and any cap-disarm we just applied is undone.
         # last_tick_at intentionally NOT rolled back: it's an observability
         # field for "we attempted a tick at this time," not a budget input.
         with transaction.atomic():
             rollback = (
-                IssueAgentSchedule.objects.select_for_update()
-                .filter(pk=sched_id)
+                IssueAgentTicker.objects.select_for_update()
+                .filter(pk=ticker_id)
                 .first()
             )
             if rollback is not None:
@@ -198,15 +202,15 @@ def fire_tick(sched_id: str) -> bool:
                     ]
                 )
         logger.info(
-            "agent_schedule.fire_tick: dispatch returned None issue=%s; rolled back claim",
+            "agent_ticker.fire_tick: dispatch returned None issue=%s; rolled back claim",
             issue.pk,
         )
         return False
     logger.info(
-        "agent_schedule.fire_tick: dispatched run=%s issue=%s tick_count=%d cap_hit=%s",
+        "agent_ticker.fire_tick: dispatched run=%s issue=%s tick_count=%d cap_hit=%s",
         run.pk,
         issue.pk,
-        sched.tick_count,
+        ticker.tick_count,
         cap_hit_now,
     )
     return True

--- a/apps/api/pi_dash/bgtasks/agent_ticker.py
+++ b/apps/api/pi_dash/bgtasks/agent_ticker.py
@@ -9,9 +9,8 @@ and fans out one ``fire_tick`` task per due ticker row. ``fire_tick``
 performs the atomic claim under ``select_for_update`` and dispatches the
 continuation run.
 
-Distinct from ``pi_dash.bgtasks.scheduler`` which fires user-authored
-project-level schedulers — this module is the per-issue continuation
-clock and is system-armed on state transitions, not user-installed.
+This module is the per-issue continuation clock and is system-armed on
+state transitions; it is not a user-authored periodic job.
 
 See ``.ai_design/issue_ticking_system/design.md`` §6 for the design and
 §11 (item 11) for the atomic-claim invariant.

--- a/apps/api/pi_dash/bgtasks/apps.py
+++ b/apps/api/pi_dash/bgtasks/apps.py
@@ -13,4 +13,4 @@ class BgtasksConfig(AppConfig):
         from pi_dash.bgtasks import github_signals  # noqa: F401
         # Eagerly import task modules that no other startup code imports,
         # so their @shared_task decorators register with Celery at worker boot.
-        from pi_dash.bgtasks import agent_schedule  # noqa: F401
+        from pi_dash.bgtasks import agent_ticker  # noqa: F401

--- a/apps/api/pi_dash/celery.py
+++ b/apps/api/pi_dash/celery.py
@@ -87,8 +87,8 @@ app.conf.beat_schedule = {
         "schedule": crontab(minute="*/1"),
     },
     # Issue ticking — see .ai_design/issue_ticking_system/design.md §6
-    "scan-due-agent-schedules": {
-        "task": "pi_dash.bgtasks.agent_schedule.scan_due_schedules",
+    "scan-due-agent-tickers": {
+        "task": "pi_dash.bgtasks.agent_ticker.scan_due_tickers",
         "schedule": crontab(minute="*"),
     },
     # GitHub Issue Sync — see .ai_design/github_sync/design.md §6.3.

--- a/apps/api/pi_dash/db/migrations/0131_rename_issue_agent_schedule_to_ticker.py
+++ b/apps/api/pi_dash/db/migrations/0131_rename_issue_agent_schedule_to_ticker.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Rename ``IssueAgentSchedule`` to ``IssueAgentTicker``.
+
+Frees the word "scheduler" exclusively for the new project-level
+:class:`Scheduler` / :class:`SchedulerBinding` concept (added in
+``0131_project_scheduler_mvp``). The per-issue continuation clock is
+re-cast as a "ticker" — its existing fields already use that vocabulary
+(``tick_count``, ``last_tick_at``, ``fire_tick``).
+
+Operations:
+  - Rename the model (state-graph + auto-renamed FK reverse accessor).
+  - Rename the underlying ``db_table`` from ``issue_agent_schedule`` to
+    ``issue_agent_ticker``.
+  - Rename the ``related_name`` on ``Issue`` from ``agent_schedule`` to
+    ``agent_ticker``.
+  - Rename the supporting index for clarity.
+
+Pure rename: no column changes, no data migration, no row count change.
+"""
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("db", "0130_merge_agent_schedule_and_github_sync"),
+    ]
+
+    operations = [
+        migrations.RenameModel(
+            old_name="IssueAgentSchedule",
+            new_name="IssueAgentTicker",
+        ),
+        migrations.AlterModelTable(
+            name="issueagentticker",
+            table="issue_agent_ticker",
+        ),
+        migrations.AlterField(
+            model_name="issueagentticker",
+            name="issue",
+            field=models.OneToOneField(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="agent_ticker",
+                to="db.issue",
+            ),
+        ),
+        migrations.RemoveIndex(
+            model_name="issueagentticker",
+            name="iasched_enabled_next_run_idx",
+        ),
+        migrations.AddIndex(
+            model_name="issueagentticker",
+            index=models.Index(
+                fields=["enabled", "next_run_at"],
+                name="iaticker_enabled_next_run_idx",
+            ),
+        ),
+    ]

--- a/apps/api/pi_dash/db/migrations/0131_rename_issue_agent_schedule_to_ticker.py
+++ b/apps/api/pi_dash/db/migrations/0131_rename_issue_agent_schedule_to_ticker.py
@@ -4,10 +4,9 @@
 
 """Rename ``IssueAgentSchedule`` to ``IssueAgentTicker``.
 
-Frees the word "scheduler" exclusively for the new project-level
-:class:`Scheduler` / :class:`SchedulerBinding` concept (added in
-``0131_project_scheduler_mvp``). The per-issue continuation clock is
-re-cast as a "ticker" — its existing fields already use that vocabulary
+Frees the word "scheduler" for a future user-authored project-level
+scheduling concept. The per-issue continuation clock is re-cast as a
+"ticker" — its existing fields already use that vocabulary
 (``tick_count``, ``last_tick_at``, ``fire_tick``).
 
 Operations:

--- a/apps/api/pi_dash/db/models/__init__.py
+++ b/apps/api/pi_dash/db/models/__init__.py
@@ -91,4 +91,4 @@ from .sticky import Sticky
 
 from .description import Description, DescriptionVersion
 
-from .issue_agent_schedule import IssueAgentSchedule
+from .issue_agent_ticker import IssueAgentTicker

--- a/apps/api/pi_dash/db/models/issue_agent_ticker.py
+++ b/apps/api/pi_dash/db/models/issue_agent_ticker.py
@@ -5,10 +5,10 @@
 """Per-issue agent ticker.
 
 The continuation clock that re-invokes the agent on a single in-progress
-issue. Distinct from ``Scheduler`` / ``SchedulerBinding`` (project-level
-periodic jobs); this is internal lifecycle machinery, not a user-authored
-periodic task. Renamed from ``IssueAgentSchedule`` to free the word
-"scheduler" for the project-level concept.
+issue. Internal lifecycle machinery, system-armed on Issue state
+transitions; it is not a user-authored periodic task. Renamed from
+``IssueAgentSchedule`` to free the word "scheduler" for a future
+user-authored project-level scheduling concept.
 
 See ``.ai_design/issue_ticking_system/design.md`` §7.1.
 """

--- a/apps/api/pi_dash/db/models/issue_agent_ticker.py
+++ b/apps/api/pi_dash/db/models/issue_agent_ticker.py
@@ -2,7 +2,13 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # See the LICENSE file for details.
 
-"""Per-issue agent ticking schedule.
+"""Per-issue agent ticker.
+
+The continuation clock that re-invokes the agent on a single in-progress
+issue. Distinct from ``Scheduler`` / ``SchedulerBinding`` (project-level
+periodic jobs); this is internal lifecycle machinery, not a user-authored
+periodic task. Renamed from ``IssueAgentSchedule`` to free the word
+"scheduler" for the project-level concept.
 
 See ``.ai_design/issue_ticking_system/design.md`` §7.1.
 """
@@ -26,7 +32,7 @@ JITTER_FRACTION = 0.1
 def jitter_seconds(interval_seconds: int) -> float:
     """Uniform random offset in ``[0, interval × JITTER_FRACTION)``.
 
-    Spreads out scheduled fires so that bulk transitions (e.g. sprint planning
+    Spreads out tick fires so that bulk transitions (e.g. sprint planning
     moving 50 issues to In Progress at once) do not re-cluster every cycle.
     """
     if interval_seconds <= 0:
@@ -34,7 +40,7 @@ def jitter_seconds(interval_seconds: int) -> float:
     return random.uniform(0, interval_seconds * JITTER_FRACTION)
 
 
-class IssueAgentSchedule(BaseModel):
+class IssueAgentTicker(BaseModel):
     """The clock that drives periodic agent re-invocation for one issue.
 
     Exactly one row per issue (``issue`` is unique). Arming, disarming, and
@@ -45,7 +51,7 @@ class IssueAgentSchedule(BaseModel):
     issue = models.OneToOneField(
         Issue,
         on_delete=models.CASCADE,
-        related_name="agent_schedule",
+        related_name="agent_ticker",
     )
 
     # User-configured overrides. ``null`` means "inherit from project".
@@ -60,18 +66,18 @@ class IssueAgentSchedule(BaseModel):
     enabled = models.BooleanField(default=True)
 
     class Meta:
-        db_table = "issue_agent_schedule"
-        verbose_name = "Issue Agent Schedule"
-        verbose_name_plural = "Issue Agent Schedules"
+        db_table = "issue_agent_ticker"
+        verbose_name = "Issue Agent Ticker"
+        verbose_name_plural = "Issue Agent Tickers"
         indexes = [
             models.Index(
                 fields=["enabled", "next_run_at"],
-                name="iasched_enabled_next_run_idx",
+                name="iaticker_enabled_next_run_idx",
             ),
         ]
 
     def __str__(self) -> str:
-        return f"IssueAgentSchedule(issue={self.issue_id}, enabled={self.enabled})"
+        return f"IssueAgentTicker(issue={self.issue_id}, enabled={self.enabled})"
 
     # ------------------------------------------------------------------
     # Effective values (override-or-project-default)
@@ -92,7 +98,7 @@ class IssueAgentSchedule(BaseModel):
         return getattr(project, "agent_default_max_ticks", DEFAULT_MAX_TICKS)
 
     def cap_reached(self) -> bool:
-        """Has this schedule already exhausted its tick budget?"""
+        """Has this ticker already exhausted its tick budget?"""
         cap = self.effective_max_ticks()
         if cap == INFINITE_MAX_TICKS:
             return False

--- a/apps/api/pi_dash/orchestration/scheduling.py
+++ b/apps/api/pi_dash/orchestration/scheduling.py
@@ -2,11 +2,15 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # See the LICENSE file for details.
 
-"""Periodic agent ticking — scheduling primitives.
+"""Periodic agent ticking — primitives for the per-issue ticker clock.
 
-This module owns the per-issue ``IssueAgentSchedule`` row: when to arm it,
+This module owns the per-issue ``IssueAgentTicker`` row: when to arm it,
 when to disarm it, when to reset it, how to dispatch a continuation run on
 a tick, and how to apply the deferred cap-hit pause.
+
+Distinct from ``pi_dash.db.models.Scheduler`` (project-level user-authored
+periodic jobs); this is internal continuation-cadence machinery, system-
+armed on Issue state transitions.
 
 See ``.ai_design/issue_ticking_system/design.md`` for the full design;
 quick links:
@@ -28,11 +32,11 @@ from django.db import transaction
 from django.utils import timezone
 
 from pi_dash.db.models.issue import Issue
-from pi_dash.db.models.issue_agent_schedule import (
+from pi_dash.db.models.issue_agent_ticker import (
     DEFAULT_INTERVAL_SECONDS,
     DEFAULT_MAX_TICKS,
     INFINITE_MAX_TICKS,
-    IssueAgentSchedule,
+    IssueAgentTicker,
     jitter_seconds,
 )
 from pi_dash.db.models.state import StateGroup
@@ -70,12 +74,12 @@ def _compute_next_run_at(interval_seconds: int, *, base=None):
     return base + timedelta(seconds=interval_seconds + jitter_seconds(interval_seconds))
 
 
-def arm_schedule(
+def arm_ticker(
     issue: Issue,
     *,
     dispatch_immediate: bool = True,  # noqa: ARG001 — caller-only signal
-) -> IssueAgentSchedule:
-    """Create or reset the schedule for an issue entering Started/In Progress.
+) -> IssueAgentTicker:
+    """Create or reset the ticker for an issue entering Started/In Progress.
 
     ``dispatch_immediate`` does not affect the schedule itself — arming
     *never* fires a run. The flag exists only to document the caller's
@@ -91,7 +95,7 @@ def arm_schedule(
 
     with transaction.atomic():
         sched = (
-            IssueAgentSchedule.objects.select_for_update()
+            IssueAgentTicker.objects.select_for_update()
             .filter(issue=issue)
             .first()
         )
@@ -99,7 +103,7 @@ def arm_schedule(
             # Brand-new row — single INSERT with the right values. No
             # follow-up UPDATE needed.
             interval = _project_default_interval(issue)
-            sched = IssueAgentSchedule.objects.create(
+            sched = IssueAgentTicker.objects.create(
                 issue=issue,
                 interval_seconds=None,
                 max_ticks=None,
@@ -126,7 +130,7 @@ def arm_schedule(
             )
 
     logger.info(
-        "agent_schedule: armed issue=%s enabled=%s next_run_at=%s",
+        "agent_ticker: armed issue=%s enabled=%s next_run_at=%s",
         issue.pk,
         sched.enabled,
         sched.next_run_at,
@@ -134,7 +138,7 @@ def arm_schedule(
     return sched
 
 
-def disarm_schedule(issue: Issue) -> Optional[IssueAgentSchedule]:
+def disarm_ticker(issue: Issue) -> Optional[IssueAgentTicker]:
     """Set ``enabled = False``. Idempotent.
 
     Called when issue leaves Started, on cap hit, on terminal done-signal,
@@ -143,7 +147,7 @@ def disarm_schedule(issue: Issue) -> Optional[IssueAgentSchedule]:
     """
     with transaction.atomic():
         sched = (
-            IssueAgentSchedule.objects.select_for_update()
+            IssueAgentTicker.objects.select_for_update()
             .filter(issue=issue)
             .first()
         )
@@ -152,11 +156,11 @@ def disarm_schedule(issue: Issue) -> Optional[IssueAgentSchedule]:
         if sched.enabled:
             sched.enabled = False
             sched.save(update_fields=["enabled", "updated_at"])
-    logger.info("agent_schedule: disarmed issue=%s", issue.pk)
+    logger.info("agent_ticker: disarmed issue=%s", issue.pk)
     return sched
 
 
-def reset_schedule_after_comment_and_run(issue: Issue) -> Optional[IssueAgentSchedule]:
+def reset_ticker_after_comment_and_run(issue: Issue) -> Optional[IssueAgentTicker]:
     """Reset ``tick_count = 0`` and ``next_run_at = NOW() + interval + jitter``.
 
     Called by the Comment & Run handler after the run is dispatched
@@ -165,7 +169,7 @@ def reset_schedule_after_comment_and_run(issue: Issue) -> Optional[IssueAgentSch
     """
     with transaction.atomic():
         sched = (
-            IssueAgentSchedule.objects.select_for_update()
+            IssueAgentTicker.objects.select_for_update()
             .filter(issue=issue)
             .first()
         )
@@ -186,7 +190,7 @@ def reset_schedule_after_comment_and_run(issue: Issue) -> Optional[IssueAgentSch
             ]
         )
     logger.info(
-        "agent_schedule: reset issue=%s next_run_at=%s",
+        "agent_ticker: reset issue=%s next_run_at=%s",
         issue.pk,
         sched.next_run_at,
     )
@@ -246,7 +250,7 @@ def dispatch_continuation_run(
 
     if orchestration_service._active_run_for(issue) is not None:
         logger.info(
-            "agent_schedule: skip dispatch issue=%s reason=active-run-exists triggered_by=%s",
+            "agent_ticker: skip dispatch issue=%s reason=active-run-exists triggered_by=%s",
             issue.pk,
             triggered_by,
         )
@@ -255,7 +259,7 @@ def dispatch_continuation_run(
     parent = orchestration_service._latest_prior_run(issue)
     if parent is None:
         logger.info(
-            "agent_schedule: skip dispatch issue=%s reason=no-prior-run triggered_by=%s",
+            "agent_ticker: skip dispatch issue=%s reason=no-prior-run triggered_by=%s",
             issue.pk,
             triggered_by,
         )
@@ -266,7 +270,7 @@ def dispatch_continuation_run(
     )
     if creator is None:
         logger.warning(
-            "agent_schedule: skip dispatch issue=%s reason=no-creator triggered_by=%s",
+            "agent_ticker: skip dispatch issue=%s reason=no-creator triggered_by=%s",
             issue.pk,
             triggered_by,
         )
@@ -275,7 +279,7 @@ def dispatch_continuation_run(
     pod = _resolve_pod_for_issue(issue)
     if pod is None:
         logger.warning(
-            "agent_schedule: skip dispatch issue=%s reason=no-pod triggered_by=%s",
+            "agent_ticker: skip dispatch issue=%s reason=no-pod triggered_by=%s",
             issue.pk,
             triggered_by,
         )
@@ -310,7 +314,7 @@ def maybe_apply_deferred_pause(run: AgentRun) -> bool:
         return False
 
     issue = run.work_item
-    sched = IssueAgentSchedule.objects.filter(issue=issue).first()
+    sched = IssueAgentTicker.objects.filter(issue=issue).first()
     if sched is None or sched.enabled:
         return False
 
@@ -340,7 +344,7 @@ def maybe_apply_deferred_pause(run: AgentRun) -> bool:
     )
     if paused_state is None:
         logger.warning(
-            "agent_schedule: cannot auto-pause issue=%s — no Paused state in project",
+            "agent_ticker: cannot auto-pause issue=%s — no Paused state in project",
             issue.pk,
         )
         return False
@@ -351,11 +355,11 @@ def maybe_apply_deferred_pause(run: AgentRun) -> bool:
     with transaction.atomic():
         # Re-fetch the schedule under a row lock so the disarmed-check we
         # made above stays valid for the rest of this transaction. Without
-        # this, a concurrent ``arm_schedule`` (e.g. user manually re-starts
+        # this, a concurrent ``arm_ticker`` (e.g. user manually re-starts
         # the issue between the unlocked read on line ~314 and here) can
         # re-enable the schedule while we auto-pause its issue.
         locked_sched = (
-            IssueAgentSchedule.objects.select_for_update()
+            IssueAgentTicker.objects.select_for_update()
             .filter(pk=sched.pk)
             .first()
         )
@@ -377,7 +381,7 @@ def maybe_apply_deferred_pause(run: AgentRun) -> bool:
         locked.save(update_fields=["state", "updated_at"])
 
     logger.info(
-        "agent_schedule: auto-paused issue=%s after cap hit",
+        "agent_ticker: auto-paused issue=%s after cap hit",
         issue.pk,
     )
     return True
@@ -390,9 +394,9 @@ __all__ = [
     "PAUSED_STATE_NAME",
     "TRIGGER_COMMENT_AND_RUN",
     "TRIGGER_TICK",
-    "arm_schedule",
-    "disarm_schedule",
+    "arm_ticker",
+    "disarm_ticker",
     "dispatch_continuation_run",
     "maybe_apply_deferred_pause",
-    "reset_schedule_after_comment_and_run",
+    "reset_ticker_after_comment_and_run",
 ]

--- a/apps/api/pi_dash/orchestration/scheduling.py
+++ b/apps/api/pi_dash/orchestration/scheduling.py
@@ -8,9 +8,8 @@ This module owns the per-issue ``IssueAgentTicker`` row: when to arm it,
 when to disarm it, when to reset it, how to dispatch a continuation run on
 a tick, and how to apply the deferred cap-hit pause.
 
-Distinct from ``pi_dash.db.models.Scheduler`` (project-level user-authored
-periodic jobs); this is internal continuation-cadence machinery, system-
-armed on Issue state transitions.
+This is internal continuation-cadence machinery, system-armed on Issue
+state transitions; it is not a user-authored periodic-job system.
 
 See ``.ai_design/issue_ticking_system/design.md`` for the full design;
 quick links:

--- a/apps/api/pi_dash/orchestration/service.py
+++ b/apps/api/pi_dash/orchestration/service.py
@@ -99,14 +99,14 @@ def handle_issue_state_transition(
     transition matches the MVP trigger rule (``Todo -> In Progress``) and the
     single-active-run guardrail allows it.
 
-    Also arms/disarms the per-issue ticking schedule:
+    Also arms/disarms the per-issue ticker:
 
-    - Entering the literal "In Progress" state arms the schedule (or
+    - Entering the literal "In Progress" state arms the ticker (or
       re-arms it on Paused → In Progress).
-    - Leaving the Started group disarms the schedule.
+    - Leaving the Started group disarms the ticker.
 
     ``dispatch_immediate=False`` lets a caller (e.g., the Comment & Run
-    flow re-opening a Paused issue) arm the schedule without firing the
+    flow re-opening a Paused issue) arm the ticker without firing the
     state-transition's own immediate dispatch — the caller will dispatch
     its own run.
     """
@@ -120,15 +120,15 @@ def handle_issue_state_transition(
         from_group == StateGroup.STARTED.value
         and to_group != StateGroup.STARTED.value
     ):
-        scheduling.disarm_schedule(issue)
+        scheduling.disarm_ticker(issue)
 
     if not _is_delegation_trigger(to_state):
         return TransitionOutcome(reason="not-a-trigger-state")
 
     # Arming is independent of whether the immediate dispatch is fired by
-    # this handler or by the caller — the schedule is the steady-state
-    # tick source either way.
-    scheduling.arm_schedule(issue, dispatch_immediate=dispatch_immediate)
+    # this handler or by the caller — the ticker is the steady-state tick
+    # source either way.
+    scheduling.arm_ticker(issue, dispatch_immediate=dispatch_immediate)
 
     if not dispatch_immediate:
         return TransitionOutcome(reason="dispatch-deferred-to-caller")

--- a/apps/api/pi_dash/orchestration/signals.py
+++ b/apps/api/pi_dash/orchestration/signals.py
@@ -10,8 +10,8 @@ compare in post_save. Using signals keeps the trigger out of every writer path
 ``orchestration.service``.
 
 Comments are intentionally inert — there is no ``post_save(IssueComment)``
-receiver here. The agent is woken on a periodic schedule
-(``pi_dash.bgtasks.agent_schedule``) or by the explicit Comment & Run
+receiver here. The agent is woken by the per-issue ticker
+(``pi_dash.bgtasks.agent_ticker``) or by the explicit Comment & Run
 button, which calls into ``orchestration.service.handle_issue_comment``
 directly. See ``.ai_design/issue_ticking_system/design.md`` §9.
 """

--- a/apps/api/pi_dash/runner/views/runs.py
+++ b/apps/api/pi_dash/runner/views/runs.py
@@ -186,7 +186,7 @@ class AgentRunListEndpoint(APIView):
             # invocation, so the cap budget shouldn't be refunded and the
             # next-tick clock shouldn't be pushed out.
             if run is not None:
-                scheduling.reset_schedule_after_comment_and_run(issue)
+                scheduling.reset_ticker_after_comment_and_run(issue)
         if run is None:
             return Response(
                 {

--- a/apps/api/pi_dash/tests/unit/bg_tasks/test_agent_ticker.py
+++ b/apps/api/pi_dash/tests/unit/bg_tasks/test_agent_ticker.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # See the LICENSE file for details.
 
-"""Tests for ``pi_dash.bgtasks.agent_schedule`` (PR C)."""
+"""Tests for ``pi_dash.bgtasks.agent_ticker``."""
 
 from __future__ import annotations
 
@@ -13,7 +13,7 @@ import pytest
 from crum import impersonate
 from django.utils import timezone
 
-from pi_dash.bgtasks.agent_schedule import fire_tick, scan_due_schedules
+from pi_dash.bgtasks.agent_ticker import fire_tick, scan_due_tickers
 from pi_dash.db.models import Issue, Project, State
 from pi_dash.orchestration import scheduling
 from pi_dash.prompting.seed import seed_default_template
@@ -119,7 +119,7 @@ def _make_prior_run(issue, runner):
 
 
 def _make_due_schedule(issue, *, tick_count=0, max_ticks=None):
-    sched = scheduling.arm_schedule(issue)
+    sched = scheduling.arm_ticker(issue)
     sched.next_run_at = timezone.now() - timedelta(seconds=1)
     sched.tick_count = tick_count
     if max_ticks is not None:
@@ -131,7 +131,7 @@ def _make_due_schedule(issue, *, tick_count=0, max_ticks=None):
 
 
 # ---------------------------------------------------------------------------
-# scan_due_schedules
+# scan_due_tickers
 # ---------------------------------------------------------------------------
 
 
@@ -149,18 +149,18 @@ def test_scan_picks_up_only_due_enabled_under_cap_rows(
         state=issue.state, created_by=issue.created_by,
     )
     _make_due_schedule(issue)
-    not_due = scheduling.arm_schedule(issue2)
+    not_due = scheduling.arm_ticker(issue2)
     not_due.next_run_at = timezone.now() + timedelta(hours=2)
     not_due.save(update_fields=["next_run_at"])
-    disabled = scheduling.arm_schedule(issue3)
+    disabled = scheduling.arm_ticker(issue3)
     disabled.next_run_at = timezone.now() - timedelta(seconds=1)
     disabled.enabled = False
     disabled.save(update_fields=["next_run_at", "enabled"])
 
     with mock.patch(
-        "pi_dash.bgtasks.agent_schedule.fire_tick.delay"
+        "pi_dash.bgtasks.agent_ticker.fire_tick.delay"
     ) as fire:
-        count = scan_due_schedules()
+        count = scan_due_tickers()
     assert count == 1
     assert fire.call_count == 1
 
@@ -195,7 +195,7 @@ def test_fire_tick_skips_when_already_advanced(seeded, issue, runner_for_workspa
     """If another fire advances ``next_run_at`` between scan and worker
     pickup, this fire is a no-op."""
     _make_prior_run(issue, runner_for_workspace)
-    sched = scheduling.arm_schedule(issue)
+    sched = scheduling.arm_ticker(issue)
     # next_run_at already in the future — fire_tick must not advance.
     sched.next_run_at = timezone.now() + timedelta(hours=2)
     sched.save(update_fields=["next_run_at"])

--- a/apps/api/pi_dash/tests/unit/orchestration/test_scheduling.py
+++ b/apps/api/pi_dash/tests/unit/orchestration/test_scheduling.py
@@ -13,7 +13,7 @@ from crum import impersonate
 from django.utils import timezone
 
 from pi_dash.db.models import Issue, Project, State
-from pi_dash.db.models.issue_agent_schedule import IssueAgentSchedule
+from pi_dash.db.models.issue_agent_ticker import IssueAgentTicker
 from pi_dash.orchestration import scheduling
 from pi_dash.prompting.seed import seed_default_template
 from pi_dash.runner.models import AgentRun, AgentRunStatus
@@ -108,14 +108,14 @@ def stub_drain(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# arm_schedule
+# arm_ticker
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
-def test_arm_schedule_creates_row_and_sets_next_run_at(seeded, issue, states):
+def test_arm_ticker_creates_row_and_sets_next_run_at(seeded, issue, states):
     _to_in_progress(issue, states)
-    sched = scheduling.arm_schedule(issue)
+    sched = scheduling.arm_ticker(issue)
     assert sched.tick_count == 0
     assert sched.next_run_at is not None
     assert sched.next_run_at > timezone.now()
@@ -123,82 +123,82 @@ def test_arm_schedule_creates_row_and_sets_next_run_at(seeded, issue, states):
 
 
 @pytest.mark.unit
-def test_arm_schedule_is_idempotent_resets_tick_count(seeded, issue, states):
+def test_arm_ticker_is_idempotent_resets_tick_count(seeded, issue, states):
     _to_in_progress(issue, states)
-    sched = scheduling.arm_schedule(issue)
+    sched = scheduling.arm_ticker(issue)
     sched.tick_count = 5
     sched.save(update_fields=["tick_count"])
-    again = scheduling.arm_schedule(issue)
+    again = scheduling.arm_ticker(issue)
     assert again.tick_count == 0
     assert again.pk == sched.pk  # one row per issue
 
 
 @pytest.mark.unit
-def test_arm_schedule_respects_user_disabled(seeded, issue, states):
+def test_arm_ticker_respects_user_disabled(seeded, issue, states):
     _to_in_progress(issue, states)
-    IssueAgentSchedule.objects.create(issue=issue, user_disabled=True)
-    sched = scheduling.arm_schedule(issue)
+    IssueAgentTicker.objects.create(issue=issue, user_disabled=True)
+    sched = scheduling.arm_ticker(issue)
     assert sched.user_disabled is True
     assert sched.enabled is False
 
 
 @pytest.mark.unit
-def test_arm_schedule_respects_project_disabled(seeded, issue, project, states):
+def test_arm_ticker_respects_project_disabled(seeded, issue, project, states):
     _to_in_progress(issue, states)
     project.agent_ticking_enabled = False
     project.save(update_fields=["agent_ticking_enabled"])
-    sched = scheduling.arm_schedule(issue)
+    sched = scheduling.arm_ticker(issue)
     assert sched.enabled is False
 
 
 @pytest.mark.unit
-def test_arm_schedule_dispatch_immediate_false_does_not_dispatch(
+def test_arm_ticker_dispatch_immediate_false_does_not_dispatch(
     seeded, issue, states, runner_for_workspace
 ):
     """``dispatch_immediate=False`` is a documentation flag — arming itself
     never creates a run regardless of value."""
     _to_in_progress(issue, states)
-    scheduling.arm_schedule(issue, dispatch_immediate=False)
+    scheduling.arm_ticker(issue, dispatch_immediate=False)
     assert AgentRun.objects.filter(work_item=issue).count() == 0
 
 
 # ---------------------------------------------------------------------------
-# disarm_schedule
+# disarm_ticker
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
-def test_disarm_schedule_idempotent(seeded, issue, states):
+def test_disarm_ticker_idempotent(seeded, issue, states):
     _to_in_progress(issue, states)
-    scheduling.arm_schedule(issue)
-    scheduling.disarm_schedule(issue)
-    sched = IssueAgentSchedule.objects.get(issue=issue)
+    scheduling.arm_ticker(issue)
+    scheduling.disarm_ticker(issue)
+    sched = IssueAgentTicker.objects.get(issue=issue)
     assert sched.enabled is False
     # Calling again is a no-op.
-    scheduling.disarm_schedule(issue)
+    scheduling.disarm_ticker(issue)
     sched.refresh_from_db()
     assert sched.enabled is False
 
 
 @pytest.mark.unit
-def test_disarm_schedule_with_no_row_returns_none(seeded, issue):
+def test_disarm_ticker_with_no_row_returns_none(seeded, issue):
     """No state transition has happened, so no schedule row exists yet."""
-    assert IssueAgentSchedule.objects.filter(issue=issue).exists() is False
-    assert scheduling.disarm_schedule(issue) is None
+    assert IssueAgentTicker.objects.filter(issue=issue).exists() is False
+    assert scheduling.disarm_ticker(issue) is None
 
 
 # ---------------------------------------------------------------------------
-# reset_schedule_after_comment_and_run
+# reset_ticker_after_comment_and_run
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
 def test_reset_after_comment_and_run_resets_tick_count(seeded, issue, states):
     _to_in_progress(issue, states)
-    sched = scheduling.arm_schedule(issue)
+    sched = scheduling.arm_ticker(issue)
     sched.tick_count = 17
     sched.save(update_fields=["tick_count"])
-    out = scheduling.reset_schedule_after_comment_and_run(issue)
+    out = scheduling.reset_ticker_after_comment_and_run(issue)
     assert out.tick_count == 0
     assert out.next_run_at > timezone.now()
 
@@ -276,7 +276,7 @@ def test_deferred_pause_skips_when_schedule_still_enabled(
     seeded, issue, states, runner_for_workspace, create_user
 ):
     _to_in_progress(issue, states)
-    scheduling.arm_schedule(issue)
+    scheduling.arm_ticker(issue)
     run = AgentRun.objects.create(
         workspace=issue.workspace,
         created_by=create_user,
@@ -296,7 +296,7 @@ def test_deferred_pause_applies_when_disarmed_and_no_active_runs(
     seeded, issue, states, runner_for_workspace, create_user
 ):
     _to_in_progress(issue, states)
-    sched = scheduling.arm_schedule(issue)
+    sched = scheduling.arm_ticker(issue)
     sched.enabled = False
     sched.save(update_fields=["enabled"])
     run = AgentRun.objects.create(
@@ -318,7 +318,7 @@ def test_deferred_pause_skips_when_other_active_run_exists(
     seeded, issue, states, runner_for_workspace, create_user
 ):
     _to_in_progress(issue, states)
-    sched = scheduling.arm_schedule(issue)
+    sched = scheduling.arm_ticker(issue)
     sched.enabled = False
     sched.save(update_fields=["enabled"])
     AgentRun.objects.create(

--- a/apps/api/pi_dash/tests/unit/orchestration/test_service.py
+++ b/apps/api/pi_dash/tests/unit/orchestration/test_service.py
@@ -206,15 +206,15 @@ def paused_state(project, create_user):
 def test_state_transition_arms_schedule_on_in_progress_entry(
     seeded, issue, states
 ):
-    from pi_dash.db.models.issue_agent_schedule import IssueAgentSchedule
+    from pi_dash.db.models.issue_agent_ticker import IssueAgentTicker
 
-    assert IssueAgentSchedule.objects.filter(issue=issue).exists() is False
+    assert IssueAgentTicker.objects.filter(issue=issue).exists() is False
     service.handle_issue_state_transition(
         issue=issue,
         from_state=states["todo"],
         to_state=states["in_progress"],
     )
-    sched = IssueAgentSchedule.objects.get(issue=issue)
+    sched = IssueAgentTicker.objects.get(issue=issue)
     assert sched.enabled is True
     assert sched.tick_count == 0
     assert sched.next_run_at is not None
@@ -224,7 +224,7 @@ def test_state_transition_arms_schedule_on_in_progress_entry(
 def test_state_transition_disarms_schedule_on_started_exit(
     seeded, issue, states, paused_state
 ):
-    from pi_dash.db.models.issue_agent_schedule import IssueAgentSchedule
+    from pi_dash.db.models.issue_agent_ticker import IssueAgentTicker
 
     # Seed an active schedule by transitioning into In Progress.
     service.handle_issue_state_transition(
@@ -232,7 +232,7 @@ def test_state_transition_disarms_schedule_on_started_exit(
         from_state=states["todo"],
         to_state=states["in_progress"],
     )
-    assert IssueAgentSchedule.objects.get(issue=issue).enabled is True
+    assert IssueAgentTicker.objects.get(issue=issue).enabled is True
 
     # Now leave Started — schedule must disarm.
     service.handle_issue_state_transition(
@@ -240,7 +240,7 @@ def test_state_transition_disarms_schedule_on_started_exit(
         from_state=states["in_progress"],
         to_state=paused_state,
     )
-    assert IssueAgentSchedule.objects.get(issue=issue).enabled is False
+    assert IssueAgentTicker.objects.get(issue=issue).enabled is False
 
 
 @pytest.mark.unit
@@ -249,7 +249,7 @@ def test_state_transition_dispatch_immediate_false_skips_run_creation(
 ):
     """Comment & Run on Paused issue path: caller arms schedule via the
     transition but owns the dispatch separately."""
-    from pi_dash.db.models.issue_agent_schedule import IssueAgentSchedule
+    from pi_dash.db.models.issue_agent_ticker import IssueAgentTicker
 
     outcome = service.handle_issue_state_transition(
         issue=issue,
@@ -261,7 +261,7 @@ def test_state_transition_dispatch_immediate_false_skips_run_creation(
     assert outcome.created_run is None
     assert AgentRun.objects.filter(work_item=issue).count() == 0
     # Schedule still armed — the caller will dispatch its own run.
-    assert IssueAgentSchedule.objects.get(issue=issue).enabled is True
+    assert IssueAgentTicker.objects.get(issue=issue).enabled is True
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/pi_dash/tests/unit/runner/test_runs_views.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_runs_views.py
@@ -419,7 +419,7 @@ def test_release_pin_404_for_run_in_other_workspace(
 #
 # POST /api/runners/runs/ with ``triggered_by="comment_and_run"`` reuses the
 # continuation pipeline (parent resolution, runner pinning, drain) and
-# resets the issue's ``IssueAgentSchedule``. See
+# resets the issue's ``IssueAgentTicker``. See
 # ``.ai_design/issue_ticking_system/design.md`` §4.6.
 # ---------------------------------------------------------------------------
 
@@ -517,10 +517,10 @@ def test_comment_and_run_resets_schedule(db, session_client, workspace):
 
     from django.utils import timezone
 
-    from pi_dash.db.models.issue_agent_schedule import IssueAgentSchedule
+    from pi_dash.db.models.issue_agent_ticker import IssueAgentTicker
 
     issue, _ = _make_in_progress_issue_with_paused_run(workspace)
-    sched = IssueAgentSchedule.objects.get(issue=issue)
+    sched = IssueAgentTicker.objects.get(issue=issue)
     sched.tick_count = 7
     stale = timezone.now() + timedelta(hours=2)
     sched.next_run_at = stale
@@ -635,7 +635,7 @@ def test_skip_immediate_dispatch_header_suppresses_run_creation_on_state_change(
     from crum import impersonate
 
     from pi_dash.db.models import Issue, Project, State
-    from pi_dash.db.models.issue_agent_schedule import IssueAgentSchedule
+    from pi_dash.db.models.issue_agent_ticker import IssueAgentTicker
     from pi_dash.prompting.seed import seed_default_template
 
     seed_default_template()
@@ -667,7 +667,7 @@ def test_skip_immediate_dispatch_header_suppresses_run_creation_on_state_change(
     assert AgentRun.objects.filter(work_item=issue).count() == 0
     # Schedule armed: the steady-state tick source is in place even
     # though dispatch was deferred to the caller.
-    sched = IssueAgentSchedule.objects.get(issue=issue)
+    sched = IssueAgentTicker.objects.get(issue=issue)
     assert sched.enabled is True
 
 


### PR DESCRIPTION
## Summary

Frees the word "scheduler" exclusively for the new project-level `Scheduler` / `SchedulerBinding` feature in #76. The per-issue continuation clock — already using "tick" vocabulary in its fields (`tick_count`, `last_tick_at`, `fire_tick`) — is renamed to **`IssueAgentTicker`** to match.

**Independent of #76.** Either PR can merge first; the other rebases. Recommended order: this one first.

## What renames

| Before | After |
|---|---|
| `IssueAgentSchedule` (class) | `IssueAgentTicker` |
| `db/models/issue_agent_schedule.py` | `issue_agent_ticker.py` |
| `bgtasks/agent_schedule.py` | `bgtasks/agent_ticker.py` |
| DB table `issue_agent_schedule` | `issue_agent_ticker` |
| `Issue.agent_schedule` (related_name) | `Issue.agent_ticker` |
| `arm_schedule` / `disarm_schedule` / `reset_schedule_after_comment_and_run` | `arm_ticker` / `disarm_ticker` / `reset_ticker_after_comment_and_run` |
| Beat task `scan_due_schedules` | `scan_due_tickers` |
| Beat entry `scan-due-agent-schedules` | `scan-due-agent-tickers` |
| Log prefix `agent_schedule:` | `agent_ticker:` |
| `IssueDetailSerializer.agent_schedule` (REST field) | `agent_ticker` |

## Migration

`0131_rename_issue_agent_schedule_to_ticker` is a pure rename: `RenameModel` + `AlterModelTable` + `AlterField` (related_name) + index swap. No data migration, no column changes, no row count change.

## Safety

- Frontend grep for `agent_schedule` returned zero matches in `apps/web/` and `packages/` — the REST field rename is API-safe.
- All call sites updated; only the model file's own historical-rationale docstring and the rename migration retain the old name.
- 4 existing test files updated to use the new symbols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)