### PR TITLE
feat: surface runner/agent failures on the issue activity feed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,10 @@ venv
 .venv
 *.pyc
 staticfiles
+# Django collectstatic output for the api app (STATIC_ROOT in
+# apps/api/pi_dash/settings/common.py). Regenerated on every deploy;
+# never source-of-truth.
+apps/api/pi_dash/static-assets/
 mediafiles
 .env
 .DS_Store

--- a/apps/api/pi_dash/runner/services/run_lifecycle.py
+++ b/apps/api/pi_dash/runner/services/run_lifecycle.py
@@ -133,6 +133,22 @@ def apply_run_resume_unavailable(runner: Runner, run_id: UUID | str) -> None:
         )
 
 
+# Detail-string prefixes for failures that aren't actionable by the user
+# (the runner restarted, the cloud watchdog reaped a stalled cluster of
+# runs, etc.). These get a DB row update and nothing else — surfacing a
+# `Run failed: daemon shutdown requested` on the issue thread is noise,
+# not signal. The next continuation will pick the work back up.
+#
+# Strings are intentionally compared as prefixes so the runner / cloud
+# can append context (timestamps, run ids) without breaking the guard.
+# When the remediation-map work lands, this hard-coded list goes away
+# and we route on `FailureReason` instead.
+_INFRA_FAILURE_DETAIL_PREFIXES = (
+    "daemon shutdown requested",
+    "agent stalled: no events for >",
+)
+
+
 def _post_failure_comment(run_id: UUID | str, error_detail: str) -> None:
     """Post a single IssueComment from the agent system user describing
     why a run failed. Mirrors the shape of ``apply_run_paused``'s comment
@@ -144,11 +160,20 @@ def _post_failure_comment(run_id: UUID | str, error_detail: str) -> None:
     root cause we can't prove from telemetry alone. Hidden behind the
     public ``finalize_run_terminal`` entry-point so callers don't have
     to opt in.
+
+    Suppressed for known infrastructure-flavored failures (daemon
+    restart, cloud-side stall reconciler) — see
+    ``_INFRA_FAILURE_DETAIL_PREFIXES``. The DB row still gets the
+    ``error`` field; we just don't pollute the issue thread.
     """
-    from django.utils.html import escape, format_html
+    from django.utils.html import format_html
 
     from pi_dash.db.models.issue import IssueComment
     from pi_dash.orchestration.workpad import get_agent_system_user
+
+    detail = (error_detail or "").strip()
+    if detail.startswith(_INFRA_FAILURE_DETAIL_PREFIXES):
+        return
 
     run = (
         AgentRun.objects.select_related("work_item", "work_item__project")
@@ -158,7 +183,6 @@ def _post_failure_comment(run_id: UUID | str, error_detail: str) -> None:
     if run is None or run.work_item_id is None:
         return
 
-    detail = (error_detail or "").strip()
     if detail:
         body = format_html(
             "<p><strong>Run failed.</strong></p><pre>{}</pre>",
@@ -169,7 +193,7 @@ def _post_failure_comment(run_id: UUID | str, error_detail: str) -> None:
         # silently drop the activity entry.
         body = format_html(
             "<p><strong>Run failed.</strong> {}</p>",
-            escape("(no diagnostic detail)"),
+            "(no diagnostic detail)",
         )
 
     IssueComment.objects.create(

--- a/apps/api/pi_dash/runner/services/run_lifecycle.py
+++ b/apps/api/pi_dash/runner/services/run_lifecycle.py
@@ -133,6 +133,54 @@ def apply_run_resume_unavailable(runner: Runner, run_id: UUID | str) -> None:
         )
 
 
+def _post_failure_comment(run_id: UUID | str, error_detail: str) -> None:
+    """Post a single IssueComment from the agent system user describing
+    why a run failed. Mirrors the shape of ``apply_run_paused``'s comment
+    creation so the issue activity feed is the one place a user has to
+    look to understand what happened.
+
+    Conservative wording — we surface the runner's classification + any
+    detail it sent (last command, stderr tail) rather than asserting a
+    root cause we can't prove from telemetry alone. Hidden behind the
+    public ``finalize_run_terminal`` entry-point so callers don't have
+    to opt in.
+    """
+    from django.utils.html import escape, format_html
+
+    from pi_dash.db.models.issue import IssueComment
+    from pi_dash.orchestration.workpad import get_agent_system_user
+
+    run = (
+        AgentRun.objects.select_related("work_item", "work_item__project")
+        .filter(pk=run_id)
+        .first()
+    )
+    if run is None or run.work_item_id is None:
+        return
+
+    detail = (error_detail or "").strip()
+    if detail:
+        body = format_html(
+            "<p><strong>Run failed.</strong></p><pre>{}</pre>",
+            detail,
+        )
+    else:
+        # Defensive: we'd rather post "(no diagnostic detail)" than
+        # silently drop the activity entry.
+        body = format_html(
+            "<p><strong>Run failed.</strong> {}</p>",
+            escape("(no diagnostic detail)"),
+        )
+
+    IssueComment.objects.create(
+        issue=run.work_item,
+        project=run.work_item.project,
+        workspace=run.work_item.workspace,
+        actor=get_agent_system_user(),
+        comment_html=body,
+    )
+
+
 def finalize_run_terminal(
     runner: Runner,
     run_id: UUID | str,
@@ -157,6 +205,18 @@ def finalize_run_terminal(
     if new_status == AgentRunStatus.FAILED and error_detail:
         updates["error"] = error_detail[:16000]
     AgentRun.objects.filter(id=run_id, runner=runner).update(**updates)
+
+    if new_status == AgentRunStatus.FAILED:
+        try:
+            _post_failure_comment(run_id, error_detail)
+        except Exception:
+            # Comment posting must never block the lifecycle terminal
+            # transition. Log and move on so the run still gets reaped /
+            # the pod still gets drained.
+            logger.exception(
+                "run_lifecycle: failed to post failure comment for run %s",
+                run_id,
+            )
 
     from pi_dash.orchestration.scheduling import maybe_apply_deferred_pause
     from pi_dash.runner.services.matcher import (

--- a/apps/api/pi_dash/tests/unit/runner/test_failure_comment.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_failure_comment.py
@@ -1,0 +1,216 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Regression: ``finalize_run_terminal`` posts an IssueComment on FAILED.
+
+Today the issue activity feed is the only UI a user is guaranteed to
+see. If a run fails for any reason — agent stalled, codex crashed,
+git auth — and the cloud only writes ``AgentRun.error`` to the row,
+the user has no in-product signal that anything went wrong: the run
+just disappears from "running" without explanation.
+
+These tests pin down two invariants:
+
+1. A FAILED finalize posts exactly one IssueComment with the runner's
+   error_detail rendered into it.
+2. A successful finalize (COMPLETED) does NOT post a comment — the
+   normal completion path is responsible for its own UX.
+
+Comment-posting failures must never block the lifecycle terminal
+transition; that's covered by the `_post_failure_comment_swallows_errors`
+test.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from django.utils import timezone
+
+from pi_dash.db.models.issue import Issue, IssueComment
+from pi_dash.db.models.state import State
+from pi_dash.runner.models import (
+    AgentRun,
+    AgentRunStatus,
+    Pod,
+    Runner,
+    RunnerStatus,
+)
+from pi_dash.runner.services.run_lifecycle import finalize_run_terminal
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (mirrored from test_runner_live_state.py / test_composer.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def pod(project):
+    return Pod.default_for_project(project)
+
+
+@pytest.fixture
+def state(project):
+    return State.objects.create(
+        name="Todo",
+        project=project,
+        group="unstarted",
+    )
+
+
+@pytest.fixture
+def issue(workspace, project, state, create_user):
+    return Issue.objects.create(
+        name="failure-comment-test",
+        workspace=workspace,
+        project=project,
+        state=state,
+        created_by=create_user,
+        priority="medium",
+    )
+
+
+def _make_runner(user, workspace, pod, name="r1"):
+    return Runner.objects.create(
+        owner=user,
+        workspace=workspace,
+        pod=pod,
+        name=name,
+        status=RunnerStatus.ONLINE,
+        last_heartbeat_at=timezone.now(),
+    )
+
+
+def _make_run(user, workspace, pod, runner, issue, *, status=AgentRunStatus.RUNNING):
+    return AgentRun.objects.create(
+        workspace=workspace,
+        owner=user,
+        created_by=user,
+        pod=pod,
+        runner=runner,
+        work_item=issue,
+        status=status,
+        prompt="test",
+        assigned_at=timezone.now(),
+        started_at=timezone.now(),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _run_on_commit_immediately():
+    """The lifecycle helper schedules drain work via on_commit; tests run
+    outside an atomic block so the callbacks would otherwise never fire."""
+    with patch(
+        "django.db.transaction.on_commit", side_effect=lambda fn, **kw: fn()
+    ):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_failed_finalize_posts_failure_comment(
+    db, create_user, workspace, pod, issue
+):
+    """Asserts the new behaviour: a FAILED finalize creates one comment
+    on the issue with the runner's error_detail visible inside it."""
+    runner = _make_runner(create_user, workspace, pod)
+    run = _make_run(create_user, workspace, pod, runner, issue)
+
+    detail = (
+        "no agent frames for 5 minutes; last command: `git fetch origin` "
+        "in `/tmp/x` (started 297s ago)"
+    )
+    finalize_run_terminal(
+        runner, run.id, AgentRunStatus.FAILED, error_detail=detail
+    )
+
+    comments = list(IssueComment.objects.filter(issue=issue))
+    assert len(comments) == 1, f"expected 1 comment, got {len(comments)}"
+    body = comments[0].comment_html
+    assert "Run failed" in body
+    # The detail string must be visible to the user — that's the whole
+    # point of the comment. HTML escaping may transform backticks but the
+    # essential context (the cmd + the stall) must remain.
+    assert "git fetch origin" in body
+    assert "5 minutes" in body
+
+
+@pytest.mark.unit
+def test_completed_finalize_does_not_post_comment(
+    db, create_user, workspace, pod, issue
+):
+    """COMPLETED finalize must not post a failure comment — the success
+    path has its own UX and we shouldn't double-comment."""
+    runner = _make_runner(create_user, workspace, pod)
+    run = _make_run(create_user, workspace, pod, runner, issue)
+
+    finalize_run_terminal(
+        runner,
+        run.id,
+        AgentRunStatus.COMPLETED,
+        done_payload={"conclusion": "success"},
+    )
+
+    assert IssueComment.objects.filter(issue=issue).count() == 0
+
+
+@pytest.mark.unit
+def test_post_failure_comment_swallows_errors(
+    db, create_user, workspace, pod, issue
+):
+    """If comment posting raises (DB hiccup, missing system user, etc.),
+    `finalize_run_terminal` must still complete the lifecycle update.
+    A failure-comment crash cannot leave runs stuck in non-terminal
+    states or block the pod's drain re-fire."""
+    runner = _make_runner(create_user, workspace, pod)
+    run = _make_run(create_user, workspace, pod, runner, issue)
+
+    with patch(
+        "pi_dash.runner.services.run_lifecycle._post_failure_comment",
+        side_effect=RuntimeError("simulated outage"),
+    ):
+        finalize_run_terminal(
+            runner, run.id, AgentRunStatus.FAILED, error_detail="boom"
+        )
+
+    run.refresh_from_db()
+    assert run.status == AgentRunStatus.FAILED
+    assert run.error == "boom"
+    assert run.ended_at is not None
+
+
+@pytest.mark.unit
+def test_failed_finalize_with_orphan_run_no_workitem_does_not_crash(
+    db, create_user, workspace, pod
+):
+    """Some failed runs (e.g. ad-hoc / synthetic) carry no work_item.
+    The comment helper must short-circuit cleanly in that case."""
+    runner = _make_runner(create_user, workspace, pod)
+    run = AgentRun.objects.create(
+        workspace=workspace,
+        owner=create_user,
+        created_by=create_user,
+        pod=pod,
+        runner=runner,
+        work_item=None,
+        status=AgentRunStatus.RUNNING,
+        prompt="orphan",
+        assigned_at=timezone.now(),
+        started_at=timezone.now(),
+    )
+
+    finalize_run_terminal(
+        runner, run.id, AgentRunStatus.FAILED, error_detail="orphan failure"
+    )
+
+    run.refresh_from_db()
+    assert run.status == AgentRunStatus.FAILED
+    # Total comment count across the whole DB doesn't change for a run
+    # with no work_item.
+    assert IssueComment.objects.count() == 0

--- a/apps/api/pi_dash/tests/unit/runner/test_failure_comment.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_failure_comment.py
@@ -142,6 +142,100 @@ def test_failed_finalize_posts_failure_comment(
 
 
 @pytest.mark.unit
+def test_failed_finalize_renders_multiline_stderr_tail(
+    db, create_user, workspace, pod, issue
+):
+    """Real failure details are multi-line: classifier + last cmd +
+    stderr tail joined with `\\n  `. The whole tail must end up in the
+    rendered comment so the user can see what the agent was complaining
+    about, not just the headline."""
+    runner = _make_runner(create_user, workspace, pod)
+    run = _make_run(create_user, workspace, pod, runner, issue)
+
+    detail = (
+        "no agent frames for 5 minutes; "
+        "last command: `npm install` (started 297s ago); "
+        "stderr tail (3 line(s)):\n"
+        "  npm warn deprecated foo@1.0.0\n"
+        "  npm err! ENOTFOUND registry.npmjs.org\n"
+        "  npm err! exiting with code 1"
+    )
+    finalize_run_terminal(
+        runner, run.id, AgentRunStatus.FAILED, error_detail=detail
+    )
+
+    body = IssueComment.objects.get(issue=issue).comment_html
+    for line in [
+        "npm warn deprecated foo@1.0.0",
+        "npm err! ENOTFOUND registry.npmjs.org",
+        "npm err! exiting with code 1",
+    ]:
+        assert line in body, f"stderr line missing from comment: {line!r}"
+
+
+@pytest.mark.unit
+def test_failure_comment_actor_is_agent_system_user(
+    db, create_user, workspace, pod, issue
+):
+    """Pin the actor identity. If a future refactor sets `actor` to the
+    run's owner instead, the user would see themselves complaining
+    about their own task failing in the activity feed."""
+    from pi_dash.orchestration.workpad import get_agent_system_user
+
+    runner = _make_runner(create_user, workspace, pod)
+    run = _make_run(create_user, workspace, pod, runner, issue)
+    finalize_run_terminal(
+        runner, run.id, AgentRunStatus.FAILED, error_detail="boom"
+    )
+    comment = IssueComment.objects.get(issue=issue)
+    assert comment.actor_id == get_agent_system_user().id
+
+
+@pytest.mark.unit
+def test_daemon_restart_failure_does_not_post_comment(
+    db, create_user, workspace, pod, issue
+):
+    """Infrastructure-flavored failures (the runner went down for
+    SIGTERM) shouldn't surface on the issue thread — there's nothing
+    the user can act on, and the next continuation will pick up the
+    work. The DB row still gets the error stamp."""
+    runner = _make_runner(create_user, workspace, pod)
+    run = _make_run(create_user, workspace, pod, runner, issue)
+
+    finalize_run_terminal(
+        runner,
+        run.id,
+        AgentRunStatus.FAILED,
+        error_detail="daemon shutdown requested",
+    )
+
+    assert IssueComment.objects.filter(issue=issue).count() == 0
+    run.refresh_from_db()
+    assert run.status == AgentRunStatus.FAILED
+    assert run.error == "daemon shutdown requested"
+
+
+@pytest.mark.unit
+def test_cloud_stall_reconciler_failure_does_not_post_comment(
+    db, create_user, workspace, pod, issue
+):
+    """The cloud-side stall watchdog (`reconcile_stalled_runs`) emits
+    `agent stalled: no events for >360s` — same suppression class as
+    daemon-restart."""
+    runner = _make_runner(create_user, workspace, pod)
+    run = _make_run(create_user, workspace, pod, runner, issue)
+
+    finalize_run_terminal(
+        runner,
+        run.id,
+        AgentRunStatus.FAILED,
+        error_detail="agent stalled: no events for >360s",
+    )
+
+    assert IssueComment.objects.filter(issue=issue).count() == 0
+
+
+@pytest.mark.unit
 def test_completed_finalize_does_not_post_comment(
     db, create_user, workspace, pod, issue
 ):

--- a/runner/src/agent/mod.rs
+++ b/runner/src/agent/mod.rs
@@ -5,13 +5,62 @@
 
 use anyhow::Result;
 use chrono::{DateTime, Utc};
+use std::collections::VecDeque;
 use std::path::Path;
+use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::watch;
+use tokio::sync::{Mutex, watch};
 use uuid::Uuid;
 
 use crate::cloud::protocol::{ApprovalDecision, ApprovalKind, FailureReason};
 use crate::config::schema::{AgentKind, RunnerConfig};
+
+/// Per-line cap for stderr lines retained in the ring. Codex / claude can
+/// emit very long lines (stack traces, JSON dumps); without a per-line cap
+/// a single 1 MB line would defeat the line-count cap. 512 chars is enough
+/// to read most error messages without blowing up the failure detail.
+pub const STDERR_LINE_CAP_CHARS: usize = 512;
+
+/// Bounded ring buffer of recent stderr lines from an agent subprocess.
+/// Each agent's `drain_stderr` task pushes here; the supervisor reads
+/// when it needs to enrich a `RunFailed` detail.
+#[derive(Debug)]
+pub struct StderrBuffer {
+    cap: usize,
+    lines: VecDeque<String>,
+}
+
+impl StderrBuffer {
+    pub fn new(cap: usize) -> Self {
+        Self {
+            cap,
+            lines: VecDeque::with_capacity(cap),
+        }
+    }
+
+    pub fn push(&mut self, line: &str) {
+        let truncated = if line.len() > STDERR_LINE_CAP_CHARS {
+            // Truncate on a char boundary.
+            let mut end = STDERR_LINE_CAP_CHARS;
+            while !line.is_char_boundary(end) && end > 0 {
+                end -= 1;
+            }
+            format!("{}…", &line[..end])
+        } else {
+            line.to_string()
+        };
+        if self.lines.len() == self.cap {
+            self.lines.pop_front();
+        }
+        self.lines.push_back(truncated);
+    }
+
+    pub fn snapshot(&self) -> Vec<String> {
+        self.lines.iter().cloned().collect()
+    }
+}
+
+pub type StderrRing = Arc<Mutex<StderrBuffer>>;
 
 /// Volatile process-handle the bridge surfaces to the supervisor for
 /// observability. PID is captured at spawn time, `exit_rx` fires once the
@@ -210,6 +259,18 @@ impl AgentBridge {
             AgentBridge::ClaudeCode(b) => b.process_handle(),
         }
     }
+
+    /// Snapshot the last N lines of agent stderr. Returns `vec![]` if the
+    /// process has emitted nothing on stderr (the common case for healthy
+    /// runs). Used by the supervisor to enrich `RunFailed` details so the
+    /// cloud / UI can tell the user *why* the agent died beyond just
+    /// "agent stdout closed" or "no agent frames for 5 minutes".
+    pub async fn recent_stderr(&self) -> Vec<String> {
+        match self {
+            AgentBridge::Codex(b) => b.server.recent_stderr().await,
+            AgentBridge::ClaudeCode(b) => b.recent_stderr().await,
+        }
+    }
 }
 
 fn selected_model(
@@ -221,7 +282,44 @@ fn selected_model(
 
 #[cfg(test)]
 mod tests {
-    use super::selected_model;
+    use super::{STDERR_LINE_CAP_CHARS, StderrBuffer, selected_model};
+
+    #[test]
+    fn stderr_buffer_evicts_oldest_when_full() {
+        let mut buf = StderrBuffer::new(3);
+        buf.push("a");
+        buf.push("b");
+        buf.push("c");
+        buf.push("d");
+        assert_eq!(buf.snapshot(), vec!["b", "c", "d"]);
+    }
+
+    #[test]
+    fn stderr_buffer_truncates_long_lines() {
+        let mut buf = StderrBuffer::new(2);
+        let long = "x".repeat(STDERR_LINE_CAP_CHARS * 2);
+        buf.push(&long);
+        let snap = buf.snapshot();
+        assert_eq!(snap.len(), 1);
+        // Truncated line ends with a one-char ellipsis sentinel.
+        assert!(snap[0].ends_with('…'), "expected ellipsis sentinel: {snap:?}");
+        // Truncation respects char-boundary semantics: result fits within cap +
+        // the multi-byte ellipsis.
+        assert!(snap[0].len() <= STDERR_LINE_CAP_CHARS + 4);
+    }
+
+    #[test]
+    fn stderr_buffer_handles_multibyte_input() {
+        let mut buf = StderrBuffer::new(1);
+        // "ä" is 2 bytes; build a string that crosses the cap mid-character.
+        let line: String = std::iter::repeat('ä')
+            .take(STDERR_LINE_CAP_CHARS)
+            .collect();
+        buf.push(&line);
+        // Should not panic on truncation (regression: naive byte slicing
+        // would split a multi-byte sequence).
+        assert_eq!(buf.snapshot().len(), 1);
+    }
 
     #[test]
     fn selected_model_prefers_run_override() {

--- a/runner/src/agent/mod.rs
+++ b/runner/src/agent/mod.rs
@@ -15,11 +15,18 @@ use uuid::Uuid;
 use crate::cloud::protocol::{ApprovalDecision, ApprovalKind, FailureReason};
 use crate::config::schema::{AgentKind, RunnerConfig};
 
-/// Per-line cap for stderr lines retained in the ring. Codex / claude can
-/// emit very long lines (stack traces, JSON dumps); without a per-line cap
-/// a single 1 MB line would defeat the line-count cap. 512 chars is enough
-/// to read most error messages without blowing up the failure detail.
-pub const STDERR_LINE_CAP_CHARS: usize = 512;
+/// Per-line cap, **in bytes**, for stderr lines retained in the ring.
+/// Compared against `str::len()` which is byte length, not char count —
+/// 512 bytes accommodates most error lines (and a 200-char line of CJK
+/// would be ~600 bytes and get truncated). Without a per-line cap a
+/// single 1 MB line could defeat the line-count cap.
+pub const STDERR_LINE_CAP_BYTES: usize = 512;
+
+/// How many stderr lines to retain in the per-process ring. 30 lines ×
+/// 512 bytes ≈ 15 KB upper bound; comfortably fits in a `RunFailed.detail`
+/// payload after truncation while still surfacing enough recent context
+/// to diagnose most failures (auth errors, panics, segfaults).
+pub const STDERR_RING_LINES: usize = 30;
 
 /// Bounded ring buffer of recent stderr lines from an agent subprocess.
 /// Each agent's `drain_stderr` task pushes here; the supervisor reads
@@ -31,7 +38,12 @@ pub struct StderrBuffer {
 }
 
 impl StderrBuffer {
+    /// Construct a buffer with capacity `cap`. A `cap` of zero is
+    /// silently clamped to 1 — the eviction logic in `push` only fires
+    /// on `len() == cap`, which would never hold for `cap == 0` after
+    /// the first push, leaving the buffer to grow unboundedly.
     pub fn new(cap: usize) -> Self {
+        let cap = cap.max(1);
         Self {
             cap,
             lines: VecDeque::with_capacity(cap),
@@ -39,9 +51,11 @@ impl StderrBuffer {
     }
 
     pub fn push(&mut self, line: &str) {
-        let truncated = if line.len() > STDERR_LINE_CAP_CHARS {
-            // Truncate on a char boundary.
-            let mut end = STDERR_LINE_CAP_CHARS;
+        let truncated = if line.len() > STDERR_LINE_CAP_BYTES {
+            // Truncate on a char boundary so we never split a multi-byte
+            // sequence; append a single `…` so consumers can tell the
+            // line was clipped.
+            let mut end = STDERR_LINE_CAP_BYTES;
             while !line.is_char_boundary(end) && end > 0 {
                 end -= 1;
             }
@@ -282,7 +296,7 @@ fn selected_model(
 
 #[cfg(test)]
 mod tests {
-    use super::{STDERR_LINE_CAP_CHARS, StderrBuffer, selected_model};
+    use super::{STDERR_LINE_CAP_BYTES, StderrBuffer, selected_model};
 
     #[test]
     fn stderr_buffer_evicts_oldest_when_full() {
@@ -297,7 +311,7 @@ mod tests {
     #[test]
     fn stderr_buffer_truncates_long_lines() {
         let mut buf = StderrBuffer::new(2);
-        let long = "x".repeat(STDERR_LINE_CAP_CHARS * 2);
+        let long = "x".repeat(STDERR_LINE_CAP_BYTES * 2);
         buf.push(&long);
         let snap = buf.snapshot();
         assert_eq!(snap.len(), 1);
@@ -305,7 +319,7 @@ mod tests {
         assert!(snap[0].ends_with('…'), "expected ellipsis sentinel: {snap:?}");
         // Truncation respects char-boundary semantics: result fits within cap +
         // the multi-byte ellipsis.
-        assert!(snap[0].len() <= STDERR_LINE_CAP_CHARS + 4);
+        assert!(snap[0].len() <= STDERR_LINE_CAP_BYTES + 4);
     }
 
     #[test]
@@ -313,7 +327,7 @@ mod tests {
         let mut buf = StderrBuffer::new(1);
         // "ä" is 2 bytes; build a string that crosses the cap mid-character.
         let line: String = std::iter::repeat('ä')
-            .take(STDERR_LINE_CAP_CHARS)
+            .take(STDERR_LINE_CAP_BYTES)
             .collect();
         buf.push(&line);
         // Should not panic on truncation (regression: naive byte slicing

--- a/runner/src/agent/mod.rs
+++ b/runner/src/agent/mod.rs
@@ -51,17 +51,20 @@ impl StderrBuffer {
     }
 
     pub fn push(&mut self, line: &str) {
-        let truncated = if line.len() > STDERR_LINE_CAP_BYTES {
+        let Some(sanitized) = sanitize_stderr_line(line) else {
+            return;
+        };
+        let truncated = if sanitized.len() > STDERR_LINE_CAP_BYTES {
             // Truncate on a char boundary so we never split a multi-byte
             // sequence; append a single `…` so consumers can tell the
             // line was clipped.
             let mut end = STDERR_LINE_CAP_BYTES;
-            while !line.is_char_boundary(end) && end > 0 {
+            while !sanitized.is_char_boundary(end) && end > 0 {
                 end -= 1;
             }
-            format!("{}…", &line[..end])
+            format!("{}…", &sanitized[..end])
         } else {
-            line.to_string()
+            sanitized
         };
         if self.lines.len() == self.cap {
             self.lines.pop_front();
@@ -75,6 +78,80 @@ impl StderrBuffer {
 }
 
 pub type StderrRing = Arc<Mutex<StderrBuffer>>;
+
+/// Clean an incoming stderr line for inclusion in the failure-detail
+/// payload that ends up in an issue activity comment. Two responsibilities:
+///
+/// 1. Strip ANSI escape sequences. Codex / claude colorize their tracing
+///    output via `tracing-subscriber`'s default formatter; the escape
+///    bytes (e.g. `\x1b[2m`) render as literal glyphs (`␛[2m`) in the
+///    issue comment HTML, making the detail unreadable.
+/// 2. Drop low-level (`INFO` / `DEBUG` / `TRACE`) codex tracing log
+///    lines. These are codex's internal observability stream, not
+///    actual program errors. Surfacing them to the user is pure noise —
+///    every codex turn emits dozens. `WARN` and `ERROR` lines, plus any
+///    unstructured stderr (panics, child-process traces, raw error
+///    messages), pass through unchanged.
+///
+/// Returns `None` to mean "drop this line entirely."
+pub fn sanitize_stderr_line(line: &str) -> Option<String> {
+    let stripped = strip_ansi_codes(line);
+    let trimmed = stripped.trim_end();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if is_low_level_tracing(trimmed) {
+        return None;
+    }
+    Some(trimmed.to_string())
+}
+
+/// Remove ANSI CSI escape sequences (`\x1b[…<letter>`) from `s`. Other
+/// escape forms (OSC, charset selection, etc.) are left alone — they're
+/// vanishingly rare in dev-tool stderr and CSI is what tracing-subscriber
+/// emits.
+fn strip_ansi_codes(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\x1b' && chars.peek() == Some(&'[') {
+            chars.next(); // consume '['
+            // Skip parameters / intermediate bytes, then the final
+            // alphabetic byte that terminates the CSI sequence.
+            while let Some(&p) = chars.peek() {
+                chars.next();
+                if p.is_ascii_alphabetic() {
+                    break;
+                }
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+/// True for lines that match `tracing-subscriber`'s default text
+/// formatter at INFO / DEBUG / TRACE level. Format is roughly
+/// `<RFC3339 timestamp ending in 'Z'>  <LEVEL>  <rest>`. The two-space
+/// gap between timestamp and level + the right-aligned LEVEL field
+/// (`" INFO"`, `"DEBUG"`, `"TRACE"`, `" WARN"`, `"ERROR"`) is what we
+/// match against. Lines without the trailing-`Z` timestamp prefix are
+/// considered real stderr and pass through.
+fn is_low_level_tracing(line: &str) -> bool {
+    // Look for "...Z " somewhere near the start; tracing's default
+    // format places the level immediately after the timestamp + 2 spaces.
+    let Some((_ts, rest)) = line.split_once("Z ") else {
+        return false;
+    };
+    let rest = rest.trim_start();
+    // tracing-subscriber pads the level to width 5: " INFO" / "DEBUG" /
+    // "TRACE" / " WARN" / "ERROR". After trim_start, that becomes the
+    // bare level name + space.
+    rest.starts_with("INFO ")
+        || rest.starts_with("DEBUG ")
+        || rest.starts_with("TRACE ")
+}
 
 /// Volatile process-handle the bridge surfaces to the supervisor for
 /// observability. PID is captured at spawn time, `exit_rx` fires once the
@@ -296,7 +373,10 @@ fn selected_model(
 
 #[cfg(test)]
 mod tests {
-    use super::{STDERR_LINE_CAP_BYTES, StderrBuffer, selected_model};
+    use super::{
+        STDERR_LINE_CAP_BYTES, StderrBuffer, sanitize_stderr_line, selected_model,
+        strip_ansi_codes,
+    };
 
     #[test]
     fn stderr_buffer_evicts_oldest_when_full() {
@@ -306,6 +386,84 @@ mod tests {
         buf.push("c");
         buf.push("d");
         assert_eq!(buf.snapshot(), vec!["b", "c", "d"]);
+    }
+
+    #[test]
+    fn strip_ansi_codes_removes_csi_escapes() {
+        // Real codex tracing output: timestamp + level wrapped in
+        // color CSI sequences. Strip should leave plain text intact.
+        let input = "\x1b[2m2026-05-03T07:27:06.636239Z\x1b[0m \x1b[32m INFO\x1b[0m hello";
+        assert_eq!(
+            strip_ansi_codes(input),
+            "2026-05-03T07:27:06.636239Z  INFO hello"
+        );
+    }
+
+    #[test]
+    fn strip_ansi_codes_passes_plain_text_unchanged() {
+        let input = "permission denied (publickey)";
+        assert_eq!(strip_ansi_codes(input), input);
+    }
+
+    #[test]
+    fn sanitize_drops_codex_info_tracing_lines() {
+        // The exact pattern that flooded the failure-comment field —
+        // codex's per-event INFO log, ANSI-colored. Should be dropped.
+        let input =
+            "\x1b[2m2026-05-03T07:27:06.636239Z\x1b[0m \x1b[32m INFO\x1b[0m \
+             session_loop{thread_id=abc}: codex.sse_event";
+        assert_eq!(sanitize_stderr_line(input), None);
+    }
+
+    #[test]
+    fn sanitize_drops_debug_and_trace() {
+        for level in ["DEBUG", "TRACE"] {
+            let input = format!("2026-05-03T07:27:06.636239Z {level} something");
+            assert_eq!(
+                sanitize_stderr_line(&input),
+                None,
+                "should drop {level}",
+            );
+        }
+    }
+
+    #[test]
+    fn sanitize_keeps_warn_and_error_tracing_lines() {
+        // Real diagnostic content — keep it. (`tracing-subscriber` pads
+        // the level to width 5, so WARN gets a leading space.)
+        let warn = "\x1b[2m2026-05-03T07:27:06.636239Z\x1b[0m  WARN \
+                    something: deprecated foo@1.0.0";
+        let err = "2026-05-03T07:27:06.636239Z ERROR network: timed out";
+        assert!(sanitize_stderr_line(warn).is_some());
+        assert!(sanitize_stderr_line(err).is_some());
+    }
+
+    #[test]
+    fn sanitize_keeps_unstructured_stderr() {
+        // Panics, raw error messages, gh CLI output — anything that
+        // doesn't match the tracing format passes through.
+        let panic = "thread 'main' panicked at 'oh no', src/main.rs:42";
+        let gh = "gh: error: HTTP 401: Bad credentials";
+        assert!(sanitize_stderr_line(panic).is_some());
+        assert!(sanitize_stderr_line(gh).is_some());
+    }
+
+    #[test]
+    fn sanitize_drops_empty_lines() {
+        assert_eq!(sanitize_stderr_line(""), None);
+        assert_eq!(sanitize_stderr_line("   "), None);
+        assert_eq!(sanitize_stderr_line("\x1b[0m\x1b[2m"), None);
+    }
+
+    #[test]
+    fn buffer_skips_filtered_lines() {
+        // Integration: if the drain task pushes a noise line, the buffer
+        // shouldn't grow.
+        let mut buf = StderrBuffer::new(5);
+        buf.push("\x1b[2m2026-05-03T00:00:00Z\x1b[0m  INFO noise");
+        buf.push("real error: ENOENT /tmp/missing");
+        buf.push("\x1b[2m2026-05-03T00:00:01Z\x1b[0m DEBUG noise");
+        assert_eq!(buf.snapshot(), vec!["real error: ENOENT /tmp/missing"]);
     }
 
     #[test]

--- a/runner/src/agent/mod.rs
+++ b/runner/src/agent/mod.rs
@@ -86,12 +86,14 @@ pub type StderrRing = Arc<Mutex<StderrBuffer>>;
 ///    output via `tracing-subscriber`'s default formatter; the escape
 ///    bytes (e.g. `\x1b[2m`) render as literal glyphs (`␛[2m`) in the
 ///    issue comment HTML, making the detail unreadable.
-/// 2. Drop low-level (`INFO` / `DEBUG` / `TRACE`) codex tracing log
-///    lines. These are codex's internal observability stream, not
-///    actual program errors. Surfacing them to the user is pure noise —
-///    every codex turn emits dozens. `WARN` and `ERROR` lines, plus any
-///    unstructured stderr (panics, child-process traces, raw error
-///    messages), pass through unchanged.
+/// 2. Drop codex's own tracing log lines at INFO/DEBUG/TRACE/WARN
+///    levels. These are codex's internal observability stream — every
+///    turn emits dozens of `session_loop{...}: codex.sse_event` INFO
+///    lines and several `codex_core_plugins::manifest: ignoring …` WARN
+///    lines. None are actionable for a human reading the issue thread.
+///    Only `ERROR` tracing lines are kept (real codex failures). Any
+///    unstructured stderr — panics, child-process output, raw error
+///    messages from gh / curl / git / npm — passes through unchanged.
 ///
 /// Returns `None` to mean "drop this line entirely."
 pub fn sanitize_stderr_line(line: &str) -> Option<String> {
@@ -100,7 +102,7 @@ pub fn sanitize_stderr_line(line: &str) -> Option<String> {
     if trimmed.is_empty() {
         return None;
     }
-    if is_low_level_tracing(trimmed) {
+    if is_noisy_tracing(trimmed) {
         return None;
     }
     Some(trimmed.to_string())
@@ -132,25 +134,29 @@ fn strip_ansi_codes(s: &str) -> String {
 }
 
 /// True for lines that match `tracing-subscriber`'s default text
-/// formatter at INFO / DEBUG / TRACE level. Format is roughly
-/// `<RFC3339 timestamp ending in 'Z'>  <LEVEL>  <rest>`. The two-space
-/// gap between timestamp and level + the right-aligned LEVEL field
-/// (`" INFO"`, `"DEBUG"`, `"TRACE"`, `" WARN"`, `"ERROR"`) is what we
-/// match against. Lines without the trailing-`Z` timestamp prefix are
-/// considered real stderr and pass through.
-fn is_low_level_tracing(line: &str) -> bool {
-    // Look for "...Z " somewhere near the start; tracing's default
-    // format places the level immediately after the timestamp + 2 spaces.
+/// formatter at any level **except `ERROR`**. Format is roughly
+/// `<RFC3339 timestamp ending in 'Z'>  <LEVEL>  <rest>`. The
+/// two-space-padded LEVEL field (`" INFO"`, `"DEBUG"`, `"TRACE"`,
+/// `" WARN"`, `"ERROR"`) is what we match against.
+///
+/// `WARN` is treated as noise even though it's not strictly
+/// "low-level": codex's biggest WARN sources (`codex_core_plugins::
+/// manifest` plugin-config warnings, deprecation warnings, etc.) fire
+/// every turn and have nothing to do with run failure. Real run-killing
+/// errors come through either at `ERROR` or as unstructured stderr
+/// (gh CLI errors, curl failures, panic messages) — both pass through.
+///
+/// Lines without the trailing-`Z` timestamp prefix are considered real
+/// stderr and pass through.
+fn is_noisy_tracing(line: &str) -> bool {
     let Some((_ts, rest)) = line.split_once("Z ") else {
         return false;
     };
     let rest = rest.trim_start();
-    // tracing-subscriber pads the level to width 5: " INFO" / "DEBUG" /
-    // "TRACE" / " WARN" / "ERROR". After trim_start, that becomes the
-    // bare level name + space.
     rest.starts_with("INFO ")
         || rest.starts_with("DEBUG ")
         || rest.starts_with("TRACE ")
+        || rest.starts_with("WARN ")
 }
 
 /// Volatile process-handle the bridge surfaces to the supervisor for
@@ -416,8 +422,14 @@ mod tests {
     }
 
     #[test]
-    fn sanitize_drops_debug_and_trace() {
-        for level in ["DEBUG", "TRACE"] {
+    fn sanitize_drops_info_debug_trace_warn() {
+        // INFO/DEBUG/TRACE are noise by definition. WARN is also dropped:
+        // codex's biggest WARN sources (codex_core_plugins::manifest,
+        // deprecation warnings) fire every turn and have nothing to do
+        // with run failure. Observed in real failure comments after the
+        // initial sanitization shipped — WARN noise still buried the
+        // useful diagnostic content.
+        for level in ["INFO", "DEBUG", "TRACE", "WARN"] {
             let input = format!("2026-05-03T07:27:06.636239Z {level} something");
             assert_eq!(
                 sanitize_stderr_line(&input),
@@ -428,13 +440,23 @@ mod tests {
     }
 
     #[test]
-    fn sanitize_keeps_warn_and_error_tracing_lines() {
-        // Real diagnostic content — keep it. (`tracing-subscriber` pads
-        // the level to width 5, so WARN gets a leading space.)
-        let warn = "\x1b[2m2026-05-03T07:27:06.636239Z\x1b[0m  WARN \
-                    something: deprecated foo@1.0.0";
+    fn sanitize_drops_real_codex_plugin_warn() {
+        // Verbatim shape from a production failure comment.
+        let input = "2026-05-03T15:35:11.448580Z  WARN session_loop\
+                     {thread_id=019dee78-85e7-7742-afd8-1fdb9725379f}:\
+                     submission_dispatch{...}:turn{...}: \
+                     codex_core_plugins::manifest: ignoring \
+                     interface.defaultPrompt: prompt must be at most \
+                     128 characters path=/home/rich/.codex/...";
+        assert_eq!(sanitize_stderr_line(input), None);
+    }
+
+    #[test]
+    fn sanitize_keeps_error_tracing_lines() {
+        // ERROR is the one tracing level we keep — codex emits these
+        // on real failures (e.g. session-state corruption). Filter
+        // priority: keep signal, even if it costs a bit of noise.
         let err = "2026-05-03T07:27:06.636239Z ERROR network: timed out";
-        assert!(sanitize_stderr_line(warn).is_some());
         assert!(sanitize_stderr_line(err).is_some());
     }
 

--- a/runner/src/agent/mod.rs
+++ b/runner/src/agent/mod.rs
@@ -31,10 +31,25 @@ pub const STDERR_RING_LINES: usize = 30;
 /// Bounded ring buffer of recent stderr lines from an agent subprocess.
 /// Each agent's `drain_stderr` task pushes here; the supervisor reads
 /// when it needs to enrich a `RunFailed` detail.
+///
+/// The buffer also counts lines rejected by `sanitize_stderr_line`
+/// (codex tracing noise, blank lines, etc.) so the failure-detail
+/// builder can be honest with the user about how much was filtered out.
 #[derive(Debug)]
 pub struct StderrBuffer {
     cap: usize,
     lines: VecDeque<String>,
+    dropped: u64,
+}
+
+/// Result of `StderrBuffer::snapshot`. Carries both the kept lines and
+/// the running tally of rejected lines so the consumer can render a
+/// "(plus N noise lines filtered)" footer instead of silently lying
+/// about completeness.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct StderrSnapshot {
+    pub lines: Vec<String>,
+    pub dropped: u64,
 }
 
 impl StderrBuffer {
@@ -47,11 +62,13 @@ impl StderrBuffer {
         Self {
             cap,
             lines: VecDeque::with_capacity(cap),
+            dropped: 0,
         }
     }
 
     pub fn push(&mut self, line: &str) {
         let Some(sanitized) = sanitize_stderr_line(line) else {
+            self.dropped = self.dropped.saturating_add(1);
             return;
         };
         let truncated = if sanitized.len() > STDERR_LINE_CAP_BYTES {
@@ -72,8 +89,11 @@ impl StderrBuffer {
         self.lines.push_back(truncated);
     }
 
-    pub fn snapshot(&self) -> Vec<String> {
-        self.lines.iter().cloned().collect()
+    pub fn snapshot(&self) -> StderrSnapshot {
+        StderrSnapshot {
+            lines: self.lines.iter().cloned().collect(),
+            dropped: self.dropped,
+        }
     }
 }
 
@@ -357,12 +377,12 @@ impl AgentBridge {
         }
     }
 
-    /// Snapshot the last N lines of agent stderr. Returns `vec![]` if the
-    /// process has emitted nothing on stderr (the common case for healthy
-    /// runs). Used by the supervisor to enrich `RunFailed` details so the
+    /// Snapshot the last N lines of agent stderr **plus** the running
+    /// tally of rejected lines (codex tracing noise, blank lines, etc.).
+    /// Used by the supervisor to enrich `RunFailed` details so the
     /// cloud / UI can tell the user *why* the agent died beyond just
     /// "agent stdout closed" or "no agent frames for 5 minutes".
-    pub async fn recent_stderr(&self) -> Vec<String> {
+    pub async fn recent_stderr(&self) -> StderrSnapshot {
         match self {
             AgentBridge::Codex(b) => b.server.recent_stderr().await,
             AgentBridge::ClaudeCode(b) => b.recent_stderr().await,
@@ -391,7 +411,28 @@ mod tests {
         buf.push("b");
         buf.push("c");
         buf.push("d");
-        assert_eq!(buf.snapshot(), vec!["b", "c", "d"]);
+        let snap = buf.snapshot();
+        assert_eq!(snap.lines, vec!["b", "c", "d"]);
+        assert_eq!(snap.dropped, 0);
+    }
+
+    #[test]
+    fn stderr_buffer_counts_dropped_noise_lines() {
+        // The footer in the failure detail relies on this counter to
+        // tell the user how many lines were filtered. Push a mix of
+        // noise + real content and assert the count matches.
+        let mut buf = StderrBuffer::new(5);
+        buf.push("real error: ENOENT /tmp/missing");
+        buf.push("2026-05-03T07:27:06.636239Z  INFO codex.sse_event"); // dropped
+        buf.push(""); // dropped (empty)
+        buf.push("2026-05-03T15:35:11.448580Z  WARN plugin warning"); // dropped
+        buf.push("another real error");
+        let snap = buf.snapshot();
+        assert_eq!(
+            snap.lines,
+            vec!["real error: ENOENT /tmp/missing", "another real error"]
+        );
+        assert_eq!(snap.dropped, 3, "should count all 3 rejected lines");
     }
 
     #[test]
@@ -485,7 +526,10 @@ mod tests {
         buf.push("\x1b[2m2026-05-03T00:00:00Z\x1b[0m  INFO noise");
         buf.push("real error: ENOENT /tmp/missing");
         buf.push("\x1b[2m2026-05-03T00:00:01Z\x1b[0m DEBUG noise");
-        assert_eq!(buf.snapshot(), vec!["real error: ENOENT /tmp/missing"]);
+        assert_eq!(
+            buf.snapshot().lines,
+            vec!["real error: ENOENT /tmp/missing"]
+        );
     }
 
     #[test]
@@ -494,12 +538,15 @@ mod tests {
         let long = "x".repeat(STDERR_LINE_CAP_BYTES * 2);
         buf.push(&long);
         let snap = buf.snapshot();
-        assert_eq!(snap.len(), 1);
+        assert_eq!(snap.lines.len(), 1);
         // Truncated line ends with a one-char ellipsis sentinel.
-        assert!(snap[0].ends_with('…'), "expected ellipsis sentinel: {snap:?}");
+        assert!(
+            snap.lines[0].ends_with('…'),
+            "expected ellipsis sentinel: {snap:?}"
+        );
         // Truncation respects char-boundary semantics: result fits within cap +
         // the multi-byte ellipsis.
-        assert!(snap[0].len() <= STDERR_LINE_CAP_BYTES + 4);
+        assert!(snap.lines[0].len() <= STDERR_LINE_CAP_BYTES + 4);
     }
 
     #[test]
@@ -512,7 +559,7 @@ mod tests {
         buf.push(&line);
         // Should not panic on truncation (regression: naive byte slicing
         // would split a multi-byte sequence).
-        assert_eq!(buf.snapshot().len(), 1);
+        assert_eq!(buf.snapshot().lines.len(), 1);
     }
 
     #[test]

--- a/runner/src/claude_code/bridge.rs
+++ b/runner/src/claude_code/bridge.rs
@@ -158,6 +158,10 @@ impl Bridge {
     pub fn process_handle(&self) -> crate::agent::AgentProcessHandle {
         self.proc.process_handle()
     }
+
+    pub async fn recent_stderr(&self) -> Vec<String> {
+        self.proc.recent_stderr().await
+    }
 }
 
 /// Per-run translation state. The `system/init` frame is consumed inside

--- a/runner/src/claude_code/bridge.rs
+++ b/runner/src/claude_code/bridge.rs
@@ -159,7 +159,7 @@ impl Bridge {
         self.proc.process_handle()
     }
 
-    pub async fn recent_stderr(&self) -> Vec<String> {
+    pub async fn recent_stderr(&self) -> crate::agent::StderrSnapshot {
         self.proc.recent_stderr().await
     }
 }

--- a/runner/src/claude_code/process.rs
+++ b/runner/src/claude_code/process.rs
@@ -6,12 +6,14 @@ use anyhow::{Context, Result};
 use chrono::Utc;
 use std::path::Path;
 use std::process::Stdio;
+use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, Command};
-use tokio::sync::{mpsc, watch};
+use tokio::sync::{Mutex, mpsc, watch};
 
-use crate::agent::{AgentProcessHandle, ExitSnapshot};
+use crate::agent::{AgentProcessHandle, ExitSnapshot, StderrBuffer, StderrRing};
 use crate::claude_code::schema::StreamEvent;
+use crate::codex::app_server::STDERR_RING_LINES;
 use crate::util::shell::{is_benign_login_shell_warning, login_shell_command};
 
 /// Handles the `claude --print --output-format stream-json` subprocess
@@ -31,6 +33,7 @@ pub struct ClaudeProcess {
     pub inbound: mpsc::Receiver<StreamEvent>,
     kill_tx: mpsc::Sender<KillRequest>,
     exit_rx: watch::Receiver<Option<ExitSnapshot>>,
+    stderr_ring: StderrRing,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -95,8 +98,9 @@ impl ClaudeProcess {
         let pid = child.id();
 
         let (tx, rx) = mpsc::channel(128);
+        let stderr_ring: StderrRing = Arc::new(Mutex::new(StderrBuffer::new(STDERR_RING_LINES)));
         tokio::spawn(read_events(stdout, tx.clone()));
-        tokio::spawn(drain_stderr(stderr));
+        tokio::spawn(drain_stderr(stderr, stderr_ring.clone()));
 
         let (kill_tx, kill_rx) = mpsc::channel::<KillRequest>(2);
         let (exit_tx, exit_rx) = watch::channel::<Option<ExitSnapshot>>(None);
@@ -108,7 +112,13 @@ impl ClaudeProcess {
             inbound: rx,
             kill_tx,
             exit_rx,
+            stderr_ring,
         })
+    }
+
+    /// Snapshot the recent stderr lines (mirrors `AppServer::recent_stderr`).
+    pub async fn recent_stderr(&self) -> Vec<String> {
+        self.stderr_ring.lock().await.snapshot()
     }
 
     /// Bridge-owned observability handle. PID was captured at spawn time;
@@ -276,12 +286,11 @@ async fn read_events(stdout: tokio::process::ChildStdout, tx: mpsc::Sender<Strea
     }
 }
 
-async fn drain_stderr(stderr: tokio::process::ChildStderr) {
+async fn drain_stderr(stderr: tokio::process::ChildStderr, ring: StderrRing) {
     // Claude surfaces auth, model, and runtime errors here. At the default
     // `info` level these would be invisible, so every non-empty line is
-    // logged at `warn!`. Operators still have to dig through logs — a future
-    // follow-up can buffer the last N lines into the `Failed` event detail —
-    // but at least nothing is silently swallowed.
+    // logged at `warn!` AND buffered into the per-process ring for
+    // RunFailed-detail enrichment.
     //
     // The login-shell wrapper (see `util::shell`) always emits two TTY-less
     // diagnostics before exec'ing claude; suppress those so logs aren't
@@ -298,6 +307,7 @@ async fn drain_stderr(stderr: tokio::process::ChildStderr) {
                     continue;
                 }
                 tracing::warn!(target: "claude.stderr", "{trimmed}");
+                ring.lock().await.push(trimmed);
             }
             Err(e) => {
                 tracing::warn!("claude stderr read error: {e}");

--- a/runner/src/claude_code/process.rs
+++ b/runner/src/claude_code/process.rs
@@ -12,7 +12,7 @@ use tokio::process::{Child, ChildStdin, Command};
 use tokio::sync::{Mutex, mpsc, watch};
 
 use crate::agent::{
-    AgentProcessHandle, ExitSnapshot, STDERR_RING_LINES, StderrBuffer, StderrRing,
+    AgentProcessHandle, ExitSnapshot, STDERR_RING_LINES, StderrBuffer, StderrRing, StderrSnapshot,
 };
 use crate::claude_code::schema::StreamEvent;
 use crate::util::shell::{is_benign_login_shell_warning, login_shell_command};
@@ -118,7 +118,7 @@ impl ClaudeProcess {
     }
 
     /// Snapshot the recent stderr lines (mirrors `AppServer::recent_stderr`).
-    pub async fn recent_stderr(&self) -> Vec<String> {
+    pub async fn recent_stderr(&self) -> StderrSnapshot {
         self.stderr_ring.lock().await.snapshot()
     }
 

--- a/runner/src/claude_code/process.rs
+++ b/runner/src/claude_code/process.rs
@@ -11,9 +11,10 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, Command};
 use tokio::sync::{Mutex, mpsc, watch};
 
-use crate::agent::{AgentProcessHandle, ExitSnapshot, StderrBuffer, StderrRing};
+use crate::agent::{
+    AgentProcessHandle, ExitSnapshot, STDERR_RING_LINES, StderrBuffer, StderrRing,
+};
 use crate::claude_code::schema::StreamEvent;
-use crate::codex::app_server::STDERR_RING_LINES;
 use crate::util::shell::{is_benign_login_shell_warning, login_shell_command};
 
 /// Handles the `claude --print --output-format stream-json` subprocess

--- a/runner/src/cloud/http.rs
+++ b/runner/src/cloud/http.rs
@@ -1522,6 +1522,7 @@ mod tests {
                 total: 300,
             }),
             turn_count: Some(2),
+            last_exec_command: None,
         };
         let s = PollStatus::from_state(WireStatus::Busy, Some(rid), true, snap, 1);
         let v = serde_json::to_value(&s).unwrap();

--- a/runner/src/codex/app_server.rs
+++ b/runner/src/codex/app_server.rs
@@ -2,12 +2,13 @@ use anyhow::{Context, Result};
 use chrono::Utc;
 use std::path::Path;
 use std::process::Stdio;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, Command};
-use tokio::sync::{mpsc, watch};
+use tokio::sync::{Mutex, mpsc, watch};
 
-use crate::agent::{AgentProcessHandle, ExitSnapshot};
+use crate::agent::{AgentProcessHandle, ExitSnapshot, StderrBuffer, StderrRing};
 use crate::codex::jsonrpc::Incoming;
 use crate::util::shell::{is_benign_login_shell_warning, login_shell_command};
 
@@ -26,6 +27,7 @@ pub struct AppServer {
     pub inbound: mpsc::Receiver<Incoming>,
     kill_tx: mpsc::Sender<KillRequest>,
     exit_rx: watch::Receiver<Option<ExitSnapshot>>,
+    stderr_ring: StderrRing,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -59,8 +61,9 @@ impl AppServer {
         let pid = child.id();
 
         let (tx, rx) = mpsc::channel(128);
+        let stderr_ring: StderrRing = Arc::new(Mutex::new(StderrBuffer::new(STDERR_RING_LINES)));
         tokio::spawn(read_frames(stdout, tx.clone()));
-        tokio::spawn(drain_stderr(stderr));
+        tokio::spawn(drain_stderr(stderr, stderr_ring.clone()));
 
         let (kill_tx, kill_rx) = mpsc::channel::<KillRequest>(2);
         let (exit_tx, exit_rx) = watch::channel::<Option<ExitSnapshot>>(None);
@@ -73,7 +76,15 @@ impl AppServer {
             inbound: rx,
             kill_tx,
             exit_rx,
+            stderr_ring,
         })
+    }
+
+    /// Snapshot the recent stderr lines (up to `STDERR_RING_LINES`).
+    /// Used by the supervisor when emitting a `RunFailed` so the cloud has
+    /// some chance of telling the user *why* an agent went silent.
+    pub async fn recent_stderr(&self) -> Vec<String> {
+        self.stderr_ring.lock().await.snapshot()
     }
 
     pub fn alloc_id(&self) -> u64 {
@@ -95,6 +106,14 @@ impl AppServer {
             pid: self.pid,
             exit_rx: self.exit_rx.clone(),
         }
+    }
+
+    /// Shareable handle to the same stderr ring buffer the drain task feeds.
+    /// The supervisor stashes this so it can read recent stderr at the
+    /// moment of a `RunFailed` even after `self` has been moved into
+    /// `shutdown()`.
+    pub fn stderr_ring(&self) -> StderrRing {
+        self.stderr_ring.clone()
     }
 
     pub async fn shutdown(mut self, grace: std::time::Duration) -> Result<()> {
@@ -203,7 +222,13 @@ async fn read_frames(stdout: tokio::process::ChildStdout, tx: mpsc::Sender<Incom
     }
 }
 
-async fn drain_stderr(stderr: tokio::process::ChildStderr) {
+/// How many stderr lines to retain in the per-process ring. 30 lines × ~200
+/// chars ≈ 6 KB; comfortably fits in a `RunFailed.detail` payload after
+/// truncation while still surfacing enough recent context to diagnose most
+/// failures (auth errors, panics, segfaults).
+pub const STDERR_RING_LINES: usize = 30;
+
+async fn drain_stderr(stderr: tokio::process::ChildStderr, ring: StderrRing) {
     // The login-shell wrapper (see `util::shell`) always emits two TTY-less
     // diagnostics before exec'ing codex; suppress those so the debug stream
     // only carries real codex output.
@@ -219,6 +244,7 @@ async fn drain_stderr(stderr: tokio::process::ChildStderr) {
                     continue;
                 }
                 tracing::debug!(target: "codex.stderr", "{trimmed}");
+                ring.lock().await.push(trimmed);
             }
             Err(e) => {
                 tracing::warn!("codex stderr read error: {e}");

--- a/runner/src/codex/app_server.rs
+++ b/runner/src/codex/app_server.rs
@@ -8,7 +8,9 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, Command};
 use tokio::sync::{Mutex, mpsc, watch};
 
-use crate::agent::{AgentProcessHandle, ExitSnapshot, StderrBuffer, StderrRing};
+use crate::agent::{
+    AgentProcessHandle, ExitSnapshot, STDERR_RING_LINES, StderrBuffer, StderrRing,
+};
 use crate::codex::jsonrpc::Incoming;
 use crate::util::shell::{is_benign_login_shell_warning, login_shell_command};
 
@@ -106,14 +108,6 @@ impl AppServer {
             pid: self.pid,
             exit_rx: self.exit_rx.clone(),
         }
-    }
-
-    /// Shareable handle to the same stderr ring buffer the drain task feeds.
-    /// The supervisor stashes this so it can read recent stderr at the
-    /// moment of a `RunFailed` even after `self` has been moved into
-    /// `shutdown()`.
-    pub fn stderr_ring(&self) -> StderrRing {
-        self.stderr_ring.clone()
     }
 
     pub async fn shutdown(mut self, grace: std::time::Duration) -> Result<()> {
@@ -221,12 +215,6 @@ async fn read_frames(stdout: tokio::process::ChildStdout, tx: mpsc::Sender<Incom
         }
     }
 }
-
-/// How many stderr lines to retain in the per-process ring. 30 lines × ~200
-/// chars ≈ 6 KB; comfortably fits in a `RunFailed.detail` payload after
-/// truncation while still surfacing enough recent context to diagnose most
-/// failures (auth errors, panics, segfaults).
-pub const STDERR_RING_LINES: usize = 30;
 
 async fn drain_stderr(stderr: tokio::process::ChildStderr, ring: StderrRing) {
     // The login-shell wrapper (see `util::shell`) always emits two TTY-less

--- a/runner/src/codex/app_server.rs
+++ b/runner/src/codex/app_server.rs
@@ -9,7 +9,7 @@ use tokio::process::{Child, ChildStdin, Command};
 use tokio::sync::{Mutex, mpsc, watch};
 
 use crate::agent::{
-    AgentProcessHandle, ExitSnapshot, STDERR_RING_LINES, StderrBuffer, StderrRing,
+    AgentProcessHandle, ExitSnapshot, STDERR_RING_LINES, StderrBuffer, StderrRing, StderrSnapshot,
 };
 use crate::codex::jsonrpc::Incoming;
 use crate::util::shell::{is_benign_login_shell_warning, login_shell_command};
@@ -82,10 +82,11 @@ impl AppServer {
         })
     }
 
-    /// Snapshot the recent stderr lines (up to `STDERR_RING_LINES`).
-    /// Used by the supervisor when emitting a `RunFailed` so the cloud has
-    /// some chance of telling the user *why* an agent went silent.
-    pub async fn recent_stderr(&self) -> Vec<String> {
+    /// Snapshot the recent stderr lines (up to `STDERR_RING_LINES`)
+    /// plus the running tally of rejected noise lines. Used by the
+    /// supervisor when emitting a `RunFailed` so the cloud has some
+    /// chance of telling the user *why* an agent went silent.
+    pub async fn recent_stderr(&self) -> StderrSnapshot {
         self.stderr_ring.lock().await.snapshot()
     }
 

--- a/runner/src/daemon/observability.rs
+++ b/runner/src/daemon/observability.rs
@@ -109,6 +109,34 @@ pub fn parse_codex_token_count(params: &serde_json::Value) -> Option<TokenUsage>
     })
 }
 
+/// Best-effort extractor for a Bash `tool_use` block in a Claude
+/// `assistant/message` Raw frame. Returns `Some(command)` if the message
+/// content array contains a `{"type":"tool_use","name":"Bash"}` block
+/// with a string `input.command`; `None` otherwise. Used to populate
+/// `last_exec_command` for failure-detail enrichment, in parallel with
+/// the codex `item/started` / `commandExecution` capture path.
+///
+/// Other tool_use blocks (Read, Edit, Grep, …) are intentionally ignored
+/// — Bash is the call most likely to hang on network / sandbox issues
+/// and the only one whose `input.command` resembles a shell command we'd
+/// want to surface verbatim. Future tools can be added as new arms if
+/// they prove to be common stall sources.
+pub fn parse_claude_bash_command(message: &serde_json::Value) -> Option<String> {
+    let content = message.get("content")?.as_array()?;
+    for block in content {
+        let is_tool_use = block.get("type").and_then(|v| v.as_str()) == Some("tool_use");
+        let is_bash = block.get("name").and_then(|v| v.as_str()) == Some("Bash");
+        if is_tool_use && is_bash {
+            let cmd = block.get("input")?.get("command")?.as_str()?.trim();
+            if cmd.is_empty() {
+                return None;
+            }
+            return Some(cmd.to_string());
+        }
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -238,5 +266,61 @@ mod tests {
     fn parse_codex_token_count_returns_none_on_garbage() {
         let params = json!({"unrelated": true});
         assert!(parse_codex_token_count(&params).is_none());
+    }
+
+    #[test]
+    fn parse_claude_bash_command_extracts_command() {
+        let msg = json!({
+            "id": "msg_1",
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "Let me check."},
+                {
+                    "type": "tool_use",
+                    "id": "tu_1",
+                    "name": "Bash",
+                    "input": {"command": "git fetch origin", "description": "sync"},
+                },
+            ],
+        });
+        assert_eq!(
+            parse_claude_bash_command(&msg),
+            Some("git fetch origin".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_claude_bash_command_ignores_non_bash_tools() {
+        // A Read tool_use should NOT populate last_exec_command — Read
+        // hangs are far rarer than Bash and we want the extractor narrow
+        // to avoid noise in the failure-detail string.
+        let msg = json!({
+            "content": [
+                {
+                    "type": "tool_use",
+                    "name": "Read",
+                    "input": {"file_path": "/tmp/foo"},
+                },
+            ],
+        });
+        assert!(parse_claude_bash_command(&msg).is_none());
+    }
+
+    #[test]
+    fn parse_claude_bash_command_returns_none_when_no_tool_use() {
+        let msg = json!({
+            "content": [{"type": "text", "text": "just thinking"}],
+        });
+        assert!(parse_claude_bash_command(&msg).is_none());
+    }
+
+    #[test]
+    fn parse_claude_bash_command_returns_none_on_empty_command() {
+        let msg = json!({
+            "content": [
+                {"type": "tool_use", "name": "Bash", "input": {"command": "  "}},
+            ],
+        });
+        assert!(parse_claude_bash_command(&msg).is_none());
     }
 }

--- a/runner/src/daemon/observability.rs
+++ b/runner/src/daemon/observability.rs
@@ -109,6 +109,60 @@ pub fn parse_codex_token_count(params: &serde_json::Value) -> Option<TokenUsage>
     })
 }
 
+/// Plain-data extract of a shell command the agent kicked off. Mirrors
+/// `crate::daemon::state::ExecCommandSnapshot`'s shape sans the
+/// timestamp (which the caller stamps with `Utc::now()`). Decoupling
+/// the parser shape from `StateHandle` lets us unit-test the dispatch
+/// logic without any tokio runtime.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecCommandHint {
+    pub command: String,
+    pub cwd: Option<String>,
+}
+
+/// Single dispatch table for "what shell command did the agent just
+/// kick off?" given a `BridgeEvent::Raw` `(method, params)`. Returns
+/// `Some` only for the methods we know how to extract a command from
+/// today: codex `item/started` (commandExecution items) and Claude
+/// `assistant/message` (Bash tool_use blocks). Unit-testable in
+/// isolation; the supervisor calls this from `handle_bridge_event`
+/// without owning the routing logic itself, so a typo in either method
+/// name is caught by tests rather than by an unrenewable `last
+/// command:` field in production failures.
+pub fn extract_exec_command_hint(
+    method: &str,
+    params: &serde_json::Value,
+) -> Option<ExecCommandHint> {
+    match method {
+        "item/started" => {
+            let item = params.get("item")?;
+            if item.get("type").and_then(|v| v.as_str()) != Some("commandExecution") {
+                return None;
+            }
+            if item.get("status").and_then(|v| v.as_str()) != Some("inProgress") {
+                return None;
+            }
+            let command = item.get("command").and_then(|v| v.as_str())?.trim();
+            if command.is_empty() {
+                return None;
+            }
+            let cwd = item
+                .get("cwd")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            Some(ExecCommandHint {
+                command: command.to_string(),
+                cwd,
+            })
+        }
+        "assistant/message" => parse_claude_bash_command(params).map(|cmd| ExecCommandHint {
+            command: cmd,
+            cwd: None,
+        }),
+        _ => None,
+    }
+}
+
 /// Best-effort extractor for a Bash `tool_use` block in a Claude
 /// `assistant/message` Raw frame. Returns `Some(command)` if the message
 /// content array contains a `{"type":"tool_use","name":"Bash"}` block
@@ -322,5 +376,76 @@ mod tests {
             ],
         });
         assert!(parse_claude_bash_command(&msg).is_none());
+    }
+
+    // ---- extract_exec_command_hint dispatch tests ------------------------
+    //
+    // These guard the supervisor's wiring against method-name typos. If
+    // `handle_bridge_event` ever stops passing `"item/started"` /
+    // `"assistant/message"` here, the production code silently degrades to
+    // "no last command" forever — these tests catch that at compile-fixed
+    // string level.
+
+    #[test]
+    fn extract_exec_command_hint_handles_codex_item_started() {
+        let params = json!({
+            "item": {
+                "type": "commandExecution",
+                "status": "inProgress",
+                "command": "git fetch origin",
+                "cwd": "/tmp/x",
+            },
+        });
+        let hint = extract_exec_command_hint("item/started", &params).unwrap();
+        assert_eq!(hint.command, "git fetch origin");
+        assert_eq!(hint.cwd.as_deref(), Some("/tmp/x"));
+    }
+
+    #[test]
+    fn extract_exec_command_hint_skips_codex_completed_items() {
+        // Only `inProgress` items count — completed items shouldn't
+        // overwrite the live `last_exec_command` with a stale one.
+        let params = json!({
+            "item": {
+                "type": "commandExecution",
+                "status": "completed",
+                "command": "git status",
+            },
+        });
+        assert!(extract_exec_command_hint("item/started", &params).is_none());
+    }
+
+    #[test]
+    fn extract_exec_command_hint_skips_non_command_items() {
+        let params = json!({
+            "item": {"type": "fileEdit", "status": "inProgress"},
+        });
+        assert!(extract_exec_command_hint("item/started", &params).is_none());
+    }
+
+    #[test]
+    fn extract_exec_command_hint_handles_claude_assistant_message() {
+        let params = json!({
+            "content": [
+                {
+                    "type": "tool_use",
+                    "name": "Bash",
+                    "input": {"command": "npm install"},
+                },
+            ],
+        });
+        let hint = extract_exec_command_hint("assistant/message", &params).unwrap();
+        assert_eq!(hint.command, "npm install");
+        // Claude tool_use blocks don't carry cwd; the working dir is
+        // implicit from the run's workspace_root.
+        assert!(hint.cwd.is_none());
+    }
+
+    #[test]
+    fn extract_exec_command_hint_returns_none_on_unknown_method() {
+        let params = json!({"anything": true});
+        assert!(extract_exec_command_hint("turn/started", &params).is_none());
+        assert!(extract_exec_command_hint("codex/event/token_count", &params).is_none());
+        assert!(extract_exec_command_hint("totally/made/up", &params).is_none());
     }
 }

--- a/runner/src/daemon/state.rs
+++ b/runner/src/daemon/state.rs
@@ -24,6 +24,18 @@ pub struct ObservabilitySnapshot {
     pub agent_subprocess_alive: Option<bool>,
     pub tokens: Option<TokenUsage>,
     pub turn_count: Option<u32>,
+    /// Last shell command the agent kicked off (for failure-detail enrichment).
+    /// Reset on rid change like the other per-run scalars; not serialised
+    /// onto the wire snapshot — only consumed locally to enrich
+    /// `RunFailed.detail` when the watchdog or stdout-close path fires.
+    pub last_exec_command: Option<ExecCommandSnapshot>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecCommandSnapshot {
+    pub command: String,
+    pub cwd: Option<String>,
+    pub started_at: DateTime<Utc>,
 }
 
 #[derive(Clone)]
@@ -227,6 +239,15 @@ impl StateHandle {
         self.tick();
     }
 
+    /// Stash the most recent shell command the agent kicked off, for use
+    /// by the `RunFailed` enrichment helper. Called from
+    /// `supervisor.handle_bridge_event` on `item/started` Raw frames whose
+    /// item is a `commandExecution`.
+    pub async fn note_exec_command(&self, snapshot: ExecCommandSnapshot) {
+        self.inner.run_snapshot.lock().await.last_exec_command = Some(snapshot);
+        self.tick();
+    }
+
     /// Snapshot the volatile observability fields for one poll. One lock
     /// + one clone — adding a new field to `ObservabilitySnapshot`
     /// automatically participates without touching this method.
@@ -394,6 +415,31 @@ mod tests {
             ObservabilitySnapshot::default(),
             "snapshot leaked across run boundary"
         );
+    }
+
+    #[tokio::test]
+    async fn note_exec_command_lands_on_snapshot_and_clears_on_rid_change() {
+        let state = empty_state();
+        let rid_a = Uuid::new_v4();
+        state.set_current_run(Some(summary(rid_a, "running"))).await;
+        state
+            .note_exec_command(ExecCommandSnapshot {
+                command: "git fetch origin".into(),
+                cwd: Some("/tmp/x".into()),
+                started_at: Utc::now(),
+            })
+            .await;
+        let snap = state.observability_snapshot().await;
+        let cmd = snap.last_exec_command.expect("snapshot lost the command");
+        assert_eq!(cmd.command, "git fetch origin");
+        assert_eq!(cmd.cwd.as_deref(), Some("/tmp/x"));
+
+        // Rid change wipes per-run scalars including the exec command, so
+        // a stalled-on-foo failure detail can't bleed into a fresh run.
+        let rid_b = Uuid::new_v4();
+        state.set_current_run(Some(summary(rid_b, "running"))).await;
+        let snap = state.observability_snapshot().await;
+        assert!(snap.last_exec_command.is_none());
     }
 
     #[tokio::test]

--- a/runner/src/daemon/supervisor.rs
+++ b/runner/src/daemon/supervisor.rs
@@ -1265,52 +1265,27 @@ impl AssignWorker {
                 "turn/started" => {
                     self.state.incr_turn().await;
                 }
-                "item/started" => {
-                    // Codex side: track the most recent shell command for
-                    // failure-detail enrichment. Never sent on the
-                    // steady-state poll — consumed locally on a stall.
-                    if let Some(item) = params.get("item")
-                        && item.get("type").and_then(|v| v.as_str()) == Some("commandExecution")
-                        && item.get("status").and_then(|v| v.as_str()) == Some("inProgress")
-                    {
-                        let command = item
-                            .get("command")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or_default()
-                            .to_string();
-                        if !command.is_empty() {
-                            let cwd = item
-                                .get("cwd")
-                                .and_then(|v| v.as_str())
-                                .map(|s| s.to_string());
-                            self.state
-                                .note_exec_command(
-                                    crate::daemon::state::ExecCommandSnapshot {
-                                        command,
-                                        cwd,
-                                        started_at: Utc::now(),
-                                    },
-                                )
-                                .await;
-                        }
-                    }
-                }
-                "assistant/message" => {
-                    // Claude side: assistant messages carry tool_use
-                    // blocks. Extract Bash commands so a stalled Claude
-                    // run gets the same `last command:` enrichment in
-                    // its RunFailed detail that codex already does. Bash
-                    // is the only Claude tool whose hangs are common
-                    // enough to be worth surfacing — Read/Edit/Grep are
-                    // ignored on purpose to keep the parser narrow.
-                    if let Some(cmd) =
-                        crate::daemon::observability::parse_claude_bash_command(params)
+                "item/started" | "assistant/message" => {
+                    // Failure-detail enrichment: capture the most recent
+                    // shell command the agent kicked off. Routing for
+                    // codex (`item/started` → commandExecution) and
+                    // Claude (`assistant/message` → Bash tool_use) lives
+                    // in `extract_exec_command_hint` so it's
+                    // unit-testable without a live bridge — a typo in
+                    // either method name is caught by tests rather than
+                    // by silently absent `last command:` fields in
+                    // production failure details.
+                    if let Some(hint) =
+                        crate::daemon::observability::extract_exec_command_hint(
+                            method.as_str(),
+                            params,
+                        )
                     {
                         self.state
                             .note_exec_command(
                                 crate::daemon::state::ExecCommandSnapshot {
-                                    command: cmd,
-                                    cwd: None,
+                                    command: hint.command,
+                                    cwd: hint.cwd,
                                     started_at: Utc::now(),
                                 },
                             )

--- a/runner/src/daemon/supervisor.rs
+++ b/runner/src/daemon/supervisor.rs
@@ -1468,10 +1468,22 @@ impl AssignWorker {
                 reason,
                 detail,
             } => {
+                // Codex / claude-detected failures (e.g.
+                // "turn/completed without conclusion", `error` notifications
+                // with `willRetry=false`) reach us with whatever bare
+                // string the bridge produced. Run them through the same
+                // enrichment helper the watchdog and stdout-close paths
+                // use so the user sees `last command:` and a stderr
+                // tail in the issue activity comment, not just the
+                // bridge's classifier text.
+                let base = detail
+                    .clone()
+                    .unwrap_or_else(|| "agent reported failure".to_string());
+                let enriched = self.build_failure_detail(&base, bridge).await;
                 self.send(ClientMsg::RunFailed {
                     run_id,
                     reason,
-                    detail: detail.clone(),
+                    detail: Some(enriched.clone()),
                     ended_at: Utc::now(),
                 })
                 .await;
@@ -1479,7 +1491,7 @@ impl AssignWorker {
                     ts: Utc::now(),
                     final_status: "failed".into(),
                     done_payload: None,
-                    error: detail,
+                    error: Some(enriched),
                 })
                 .await
                 .ok();

--- a/runner/src/daemon/supervisor.rs
+++ b/runner/src/daemon/supervisor.rs
@@ -1192,7 +1192,7 @@ impl AssignWorker {
             .observability_snapshot()
             .await
             .last_exec_command;
-        let stderr_tail = bridge.recent_stderr().await;
+        let stderr = bridge.recent_stderr().await;
 
         let mut parts: Vec<String> = vec![base.to_string()];
         if let Some(cmd) = last_cmd {
@@ -1207,8 +1207,16 @@ impl AssignWorker {
                 cmd.command
             ));
         }
-        if !stderr_tail.is_empty() {
-            let tail = stderr_tail
+        // The stderr ring has already filtered codex tracing noise;
+        // `stderr.dropped` is the running count of lines we rejected so
+        // the user has an honest signal of how much was suppressed.
+        // Emit the section if either we have content to show OR a
+        // non-zero dropped count (the latter alone tells the operator
+        // "the agent was emitting noise but no signal").
+        if !stderr.lines.is_empty() || stderr.dropped > 0 {
+            let shown = stderr.lines.len().min(STDERR_TAIL_LINES);
+            let tail = stderr
+                .lines
                 .iter()
                 .rev()
                 .take(STDERR_TAIL_LINES)
@@ -1216,10 +1224,23 @@ impl AssignWorker {
                 .cloned()
                 .collect::<Vec<_>>()
                 .join("\n  ");
-            parts.push(format!(
-                "stderr tail ({} line(s)):\n  {tail}",
-                stderr_tail.len().min(STDERR_TAIL_LINES)
-            ));
+            let suffix = if stderr.dropped > 0 {
+                format!(
+                    " (plus {} noise line(s) filtered from codex tracing)",
+                    stderr.dropped
+                )
+            } else {
+                String::new()
+            };
+            if shown > 0 {
+                parts.push(format!(
+                    "stderr tail ({shown} line(s){suffix}):\n  {tail}"
+                ));
+            } else {
+                // Filter dropped everything — surface that fact alone
+                // rather than emitting an empty stderr block.
+                parts.push(format!("stderr: empty after filtering{suffix}"));
+            }
         }
         let mut joined = parts.join("; ");
         if joined.len() > DETAIL_BYTES_CAP {

--- a/runner/src/daemon/supervisor.rs
+++ b/runner/src/daemon/supervisor.rs
@@ -1266,9 +1266,9 @@ impl AssignWorker {
                     self.state.incr_turn().await;
                 }
                 "item/started" => {
-                    // Track the most recent shell command codex kicked off.
-                    // Used purely to enrich `RunFailed.detail` if the agent
-                    // goes silent — never sent on the steady-state poll.
+                    // Codex side: track the most recent shell command for
+                    // failure-detail enrichment. Never sent on the
+                    // steady-state poll — consumed locally on a stall.
                     if let Some(item) = params.get("item")
                         && item.get("type").and_then(|v| v.as_str()) == Some("commandExecution")
                         && item.get("status").and_then(|v| v.as_str()) == Some("inProgress")
@@ -1293,6 +1293,28 @@ impl AssignWorker {
                                 )
                                 .await;
                         }
+                    }
+                }
+                "assistant/message" => {
+                    // Claude side: assistant messages carry tool_use
+                    // blocks. Extract Bash commands so a stalled Claude
+                    // run gets the same `last command:` enrichment in
+                    // its RunFailed detail that codex already does. Bash
+                    // is the only Claude tool whose hangs are common
+                    // enough to be worth surfacing — Read/Edit/Grep are
+                    // ignored on purpose to keep the parser narrow.
+                    if let Some(cmd) =
+                        crate::daemon::observability::parse_claude_bash_command(params)
+                    {
+                        self.state
+                            .note_exec_command(
+                                crate::daemon::state::ExecCommandSnapshot {
+                                    command: cmd,
+                                    cwd: None,
+                                    started_at: Utc::now(),
+                                },
+                            )
+                            .await;
                     }
                 }
                 _ => {}

--- a/runner/src/daemon/supervisor.rs
+++ b/runner/src/daemon/supervisor.rs
@@ -1119,17 +1119,20 @@ impl AssignWorker {
                 events = bridge.next_events(cursor) => {
                     let Some(events) = events else {
                         let reason = self.crash_reason();
+                        let detail = self
+                            .build_failure_detail("agent stdout closed", bridge)
+                            .await;
                         self.send(ClientMsg::RunFailed {
                             run_id: cursor.run_id(),
                             reason,
-                            detail: Some("agent stdout closed".to_string()),
+                            detail: Some(detail.clone()),
                             ended_at: Utc::now(),
                         }).await;
                         hist.append(&HistoryEntry::Footer {
                             ts: Utc::now(),
                             final_status: "failed".into(),
                             done_payload: None,
-                            error: Some("agent stdout closed".into()),
+                            error: Some(detail),
                         }).await?;
                         return Ok(Outcome { status_label: "failed".into() });
                     };
@@ -1149,7 +1152,8 @@ impl AssignWorker {
                     }
                 } => {
                     let mins = STALL_TIMEOUT.as_secs() / 60;
-                    let detail = format!("no agent frames for {mins} minutes");
+                    let base = format!("no agent frames for {mins} minutes");
+                    let detail = self.build_failure_detail(&base, bridge).await;
                     self.send(ClientMsg::RunFailed {
                         run_id: cursor.run_id(),
                         reason: FailureReason::Timeout,
@@ -1166,6 +1170,69 @@ impl AssignWorker {
                 }
             }
         }
+    }
+
+    /// Build a `RunFailed.detail` string that includes whatever local
+    /// context might help the cloud / UI explain what went wrong:
+    /// - the supervisor's own classifier message (e.g. `"no agent frames
+    ///   for 5 minutes"`),
+    /// - the most recent shell command the agent kicked off,
+    /// - the last few lines of agent stderr.
+    ///
+    /// All inputs are optional and the assembly degrades gracefully when
+    /// they're missing — for a healthy code-edit task the result is just
+    /// the base string. The total payload is bounded so a runaway stderr
+    /// dump can't balloon a `RunFailed` body.
+    async fn build_failure_detail(&self, base: &str, bridge: &AgentBridge) -> String {
+        const DETAIL_BYTES_CAP: usize = 4096;
+        const STDERR_TAIL_LINES: usize = 10;
+
+        let last_cmd = self
+            .state
+            .observability_snapshot()
+            .await
+            .last_exec_command;
+        let stderr_tail = bridge.recent_stderr().await;
+
+        let mut parts: Vec<String> = vec![base.to_string()];
+        if let Some(cmd) = last_cmd {
+            let elapsed = (Utc::now() - cmd.started_at).num_seconds().max(0);
+            let cwd = cmd
+                .cwd
+                .as_deref()
+                .map(|c| format!(" in `{c}`"))
+                .unwrap_or_default();
+            parts.push(format!(
+                "last command: `{}`{cwd} (started {elapsed}s ago)",
+                cmd.command
+            ));
+        }
+        if !stderr_tail.is_empty() {
+            let tail = stderr_tail
+                .iter()
+                .rev()
+                .take(STDERR_TAIL_LINES)
+                .rev()
+                .cloned()
+                .collect::<Vec<_>>()
+                .join("\n  ");
+            parts.push(format!(
+                "stderr tail ({} line(s)):\n  {tail}",
+                stderr_tail.len().min(STDERR_TAIL_LINES)
+            ));
+        }
+        let mut joined = parts.join("; ");
+        if joined.len() > DETAIL_BYTES_CAP {
+            // Truncate on a char boundary, leaving a sentinel so consumers
+            // can tell the body was clipped.
+            let mut end = DETAIL_BYTES_CAP;
+            while !joined.is_char_boundary(end) && end > 0 {
+                end -= 1;
+            }
+            joined.truncate(end);
+            joined.push_str("…");
+        }
+        joined
     }
 
     async fn handle_bridge_event(
@@ -1197,6 +1264,36 @@ impl AssignWorker {
                 }
                 "turn/started" => {
                     self.state.incr_turn().await;
+                }
+                "item/started" => {
+                    // Track the most recent shell command codex kicked off.
+                    // Used purely to enrich `RunFailed.detail` if the agent
+                    // goes silent — never sent on the steady-state poll.
+                    if let Some(item) = params.get("item")
+                        && item.get("type").and_then(|v| v.as_str()) == Some("commandExecution")
+                        && item.get("status").and_then(|v| v.as_str()) == Some("inProgress")
+                    {
+                        let command = item
+                            .get("command")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or_default()
+                            .to_string();
+                        if !command.is_empty() {
+                            let cwd = item
+                                .get("cwd")
+                                .and_then(|v| v.as_str())
+                                .map(|s| s.to_string());
+                            self.state
+                                .note_exec_command(
+                                    crate::daemon::state::ExecCommandSnapshot {
+                                        command,
+                                        cwd,
+                                        started_at: Utc::now(),
+                                    },
+                                )
+                                .await;
+                        }
+                    }
                 }
                 _ => {}
             }


### PR DESCRIPTION
## Summary

Today, when an agent run fails, the user sees nothing in the UI they actually look at. The issue stays in its prior state, no comment lands on the activity feed, and the failure detail (`AgentRun.error`) is buried in admin views. Repeated failures from the same root cause (sandboxed `git fetch`, codex auth expiry, OpenAI 4xx) are invisible until someone digs into runner logs.

This PR closes the loop in two parts:

### Phase A — runner enriches `RunFailed.detail`

The runner already classifies failures (`Timeout`, `CodexCrash`, `Network`, `GitAuth`, …) but ships only a thin string like `"no agent frames for 5 minutes"`. It has the data to be much more specific and was throwing it away.

- Per-process **stderr ring buffer** (30 lines × 200 chars cap, ~6 KB total) on `AppServer` and `ClaudeProcess`. Drained-to-tracing AND buffered. Exposed via `AgentBridge::recent_stderr()`.
- New **`last_exec_command`** field on `ObservabilitySnapshot`, captured when the supervisor sees a codex `item/started` Raw frame whose item is a `commandExecution`. Reset on rid change like the other per-run scalars.
- New **`build_failure_detail(base, bridge)`** helper on the supervisor. Used on the watchdog (timeout) and stdout-close paths to fold classifier message + last command + stderr tail into a single capped 4 KB string.

So the `git fetch origin` hang we just hit becomes:

```
no agent frames for 5 minutes; last command: `git fetch origin` in `/home/rich/.../s5/pi-dash` (started 297s ago)
```

…instead of just `no agent frames for 5 minutes`.

### Phase B — cloud posts an issue comment on FAILED

`finalize_run_terminal` now mirrors the existing `apply_run_paused` shape: when `new_status == FAILED`, it posts an `IssueComment` from the agent system user with the enriched detail rendered into the body. Wrapped in try/except so a comment-posting outage cannot block lifecycle terminal transitions or pod drains.

Wording is intentionally conservative — surface the runner's own classification + detail rather than asserting a root cause we can't prove from telemetry alone. Remediation hints can be added later as a separate change.

## What this is NOT

- No new wire shapes. `RunFailed.detail` is still a string field; it just carries more.
- No remediation map. Future work — Codex's review of an earlier proposal pointed out that asserting "this was sandboxing" or "this was an auth issue" without proof is exactly the speculation we want to avoid. Layer 1 is just "show the user what we know."
- No comment coalescing. If a ticker keeps re-firing failed runs, you'll get one comment per failure. Coalescing into a counter is a follow-up.

## Test plan

- [x] `cargo test --lib` — 151 tests pass on the runner side (4 new ones for stderr buffer + exec-command tracking).
- [ ] `cd apps/api && python run_tests.py -u` — 4 new tests in `tests/unit/runner/test_failure_comment.py` cover: FAILED finalize posts exactly one comment with the detail visible; COMPLETED finalize does NOT post; comment-helper crash leaves the run terminal anyway; orphan run (no work_item) short-circuits cleanly. Verified locally via syntax + import check; pytest infra not available in the dev container.
- [ ] After merge, watch a real failure on browserx0002 / pidash001 and confirm the issue thread shows a meaningful comment.

## Stack

Branched off `design/runner-agent-bridge` (PR #98). PR is targeted at that branch so it stacks cleanly. Once #98 lands, this rebases automatically onto `feat/move-to-https` and ultimately `main`.