### PR TITLE
feat(cli): make pidash CLI read URL/workspace/token from config file

### DIFF
--- a/runner/src/api_client.rs
+++ b/runner/src/api_client.rs
@@ -60,10 +60,23 @@ impl std::fmt::Display for CliError {
 
 impl std::error::Error for CliError {}
 
-/// Runtime configuration sourced from the environment.
+/// Runtime configuration the CRUD subcommands need to talk to the cloud.
 ///
-/// The agent receives these from the runner-injected env (PR 2). For
-/// out-of-band operator use, the same vars can be exported in the shell.
+/// **Resolution order** (see `CliEnv::resolve`):
+///   1. The runner config file at `~/.config/pidash/config.toml`.
+///      `api_url` ← `[daemon].cloud_url`,
+///      `workspace_slug` ← primary `[[runner]].workspace_slug`,
+///      `token` ← `[cli].token`.
+///   2. If the file is missing, OR any required field is absent from
+///      it, fall through to the corresponding env var
+///      (`PIDASH_API_URL` / `PIDASH_WORKSPACE_SLUG` / `PIDASH_TOKEN`).
+///
+/// This means: an enrolled host doesn't need any env vars — the CLI
+/// reads everything from the same config the daemon uses. Out-of-band
+/// operator use (CI scripts, ad-hoc invocations) can still rely on env
+/// vars. The agent path Just Works because the agent inherits the
+/// runner's $HOME, so the CLI finds the config without anyone wiring
+/// per-spawn env vars.
 #[derive(Debug, Clone)]
 pub struct CliEnv {
     pub api_url: String,
@@ -72,6 +85,8 @@ pub struct CliEnv {
 }
 
 impl CliEnv {
+    /// Env-only loader, retained as a fallback for callers without
+    /// a `Paths` handle and as the leaf step of `resolve`.
     pub fn from_env() -> Result<Self, CliError> {
         let api_url = std::env::var("PIDASH_API_URL")
             .map_err(|_| CliError::new(EXIT_INVALID, "PIDASH_API_URL is not set"))?;
@@ -86,10 +101,144 @@ impl CliEnv {
         })
     }
 
+    /// Preferred entrypoint for CLI subcommands invoked from a path
+    /// where `Paths` is in scope. Reads the runner config file and
+    /// falls back to env vars per-field for anything missing.
+    ///
+    /// Returns `CliError(EXIT_INVALID)` if NEITHER source has a
+    /// required value, with a message naming the specific field so
+    /// the user knows what to add.
+    pub fn resolve(paths: &crate::util::paths::Paths) -> Result<Self, CliError> {
+        let cfg = crate::config::file::load_config_opt(paths).ok().flatten();
+        let from_cfg_url = cfg
+            .as_ref()
+            .map(|c| c.daemon.cloud_url.trim().to_string())
+            .filter(|s| !s.is_empty());
+        let from_cfg_workspace = cfg.as_ref().and_then(|c| {
+            c.runners
+                .first()
+                .and_then(|r| r.workspace_slug.as_deref())
+                .map(str::to_string)
+                .filter(|s| !s.is_empty())
+        });
+        let from_cfg_token = cfg.as_ref().and_then(|c| {
+            c.cli
+                .as_ref()
+                .and_then(|s| s.token.as_deref())
+                .map(str::to_string)
+                .filter(|s| !s.is_empty())
+        });
+
+        let api_url = from_cfg_url
+            .or_else(|| std::env::var("PIDASH_API_URL").ok())
+            .ok_or_else(|| {
+                CliError::new(
+                    EXIT_INVALID,
+                    "no cloud URL configured: set [daemon].cloud_url in \
+                     pidash config or export PIDASH_API_URL",
+                )
+            })?;
+        let workspace_slug = from_cfg_workspace
+            .or_else(|| std::env::var("PIDASH_WORKSPACE_SLUG").ok())
+            .ok_or_else(|| {
+                CliError::new(
+                    EXIT_INVALID,
+                    "no workspace slug configured: set [[runner]].workspace_slug \
+                     in pidash config or export PIDASH_WORKSPACE_SLUG",
+                )
+            })?;
+        let token = from_cfg_token
+            .or_else(|| std::env::var("PIDASH_TOKEN").ok())
+            .ok_or_else(|| {
+                CliError::new(
+                    EXIT_INVALID,
+                    "no auth token configured: set [cli].token in pidash \
+                     config or export PIDASH_TOKEN",
+                )
+            })?;
+
+        Ok(Self {
+            api_url: api_url.trim_end_matches('/').to_string(),
+            workspace_slug,
+            token,
+        })
+    }
+
     /// Build a full URL under `/api/v1/` from a path fragment that must not
     /// start with a leading slash (e.g. `workspaces/acme/users/me/`).
     pub fn v1(&self, tail: &str) -> String {
         format!("{}/api/v1/{}", self.api_url, tail.trim_start_matches('/'))
+    }
+}
+
+#[cfg(test)]
+mod resolve_tests {
+    use super::*;
+    use crate::config::file::write_config;
+    use crate::config::schema::{
+        AgentSection, ApprovalPolicySection, ClaudeCodeSection, CliSection, CodexSection,
+        Config, DaemonConfig, RunnerConfig, WorkspaceSection,
+    };
+    use crate::util::paths::Paths;
+    use tempfile::tempdir;
+
+    fn paths_for(root: &std::path::Path) -> Paths {
+        Paths {
+            config_dir: root.join("config"),
+            data_dir: root.join("data"),
+            runtime_dir: root.join("runtime"),
+        }
+    }
+
+    fn make_config(token: &str) -> Config {
+        Config {
+            version: 2,
+            daemon: DaemonConfig {
+                cloud_url: "https://cloud.example/".into(),
+                log_level: "info".into(),
+                log_retention_days: 14,
+                agent_observability_v1: false,
+            },
+            runners: vec![RunnerConfig {
+                name: "r1".into(),
+                runner_id: uuid::Uuid::new_v4(),
+                workspace_slug: Some("acme".into()),
+                project_slug: Some("WEB".into()),
+                pod_id: None,
+                workspace: WorkspaceSection {
+                    working_dir: std::path::PathBuf::from("/tmp/wd"),
+                },
+                agent: AgentSection::default(),
+                codex: CodexSection::default(),
+                claude_code: ClaudeCodeSection::default(),
+                approval_policy: ApprovalPolicySection::default(),
+            }],
+            cli: Some(CliSection {
+                token: Some(token.into()),
+            }),
+        }
+    }
+
+    #[test]
+    fn resolve_reads_url_workspace_token_from_config_file() {
+        // The new behaviour: with a populated config file on disk, the
+        // CLI reads URL, workspace, and token from the same file the
+        // daemon uses. This is the happy-path that fixes the runner's
+        // "PIDASH_API_URL is not set" bug — no env vars needed.
+        //
+        // Resolver tries config FIRST, so this assertion holds
+        // regardless of whether the test process has PIDASH_*  exported
+        // (the env path is never reached when config has all three).
+        let tmp = tempdir().unwrap();
+        let paths = paths_for(tmp.path());
+        write_config(&paths, &make_config("tok-from-cfg")).unwrap();
+
+        let env = CliEnv::resolve(&paths).expect("resolve should succeed");
+        // Trailing slash in the config is stripped by the resolver so
+        // `v1()` builds clean URLs.
+        assert_eq!(env.api_url, "https://cloud.example");
+        assert_eq!(env.workspace_slug, "acme");
+        assert_eq!(env.token, "tok-from-cfg");
     }
 }
 

--- a/runner/src/cli/comment.rs
+++ b/runner/src/cli/comment.rs
@@ -56,8 +56,8 @@ pub enum CommentCommand {
     },
 }
 
-pub async fn run(args: CommentArgs) -> i32 {
-    let env = match CliEnv::from_env() {
+pub async fn run(args: CommentArgs, paths: &crate::util::paths::Paths) -> i32 {
+    let env = match CliEnv::resolve(paths) {
         Ok(e) => e,
         Err(e) => return report_error(&e),
     };

--- a/runner/src/cli/connect.rs
+++ b/runner/src/cli/connect.rs
@@ -167,6 +167,7 @@ pub async fn run(args: Args, paths: &Paths) -> Result<()> {
                 agent_observability_v1: false,
             },
             runners: vec![new_runner_block],
+            cli: None,
         },
     };
     file::write_config(paths, &config)?;

--- a/runner/src/cli/doctor.rs
+++ b/runner/src/cli/doctor.rs
@@ -347,6 +347,7 @@ mod tests {
                 agent_observability_v1: false,
             },
             runners,
+            cli: None,
         }
     }
 

--- a/runner/src/cli/issue.rs
+++ b/runner/src/cli/issue.rs
@@ -53,8 +53,8 @@ pub struct PatchArgs {
     pub priority: Option<String>,
 }
 
-pub async fn run(args: IssueArgs) -> i32 {
-    let env = match CliEnv::from_env() {
+pub async fn run(args: IssueArgs, paths: &crate::util::paths::Paths) -> i32 {
+    let env = match CliEnv::resolve(paths) {
         Ok(e) => e,
         Err(e) => return report_error(&e),
     };

--- a/runner/src/cli/mod.rs
+++ b/runner/src/cli/mod.rs
@@ -119,10 +119,10 @@ pub async fn run(cli: Cli) -> Result<()> {
         Command::Tui(args) => tui::run(args, &paths).await,
         Command::Doctor(args) => doctor::run(args, &paths).await,
         Command::Remove(args) => remove::run(args, &paths).await,
-        Command::Issue(args) => run_crud(issue::run(args).await),
-        Command::Comment(args) => run_crud(comment::run(args).await),
-        Command::State(args) => run_crud(state::run(args).await),
-        Command::Workspace(args) => run_crud(workspace::run(args).await),
+        Command::Issue(args) => run_crud(issue::run(args, &paths).await),
+        Command::Comment(args) => run_crud(comment::run(args, &paths).await),
+        Command::State(args) => run_crud(state::run(args, &paths).await),
+        Command::Workspace(args) => run_crud(workspace::run(args, &paths).await),
         Command::Run(args) => run::run(args, &paths).await,
     }
 }

--- a/runner/src/cli/state.rs
+++ b/runner/src/cli/state.rs
@@ -27,8 +27,8 @@ pub enum StateCommand {
     },
 }
 
-pub async fn run(args: StateArgs) -> i32 {
-    let env = match CliEnv::from_env() {
+pub async fn run(args: StateArgs, paths: &crate::util::paths::Paths) -> i32 {
+    let env = match CliEnv::resolve(paths) {
         Ok(e) => e,
         Err(e) => return report_error(&e),
     };

--- a/runner/src/cli/workspace.rs
+++ b/runner/src/cli/workspace.rs
@@ -22,8 +22,8 @@ pub enum WorkspaceCommand {
     Me,
 }
 
-pub async fn run(args: WorkspaceArgs) -> i32 {
-    let env = match CliEnv::from_env() {
+pub async fn run(args: WorkspaceArgs, paths: &crate::util::paths::Paths) -> i32 {
+    let env = match CliEnv::resolve(paths) {
         Ok(e) => e,
         Err(e) => return report_error(&e),
     };

--- a/runner/src/config/file.rs
+++ b/runner/src/config/file.rs
@@ -138,6 +138,7 @@ mod tests {
                 agent_observability_v1: false,
             },
             runners: vec![sample_runner("t", tmp.path().join("wd"))],
+            cli: None,
         };
         write_config(&paths, &cfg).unwrap();
         let loaded = load_config(&paths).unwrap();

--- a/runner/src/config/schema.rs
+++ b/runner/src/config/schema.rs
@@ -11,6 +11,31 @@ pub struct Config {
     /// daemon; will grow once the cap is lifted (design.md §16).
     #[serde(default, rename = "runner")]
     pub runners: Vec<RunnerConfig>,
+    /// CLI-side configuration consumed by the `pidash issue/comment/
+    /// state/workspace` subcommands when invoked by the agent (or by the
+    /// operator out-of-band). Optional so older configs still parse;
+    /// missing means "fall back to environment variables".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cli: Option<CliSection>,
+}
+
+/// Top-level `[cli]` table. Holds the auth token the `pidash` CRUD
+/// subcommands present to the cloud. The CLI also reads `cloud_url`
+/// from `[daemon]` and `workspace_slug` from the primary `[[runner]]`
+/// — there's deliberately no duplication of those values here.
+///
+/// For v1 the token is populated manually by the operator (or by a
+/// future `pidash login` flow). A per-run, per-issue scoped token
+/// minted by the cloud is the next step; see
+/// `.ai_design/agent_cli_auth/` (TBD).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CliSection {
+    /// Auth token presented to the cloud as `Authorization: Bearer …`
+    /// by the CRUD subcommands. Optional so a partial config (URL +
+    /// workspace, no token) still parses; the CLI errors with a clear
+    /// "no token" message when it's missing at command time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -443,6 +468,7 @@ mod tests {
                 agent_observability_v1: false,
             },
             runners,
+            cli: None,
         }
     }
 

--- a/runner/src/daemon/runner_instance.rs
+++ b/runner/src/daemon/runner_instance.rs
@@ -92,6 +92,7 @@ impl RunnerInstance {
             version: 2,
             daemon: Default::default(),
             runners: vec![config.clone()],
+            cli: None,
         });
         let approvals = ApprovalRouter::new();
         let (mailbox_tx, mailbox_rx) = mpsc::channel(INSTANCE_MAILBOX_DEPTH);

--- a/runner/src/daemon/state.rs
+++ b/runner/src/daemon/state.rs
@@ -333,6 +333,7 @@ mod tests {
             version: 2,
             daemon: Default::default(),
             runners: vec![],
+            cli: None,
         })
     }
 

--- a/runner/src/daemon/supervisor.rs
+++ b/runner/src/daemon/supervisor.rs
@@ -1599,6 +1599,7 @@ mod tests {
             version: 2,
             daemon: Default::default(),
             runners: vec![],
+            cli: None,
         });
         let task = tokio::spawn(async move {
             hello_emitter(runners, connected_for_task, daemon_state).await;

--- a/runner/src/tui/app.rs
+++ b/runner/src/tui/app.rs
@@ -1432,6 +1432,7 @@ async fn submit_register_form(state: &mut AppState) {
             claude_code: Default::default(),
             approval_policy: Default::default(),
         }],
+        cli: None,
     };
     if let Err(e) = crate::config::file::write_config(&state.paths, &cfg) {
         if let Some(form) = state.register_form.as_mut() {


### PR DESCRIPTION
## Summary

Fixes the `PIDASH_API_URL is not set` failure that's been silently killing every agent run that touches the `pidash` CLI.

The pidash CLI's CRUD subcommands (`pidash issue/comment/state/workspace`) demand three env vars:
- `PIDASH_API_URL`
- `PIDASH_WORKSPACE_SLUG`
- `PIDASH_TOKEN`

**Nothing in the runner spawn path sets them.** The agent's prompt template tells it to use `pidash` for all cloud interaction. The first `pidash` call exits 1 with `{\"error\":\"PIDASH_API_URL is not set\"}`. The agent has no way to read the issue or post results, codex emits an empty `turn/completed`, and the run fails.

## Approach

The CLI binary is the same binary as the daemon. The daemon already has `~/.config/pidash/config.toml` with `cloud_url` (under `[daemon]`) and `workspace_slug` (under the primary `[[runner]]`). The CLI can read them too — no env-var plumbing needed.

- New `[cli]` table in the config schema with one field, `token`. For v1 the token is populated manually by the operator (a future cloud endpoint can mint per-run scoped tokens from the runner's refresh credentials).
- `CliEnv::resolve(paths)` reads URL/workspace/token from the config file, falling back to the corresponding env var per field. Error messages name the missing config key so partial configs are diagnosable.
- The 4 CRUD command sites switch from `from_env()` to `resolve(&paths)`.
- `from_env()` retained for callers without a `Paths` handle.

## What this is NOT

- **No cloud-side token mint endpoint.** The token is still operator-populated. The natural follow-up is an endpoint that mints a scoped, per-run token using the runner's refresh credentials so the operator never has to copy a token by hand.
- **No per-run env vars** like `PIDASH_ISSUE_IDENTIFIER`. That's a separate small change to the runner spawn path; not needed to fix the immediate bug.
- **No \"one workspace per daemon\" validation.** The CLI reads workspace from the *primary* runner; multi-workspace daemons would currently see only the first workspace's slug. Tightening to a single workspace per daemon is a config-validator change worth doing but separate.

## Test plan

- [x] `cargo test --lib` — 171 passing (+1 for the new resolver path).
- [ ] After merge: populate `[cli] token = \"…\"` in `~/.config/pidash/config.toml` on the dev host, restart pidash, trigger a run that calls `pidash issue get`, confirm the call succeeds.

## Stack

Branched off `design/ticking-drop-resume`. Once that lands, this PR rebases onto wherever the chain ends up.