### PR TITLE
fix(runner): codex bridge approval/error handling + stall watchdog

### DIFF
--- a/runner/src/codex/bridge.rs
+++ b/runner/src/codex/bridge.rs
@@ -363,12 +363,21 @@ impl BridgeCursor {
                         })
                         .unwrap_or(false);
                     if waiting && let Some(pending) = self.pending_command.clone() {
-                        // Reuse the open approval id when the same flag
-                        // re-fires so we don't open duplicate rows.
-                        let approval_id = self
-                            .pending_command_approval_id
-                            .clone()
-                            .unwrap_or_else(|| Uuid::new_v4().to_string());
+                        // We've already emitted an ApprovalRequest for this
+                        // pending command. Re-emitting here would re-send a
+                        // ClientMsg::ApprovalRequest to the cloud and append
+                        // a fresh "pending" history row — even though the
+                        // ApprovalRouter would self-heal via its HashMap.
+                        // Skip the duplicate; the previous approval is still
+                        // outstanding (or already decided).
+                        if self.pending_command_approval_id.is_some() {
+                            return vec![BridgeEvent::Raw {
+                                run_id: self.run_id,
+                                method,
+                                params,
+                            }];
+                        }
+                        let approval_id = Uuid::new_v4().to_string();
                         self.pending_command_approval_id = Some(approval_id.clone());
                         let reason = Some(format!(
                             "codex requesting approval to run: {}",
@@ -472,6 +481,275 @@ impl BridgeCursor {
                 }
             }
             Incoming::Response { .. } => Vec::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod translate_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn cursor() -> BridgeCursor {
+        BridgeCursor {
+            run_id: Uuid::new_v4(),
+            thread_id: "th_test".into(),
+            seq: 0,
+            pending_command: None,
+            pending_command_approval_id: None,
+        }
+    }
+
+    fn notif(method: &str, params: serde_json::Value) -> Incoming {
+        Incoming::Notification {
+            jsonrpc: Some("2.0".into()),
+            method: method.into(),
+            params,
+        }
+    }
+
+    #[test]
+    fn turn_completed_without_conclusion_fails_run() {
+        // Codex sometimes emits a bare `turn/completed` after a systemError.
+        // The previous default of "success" silently masked those failures.
+        let mut c = cursor();
+        let evs = c.translate(notif("turn/completed", json!({})));
+        assert_eq!(evs.len(), 1);
+        match &evs[0] {
+            BridgeEvent::Failed { detail, .. } => {
+                assert_eq!(
+                    detail.as_deref(),
+                    Some("turn/completed without conclusion")
+                );
+            }
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn turn_completed_with_explicit_success_completes_run() {
+        let mut c = cursor();
+        let evs = c.translate(notif("turn/completed", json!({"conclusion": "success"})));
+        assert!(matches!(evs.as_slice(), [BridgeEvent::Completed { .. }]));
+    }
+
+    #[test]
+    fn turn_completed_with_non_success_conclusion_fails_run() {
+        let mut c = cursor();
+        let evs = c.translate(notif("turn/completed", json!({"conclusion": "aborted"})));
+        match evs.as_slice() {
+            [BridgeEvent::Failed { detail, .. }] => {
+                assert_eq!(
+                    detail.as_deref(),
+                    Some("turn ended with conclusion=\"aborted\"")
+                );
+            }
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn error_notification_with_will_retry_false_fails_run() {
+        let mut c = cursor();
+        let evs = c.translate(notif(
+            "error",
+            json!({
+                "willRetry": false,
+                "error": {"message": "model not allowed"}
+            }),
+        ));
+        match evs.as_slice() {
+            [BridgeEvent::Failed { detail, .. }] => {
+                assert_eq!(detail.as_deref(), Some("model not allowed"));
+            }
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn error_notification_with_will_retry_true_passes_through_as_raw() {
+        let mut c = cursor();
+        let evs = c.translate(notif(
+            "error",
+            json!({
+                "willRetry": true,
+                "error": {"message": "transient"}
+            }),
+        ));
+        assert!(matches!(evs.as_slice(), [BridgeEvent::Raw { .. }]));
+    }
+
+    #[test]
+    fn waiting_on_approval_synthesizes_request_from_pending_command() {
+        let mut c = cursor();
+        // First, codex starts a commandExecution item.
+        let _ = c.translate(notif(
+            "item/started",
+            json!({
+                "item": {
+                    "id": "it_1",
+                    "type": "commandExecution",
+                    "status": "inProgress",
+                    "command": "rm -rf /tmp/x",
+                    "cwd": "/work",
+                }
+            }),
+        ));
+        // Then it parks on `waitingOnApproval` without firing the legacy
+        // requestApproval notification.
+        let evs = c.translate(notif(
+            "thread/status/changed",
+            json!({"status": {"activeFlags": ["waitingOnApproval"]}}),
+        ));
+        match evs.as_slice() {
+            [BridgeEvent::ApprovalRequest {
+                kind,
+                payload,
+                reason,
+                ..
+            }] => {
+                assert!(matches!(kind, ApprovalKind::CommandExecution));
+                assert_eq!(payload.get("command").and_then(|v| v.as_str()), Some("rm -rf /tmp/x"));
+                assert_eq!(payload.get("synthesized").and_then(|v| v.as_bool()), Some(true));
+                assert!(reason.as_deref().unwrap_or("").contains("rm -rf /tmp/x"));
+            }
+            other => panic!("expected ApprovalRequest, got {other:?}"),
+        }
+        assert!(c.pending_command_approval_id.is_some());
+    }
+
+    #[test]
+    fn duplicate_waiting_on_approval_does_not_re_emit() {
+        // Regression: a second `waitingOnApproval` flag for the same pending
+        // command would re-send ClientMsg::ApprovalRequest to the cloud and
+        // append another "pending" history row. Stay quiet (Raw) instead.
+        let mut c = cursor();
+        let _ = c.translate(notif(
+            "item/started",
+            json!({
+                "item": {
+                    "id": "it_1",
+                    "type": "commandExecution",
+                    "status": "inProgress",
+                    "command": "ls",
+                }
+            }),
+        ));
+        let first = c.translate(notif(
+            "thread/status/changed",
+            json!({"status": {"activeFlags": ["waitingOnApproval"]}}),
+        ));
+        assert!(matches!(first.as_slice(), [BridgeEvent::ApprovalRequest { .. }]));
+
+        let second = c.translate(notif(
+            "thread/status/changed",
+            json!({"status": {"activeFlags": ["waitingOnApproval"]}}),
+        ));
+        assert!(
+            matches!(second.as_slice(), [BridgeEvent::Raw { .. }]),
+            "second waitingOnApproval must not re-emit ApprovalRequest, got {second:?}"
+        );
+    }
+
+    #[test]
+    fn waiting_on_approval_without_pending_command_is_raw() {
+        let mut c = cursor();
+        let evs = c.translate(notif(
+            "thread/status/changed",
+            json!({"status": {"activeFlags": ["waitingOnApproval"]}}),
+        ));
+        assert!(matches!(evs.as_slice(), [BridgeEvent::Raw { .. }]));
+    }
+
+    #[test]
+    fn thread_status_without_waiting_flag_is_raw() {
+        let mut c = cursor();
+        let evs = c.translate(notif(
+            "thread/status/changed",
+            json!({"status": {"activeFlags": ["running"]}}),
+        ));
+        assert!(matches!(evs.as_slice(), [BridgeEvent::Raw { .. }]));
+    }
+
+    #[test]
+    fn item_completed_clears_cached_pending_command() {
+        let mut c = cursor();
+        let _ = c.translate(notif(
+            "item/started",
+            json!({
+                "item": {
+                    "id": "it_1",
+                    "type": "commandExecution",
+                    "status": "inProgress",
+                    "command": "ls",
+                }
+            }),
+        ));
+        let _ = c.translate(notif(
+            "thread/status/changed",
+            json!({"status": {"activeFlags": ["waitingOnApproval"]}}),
+        ));
+        assert!(c.pending_command.is_some());
+        assert!(c.pending_command_approval_id.is_some());
+
+        let _ = c.translate(notif(
+            "item/completed",
+            json!({"item": {"id": "it_1", "type": "commandExecution"}}),
+        ));
+        assert!(c.pending_command.is_none());
+        assert!(c.pending_command_approval_id.is_none());
+
+        // A late waitingOnApproval flag must not re-open the cleared command.
+        let evs = c.translate(notif(
+            "thread/status/changed",
+            json!({"status": {"activeFlags": ["waitingOnApproval"]}}),
+        ));
+        assert!(matches!(evs.as_slice(), [BridgeEvent::Raw { .. }]));
+    }
+
+    #[test]
+    fn new_item_started_resets_approval_id_so_next_waiting_mints_fresh_id() {
+        let mut c = cursor();
+        let _ = c.translate(notif(
+            "item/started",
+            json!({
+                "item": {
+                    "id": "it_1",
+                    "type": "commandExecution",
+                    "status": "inProgress",
+                    "command": "ls",
+                }
+            }),
+        ));
+        let _ = c.translate(notif(
+            "thread/status/changed",
+            json!({"status": {"activeFlags": ["waitingOnApproval"]}}),
+        ));
+        let first_id = c.pending_command_approval_id.clone().unwrap();
+
+        // A new commandExecution starts before the previous item completes.
+        let _ = c.translate(notif(
+            "item/started",
+            json!({
+                "item": {
+                    "id": "it_2",
+                    "type": "commandExecution",
+                    "status": "inProgress",
+                    "command": "pwd",
+                }
+            }),
+        ));
+        assert!(c.pending_command_approval_id.is_none());
+
+        let evs = c.translate(notif(
+            "thread/status/changed",
+            json!({"status": {"activeFlags": ["waitingOnApproval"]}}),
+        ));
+        match evs.as_slice() {
+            [BridgeEvent::ApprovalRequest { approval_id, .. }] => {
+                assert_ne!(approval_id, &first_id);
+            }
+            other => panic!("expected fresh ApprovalRequest, got {other:?}"),
         }
     }
 }

--- a/runner/src/codex/bridge.rs
+++ b/runner/src/codex/bridge.rs
@@ -68,6 +68,8 @@ impl Bridge {
             run_id: payload.run_id,
             thread_id,
             seq: 0,
+            pending_command: None,
+            pending_command_approval_id: None,
         })
     }
 
@@ -217,6 +219,26 @@ pub struct BridgeCursor {
     pub run_id: Uuid,
     pub thread_id: String,
     pub seq: u64,
+    /// Most recent in-progress `commandExecution` item observed on
+    /// `item/started`. Captured so we can synthesize an `ApprovalRequest`
+    /// when codex sets `thread/status/changed → activeFlags:
+    /// ["waitingOnApproval"]` (codex 0.125.0 stopped firing the legacy
+    /// `item/commandExecution/requestApproval` notification, leaving the
+    /// in-progress item + the flag as the only signal we get).
+    pending_command: Option<PendingCommand>,
+    /// Approval id last opened for `pending_command`. Stored so a stray
+    /// re-fire of the `waitingOnApproval` flag (e.g. status notifications
+    /// sent more than once for the same item) doesn't open duplicate
+    /// approval rows.
+    pending_command_approval_id: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct PendingCommand {
+    item_id: String,
+    command: String,
+    cwd: Option<String>,
+    raw: serde_json::Value,
 }
 
 impl BridgeCursor {
@@ -260,30 +282,187 @@ impl BridgeCursor {
                             .map(|s| s.to_string()),
                     }]
                 } else if matches!(kind, NotificationKind::TurnCompleted) {
+                    // Treat success only when codex explicitly says so. Any
+                    // other value (including a missing field) means the turn
+                    // ended without a clean signal — the prior default of
+                    // "success" silently masked codex errors that landed
+                    // a `turn/completed` with no conclusion right after a
+                    // systemError, so the runner reported "completed" on
+                    // 400s from OpenAI.
                     let conclusion = params
                         .get("conclusion")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("success");
-                    if conclusion == "failed" {
+                        .and_then(|v| v.as_str());
+                    if conclusion == Some("success") {
+                        vec![BridgeEvent::Completed {
+                            run_id: self.run_id,
+                            done_payload: params.get("done").cloned().unwrap_or_else(|| {
+                                serde_json::json!({
+                                    "conclusion": "success",
+                                    "ended_at": Utc::now().to_rfc3339(),
+                                })
+                            }),
+                        }]
+                    } else {
                         vec![BridgeEvent::Failed {
                             run_id: self.run_id,
                             reason: FailureReason::Internal,
                             detail: params
                                 .get("error")
                                 .and_then(|v| v.as_str())
-                                .map(|s| s.to_string()),
-                        }]
-                    } else {
-                        vec![BridgeEvent::Completed {
-                            run_id: self.run_id,
-                            done_payload: params.get("done").cloned().unwrap_or_else(|| {
-                                serde_json::json!({
-                                    "conclusion": conclusion,
-                                    "ended_at": Utc::now().to_rfc3339(),
+                                .map(|s| s.to_string())
+                                .or_else(|| {
+                                    conclusion.map(|c| format!("turn ended with conclusion={c:?}"))
                                 })
-                            }),
+                                .or_else(|| Some("turn/completed without conclusion".to_string())),
                         }]
                     }
+                } else if method == "error" {
+                    // Codex emits this for transport / API failures (e.g. a
+                    // 400 from OpenAI saying the model isn't allowed). When
+                    // `willRetry` is false it's terminal, so fail the run
+                    // instead of silently logging it as a Raw event and
+                    // waiting for a `turn/completed` that may or may not
+                    // arrive.
+                    let will_retry = params
+                        .get("willRetry")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
+                    if will_retry {
+                        vec![BridgeEvent::Raw {
+                            run_id: self.run_id,
+                            method,
+                            params,
+                        }]
+                    } else {
+                        let detail = params
+                            .get("error")
+                            .and_then(|e| e.get("message"))
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string());
+                        vec![BridgeEvent::Failed {
+                            run_id: self.run_id,
+                            reason: FailureReason::Internal,
+                            detail,
+                        }]
+                    }
+                } else if method == "thread/status/changed" {
+                    // Codex 0.125.0+ signals "I'm parked waiting for the
+                    // user to approve a command" by setting this flag,
+                    // *without* firing the legacy
+                    // `item/commandExecution/requestApproval` notification.
+                    // If we don't translate it into an ApprovalRequest, the
+                    // run deadlocks: codex blocks on stdin reading the
+                    // approval response, the runner blocks on stdout
+                    // reading frames that will never arrive.
+                    let waiting = params
+                        .get("status")
+                        .and_then(|s| s.get("activeFlags"))
+                        .and_then(|f| f.as_array())
+                        .map(|arr| {
+                            arr.iter().any(|v| v.as_str() == Some("waitingOnApproval"))
+                        })
+                        .unwrap_or(false);
+                    if waiting && let Some(pending) = self.pending_command.clone() {
+                        // Reuse the open approval id when the same flag
+                        // re-fires so we don't open duplicate rows.
+                        let approval_id = self
+                            .pending_command_approval_id
+                            .clone()
+                            .unwrap_or_else(|| Uuid::new_v4().to_string());
+                        self.pending_command_approval_id = Some(approval_id.clone());
+                        let reason = Some(format!(
+                            "codex requesting approval to run: {}",
+                            pending.command
+                        ));
+                        // Synthesise a payload that downstream consumers
+                        // (cloud-side ApprovalRequest serializer, TUI
+                        // approval card) can render the same way as a real
+                        // codex-fired approval.
+                        let payload = serde_json::json!({
+                            "command": pending.command,
+                            "cwd": pending.cwd,
+                            "item_id": pending.item_id,
+                            "synthesized": true,
+                            "raw": pending.raw,
+                        });
+                        return vec![BridgeEvent::ApprovalRequest {
+                            run_id: self.run_id,
+                            approval_id,
+                            kind: ApprovalKind::CommandExecution,
+                            payload,
+                            reason,
+                        }];
+                    }
+                    vec![BridgeEvent::Raw {
+                        run_id: self.run_id,
+                        method,
+                        params,
+                    }]
+                } else if method == "item/started" {
+                    // Cache the most recent in-progress commandExecution so
+                    // a later `waitingOnApproval` flag can refer to it.
+                    if let Some(item) = params.get("item")
+                        && item.get("type").and_then(|v| v.as_str())
+                            == Some("commandExecution")
+                        && item.get("status").and_then(|v| v.as_str())
+                            == Some("inProgress")
+                    {
+                        let item_id = item
+                            .get("id")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or_default()
+                            .to_string();
+                        let command = item
+                            .get("command")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or_default()
+                            .to_string();
+                        let cwd = item
+                            .get("cwd")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string());
+                        self.pending_command = Some(PendingCommand {
+                            item_id,
+                            command,
+                            cwd,
+                            raw: item.clone(),
+                        });
+                        // New item-started → previous waitingOnApproval (if any)
+                        // is no longer relevant; allow a fresh approval id next
+                        // time codex reports waiting.
+                        self.pending_command_approval_id = None;
+                    }
+                    vec![BridgeEvent::Raw {
+                        run_id: self.run_id,
+                        method,
+                        params,
+                    }]
+                } else if method == "item/completed" {
+                    // The cached command finished; drop the tracking so a
+                    // late waitingOnApproval doesn't re-open it.
+                    if let Some(item) = params.get("item")
+                        && item.get("type").and_then(|v| v.as_str())
+                            == Some("commandExecution")
+                    {
+                        let same = self
+                            .pending_command
+                            .as_ref()
+                            .and_then(|pc| {
+                                item.get("id")
+                                    .and_then(|v| v.as_str())
+                                    .map(|id| id == pc.item_id)
+                            })
+                            .unwrap_or(false);
+                        if same {
+                            self.pending_command = None;
+                            self.pending_command_approval_id = None;
+                        }
+                    }
+                    vec![BridgeEvent::Raw {
+                        run_id: self.run_id,
+                        method,
+                        params,
+                    }]
                 } else {
                     vec![BridgeEvent::Raw {
                         run_id: self.run_id,

--- a/runner/src/codex/schema.rs
+++ b/runner/src/codex/schema.rs
@@ -66,6 +66,11 @@ pub struct ClientInfo {
 #[serde(rename_all = "camelCase")]
 pub struct ThreadStartParams {
     pub cwd: String,
+    // Omit when None so codex's app-server falls back to its own
+    // `~/.codex/config.toml` model setting. Serializing `"model": null`
+    // makes codex skip its config and apply an internal default
+    // (`gpt-5-codex`), which is unavailable on ChatGPT-account auth.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     pub sandbox_policy: String,
     pub approval_policy: String,
@@ -76,7 +81,9 @@ pub struct ThreadStartParams {
 pub struct TurnStartParams {
     pub thread_id: String,
     pub input: Vec<TurnInputItem>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub effort: Option<String>,
 }
 

--- a/runner/src/config/file.rs
+++ b/runner/src/config/file.rs
@@ -9,7 +9,16 @@ use crate::util::paths::Paths;
 pub fn load_config(paths: &Paths) -> Result<Config> {
     let path = paths.config_path();
     let text = fs::read_to_string(&path).with_context(|| format!("reading config at {path:?}"))?;
-    let cfg: Config = toml::from_str(&text).with_context(|| format!("parsing {path:?}"))?;
+    let mut cfg: Config = toml::from_str(&text).with_context(|| format!("parsing {path:?}"))?;
+    // Migrate the prior hardcoded default. `gpt-5-codex` was written into
+    // every config produced by older runner builds; on ChatGPT-account auth
+    // the codex app-server 400s on it. Treat the literal string as a
+    // poisoned default and let codex's own config pick the model.
+    for runner in &mut cfg.runners {
+        if runner.codex.model_default.as_deref() == Some("gpt-5-codex") {
+            runner.codex.model_default = None;
+        }
+    }
     Ok(cfg)
 }
 
@@ -268,6 +277,73 @@ binary = "codex"
             msg.contains("cloud_url") || msg.contains("daemon"),
             "error should mention the missing field: {msg}",
         );
+    }
+
+    #[test]
+    fn legacy_gpt_5_codex_default_is_migrated_to_none() {
+        // Older runner builds wrote `model_default = "gpt-5-codex"` into
+        // every config. That value 400s on ChatGPT-account auth, so on load
+        // we coerce it to None and let codex pick its own default.
+        let tmp = tempdir().unwrap();
+        let paths = paths_for(tmp.path());
+        std::fs::create_dir_all(&paths.config_dir).unwrap();
+        let body = format!(
+            r#"
+version = 2
+
+[daemon]
+cloud_url = "https://x"
+
+[[runner]]
+name = "t"
+runner_id = "{}"
+
+[runner.workspace]
+working_dir = "/tmp/wd"
+
+[runner.codex]
+binary = "codex"
+model_default = "gpt-5-codex"
+"#,
+            uuid::Uuid::new_v4()
+        );
+        std::fs::write(paths.config_path(), body).unwrap();
+        let loaded = load_config(&paths).unwrap();
+        let primary = loaded.primary_runner().expect("runner");
+        assert_eq!(primary.codex.model_default, None);
+    }
+
+    #[test]
+    fn other_model_defaults_are_preserved() {
+        // Migration must only neutralise the poisoned default; an explicitly
+        // chosen model still passes through.
+        let tmp = tempdir().unwrap();
+        let paths = paths_for(tmp.path());
+        std::fs::create_dir_all(&paths.config_dir).unwrap();
+        let body = format!(
+            r#"
+version = 2
+
+[daemon]
+cloud_url = "https://x"
+
+[[runner]]
+name = "t"
+runner_id = "{}"
+
+[runner.workspace]
+working_dir = "/tmp/wd"
+
+[runner.codex]
+binary = "codex"
+model_default = "o4-mini"
+"#,
+            uuid::Uuid::new_v4()
+        );
+        std::fs::write(paths.config_path(), body).unwrap();
+        let loaded = load_config(&paths).unwrap();
+        let primary = loaded.primary_runner().expect("runner");
+        assert_eq!(primary.codex.model_default.as_deref(), Some("o4-mini"));
     }
 
     #[test]

--- a/runner/src/config/schema.rs
+++ b/runner/src/config/schema.rs
@@ -98,9 +98,11 @@ pub struct CodexSection {
 
 impl Default for CodexSection {
     fn default() -> Self {
-        // model_default stays None — the runner must not pin a model and
-        // let codex pick its own default. Hardcoding one (even a "good"
-        // one) breaks accounts whose tier doesn't carry that model.
+        // Leave model unset: when `model_default` is None we omit the `model`
+        // field from `thread/start` and `turn/start`, so codex picks its own
+        // default. Hardcoding `gpt-5-codex` here forced every fresh runner
+        // onto a model that's unavailable on ChatGPT-account auth — runs
+        // would 400 from the OpenAI side before doing any work.
         Self {
             binary: "codex".to_string(),
             model_default: None,

--- a/runner/src/daemon/supervisor.rs
+++ b/runner/src/daemon/supervisor.rs
@@ -938,10 +938,25 @@ impl AssignWorker {
         hist: &mut HistoryWriter,
         workspace_root: &std::path::Path,
     ) -> Result<Outcome> {
+        // Stall watchdog: if the agent emits no frames for this long AND
+        // no approval is in flight (a human-wait is legitimate silence),
+        // give up and fail the run. Without this, an unrecognised wait —
+        // e.g. a future codex protocol change — leaves the runner blocked
+        // on stdout and the cloud showing "running" indefinitely.
+        const STALL_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+
         let shutdown = self.state.shutdown_notified();
         let cancel = self.cancel.clone();
         let mut cancelled = false;
         loop {
+            // Re-evaluate at every loop entry: an approval that opened on
+            // the previous iteration disarms the watchdog; one that just
+            // resolved re-arms it.
+            let stall_deadline = if self.approvals.list_pending().await.is_empty() {
+                Some(tokio::time::Instant::now() + STALL_TIMEOUT)
+            } else {
+                None
+            };
             tokio::select! {
                 biased;
                 _ = shutdown.notified(), if !cancelled => {
@@ -992,6 +1007,28 @@ impl AssignWorker {
                             return Ok(out);
                         }
                     }
+                }
+                _ = async {
+                    match stall_deadline {
+                        Some(d) => tokio::time::sleep_until(d).await,
+                        None => std::future::pending::<()>().await,
+                    }
+                } => {
+                    let mins = STALL_TIMEOUT.as_secs() / 60;
+                    let detail = format!("no agent frames for {mins} minutes");
+                    self.send(ClientMsg::RunFailed {
+                        run_id: cursor.run_id(),
+                        reason: FailureReason::Timeout,
+                        detail: Some(detail.clone()),
+                        ended_at: Utc::now(),
+                    }).await;
+                    hist.append(&HistoryEntry::Footer {
+                        ts: Utc::now(),
+                        final_status: "failed".into(),
+                        done_payload: None,
+                        error: Some(detail),
+                    }).await?;
+                    return Ok(Outcome { status_label: "failed".into() });
                 }
             }
         }


### PR DESCRIPTION
## Summary
- **Stop reporting failed codex runs as "completed"**: `turn/completed` is treated as success only when `conclusion == "success"`; missing conclusion → `Failed`. Codex's silent wrap-up after a `systemError` was previously reported as a clean run.
- **Surface terminal codex errors**: `error` notifications with `willRetry: false` (OpenAI 400s, etc.) now produce `BridgeEvent::Failed` with the upstream message as detail instead of falling through to the raw-event log.
- **Wire `waitingOnApproval` to the approval router**: codex 0.125.0 stopped firing `item/commandExecution/requestApproval` and signals approval gates only via `thread/status/changed → activeFlags: ["waitingOnApproval"]`. The bridge now caches the most recent in-progress `commandExecution` item on `item/started` and synthesizes an `ApprovalRequest` when it sees the flag, so approvals reach the cloud and TUI again.
- **Stop forcing a hardcoded model**: `CodexSection::default()` no longer pins `gpt-5-codex`; `ThreadStartParams.model` / `TurnStartParams.model` / `effort` are `skip_serializing_if = Option::is_none`, so an unset model lets codex's app-server fall back to its own config rather than its internal default (which 400s on ChatGPT-account auth).
- **Add a stall watchdog**: `pump_events` fails the run after 5 minutes of no agent frames AND no pending approvals (so a legitimate human-wait doesn't trip it). Defense in depth for any future protocol drift that parks codex silently again.

## Test plan
- [ ] `cargo test --release --test codex_bridge_fake` passes (existing approval / completion / crash tests).
- [ ] Re-fire BROWSERXTE-12, BROWSERXTE-13, PIDASH-4 with three runners (two on BROWSERXTE pod, one on PIDASH pod) registered.
- [ ] Verify each lands on a different runner (multi-runner dispatch).
- [ ] If codex requires approval for any shell command, an `agent_run_approval` row appears with `kind=command_execution` and the cloud / TUI surfaces the prompt.
- [ ] If codex fails on a model / API issue, the run lands as `failed` in `agent_run` with the upstream error message in `error`.
- [ ] If codex stalls for any other reason, the run lands as `failed` with `detail = "no agent frames for 5 minutes"` after the watchdog timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)