### PR TITLE
fix(web): register /:workspaceSlug/schedulers route

### DIFF
--- a/apps/web/app/routes/core.ts
+++ b/apps/web/app/routes/core.ts
@@ -118,6 +118,11 @@ export const coreRoutes: RouteConfigEntry[] = [
           route(":workspaceSlug/prompts/:promptId", "./(all)/[workspaceSlug]/prompts/[promptId]/page.tsx"),
         ]),
 
+        // Schedulers (workspace-scoped scheduler definitions: project admins install on projects)
+        layout("./(all)/[workspaceSlug]/schedulers/layout.tsx", [
+          route(":workspaceSlug/schedulers", "./(all)/[workspaceSlug]/schedulers/page.tsx"),
+        ]),
+
         // Workspace Views
         layout("./(all)/[workspaceSlug]/(projects)/workspace-views/layout.tsx", [
           route(":workspaceSlug/workspace-views", "./(all)/[workspaceSlug]/(projects)/workspace-views/page.tsx"),


### PR DESCRIPTION
## Summary

PR #76 added ``apps/web/app/(all)/[workspaceSlug]/schedulers/{layout,page}.tsx`` but didn't register them in ``apps/web/app/routes/core.ts``. RR7 uses an **explicit** route table here, not file-based auto-discovery, so the URL falls through to the catch-all 404 even though the page files exist.

User-visible symptom: clicking the new Schedulers item in the sidebar (or visiting ``/<workspace_slug>/schedulers/`` directly) shows the app's 404 page.

## Fix

Add the layout + page registration in ``routes/core.ts``, in the same shape as the existing ``runners`` and ``prompts`` blocks:

```ts
layout("./(all)/[workspaceSlug]/schedulers/layout.tsx", [
  route(":workspaceSlug/schedulers", "./(all)/[workspaceSlug]/schedulers/page.tsx"),
]),
```

## Test plan

- [x] After web rebuild, ``/firstdream/schedulers/`` resolves to the SchedulersPage instead of the 404.
- [x] No new files; just wires the route table to the pages already shipped by #76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)