### PR TITLE
fix(web): show Schedulers in workspace sidebar (whitelist gap from #76)

### DIFF
--- a/apps/web/core/components/workspace/sidebar/sidebar-item.tsx
+++ b/apps/web/core/components/workspace/sidebar/sidebar-item.tsx
@@ -54,6 +54,7 @@ export const SidebarItemBase = observer(function SidebarItemBase({
     "projects",
     "runners",
     "prompts",
+    "schedulers",
     "your_work",
     "stickies",
     "drafts",


### PR DESCRIPTION
## Summary

PR #76 wired the Schedulers entry into ``WORKSPACE_SIDEBAR_STATIC_PINNED_NAVIGATION_ITEMS_LINKS`` in ``packages/constants/src/workspace.ts``, intending it to render alongside Projects / AI Agents / Prompts. It didn't show up in the actual sidebar.

Root cause: ``apps/web/core/components/workspace/sidebar/sidebar-item.tsx`` carries its own hardcoded ``staticItems`` allowlist:

```ts
const staticItems = [
  "home", "pi_chat", "projects", "runners", "prompts",
  "your_work", "stickies", "drafts",
  ...(additionalStaticItems || []),
];
// ...
if (!isPinned && !staticItems.includes(item.key)) return null;
```

If an item isn't pinned per-workspace AND not in this list, the component returns ``null``. ``"schedulers"`` was missing from the list, so the constant's pinned entry got rendered but then immediately filtered out.

## Fix

Add ``"schedulers"`` to the allowlist (positioned right after ``"prompts"`` to mirror the order in the constant).

## Test plan

- [x] Verified locally that the sidebar now renders the Schedulers entry as a sibling of Projects / AI Agents / Prompts.
- [x] Schedulers route at ``/<workspace_slug>/schedulers/`` was already returning 200; this PR is purely the entry-point gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)