### PR TITLE
feat(web): project Schedulers settings tab + install/toggle/uninstall flow

### DIFF
--- a/apps/web/app/(all)/[workspaceSlug]/(settings)/settings/projects/[projectId]/schedulers/header.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/(settings)/settings/projects/[projectId]/schedulers/header.tsx
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { CalendarClock } from "lucide-react";
+import { useTranslation } from "@pi-dash/i18n";
+import { Breadcrumbs } from "@pi-dash/ui";
+import { BreadcrumbLink } from "@/components/common/breadcrumb-link";
+import { SettingsPageHeader } from "@/components/settings/page-header";
+
+export function SchedulersProjectSettingsHeader() {
+  const { t } = useTranslation();
+  return (
+    <SettingsPageHeader
+      leftItem={
+        <div className="flex items-center gap-2">
+          <Breadcrumbs>
+            <Breadcrumbs.Item
+              component={
+                <BreadcrumbLink
+                  label={t("scheduler_bindings.tab_label")}
+                  icon={<CalendarClock className="size-4 text-tertiary" />}
+                />
+              }
+            />
+          </Breadcrumbs>
+        </div>
+      }
+    />
+  );
+}

--- a/apps/web/app/(all)/[workspaceSlug]/(settings)/settings/projects/[projectId]/schedulers/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/(settings)/settings/projects/[projectId]/schedulers/page.tsx
@@ -11,9 +11,10 @@ import useSWR from "swr";
 // pi dash imports
 import { EUserPermissions, EUserPermissionsLevel } from "@pi-dash/constants";
 import { useTranslation } from "@pi-dash/i18n";
+import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
 import type { IScheduler, ISchedulerBinding } from "@pi-dash/services";
 import { SchedulerService } from "@pi-dash/services";
-import { Badge, Button } from "@pi-dash/ui";
+import { Button, ToggleSwitch } from "@pi-dash/ui";
 // components
 import { NotAuthorizedView } from "@/components/auth-screens/not-authorized-view";
 import { PageHead } from "@/components/core/page-title";
@@ -99,8 +100,11 @@ const SchedulerBindingsSettingsPage = observer(function SchedulerBindingsSetting
                 <BindingRow
                   key={b.id}
                   binding={b}
+                  workspaceSlug={slug}
+                  projectId={project}
                   onEdit={() => setEditTarget(b)}
                   onUninstall={() => setUninstallTarget(b)}
+                  onToggled={() => mutateBindings()}
                 />
               ))}
               {rows.length === 0 && (
@@ -146,13 +150,45 @@ const SchedulerBindingsSettingsPage = observer(function SchedulerBindingsSetting
 
 type RowProps = {
   binding: ISchedulerBinding;
+  workspaceSlug: string;
+  projectId: string;
   onEdit: () => void;
   onUninstall: () => void;
+  onToggled: () => void;
 };
 
-function BindingRow({ binding, onEdit, onUninstall }: RowProps) {
+function BindingRow({ binding, workspaceSlug, projectId, onEdit, onUninstall, onToggled }: RowProps) {
   const { t } = useTranslation();
+  const [toggling, setToggling] = useState(false);
+
   const formatTs = (ts: string | null) => (ts ? new Date(ts).toLocaleString() : t("scheduler_bindings.list.none_yet"));
+
+  // Inline toggle of the binding's enabled flag. Same PATCH the edit
+  // modal uses, but limited to the one field — saves the user a modal
+  // round-trip for the most common adjustment.
+  const handleToggle = async (next: boolean) => {
+    if (toggling) return;
+    setToggling(true);
+    try {
+      await schedulerService.updateBinding(workspaceSlug, projectId, binding.id, { enabled: next });
+      setToast({
+        type: TOAST_TYPE.SUCCESS,
+        title: t("scheduler_bindings.toast.updated_title"),
+        message: next ? t("scheduler_bindings.toast.enabled_message") : t("scheduler_bindings.toast.disabled_message"),
+      });
+      onToggled();
+    } catch (e: unknown) {
+      const err = e as { error?: string } | null;
+      setToast({
+        type: TOAST_TYPE.ERROR,
+        title: t("scheduler_bindings.toast.error_title"),
+        message: err?.error ?? t("scheduler_bindings.toast.update_failed"),
+      });
+    } finally {
+      setToggling(false);
+    }
+  };
+
   return (
     <tr className="border-t border-subtle">
       <td className="px-3 py-2 font-medium text-primary">
@@ -167,9 +203,19 @@ function BindingRow({ binding, onEdit, onUninstall }: RowProps) {
       <td className="px-3 py-2 text-secondary">{formatTs(binding.next_run_at)}</td>
       <td className="px-3 py-2 text-secondary">{formatTs(binding.last_run_ended_at)}</td>
       <td className="px-3 py-2">
-        <Badge variant={binding.enabled ? "accent-primary" : "accent-neutral"} size="sm">
-          {binding.enabled ? t("scheduler_bindings.status.enabled") : t("scheduler_bindings.status.disabled")}
-        </Badge>
+        <div className="flex items-center gap-2">
+          <ToggleSwitch
+            value={binding.enabled}
+            onChange={handleToggle}
+            disabled={toggling}
+            aria-label={
+              binding.enabled ? t("scheduler_bindings.actions.disable") : t("scheduler_bindings.actions.enable")
+            }
+          />
+          <span className="text-12 text-secondary">
+            {binding.enabled ? t("scheduler_bindings.status.enabled") : t("scheduler_bindings.status.disabled")}
+          </span>
+        </div>
       </td>
       <td className="px-3 py-2 text-secondary">{new Date(binding.updated_at).toLocaleString()}</td>
       <td className="px-3 py-2 text-right">

--- a/apps/web/app/(all)/[workspaceSlug]/(settings)/settings/projects/[projectId]/schedulers/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/(settings)/settings/projects/[projectId]/schedulers/page.tsx
@@ -100,11 +100,58 @@ const SchedulerBindingsSettingsPage = observer(function SchedulerBindingsSetting
                 <BindingRow
                   key={b.id}
                   binding={b}
-                  workspaceSlug={slug}
-                  projectId={project}
                   onEdit={() => setEditTarget(b)}
                   onUninstall={() => setUninstallTarget(b)}
-                  onToggled={() => mutateBindings()}
+                  onToggle={async (next) => {
+                    // Optimistic toggle — flip the cached row immediately, run
+                    // the PATCH, swap in the canonical server response on
+                    // success, roll back on error. SWR's optimisticData /
+                    // rollbackOnError handle the cache surgery; we just
+                    // surface the toast.
+                    try {
+                      await mutateBindings(
+                        async (current) => {
+                          const updated = await schedulerService.updateBinding(slug, project, b.id, {
+                            enabled: next,
+                          });
+                          return (current ?? []).map((row) => (row.id === b.id ? updated : row));
+                        },
+                        {
+                          // SWR diffs optimisticData by reference, so we
+                          // need a fresh array AND a fresh object for the
+                          // changed row. The spread-in-map pattern oxlint
+                          // flags as "inefficient" is the standard idiom
+                          // for immutable updates here. Build the new
+                          // array imperatively to dodge the rule and avoid
+                          // a mid-iteration spread.
+                          optimisticData: (current) => {
+                            const arr = current ?? [];
+                            const idx = arr.findIndex((row) => row.id === b.id);
+                            if (idx === -1) return arr;
+                            const out = arr.slice();
+                            out[idx] = Object.assign({}, arr[idx], { enabled: next });
+                            return out;
+                          },
+                          rollbackOnError: true,
+                          revalidate: false,
+                        }
+                      );
+                      setToast({
+                        type: TOAST_TYPE.SUCCESS,
+                        title: t("scheduler_bindings.toast.updated_title"),
+                        message: next
+                          ? t("scheduler_bindings.toast.enabled_message")
+                          : t("scheduler_bindings.toast.disabled_message"),
+                      });
+                    } catch (e: unknown) {
+                      const err = e as { error?: string } | null;
+                      setToast({
+                        type: TOAST_TYPE.ERROR,
+                        title: t("scheduler_bindings.toast.error_title"),
+                        message: err?.error ?? t("scheduler_bindings.toast.update_failed"),
+                      });
+                    }
+                  }}
                 />
               ))}
               {rows.length === 0 && (
@@ -150,40 +197,26 @@ const SchedulerBindingsSettingsPage = observer(function SchedulerBindingsSetting
 
 type RowProps = {
   binding: ISchedulerBinding;
-  workspaceSlug: string;
-  projectId: string;
   onEdit: () => void;
   onUninstall: () => void;
-  onToggled: () => void;
+  onToggle: (next: boolean) => Promise<void>;
 };
 
-function BindingRow({ binding, workspaceSlug, projectId, onEdit, onUninstall, onToggled }: RowProps) {
+function BindingRow({ binding, onEdit, onUninstall, onToggle }: RowProps) {
   const { t } = useTranslation();
   const [toggling, setToggling] = useState(false);
 
   const formatTs = (ts: string | null) => (ts ? new Date(ts).toLocaleString() : t("scheduler_bindings.list.none_yet"));
 
-  // Inline toggle of the binding's enabled flag. Same PATCH the edit
-  // modal uses, but limited to the one field — saves the user a modal
-  // round-trip for the most common adjustment.
+  // Wraps the parent's onToggle so the switch can render a disabled
+  // state during the in-flight PATCH (prevents a double-click from
+  // racing two requests). The optimistic / rollback bookkeeping lives
+  // in the parent because the SWR cache key does too.
   const handleToggle = async (next: boolean) => {
     if (toggling) return;
     setToggling(true);
     try {
-      await schedulerService.updateBinding(workspaceSlug, projectId, binding.id, { enabled: next });
-      setToast({
-        type: TOAST_TYPE.SUCCESS,
-        title: t("scheduler_bindings.toast.updated_title"),
-        message: next ? t("scheduler_bindings.toast.enabled_message") : t("scheduler_bindings.toast.disabled_message"),
-      });
-      onToggled();
-    } catch (e: unknown) {
-      const err = e as { error?: string } | null;
-      setToast({
-        type: TOAST_TYPE.ERROR,
-        title: t("scheduler_bindings.toast.error_title"),
-        message: err?.error ?? t("scheduler_bindings.toast.update_failed"),
-      });
+      await onToggle(next);
     } finally {
       setToggling(false);
     }

--- a/apps/web/app/(all)/[workspaceSlug]/(settings)/settings/projects/[projectId]/schedulers/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/(settings)/settings/projects/[projectId]/schedulers/page.tsx
@@ -1,0 +1,189 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useState } from "react";
+import { observer } from "mobx-react";
+import { useParams } from "react-router";
+import useSWR from "swr";
+// pi dash imports
+import { EUserPermissions, EUserPermissionsLevel } from "@pi-dash/constants";
+import { useTranslation } from "@pi-dash/i18n";
+import type { IScheduler, ISchedulerBinding } from "@pi-dash/services";
+import { SchedulerService } from "@pi-dash/services";
+import { Badge, Button } from "@pi-dash/ui";
+// components
+import { NotAuthorizedView } from "@/components/auth-screens/not-authorized-view";
+import { PageHead } from "@/components/core/page-title";
+import { EditSchedulerBindingModal } from "@/components/project/scheduler-bindings/edit-binding-modal";
+import { InstallSchedulerBindingModal } from "@/components/project/scheduler-bindings/install-binding-modal";
+import { UninstallSchedulerBindingModal } from "@/components/project/scheduler-bindings/uninstall-binding-modal";
+import { SettingsContentWrapper } from "@/components/settings/content-wrapper";
+// hooks
+import { useProject } from "@/hooks/store/use-project";
+import { useUserPermissions } from "@/hooks/store/user";
+import { SchedulersProjectSettingsHeader } from "./header";
+
+const schedulerService = new SchedulerService();
+
+const SchedulerBindingsSettingsPage = observer(function SchedulerBindingsSettingsPage() {
+  const { workspaceSlug, projectId } = useParams<{ workspaceSlug: string; projectId: string }>();
+  const { currentProjectDetails } = useProject();
+  const { workspaceUserInfo, allowPermissions } = useUserPermissions();
+  const { t } = useTranslation();
+
+  const slug = workspaceSlug ?? "";
+  const project = projectId ?? "";
+
+  // Project admin only — matches the route's access list and the
+  // backend's project-admin gate on binding mutations. Surfacing the
+  // page to non-admins would only show a read-only list with no
+  // actions, which adds no value over the workspace catalog view.
+  const canManage = allowPermissions([EUserPermissions.ADMIN], EUserPermissionsLevel.PROJECT, slug, project);
+
+  // Bindings: per-project. Workspace schedulers: needed to populate the
+  // install picker. Both keys include the workspace + project so a
+  // navigation between projects refetches.
+  const { data: bindings, mutate: mutateBindings } = useSWR<ISchedulerBinding[]>(
+    slug && project ? ["scheduler-bindings", slug, project] : null,
+    () => schedulerService.listBindings(slug, project)
+  );
+  const { data: schedulers } = useSWR<IScheduler[]>(slug ? ["schedulers", slug] : null, () =>
+    schedulerService.listSchedulers(slug)
+  );
+
+  const [installOpen, setInstallOpen] = useState(false);
+  const [editTarget, setEditTarget] = useState<ISchedulerBinding | null>(null);
+  const [uninstallTarget, setUninstallTarget] = useState<ISchedulerBinding | null>(null);
+
+  const pageTitle = currentProjectDetails?.name
+    ? `${currentProjectDetails.name} · ${t("scheduler_bindings.title")}`
+    : t("scheduler_bindings.title");
+
+  if (workspaceUserInfo && !canManage) {
+    return <NotAuthorizedView section="settings" isProjectView className="h-auto" />;
+  }
+
+  const rows = bindings ?? [];
+
+  return (
+    <SettingsContentWrapper header={<SchedulersProjectSettingsHeader />}>
+      <PageHead title={pageTitle} />
+
+      <div className="flex flex-col gap-6 p-6">
+        <header className="flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-16 font-semibold text-primary">{t("scheduler_bindings.title")}</h1>
+            <p className="mt-1 text-13 text-secondary">{t("scheduler_bindings.subtitle")}</p>
+          </div>
+          <Button onClick={() => setInstallOpen(true)}>{t("scheduler_bindings.install")}</Button>
+        </header>
+
+        <section className="rounded-md border border-subtle">
+          <table className="w-full text-13">
+            <thead className="bg-layer-1 text-left text-secondary">
+              <tr>
+                <th className="px-3 py-2">{t("scheduler_bindings.columns.name")}</th>
+                <th className="px-3 py-2">{t("scheduler_bindings.columns.cron")}</th>
+                <th className="px-3 py-2">{t("scheduler_bindings.columns.next_run")}</th>
+                <th className="px-3 py-2">{t("scheduler_bindings.columns.last_run")}</th>
+                <th className="px-3 py-2">{t("scheduler_bindings.columns.status")}</th>
+                <th className="px-3 py-2">{t("scheduler_bindings.columns.updated")}</th>
+                <th className="px-3 py-2"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((b) => (
+                <BindingRow
+                  key={b.id}
+                  binding={b}
+                  onEdit={() => setEditTarget(b)}
+                  onUninstall={() => setUninstallTarget(b)}
+                />
+              ))}
+              {rows.length === 0 && (
+                <tr>
+                  <td colSpan={7} className="px-3 py-8 text-center text-secondary">
+                    {t("scheduler_bindings.list.empty")}
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </section>
+      </div>
+
+      <InstallSchedulerBindingModal
+        isOpen={installOpen}
+        onClose={() => setInstallOpen(false)}
+        workspaceSlug={slug}
+        projectId={project}
+        availableSchedulers={schedulers ?? []}
+        existingBindings={rows}
+        onInstalled={() => mutateBindings()}
+      />
+      <EditSchedulerBindingModal
+        isOpen={!!editTarget}
+        onClose={() => setEditTarget(null)}
+        workspaceSlug={slug}
+        projectId={project}
+        binding={editTarget}
+        onUpdated={() => mutateBindings()}
+      />
+      <UninstallSchedulerBindingModal
+        isOpen={!!uninstallTarget}
+        onClose={() => setUninstallTarget(null)}
+        workspaceSlug={slug}
+        projectId={project}
+        binding={uninstallTarget}
+        onUninstalled={() => mutateBindings()}
+      />
+    </SettingsContentWrapper>
+  );
+});
+
+type RowProps = {
+  binding: ISchedulerBinding;
+  onEdit: () => void;
+  onUninstall: () => void;
+};
+
+function BindingRow({ binding, onEdit, onUninstall }: RowProps) {
+  const { t } = useTranslation();
+  const formatTs = (ts: string | null) => (ts ? new Date(ts).toLocaleString() : t("scheduler_bindings.list.none_yet"));
+  return (
+    <tr className="border-t border-subtle">
+      <td className="px-3 py-2 font-medium text-primary">
+        {binding.scheduler_name}
+        <div className="text-12 text-secondary">
+          <code>{binding.scheduler_slug}</code>
+        </div>
+      </td>
+      <td className="px-3 py-2 text-secondary">
+        <code className="text-12">{binding.cron}</code>
+      </td>
+      <td className="px-3 py-2 text-secondary">{formatTs(binding.next_run_at)}</td>
+      <td className="px-3 py-2 text-secondary">{formatTs(binding.last_run_ended_at)}</td>
+      <td className="px-3 py-2">
+        <Badge variant={binding.enabled ? "accent-primary" : "accent-neutral"} size="sm">
+          {binding.enabled ? t("scheduler_bindings.status.enabled") : t("scheduler_bindings.status.disabled")}
+        </Badge>
+      </td>
+      <td className="px-3 py-2 text-secondary">{new Date(binding.updated_at).toLocaleString()}</td>
+      <td className="px-3 py-2 text-right">
+        <div className="flex items-center justify-end gap-2">
+          <Button variant="link-neutral" size="sm" onClick={onEdit}>
+            {t("scheduler_bindings.actions.edit")}
+          </Button>
+          <Button variant="tertiary-danger" size="sm" onClick={onUninstall}>
+            {t("scheduler_bindings.actions.uninstall")}
+          </Button>
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+export default SchedulerBindingsSettingsPage;

--- a/apps/web/app/routes/core.ts
+++ b/apps/web/app/routes/core.ts
@@ -372,6 +372,13 @@ export const coreRoutes: RouteConfigEntry[] = [
               ":workspaceSlug/settings/projects/:projectId/github",
               "./(all)/[workspaceSlug]/(settings)/settings/projects/[projectId]/github/page.tsx"
             ),
+            // Project Scheduler bindings — install / edit / uninstall
+            // workspace schedulers on this project. See
+            // .ai_design/project_scheduler/design.md §11.
+            route(
+              ":workspaceSlug/settings/projects/:projectId/schedulers",
+              "./(all)/[workspaceSlug]/(settings)/settings/projects/[projectId]/schedulers/page.tsx"
+            ),
           ]),
         ]),
       ]),

--- a/apps/web/ce/components/workspace/sidebar/helper.tsx
+++ b/apps/web/ce/components/workspace/sidebar/helper.tsx
@@ -4,7 +4,7 @@
  * See the LICENSE file for details.
  */
 
-import { FileText, Server } from "lucide-react";
+import { CalendarClock, FileText, Server } from "lucide-react";
 import {
   AnalyticsIcon,
   ArchiveIcon,
@@ -45,5 +45,7 @@ export const getSidebarNavigationItemIcon = (key: string, className: string = ""
       return <FileText className={cn("size-4 flex-shrink-0", className)} />;
     case "runners":
       return <Server className={cn("size-4 flex-shrink-0", className)} />;
+    case "schedulers":
+      return <CalendarClock className={cn("size-4 flex-shrink-0", className)} />;
   }
 };

--- a/apps/web/core/components/project/scheduler-bindings/edit-binding-modal.tsx
+++ b/apps/web/core/components/project/scheduler-bindings/edit-binding-modal.tsx
@@ -1,0 +1,159 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useEffect } from "react";
+import { observer } from "mobx-react";
+import type { SubmitHandler } from "react-hook-form";
+import { Controller, useForm } from "react-hook-form";
+// pi dash imports
+import { useTranslation } from "@pi-dash/i18n";
+import { Button } from "@pi-dash/propel/button";
+import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
+import type { ISchedulerBinding } from "@pi-dash/services";
+import { SchedulerService } from "@pi-dash/services";
+import { EModalPosition, EModalWidth, Input, ModalCore, TextArea, ToggleSwitch } from "@pi-dash/ui";
+
+interface EditFormValues {
+  cron: string;
+  extra_context: string;
+  enabled: boolean;
+}
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+  workspaceSlug: string;
+  projectId: string;
+  binding: ISchedulerBinding | null;
+  onUpdated: (binding: ISchedulerBinding) => void;
+};
+
+const schedulerService = new SchedulerService();
+
+export const EditSchedulerBindingModal = observer(function EditSchedulerBindingModal(props: Props) {
+  const { isOpen, onClose, workspaceSlug, projectId, binding, onUpdated } = props;
+  const { t } = useTranslation();
+
+  const {
+    control,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<EditFormValues>({
+    defaultValues: { cron: "", extra_context: "", enabled: true },
+  });
+
+  useEffect(() => {
+    if (!isOpen || !binding) return;
+    reset({
+      cron: binding.cron,
+      extra_context: binding.extra_context ?? "",
+      enabled: binding.enabled,
+    });
+  }, [isOpen, binding, reset]);
+
+  const handleFormSubmit: SubmitHandler<EditFormValues> = async (values) => {
+    if (!binding) return;
+    try {
+      const updated = await schedulerService.updateBinding(workspaceSlug, projectId, binding.id, {
+        cron: values.cron.trim(),
+        extra_context: values.extra_context.trim(),
+        enabled: values.enabled,
+      });
+      setToast({
+        type: TOAST_TYPE.SUCCESS,
+        title: t("scheduler_bindings.toast.updated_title"),
+        message: t("scheduler_bindings.toast.updated_message"),
+      });
+      onUpdated(updated);
+      onClose();
+    } catch (e: unknown) {
+      const err = e as { error?: string; cron?: string[] } | null;
+      const detail = err?.error ?? err?.cron?.[0] ?? t("scheduler_bindings.toast.update_failed");
+      setToast({
+        type: TOAST_TYPE.ERROR,
+        title: t("scheduler_bindings.toast.error_title"),
+        message: detail,
+      });
+    }
+  };
+
+  return (
+    <ModalCore isOpen={isOpen} handleClose={onClose} position={EModalPosition.CENTER} width={EModalWidth.XXL}>
+      <form onSubmit={handleSubmit(handleFormSubmit)} className="flex flex-col gap-5 p-5">
+        <div className="text-18 font-medium text-primary">
+          {t("scheduler_bindings.edit_modal.title")}
+          {binding && <span className="ml-2 text-13 text-secondary">— {binding.scheduler_name}</span>}
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor="edit-binding-cron" className="text-13 font-medium text-primary">
+            {t("scheduler_bindings.install_modal.cron_label")}
+          </label>
+          <Controller
+            control={control}
+            name="cron"
+            rules={{ required: t("scheduler_bindings.install_modal.errors.cron_required") }}
+            render={({ field }) => (
+              <Input
+                {...field}
+                id="edit-binding-cron"
+                placeholder={t("scheduler_bindings.install_modal.cron_placeholder")}
+                hasError={!!errors.cron}
+              />
+            )}
+          />
+          <p className="text-12 text-secondary">{t("scheduler_bindings.install_modal.cron_help")}</p>
+          {errors.cron && <span className="text-red-500 text-12">{errors.cron.message}</span>}
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor="edit-binding-extra-context" className="text-13 font-medium text-primary">
+            {t("scheduler_bindings.install_modal.extra_context_label")}
+          </label>
+          <Controller
+            control={control}
+            name="extra_context"
+            render={({ field }) => (
+              <TextArea
+                {...field}
+                id="edit-binding-extra-context"
+                rows={4}
+                placeholder={t("scheduler_bindings.install_modal.extra_context_placeholder")}
+              />
+            )}
+          />
+          <p className="text-12 text-secondary">{t("scheduler_bindings.install_modal.extra_context_help")}</p>
+        </div>
+
+        <Controller
+          control={control}
+          name="enabled"
+          render={({ field }) => (
+            <div className="flex items-center justify-between gap-4">
+              <div className="flex flex-col">
+                <span className="text-13 font-medium text-primary">
+                  {t("scheduler_bindings.install_modal.enabled_label")}
+                </span>
+                <span className="text-12 text-secondary">{t("scheduler_bindings.install_modal.enabled_help")}</span>
+              </div>
+              <ToggleSwitch value={field.value} onChange={field.onChange} />
+            </div>
+          )}
+        />
+
+        <div className="flex justify-end gap-2">
+          <Button variant="secondary" onClick={onClose} disabled={isSubmitting}>
+            {t("scheduler_bindings.install_modal.cancel")}
+          </Button>
+          <Button type="submit" loading={isSubmitting} disabled={isSubmitting}>
+            {isSubmitting ? t("scheduler_bindings.edit_modal.saving") : t("scheduler_bindings.edit_modal.save")}
+          </Button>
+        </div>
+      </form>
+    </ModalCore>
+  );
+});

--- a/apps/web/core/components/project/scheduler-bindings/install-binding-modal.tsx
+++ b/apps/web/core/components/project/scheduler-bindings/install-binding-modal.tsx
@@ -1,0 +1,231 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useEffect, useMemo } from "react";
+import { observer } from "mobx-react";
+import type { SubmitHandler } from "react-hook-form";
+import { Controller, useForm } from "react-hook-form";
+// pi dash imports
+import { useTranslation } from "@pi-dash/i18n";
+import { Button } from "@pi-dash/propel/button";
+import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
+import type { IScheduler, ISchedulerBinding } from "@pi-dash/services";
+import { SchedulerService } from "@pi-dash/services";
+import { EModalPosition, EModalWidth, Input, ModalCore, TextArea, ToggleSwitch } from "@pi-dash/ui";
+
+interface InstallFormValues {
+  scheduler: string;
+  cron: string;
+  extra_context: string;
+  enabled: boolean;
+}
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+  workspaceSlug: string;
+  projectId: string;
+  /**
+   * The full set of workspace schedulers. The picker filters to enabled
+   * ones not already bound to this project so the user can't double-install.
+   */
+  availableSchedulers: IScheduler[];
+  /** Bindings that already exist on this project, used to filter the picker. */
+  existingBindings: ISchedulerBinding[];
+  onInstalled: (binding: ISchedulerBinding) => void;
+};
+
+const DEFAULT_VALUES: InstallFormValues = {
+  scheduler: "",
+  // 09:00 UTC daily — non-controversial default; the help text spells out
+  // the format and timezone so users editing it know what they're picking.
+  cron: "0 9 * * *",
+  extra_context: "",
+  enabled: true,
+};
+
+const schedulerService = new SchedulerService();
+
+export const InstallSchedulerBindingModal = observer(function InstallSchedulerBindingModal(props: Props) {
+  const { isOpen, onClose, workspaceSlug, projectId, availableSchedulers, existingBindings, onInstalled } = props;
+  const { t } = useTranslation();
+
+  const {
+    control,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<InstallFormValues>({ defaultValues: DEFAULT_VALUES });
+
+  // Filter to enabled workspace schedulers that don't already have a
+  // binding on this project. The cloud also enforces this with a unique
+  // constraint, but filtering client-side keeps the picker clean and
+  // means the install button is only enabled when there's something
+  // valid to install.
+  const installable = useMemo(() => {
+    const boundIds = new Set(existingBindings.map((b) => b.scheduler));
+    return availableSchedulers.filter((s) => s.is_enabled && !boundIds.has(s.id));
+  }, [availableSchedulers, existingBindings]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    // Pre-select the first installable scheduler so submitting without
+    // touching the picker still produces a valid payload.
+    reset({
+      ...DEFAULT_VALUES,
+      scheduler: installable[0]?.id ?? "",
+    });
+  }, [isOpen, installable, reset]);
+
+  const handleFormSubmit: SubmitHandler<InstallFormValues> = async (values) => {
+    try {
+      const binding = await schedulerService.createBinding(workspaceSlug, projectId, {
+        scheduler: values.scheduler,
+        cron: values.cron.trim(),
+        extra_context: values.extra_context.trim(),
+        enabled: values.enabled,
+      });
+      setToast({
+        type: TOAST_TYPE.SUCCESS,
+        title: t("scheduler_bindings.toast.installed_title"),
+        message: t("scheduler_bindings.toast.installed_message"),
+      });
+      onInstalled(binding);
+      onClose();
+    } catch (e: unknown) {
+      const err = e as { error?: string; cron?: string[]; scheduler?: string[] } | null;
+      const detail =
+        err?.error ?? err?.cron?.[0] ?? err?.scheduler?.[0] ?? t("scheduler_bindings.toast.install_failed");
+      setToast({
+        type: TOAST_TYPE.ERROR,
+        title: t("scheduler_bindings.toast.error_title"),
+        message: detail,
+      });
+    }
+  };
+
+  // Empty-state branch: no schedulers to install. Render a helpful body
+  // pointing the operator at the workspace catalog rather than an
+  // unsubmittable form.
+  if (installable.length === 0) {
+    return (
+      <ModalCore isOpen={isOpen} handleClose={onClose} position={EModalPosition.CENTER} width={EModalWidth.XL}>
+        <div className="flex flex-col gap-4 p-5">
+          <div className="text-18 font-medium text-primary">
+            {t("scheduler_bindings.install_modal.none_available_title")}
+          </div>
+          <p className="text-13 text-secondary">{t("scheduler_bindings.install_modal.none_available_body")}</p>
+          <div className="flex justify-end">
+            <Button variant="secondary" onClick={onClose}>
+              {t("scheduler_bindings.install_modal.cancel")}
+            </Button>
+          </div>
+        </div>
+      </ModalCore>
+    );
+  }
+
+  return (
+    <ModalCore isOpen={isOpen} handleClose={onClose} position={EModalPosition.CENTER} width={EModalWidth.XXL}>
+      <form onSubmit={handleSubmit(handleFormSubmit)} className="flex flex-col gap-5 p-5">
+        <div className="text-18 font-medium text-primary">{t("scheduler_bindings.install_modal.title")}</div>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor="binding-scheduler" className="text-13 font-medium text-primary">
+            {t("scheduler_bindings.install_modal.scheduler_label")}
+          </label>
+          <Controller
+            control={control}
+            name="scheduler"
+            rules={{ required: t("scheduler_bindings.install_modal.errors.scheduler_required") }}
+            render={({ field }) => (
+              <select
+                {...field}
+                id="binding-scheduler"
+                className="bg-layer-0 focus:ring-accent-primary rounded-md border border-subtle px-3 py-2 text-13 text-primary focus:ring-1 focus:outline-none"
+              >
+                {installable.map((s) => (
+                  <option key={s.id} value={s.id}>
+                    {s.name} ({s.slug})
+                  </option>
+                ))}
+              </select>
+            )}
+          />
+          <p className="text-12 text-secondary">{t("scheduler_bindings.install_modal.scheduler_help")}</p>
+          {errors.scheduler && <span className="text-red-500 text-12">{errors.scheduler.message}</span>}
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor="binding-cron" className="text-13 font-medium text-primary">
+            {t("scheduler_bindings.install_modal.cron_label")}
+          </label>
+          <Controller
+            control={control}
+            name="cron"
+            rules={{ required: t("scheduler_bindings.install_modal.errors.cron_required") }}
+            render={({ field }) => (
+              <Input
+                {...field}
+                id="binding-cron"
+                placeholder={t("scheduler_bindings.install_modal.cron_placeholder")}
+                hasError={!!errors.cron}
+              />
+            )}
+          />
+          <p className="text-12 text-secondary">{t("scheduler_bindings.install_modal.cron_help")}</p>
+          {errors.cron && <span className="text-red-500 text-12">{errors.cron.message}</span>}
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor="binding-extra-context" className="text-13 font-medium text-primary">
+            {t("scheduler_bindings.install_modal.extra_context_label")}
+          </label>
+          <Controller
+            control={control}
+            name="extra_context"
+            render={({ field }) => (
+              <TextArea
+                {...field}
+                id="binding-extra-context"
+                rows={4}
+                placeholder={t("scheduler_bindings.install_modal.extra_context_placeholder")}
+              />
+            )}
+          />
+          <p className="text-12 text-secondary">{t("scheduler_bindings.install_modal.extra_context_help")}</p>
+        </div>
+
+        <Controller
+          control={control}
+          name="enabled"
+          render={({ field }) => (
+            <div className="flex items-center justify-between gap-4">
+              <div className="flex flex-col">
+                <span className="text-13 font-medium text-primary">
+                  {t("scheduler_bindings.install_modal.enabled_label")}
+                </span>
+                <span className="text-12 text-secondary">{t("scheduler_bindings.install_modal.enabled_help")}</span>
+              </div>
+              <ToggleSwitch value={field.value} onChange={field.onChange} />
+            </div>
+          )}
+        />
+
+        <div className="flex justify-end gap-2">
+          <Button variant="secondary" onClick={onClose} disabled={isSubmitting}>
+            {t("scheduler_bindings.install_modal.cancel")}
+          </Button>
+          <Button type="submit" loading={isSubmitting} disabled={isSubmitting}>
+            {isSubmitting
+              ? t("scheduler_bindings.install_modal.installing")
+              : t("scheduler_bindings.install_modal.install")}
+          </Button>
+        </div>
+      </form>
+    </ModalCore>
+  );
+});

--- a/apps/web/core/components/project/scheduler-bindings/install-binding-modal.tsx
+++ b/apps/web/core/components/project/scheduler-bindings/install-binding-modal.tsx
@@ -84,6 +84,9 @@ export const InstallSchedulerBindingModal = observer(function InstallSchedulerBi
     try {
       const binding = await schedulerService.createBinding(workspaceSlug, projectId, {
         scheduler: values.scheduler,
+        // Cloud's serializer.is_valid() requires this even though the
+        // projectId is already in the URL — see scheduler.service.ts.
+        project: projectId,
         cron: values.cron.trim(),
         extra_context: values.extra_context.trim(),
         enabled: values.enabled,

--- a/apps/web/core/components/project/scheduler-bindings/install-binding-modal.tsx
+++ b/apps/web/core/components/project/scheduler-bindings/install-binding-modal.tsx
@@ -4,7 +4,7 @@
  * See the LICENSE file for details.
  */
 
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { observer } from "mobx-react";
 import type { SubmitHandler } from "react-hook-form";
 import { Controller, useForm } from "react-hook-form";
@@ -70,15 +70,26 @@ export const InstallSchedulerBindingModal = observer(function InstallSchedulerBi
     return availableSchedulers.filter((s) => s.is_enabled && !boundIds.has(s.id));
   }, [availableSchedulers, existingBindings]);
 
+  // Track open/closed transitions so the seed-on-open effect doesn't
+  // re-fire when `installable` changes mid-edit. SWR can revalidate the
+  // workspace schedulers query (focus event, background refresh) while
+  // the modal is open; without this guard, the new array reference would
+  // call ``reset`` and wipe whatever the user has typed into cron /
+  // extra_context. We only want to seed defaults on the closed → open
+  // edge.
+  const wasOpen = useRef(false);
   useEffect(() => {
-    if (!isOpen) return;
-    // Pre-select the first installable scheduler so submitting without
-    // touching the picker still produces a valid payload.
-    reset({
-      ...DEFAULT_VALUES,
-      scheduler: installable[0]?.id ?? "",
-    });
-  }, [isOpen, installable, reset]);
+    if (isOpen && !wasOpen.current) {
+      reset({
+        ...DEFAULT_VALUES,
+        scheduler: installable[0]?.id ?? "",
+      });
+    }
+    wasOpen.current = isOpen;
+    // installable is intentionally NOT in deps — a fresh reference from
+    // SWR mid-edit must not re-seed. Only `isOpen` triggers the reset.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, reset]);
 
   const handleFormSubmit: SubmitHandler<InstallFormValues> = async (values) => {
     try {

--- a/apps/web/core/components/project/scheduler-bindings/uninstall-binding-modal.tsx
+++ b/apps/web/core/components/project/scheduler-bindings/uninstall-binding-modal.tsx
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useState } from "react";
+import { observer } from "mobx-react";
+// pi dash imports
+import { useTranslation } from "@pi-dash/i18n";
+import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
+import type { ISchedulerBinding } from "@pi-dash/services";
+import { SchedulerService } from "@pi-dash/services";
+import { AlertModalCore } from "@pi-dash/ui";
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+  workspaceSlug: string;
+  projectId: string;
+  binding: ISchedulerBinding | null;
+  onUninstalled: (bindingId: string) => void;
+};
+
+const schedulerService = new SchedulerService();
+
+export const UninstallSchedulerBindingModal = observer(function UninstallSchedulerBindingModal(props: Props) {
+  const { isOpen, onClose, workspaceSlug, projectId, binding, onUninstalled } = props;
+  const { t } = useTranslation();
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleUninstall = async () => {
+    if (!binding) return;
+    setSubmitting(true);
+    try {
+      await schedulerService.destroyBinding(workspaceSlug, projectId, binding.id);
+      setToast({
+        type: TOAST_TYPE.SUCCESS,
+        title: t("scheduler_bindings.toast.uninstalled_title"),
+        message: t("scheduler_bindings.toast.uninstalled_message"),
+      });
+      onUninstalled(binding.id);
+      onClose();
+    } catch (e: unknown) {
+      const err = e as { error?: string } | null;
+      setToast({
+        type: TOAST_TYPE.ERROR,
+        title: t("scheduler_bindings.toast.error_title"),
+        message: err?.error ?? t("scheduler_bindings.toast.uninstall_failed"),
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <AlertModalCore
+      isOpen={isOpen}
+      handleClose={() => (submitting ? null : onClose())}
+      handleSubmit={handleUninstall}
+      isSubmitting={submitting}
+      title={t("scheduler_bindings.uninstall_modal.title")}
+      content={
+        <>
+          <p>{t("scheduler_bindings.uninstall_modal.body")}</p>
+          {binding && <p className="mt-2 font-medium text-primary">{binding.scheduler_name}</p>}
+        </>
+      }
+      primaryButtonText={{
+        default: t("scheduler_bindings.uninstall_modal.confirm"),
+        loading: t("scheduler_bindings.uninstall_modal.confirm"),
+      }}
+    />
+  );
+});

--- a/apps/web/core/components/settings/project/sidebar/item-icon.tsx
+++ b/apps/web/core/components/settings/project/sidebar/item-icon.tsx
@@ -5,7 +5,7 @@
  */
 
 import type { LucideIcon } from "lucide-react";
-import { Github, Users, Zap } from "lucide-react";
+import { CalendarClock, Github, Users, Zap } from "lucide-react";
 // pi dash imports
 import type { ISvgIcons } from "@pi-dash/propel/icons";
 import {
@@ -35,4 +35,5 @@ export const PROJECT_SETTINGS_ICONS: Record<TProjectSettingsTabs, LucideIcon | R
   estimates: EstimatePropertyIcon,
   automations: Zap,
   github: Github,
+  schedulers: CalendarClock,
 };

--- a/packages/constants/src/settings/project.ts
+++ b/packages/constants/src/settings/project.ts
@@ -111,11 +111,10 @@ export const PROJECT_SETTINGS: Record<TProjectSettingsTabs, TProjectSettingsItem
     key: "schedulers",
     i18n_label: "scheduler_bindings.tab_label",
     href: `/schedulers`,
-    // Project admin only for mutations; the page itself surfaces a
-    // read-only view for members. The sidebar gate is the same as
-    // automations / github — the loose-permissive read view is enforced
-    // inside the page rather than via a wider access list, so we don't
-    // surface the tab to non-admins who can't act on it.
+    // Project admin only — matches the github / automations gate. Members
+    // can view the workspace catalog at Workspace → Schedulers; the
+    // per-project install surface adds nothing for non-admins since
+    // every action on it requires admin privileges anyway.
     access: [EUserProjectRoles.ADMIN],
     highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}/schedulers/`,
   },

--- a/packages/constants/src/settings/project.ts
+++ b/packages/constants/src/settings/project.ts
@@ -107,6 +107,18 @@ export const PROJECT_SETTINGS: Record<TProjectSettingsTabs, TProjectSettingsItem
     access: [EUserProjectRoles.ADMIN],
     highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}/github/`,
   },
+  schedulers: {
+    key: "schedulers",
+    i18n_label: "scheduler_bindings.tab_label",
+    href: `/schedulers`,
+    // Project admin only for mutations; the page itself surfaces a
+    // read-only view for members. The sidebar gate is the same as
+    // automations / github — the loose-permissive read view is enforced
+    // inside the page rather than via a wider access list, so we don't
+    // surface the tab to non-admins who can't act on it.
+    access: [EUserProjectRoles.ADMIN],
+    highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}/schedulers/`,
+  },
 };
 
 export const PROJECT_SETTINGS_FLAT_MAP: TProjectSettingsItem[] = Object.values(PROJECT_SETTINGS);
@@ -125,5 +137,9 @@ export const GROUPED_PROJECT_SETTINGS: Record<PROJECT_SETTINGS_CATEGORY, TProjec
     PROJECT_SETTINGS["labels"],
     PROJECT_SETTINGS["estimates"],
   ],
-  [PROJECT_SETTINGS_CATEGORY.EXECUTION]: [PROJECT_SETTINGS["automations"], PROJECT_SETTINGS["github"]],
+  [PROJECT_SETTINGS_CATEGORY.EXECUTION]: [
+    PROJECT_SETTINGS["automations"],
+    PROJECT_SETTINGS["github"],
+    PROJECT_SETTINGS["schedulers"],
+  ],
 };

--- a/packages/i18n/src/locales/en/core.ts
+++ b/packages/i18n/src/locales/en/core.ts
@@ -199,6 +199,8 @@ export default {
     actions: {
       edit: "Edit",
       uninstall: "Uninstall",
+      enable: "Enable scheduler",
+      disable: "Disable scheduler",
     },
     list: {
       empty:
@@ -244,6 +246,8 @@ export default {
       installed_message: "It will fire on the configured cron.",
       updated_title: "Install updated",
       updated_message: "Subsequent runs use the new settings.",
+      enabled_message: "Scheduler enabled — it will fire on the next cron tick.",
+      disabled_message: "Scheduler disabled — it will not fire until re-enabled.",
       uninstalled_title: "Scheduler uninstalled",
       uninstalled_message: "It will not fire on this project until reinstalled.",
       error_title: "Something went wrong",

--- a/packages/i18n/src/locales/en/core.ts
+++ b/packages/i18n/src/locales/en/core.ts
@@ -178,6 +178,81 @@ export default {
     },
   },
 
+  scheduler_bindings: {
+    tab_label: "Schedulers",
+    title: "Schedulers",
+    subtitle:
+      "Schedulers installed on this project. Each install fires its prompt against the project on the configured cron.",
+    install: "Install scheduler",
+    columns: {
+      name: "Scheduler",
+      cron: "Schedule",
+      next_run: "Next run",
+      last_run: "Last run",
+      status: "Status",
+      updated: "Updated",
+    },
+    status: {
+      enabled: "Enabled",
+      disabled: "Disabled",
+    },
+    actions: {
+      edit: "Edit",
+      uninstall: "Uninstall",
+    },
+    list: {
+      empty:
+        "No schedulers installed on this project yet. Click “Install scheduler” to add one from the workspace catalog.",
+      none_yet: "(never)",
+    },
+    install_modal: {
+      title: "Install scheduler",
+      scheduler_label: "Scheduler",
+      scheduler_help: "Pick from your workspace's enabled schedulers. Already-installed ones aren't listed.",
+      none_available_title: "No schedulers available",
+      none_available_body:
+        "Either every workspace scheduler is already installed on this project, or your workspace admin hasn't enabled any. Visit Workspace → Schedulers to manage the catalog.",
+      cron_label: "Schedule (cron)",
+      cron_help: "5-field cron expression in UTC, e.g. ``0 9 * * *`` for 09:00 UTC every day.",
+      cron_placeholder: "0 9 * * *",
+      extra_context_label: "Project context (optional)",
+      extra_context_help:
+        "Appended to the scheduler's base prompt at run time. Use it to give project-specific framing the workspace prompt shouldn't carry.",
+      extra_context_placeholder: "Notes specific to this project…",
+      enabled_label: "Enabled",
+      enabled_help: "Disabled installs do not fire on the cron until re-enabled.",
+      install: "Install",
+      installing: "Installing…",
+      cancel: "Cancel",
+      errors: {
+        scheduler_required: "Pick a scheduler.",
+        cron_required: "Cron expression is required.",
+      },
+    },
+    edit_modal: {
+      title: "Edit scheduler install",
+      save: "Save",
+      saving: "Saving…",
+    },
+    uninstall_modal: {
+      title: "Uninstall scheduler?",
+      body: "The scheduler stops firing on this project. The workspace definition is unaffected and can be re-installed later.",
+      confirm: "Uninstall",
+    },
+    toast: {
+      installed_title: "Scheduler installed",
+      installed_message: "It will fire on the configured cron.",
+      updated_title: "Install updated",
+      updated_message: "Subsequent runs use the new settings.",
+      uninstalled_title: "Scheduler uninstalled",
+      uninstalled_message: "It will not fire on this project until reinstalled.",
+      error_title: "Something went wrong",
+      install_failed: "Could not install the scheduler.",
+      update_failed: "Could not update the install.",
+      uninstall_failed: "Could not uninstall the scheduler.",
+    },
+  },
+
   auth: {
     common: {
       email: {

--- a/packages/services/src/scheduler/scheduler.service.ts
+++ b/packages/services/src/scheduler/scheduler.service.ts
@@ -70,6 +70,14 @@ export interface ISchedulerBinding {
 
 export interface ISchedulerBindingCreatePayload {
   scheduler: string;
+  /**
+   * Project the binding installs on. Redundant with the projectId already
+   * encoded in the request URL, but the cloud serializer's ``is_valid()``
+   * runs before its view-level ``serializer.save(project=...)`` override
+   * and rejects the body if this isn't present. Until the backend stops
+   * requiring it, the client has to send it.
+   */
+  project: string;
   cron: string;
   extra_context?: string;
   enabled?: boolean;

--- a/packages/types/src/settings.ts
+++ b/packages/types/src/settings.ts
@@ -37,7 +37,8 @@ export type TProjectSettingsTabs =
   | "states"
   | "labels"
   | "estimates"
-  | "automations";
+  | "automations"
+  | "schedulers";
 export type TProjectSettingsItem = {
   key: TProjectSettingsTabs;
   i18n_label: string;


### PR DESCRIPTION
## Summary

Per ``.ai_design/project_scheduler/design.md`` §11, the per-project Scheduler binding management UI was deferred when #76 shipped — only the model, REST API, frontend service client, and workspace-level catalog page landed. This PR adds the missing project surface plus two related fixes.

The cloud-side endpoints (``GET/POST/PATCH/DELETE /api/workspaces/<slug>/projects/<id>/scheduler-bindings/``) and the frontend service client are already in place from #76. This PR is purely the consumer UI plus a small payload-shape correction.

## Changes

### 1. ``feat(web): project Schedulers settings tab`` (1a3f9c91)

A new tab under Project Settings → Execution, beside Automations and GitHub.

- ``packages/types`` and ``packages/constants/settings/project``: register ``"schedulers"`` in ``TProjectSettingsTabs`` and ``GROUPED_PROJECT_SETTINGS[EXECUTION]``. Project-admin only — the backend gates binding mutations the same way.
- ``apps/web/core/components/settings/project/sidebar/item-icon``: ``schedulers`` → ``CalendarClock`` (matches the workspace sidebar icon for visual continuity).
- Three modals in ``apps/web/core/components/project/scheduler-bindings/``:
  - **Install**: scheduler picker filtered to enabled workspace schedulers not already bound on this project (so the unique constraint never fires); cron field with default ``0 9 * * *`` UTC daily; optional project-context textarea; enabled toggle.
  - **Edit**: change cron / context / enabled on an existing binding.
  - **Uninstall**: confirm-and-destroy.
- Page at ``apps/web/app/(all)/[workspaceSlug]/(settings)/settings/projects/[projectId]/schedulers/``: lists bindings (name, cron, next_run, last_run, status, updated, actions), renders the modals.
- ``apps/web/app/routes/core.ts``: registers the route (RR7 uses an explicit route table here, not file-based discovery).
- ``packages/i18n/src/locales/en/core.ts``: ``scheduler_bindings`` block — title / columns / status / actions / install modal / edit modal / uninstall modal / toasts.

Data layer is SWR-driven, matching the workspace catalog page; the existing ``SchedulerStore`` explicitly states it does not carry bindings.

### 2. ``fix(web): include project in install-binding payload`` (b74a7929)

The cloud's ``SchedulerBindingSerializer`` lists ``project`` in ``Meta.fields`` without flagging it read-only, so DRF treats it as required. The view's ``serializer.is_valid()`` runs before its ``serializer.save(project=project, ...)`` override and returns 400 ``{"project": ["This field is required."]}`` whenever the body omits the field — even though the projectId is already in the URL.

Effect on the new tab: every install attempt failed with a generic toast.

- Send ``project: projectId`` in the create-binding body.
- Update ``ISchedulerBindingCreatePayload`` to include ``project: string`` so TypeScript catches anyone who forgets next time.

A cleaner backend fix is to mark ``project`` as ``read_only`` on the serializer and rely on the view's ``save(project=...)`` override — worth a follow-up cross-stack PR but out of scope here.

### 3. ``feat(web): inline enable/disable toggle`` (82c0b53a)

The status column was a static badge — flipping enabled state required opening the edit modal and clicking Save. Replace the badge with a ``ToggleSwitch`` that PATCHes the binding directly.

- Each row tracks its own ``toggling`` state so a click during the in-flight PATCH is a no-op.
- Toast names the new state: "Scheduler enabled — it will fire on the next cron tick" / "Scheduler disabled — it will not fire until re-enabled".
- Same ``updateBinding`` endpoint the edit modal uses, restricted to the ``enabled`` field.
- Edit / Uninstall buttons stay where they were.

## Test plan

- [x] ``pnpm turbo run check:types --filter=web`` — no new errors (pre-existing failures in github-* / project/form / scheduler.store unchanged).
- [x] ``pnpm exec oxlint --max-warnings=0`` on the touched files — clean.
- [x] Local docker stack: install / toggle / edit / uninstall flows verified end-to-end against the running backend.
- [ ] Smoke test on a project where the workspace catalog has every scheduler already installed (install modal should show the "No schedulers available" empty state with a pointer to Workspace → Schedulers).
- [ ] Smoke test as a non-admin project member (the tab itself shouldn't render — same gate as Automations / GitHub).

🤖 Generated with [Claude Code](https://claude.com/claude-code)