### PR TITLE
fix(migrations): runner.0007 depends on db.0126 (Issue.assigned_pod)

### DIFF
--- a/apps/api/pi_dash/runner/migrations/0007_pod_project_relationship.py
+++ b/apps/api/pi_dash/runner/migrations/0007_pod_project_relationship.py
@@ -141,7 +141,9 @@ class Migration(migrations.Migration):
     atomic = False
 
     dependencies = [
-        ("db", "0001_initial"),
+        # Issue.assigned_pod (added in db.0126) is read by
+        # _null_issue_assigned_pods below, so that field must already exist.
+        ("db", "0126_issue_assigned_pod"),
         ("runner", "0006_machine_token"),
     ]
 


### PR DESCRIPTION
## Summary

- `runner.0007_pod_project_relationship` declared only `("db", "0001_initial")` as its db-app dependency, but its first data step (`_null_issue_assigned_pods`) reads `Issue.assigned_pod`, which is added by `db.0126_issue_assigned_pod`.
- On a fresh database Django was free to schedule `runner.0007` before `db.0126`, crashing with `FieldError: Cannot resolve keyword 'assigned_pod' into field.`
- This change adds the explicit `("db", "0126_issue_assigned_pod")` dependency.

Note: the migration is `atomic = False`, so when this bites it can leave `pod.project_id` in place but `runner.0007` unrecorded — re-running then trips a separate `DuplicateColumn` until the volume is wiped.

## Test plan

- [x] `docker compose -f docker-compose-local.yml down -v && up -d` against this branch — migrator runs end-to-end (verified locally; previously failed).
- [ ] CI green.