### PR TITLE
fix(migrations): unbreak migration graph after stack merge of #71/#76/#77/#78/#81

### DIFF
--- a/apps/api/pi_dash/db/migrations/0133_seed_builtin_schedulers.py
+++ b/apps/api/pi_dash/db/migrations/0133_seed_builtin_schedulers.py
@@ -62,7 +62,7 @@ def _noop_reverse(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("db", "0131_project_scheduler_mvp"),
+        ("db", "0132_project_scheduler_mvp"),
     ]
 
     operations = [

--- a/apps/api/pi_dash/runner/migrations/0010_agentrun_scheduler_binding.py
+++ b/apps/api/pi_dash/runner/migrations/0010_agentrun_scheduler_binding.py
@@ -22,7 +22,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ("runner", "0009_index_renames_after_connection"),
-        ("db", "0131_project_scheduler_mvp"),
+        ("db", "0132_project_scheduler_mvp"),
     ]
 
     operations = [


### PR DESCRIPTION
## Summary

Hotfix for the rebase artifacts left in the migration graph after the multi-runner stack and #76 (project-scheduler) merged side-by-side. ``manage.py migrate`` currently fails on a fresh deploy with:

```
django.db.migrations.exceptions.NodeNotFoundError:
Migration db.0132_seed_builtin_schedulers dependencies reference
nonexistent parent node ('db', '0131_project_scheduler_mvp')
```

Two stale references slipped through #76's rebase:

- ``db.0131_project_scheduler_mvp`` was renumbered to ``0132`` to avoid colliding with ``0131_rename_issue_agent_schedule_to_ticker``. The sibling ``0132_seed_builtin_schedulers`` still pointed at the old ``0131`` name — and was now itself a second ``0132``, breaking ordering.
- ``runner.0006_agentrun_scheduler_binding`` was renumbered to ``0010`` but its ``("db", "0131_project_scheduler_mvp")`` dependency was missed.

## Changes

- Rename ``db.0132_seed_builtin_schedulers`` → ``db.0133_seed_builtin_schedulers`` and point its dep at ``0132_project_scheduler_mvp``.
- Point ``runner.0010_agentrun_scheduler_binding``'s dep at ``0132_project_scheduler_mvp``.

## Test plan

- [x] ``docker compose up migrator`` runs all four new migrations cleanly:
  - ``db.0131_rename_issue_agent_schedule_to_ticker`` OK
  - ``db.0132_project_scheduler_mvp`` OK
  - ``db.0133_seed_builtin_schedulers`` OK
  - ``runner.0010_agentrun_scheduler_binding`` OK
- [x] api / worker / beat-worker containers come up healthy after migrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)