### PR TITLE
feat: bring PR #98 (per-active-run agent observability + cloud stall watchdog) onto main

### DIFF
--- a/.ai_design/runner_agent_bridge/design.md
+++ b/.ai_design/runner_agent_bridge/design.md
@@ -1,0 +1,989 @@
+# Runner ↔ AI Agent Communication: Observability and Health Bridge
+
+> Directory: `.ai_design/runner_agent_bridge/`
+>
+> Successor design layer on top of the HTTPS long-poll control plane
+> (`.ai_design/move_to_https/design.md`). This proposal does **not**
+> change the transport. It enriches what the runner tells the cloud
+> about the AI agent subprocess (codex / claude) it bridges, and adds a
+> server-side stall watchdog independent of the runner's own internal
+> watchdog.
+>
+> Reference: OpenAI Symphony's elixir reference implementation
+> (`/home/irichard/dev/study/symphony`) does this well; specific
+> patterns we adopt are cited inline with file:line references.
+
+## 1. Problem Statement
+
+The runner exists for one reason: to be the bridge between the
+pi-dash cloud and a locally-running AI agent CLI (codex or claude).
+Operators care about the agent's health — _"is my codex run still
+making progress?"_ — not the runner's. Today the heartbeat the cloud
+sees only carries runner-level state:
+
+```
+{ status: "busy" | "idle", in_flight_run: <uuid> | null, ts: <iso> }
+```
+
+That is the minimum needed for the cloud's reaper to reconcile
+"runner says it's working on X" with "cloud thinks it's working on X."
+It is not enough to answer:
+
+- Is the codex subprocess **alive** right now?
+- Is it **actively producing tokens**, or has it gone silent?
+- Is it **paused on an approval request** that needs operator
+  attention?
+- What is its **OS process id** so an operator can kill it from the
+  host if necessary?
+- How many **turns** has it consumed against the cap?
+- How many **tokens** has it spent against the rate-limit window?
+
+These signals are not all readily available on the runner today,
+and that is itself part of the problem. The bridge layer
+(`runner/src/agent/mod.rs:14-47`) only emits a small set of
+agent-agnostic `BridgeEvent` variants — `RunStarted`, `Raw`,
+`ApprovalRequest`, `AwaitingReauth`, `Completed`, `Failed` —
+where everything not explicitly modelled (token counts, item
+lifecycle, turn boundaries) is folded into `BridgeEvent::Raw {
+method, params }`. For Codex, the `runner/src/codex/bridge.rs`
+translator wraps notifications in `Raw` rather than promoting them
+to discrete events; for Claude the `runner/src/claude_code/
+bridge.rs` translator only surfaces token usage at all in the
+terminal `Result` payload. So even at the supervisor layer, there
+is no "this is a token update" or "this is a turn boundary" signal
+to act on without re-parsing `Raw.params`. None of this surfaces to
+the cloud, and operators see only a cloud-side `AgentRunStatus`
+that flips every few seconds based on REST posts (`Accept`,
+`RunStarted`, `ApprovalRequest`, etc.) plus a coarse runner-level
+"busy/idle" badge. There is no continuous "agent CLI is alive and
+producing" signal.
+
+When the agent CLI hangs in a way that does _not_ close stdout — a
+deadlocked tool call, a slow network in the underlying model API, an
+unresponsive subprocess — the cloud finds out only after the runner's
+own internal `STALL_TIMEOUT = 5min` watchdog fires
+(`runner/src/daemon/supervisor.rs:933`). If the runner's tokio
+runtime itself wedges, that watchdog never fires and the cloud has no
+independent signal at all.
+
+This design closes both gaps.
+
+## 2. Reference: How Symphony Does It
+
+Symphony's runner equivalent (the `Orchestrator`) maintains a rich
+per-running-issue record that is updated on every codex frame and
+exposed on a JSON observability endpoint plus a terminal dashboard.
+Three patterns are directly applicable here.
+
+### 2.1 Per-run live state, refreshed on every event
+
+`elixir/lib/symphony_elixir/orchestrator.ex:1172-1199` — every codex
+update flowing into the orchestrator is integrated into the running
+entry:
+
+```elixir
+defp integrate_codex_update(running_entry, %{event: event, timestamp: timestamp} = update) do
+  # ...
+  Map.merge(running_entry, %{
+    last_codex_timestamp: timestamp,
+    last_codex_message: summarize_codex_update(update),
+    session_id: session_id_for_update(running_entry.session_id, update),
+    last_codex_event: event,
+    codex_app_server_pid: codex_app_server_pid_for_update(...),
+    codex_input_tokens: codex_input_tokens + token_delta.input_tokens,
+    codex_output_tokens: codex_output_tokens + token_delta.output_tokens,
+    codex_total_tokens: codex_total_tokens + token_delta.total_tokens,
+    turn_count: turn_count_for_update(turn_count, running_entry.session_id, update)
+  })
+```
+
+Every event the codex subprocess emits — token-usage updates, item
+started, item completed, tool requests, turn boundaries — touches
+this record. The orchestrator is therefore _always_ able to answer
+"when did we last hear from this agent?" without polling the
+subprocess directly.
+
+### 2.2 Server-side stall watchdog
+
+`elixir/lib/symphony_elixir/orchestrator.ex:448-487` — the
+orchestrator's poll tick walks every running entry and compares
+`now - last_codex_timestamp` against a configurable `stall_timeout_ms`:
+
+```elixir
+defp restart_stalled_issue(state, issue_id, running_entry, now, timeout_ms) do
+  elapsed_ms = stall_elapsed_ms(running_entry, now)
+  if is_integer(elapsed_ms) and elapsed_ms > timeout_ms do
+    Logger.warning("Issue stalled: ... elapsed_ms=#{elapsed_ms}; restarting with backoff")
+    state
+    |> terminate_running_issue(issue_id, false)
+    |> schedule_issue_retry(issue_id, next_attempt, %{
+      identifier: identifier,
+      error: "stalled for #{elapsed_ms}ms without codex activity"
+    })
+```
+
+This runs _outside_ the agent worker process, so a wedged worker is
+detected by the orchestrator regardless of whether the worker's own
+internal timeout fires. **Belt-and-suspenders**: per-turn timeout in
+the worker (`receive_loop` returns `{:error, :turn_timeout}` after
+`turn_timeout_ms`) **and** server-side reconciliation in the
+orchestrator. Either alone is insufficient.
+
+### 2.3 Observability surface
+
+`elixir/lib/symphony_elixir_web/presenter.ex:98-117` — the running
+entry is projected to a JSON shape that the web UI and CLI dashboard
+both consume:
+
+```elixir
+defp running_entry_payload(entry) do
+  %{
+    issue_id: entry.issue_id,
+    issue_identifier: entry.identifier,
+    state: entry.state,
+    worker_host: Map.get(entry, :worker_host),
+    workspace_path: Map.get(entry, :workspace_path),
+    session_id: entry.session_id,
+    turn_count: Map.get(entry, :turn_count, 0),
+    last_event: entry.last_codex_event,
+    last_message: summarize_message(entry.last_codex_message),
+    started_at: iso8601(entry.started_at),
+    last_event_at: iso8601(entry.last_codex_timestamp),
+    tokens: %{
+      input_tokens:  entry.codex_input_tokens,
+      output_tokens: entry.codex_output_tokens,
+      total_tokens:  entry.codex_total_tokens
+    }
+  }
+end
+```
+
+`status_dashboard.ex:590-633` renders the same record on a terminal
+UI with color-coded states keyed off `last_codex_event`:
+
+```elixir
+status_color =
+  case event do
+    :none                          -> @ansi_red
+    "codex/event/token_count"      -> @ansi_yellow
+    "codex/event/task_started"     -> @ansi_green
+    "turn_completed"               -> @ansi_magenta
+    _                              -> @ansi_blue
+  end
+```
+
+The operator at a glance sees: PID, session, age + turn, total
+tokens, last event class. Pi-dash's web UI can render the same.
+
+## 3. Goals and Non-Goals
+
+### 3.1 Goals
+
+1. The cloud must continuously receive a **per-active-run**
+   observability snapshot for the agent CLI subprocess — not just the
+   runner's commitment-level status.
+2. The cloud must be able to detect a stalled agent **without**
+   relying on the runner's own internal stall watchdog.
+3. The web UI must be able to show: agent state badge, last activity
+   age, agent OS PID, turn / token consumption, pending approvals —
+   all from one heartbeat snapshot.
+4. New fields are additive and backward-compatible. Old runners
+   without the new fields keep working; new runners against an old
+   cloud also keep working.
+
+### 3.2 Non-Goals
+
+- Replacing the existing run-lifecycle REST endpoints (`Accept`,
+  `RunStarted`, `ApprovalRequest`, etc.) — they remain the
+  authoritative source of run-state transitions.
+- Streaming live agent output to the cloud in real time — heartbeat
+  cadence (~25s) is enough for state badges; per-event detail
+  remains in run-lifecycle posts and the runner's local jsonl history.
+- Adding remote operator commands ("kill agent", "interrupt"). That
+  belongs in a follow-up; this design only adds the `agent_pid` that
+  would enable such a command, not the command itself.
+- Reimplementing the run state machine on the cloud side
+  (`AgentRunStatus`).
+
+## 4. Design
+
+The design narrows Symphony's pattern to three things only:
+
+1. update a live per-run snapshot on every agent event,
+2. expose that snapshot to operators,
+3. run a server-side stall watchdog independent of the runner's own
+   internal watchdog.
+
+What this design **does not** add:
+
+- A synthetic `AgentLifecycle` enum competing with the existing
+  `AgentRunStatus` and `RunnerStatus` enums. The cloud already has
+  authoritative lifecycle transitions via run-lifecycle endpoints
+  (`Accept`, `RunStarted`, `ApprovalRequest`, etc.); a third state
+  machine on the runner that the cloud has to keep coherent with
+  the first two creates more invariants than it pays for. Where the
+  UI wants to render "the agent is thinking" or "the agent stalled,"
+  it derives that from the descriptive scalars below
+  (`last_event_at`, `agent_subprocess_alive`) — they are a
+  presentation concern, not a state-machine concern.
+- A reshape of the `BridgeEvent` API to introduce first-class
+  `TokenUpdate` / `TurnBoundary` variants. The supervisor can
+  opportunistically parse known `Raw.method` values for token
+  deltas without changing the bridge contract, and that's enough
+  for the observability story. (See §4.3.)
+- New fields on session-open `AttachBody`. The snapshot only needs
+  to flow on the poll path, which already runs every 25s. Session
+  open is rare and is about identity + resume, not telemetry.
+- Symphony's tracker orchestration model: polling Linear, selecting
+  candidate issues, state/priority scheduling, blocker-aware
+  dispatch, SSH worker-host routing, or multi-project coordination.
+  Pi-dash already has its own run assignment and control-plane model;
+  this design only borrows how Symphony supervises and observes an
+  active agent process.
+
+### 4.0 Pre-implementation decisions
+
+These decisions are fixed for v1 so implementation does not have to
+re-open the scope boundary:
+
+| Decision                     | v1 choice                                                                                                 | Reason                                                                                                                       |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Process ownership            | Bridge-owned `AgentProcessHandle { pid, exit_rx }`; process wrappers own `child.wait()`                   | `AppServer` / `ClaudeProcess` already own the child process. The supervisor should observe process state, not own the child. |
+| `observed_run_id` clearing   | When `agent_observability_v1` is enabled, always serialize `observed_run_id`, including `null` while idle | Missing means old/disabled runner; explicit `null` means new runner is idle and the cloud should clear the run binding.      |
+| Cloud stall threshold        | `RUNNER_AGENT_STALL_THRESHOLD_SECS = 360`                                                                 | Slightly longer than the runner's existing 5-minute watchdog, so cloud acts as a backstop rather than racing the runner.     |
+| Snapshot freshness threshold | `RUNNER_AGENT_OBSERVABILITY_STALE_SECS = 90`                                                              | Covers roughly three missed 25s polls; stale live-state rows should not fail active runs.                                    |
+| Cloud stall action           | Mark the run `FAILED` in v1                                                                               | Matches today's runner watchdog behavior. Retry policy is a separate orchestration decision.                                 |
+| Claude token/turn metrics    | Leave streaming token / turn fields `NULL` for Claude unless equivalent stream events are added later     | Claude process health is covered; metric parity is not required for this watchdog.                                           |
+| UI warning state             | Derive activity / thinking / stalled labels client-side from raw scalars                                  | Keeps observability descriptive and avoids a third lifecycle state machine.                                                  |
+| Remote kill / interrupt      | Defer to a future command-channel design                                                                  | Requires authorization, audit logging, runner IPC, and safety controls.                                                      |
+| Symphony-style continuation  | Defer to a separate orchestration design                                                                  | Multi-turn retry / continuation changes work scheduling semantics, not agent-process observability.                          |
+
+### 4.1 Heartbeat snapshot fields
+
+Descriptive scalars only — no enums, no derived states. Each field
+either has a current value or is `NULL` (unknown / not applicable).
+The UI / watchdog interpret recency from `last_event_at` directly.
+
+| Field                         | Type            | Source on the runner                                                                                                                                 |
+| ----------------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `observed_run_id`             | `Uuid?`         | The run id this snapshot describes (= `rx_in_flight`'s current value). Explicit `null` means idle / clear the row's run binding.                     |
+| `last_event_at`               | `DateTime<Utc>` | Bumped on every `BridgeEvent` received in `pump_events`.                                                                                             |
+| `last_event_kind`             | `String`        | Last frame's method/kind (e.g. `"codex/event/token_count"`, `"approval/request"`, `"turn/started"`); used by UI for status colour. Length-capped 64. |
+| `last_event_summary`          | `String`        | One-line operator hint (e.g. `"tool/exec sh #14 (running 12s)"`). Length-capped 200; never carries prompt or model output content.                   |
+| `agent_pid`                   | `u32`           | OS pid from `AgentBridge::process_handle().pid`; cleared on shutdown.                                                                                |
+| `agent_subprocess_alive`      | `bool`          | Live answer from the bridge-owned exit notification (§4.4).                                                                                          |
+| `approvals_pending`           | `u32`           | Existing `rx_approvals_pending`.                                                                                                                     |
+| `tokens.{input,output,total}` | `u64`           | Optional. Codex only — supervisor opportunistically parses `codex/event/token_count` Raw frames. NULL for Claude (no streaming usage available).     |
+| `turn_count`                  | `u32`           | Optional. Codex only — supervisor opportunistically increments on `turn/started`. NULL for Claude.                                                   |
+
+The UI maps these scalars to its presentation:
+
+- `last_event_at` recent → green badge ("active")
+- `last_event_at` 30-180s old, `approvals_pending == 0` → yellow ("thinking")
+- `last_event_at` > 180s old → red ("stalled")
+- `agent_subprocess_alive == false` → red ("dead")
+- `approvals_pending > 0` → blue ("awaiting approval")
+
+These are CSS rules, not server-side state transitions. No
+enum-keeping discipline required.
+
+### 4.2 Where the snapshot rides — poll status only
+
+The runner uses two different HTTP envelopes to talk to the cloud
+(`AttachBody` at session-open, `PollStatus` nested under `"status"`
+at every poll). The observability snapshot rides **only on the
+poll**, not on session-open:
+
+- Session-open is rare (one-shot at reconnect) and its job is
+  identity + resume + bringing the runner online. The cloud already
+  ingests it via `apply_hello` (`session_service.py:55`) which only
+  cares about `version`, `os`, `arch`, `in_flight_run`. Mixing
+  observability fields into that path doubles the ingestion surface
+  and gives the cloud no information it doesn't see ~25s later from
+  the next poll.
+- Poll cadence is 25s by default. That is the natural rate for the
+  observability snapshot to refresh — same cadence as the data, one
+  ingestion path, one storage write.
+
+Concretely, only `PollStatus` (`runner/src/cloud/http.rs:756-785`)
+gains the new fields:
+
+```rust
+pub struct PollStatus {
+    // existing
+    pub status: String,
+    pub in_flight_run: Option<Uuid>,
+    pub ts: DateTime<Utc>,
+
+    // NEW — observability snapshot. `observed_run_id` is always
+    // serialized when the feature is enabled so the runner can
+    // explicitly clear the cloud row by sending null when idle.
+    pub observed_run_id: Option<Uuid>,
+
+    // Remaining fields are optional descriptive scalars. Missing means
+    // "do not change the existing value". Cross-run clears are driven by
+    // observed_run_id changes, not by per-field nulls.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_event_at: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_event_kind: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_event_summary: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_pid: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_subprocess_alive: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub approvals_pending: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tokens: Option<TokenUsage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub turn_count: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TokenUsage {
+    pub input: u64,
+    pub output: u64,
+    pub total: u64,
+}
+```
+
+`AttachBody` is **not** extended. The feature flag controls whether
+the runner serializes the new poll-status fields at all. When enabled,
+`observed_run_id` is included even when it is `null`; when disabled,
+none of the snapshot fields are sent.
+
+Wire impact: ~200 bytes per poll. At a 25s cadence that is
+~8 bytes/sec/runner — negligible.
+
+### 4.3 Runner-side state plumbing
+
+Add fields to `StateHandle::Inner` (`runner/src/daemon/state.rs`)
+and wire watch channels for the volatile fields the transport layer
+reads on each poll:
+
+```rust
+pub struct Inner {
+    // ... existing ...
+    last_event_at:        Mutex<Option<DateTime<Utc>>>,
+    last_event_kind:      Mutex<Option<String>>,
+    last_event_summary:   Mutex<Option<String>>,
+    agent_pid:            Mutex<Option<u32>>,
+    agent_subprocess_alive: Mutex<Option<bool>>,
+    tokens:               Mutex<Option<TokenUsage>>,
+    turn_count:           Mutex<Option<u32>>,
+}
+```
+
+Helper API — designed so call sites stay narrow and there is no
+state machine to keep coherent. Each setter is a small,
+independent write:
+
+```rust
+impl StateHandle {
+    /// Bump `last_event_at` and stamp `kind`/`summary`. Called from
+    /// `pump_events` on every `BridgeEvent` regardless of variant.
+    pub async fn note_agent_event(&self, ts: DateTime<Utc>, kind: &str, summary: Option<String>) { ... }
+
+    pub async fn set_agent_pid(&self, pid: Option<u32>) { ... }
+    pub async fn set_agent_alive(&self, alive: bool) { ... }
+    pub async fn set_tokens(&self, usage: TokenUsage) { ... }
+    pub async fn incr_turn(&self) { ... }
+
+    /// Wipe the per-run snapshot before a *different* run begins.
+    /// Invoked from `set_current_run(Some(_))` only when the run id
+    /// changes, so a new run never inherits the previous run's
+    /// `last_event_at`, tokens, turn count, or PID. Re-stamping the
+    /// same run id during startup must not clear live values.
+    pub async fn reset_run_snapshot(&self) {
+        *self.inner.last_event_at.lock().await = None;
+        *self.inner.last_event_kind.lock().await = None;
+        *self.inner.last_event_summary.lock().await = None;
+        *self.inner.agent_pid.lock().await = None;
+        *self.inner.agent_subprocess_alive.lock().await = None;
+        *self.inner.tokens.lock().await = None;
+        *self.inner.turn_count.lock().await = None;
+    }
+}
+```
+
+`set_current_run(Some(...))` at `runner/src/daemon/state.rs:115`
+calls `reset_run_snapshot()` only when the previous run id differs
+from the next run id, then proceeds:
+
+```rust
+pub async fn set_current_run(&self, s: Option<CurrentRunSummary>) {
+    let next = s.as_ref().map(|r| r.run_id);
+    let prev = *self.tx_in_flight.borrow();
+    if let (Some(next_id), Some(prev_id)) = (next, prev) {
+        if next_id != prev_id {
+            self.reset_run_snapshot().await;
+        }
+    } else if next.is_some() && prev.is_none() {
+        // Idle → busy: clear any leftover snapshot from a prior run that
+        // completed via `set_current_run(None)`.
+        self.reset_run_snapshot().await;
+    }
+    // ... existing body ...
+}
+```
+
+This preserves the startup invariant where the same run id may be
+stamped more than once (supervisor's early stamp on Assign +
+worker's later re-stamp at line 803 — see PR #94 commit `5e6b1c0`)
+without flickering through idle. `set_current_run(None)` does not
+reset local fields; it changes `observed_run_id` to `null` on the
+next poll so the cloud can clear the live-state row's run binding.
+
+Call sites — a small, mechanical list, with no protocol-detail
+parsing in the supervisor unless the operator wants the optional
+token/turn fields:
+
+- `supervisor.rs::pump_events`, on every `BridgeEvent`: call
+  `note_agent_event(Utc::now(), kind_of(&event), summary_of(&event))`.
+  `kind_of` is a small one-line `match` on the `BridgeEvent` variant
+  (and on `Raw.method` when the variant is `Raw`); `summary_of` is
+  similarly a thin formatter.
+- `supervisor.rs`, after `AgentBridge::spawn_*` returns: read
+  `AgentBridge::process_handle().pid` and call
+  `state.set_agent_pid(Some(pid))` when present. On shutdown,
+  `set_agent_pid(None)`.
+- `supervisor.rs`, on the process-exit notification described in
+  §4.4: `state.set_agent_alive(false)` when the notification fires.
+- Optional, opt-in via config flag — token / turn extraction.
+  Today's `BridgeEvent::Raw` carries codex's `codex/event/token_count`
+  and `turn/started` frames inline. The supervisor can match those
+  methods and call `set_tokens` / `incr_turn` without the bridge API
+  changing. This is **opportunistic observability** — when the agent
+  exposes the data we forward it; when it doesn't (e.g. Claude during
+  a run; codex of a future protocol version) we leave the fields
+  NULL. There is no separate `BridgeEvent::TokenUpdate` /
+  `TurnBoundary` variant introduced.
+
+The supervisor having a small piece of agent-protocol knowledge
+("if `Raw.method == codex/event/token_count`, parse usage") is
+acceptable for an _observability_ shim. It is not a load-bearing
+control-plane decision; if the parsing fails or the field shape
+changes, we lose a chart pixel, not run correctness.
+
+Heartbeat construction (`PollStatus::from_state(...)`) reads
+`rx_in_flight` plus the snapshot fields — the same snapshotting
+pattern as `current_attach_body()` from `http.rs`, extended to poll
+status. `observed_run_id` is set from `rx_in_flight`, not from a
+separate mutable field.
+
+### 4.4 Independent process-exit watch
+
+Today the bridge detects agent death only via stdout-close
+(`pump_events` `bridge.next_events` returning None). On Linux this is
+reliable for clean exits; for `kill -9` it usually is too, but a
+malicious process could double-fork and we'd miss it.
+
+Add an explicit bridge-owned exit notification. The supervisor cannot
+call `child.wait()` directly today because the child is owned inside
+`codex::app_server::AppServer` and `claude_code::process::
+ClaudeProcess`. So the bridge layer grows a narrow process handle:
+
+```rust
+pub struct AgentProcessHandle {
+    pub pid: Option<u32>,
+    pub exit_rx: watch::Receiver<Option<ExitSnapshot>>,
+}
+
+pub struct ExitSnapshot {
+    pub status_code: Option<i32>,
+    pub signal: Option<i32>,
+    pub observed_at: DateTime<Utc>,
+}
+```
+
+Each concrete process wrapper spawns its own wait task immediately
+after `cmd.spawn()` succeeds, updates `exit_rx` when the child exits,
+and keeps stdout-reading behaviour unchanged. `AgentBridge` exposes
+`process_handle()` so the supervisor can:
+
+> **Implementation note — Child ownership refactor.**
+> `tokio::process::Child::wait()` and `start_kill()` are both
+> `&mut self`, so only one task can hold the `Child`. The existing
+> `AppServer::shutdown()` at `runner/src/codex/app_server.rs:60-72`
+> calls `self.child.wait()` and `self.child.start_kill()` directly
+> on a `child: Child` field. To add the wait task, that field has
+> to move into the wait task itself; the existing `AppServer`
+> retains only a `kill_tx: oneshot::Sender<KillRequest>` (or
+> `mpsc::Sender` for repeatable kills) plus the `exit_rx` from this
+> design. `shutdown()` becomes "send a `KillRequest`, then await
+> `exit_rx`," with the same overall timeout semantics. The wait
+> task is the canonical Rust async-process pattern and is the only
+> change of substance in `app_server.rs` /
+> `claude_code/process.rs`; everything stdin/stdout side stays as
+> it is.
+
+- stamp `agent_pid`,
+- mark `agent_subprocess_alive = true` after spawn,
+- subscribe to `exit_rx` and mark `agent_subprocess_alive = false`
+  when an exit snapshot arrives,
+- let the existing `bridge.next_events(cursor) == None` path remain
+  the terminal run-failure path.
+
+This means the new watcher is observability-first. It does not add a
+new authoritative `BridgeEvent::Dead` state or compete with the
+existing stdout-close / `Failed` / `Completed` paths. If the process
+exits before stdout closes, the UI can show "process exited" quickly;
+the existing pump loop still finalizes the run through its current
+control-flow. Symphony's analogue is the Erlang Port's
+`{:exit_status, status}` message (`app_server.ex:356-357`), which is
+native to the Port abstraction; Tokio requires us to expose the same
+signal explicitly from the process wrapper.
+
+### 4.5 Cloud-side reconciliation
+
+#### 4.5.1 Storage — `RunnerLiveState`, keyed to the observed run
+
+The cloud stores the snapshot in a dedicated `RunnerLiveState`
+table — **not** on `Runner` (that would let a finished run's
+metrics persist as worker-wide attributes), and **not** on
+`AgentRun` (those columns would imply the data is part of the
+authoritative run record, when it is in fact volatile and may be
+overwritten / set NULL on every poll).
+
+```python
+# apps/api/pi_dash/runner/models.py
+class RunnerLiveState(models.Model):
+    runner = models.OneToOneField(
+        Runner,
+        on_delete=models.CASCADE,
+        primary_key=True,
+        related_name="live_state",
+    )
+    # The run this snapshot describes. NULL when the runner is idle.
+    # The watchdog (§4.5.3) only acts when this matches a running
+    # AgentRun's id — that is what makes the snapshot
+    # unambiguously about the run we'd be failing.
+    observed_run_id    = models.UUIDField(null=True, blank=True)
+    last_event_at      = models.DateTimeField(null=True, blank=True)
+    last_event_kind    = models.CharField(max_length=64,  null=True, blank=True)
+    last_event_summary = models.CharField(max_length=200, null=True, blank=True)
+    agent_pid          = models.PositiveIntegerField(null=True, blank=True)
+    agent_subprocess_alive = models.BooleanField(null=True, blank=True)
+    approvals_pending  = models.PositiveSmallIntegerField(null=True, blank=True)
+    input_tokens       = models.BigIntegerField(null=True, blank=True)
+    output_tokens      = models.BigIntegerField(null=True, blank=True)
+    total_tokens       = models.BigIntegerField(null=True, blank=True)
+    turn_count         = models.PositiveIntegerField(null=True, blank=True)
+    updated_at         = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        indexes = [
+            # Watchdog query in §4.5.3 filters on observed_run_id,
+            # updated_at freshness, and stale last_event_at.
+            models.Index(fields=["observed_run_id", "updated_at", "last_event_at"]),
+        ]
+```
+
+Properties this shape gives us:
+
+- One row per `Runner` (`OneToOneField`); upserted on every poll.
+  No need to look up the active `AgentRun` on each ingestion.
+- `observed_run_id` is what makes the snapshot
+  **unambiguously about a specific run.** When a new run starts,
+  the next poll overwrites the row with the new run's id, blanking
+  the old run's metrics in one write — so there is no carry-over
+  even though storage isn't physically per-run.
+- `RunnerLiveState` is treated as observability-only. Authoritative
+  run state stays on `AgentRun` (status, assigned_at, started_at,
+  ended_at, error). The two are intentionally not merged.
+
+#### 4.5.2 Ingestion — poll handler only
+
+Per §4.2, the snapshot rides only on `PollStatus`. So the only
+ingestion site is `RunnerSessionPollEndpoint` at
+`apps/api/pi_dash/runner/views/sessions.py:240-260`. `apply_hello`
+does **not** change.
+
+```python
+# apps/api/pi_dash/runner/services/session_service.py (new helper)
+SNAPSHOT_FIELDS = (
+    "last_event_at", "last_event_kind",
+    "last_event_summary", "agent_pid", "agent_subprocess_alive",
+    "approvals_pending", "input_tokens", "output_tokens", "total_tokens",
+    "turn_count",
+)
+
+def upsert_runner_live_state(runner, status_entry):
+    """Apply the volatile observability snapshot from a poll body.
+
+    `status_entry` is the dict the poll handler reads as
+    body['status']. Missing fields are left as-is on the existing
+    row — a stale poll never NULLs out a known-good value. A poll
+    that carries a different
+    `observed_run_id` than the row's current value saves a full wipe
+    of every snapshot field before applying incoming values, ensuring
+    no cross-run carryover.
+    """
+    if not status_entry:
+        return
+    state, _ = RunnerLiveState.objects.get_or_create(runner=runner)
+
+    has_snapshot = "observed_run_id" in status_entry or any(
+        key in status_entry for key in set(SNAPSHOT_FIELDS) | {"tokens"}
+    )
+    if not has_snapshot:
+        return
+
+    try:
+        incoming_run_id = parse_optional_uuid(status_entry.get("observed_run_id"))
+    except ValueError:
+        logger.warning("ignoring runner live-state update with invalid observed_run_id")
+        return
+    update_fields = []
+
+    if "observed_run_id" in status_entry and state.observed_run_id != incoming_run_id:
+        # New run, or idle/null after a completed run. Persist the full
+        # wipe, not just fields present on this poll.
+        for f in SNAPSHOT_FIELDS:
+            setattr(state, f, None)
+        update_fields.extend(SNAPSHOT_FIELDS)
+        state.observed_run_id = incoming_run_id
+        update_fields.append("observed_run_id")
+
+    for f in SNAPSHOT_FIELDS:
+        if f in status_entry:
+            setattr(state, f, status_entry[f])
+            update_fields.append(f)
+    if "tokens" in status_entry:
+        tokens = status_entry["tokens"] or {}
+        state.input_tokens = tokens.get("input")
+        state.output_tokens = tokens.get("output")
+        state.total_tokens = tokens.get("total")
+        update_fields.extend(["input_tokens", "output_tokens", "total_tokens"])
+    if update_fields:
+        state.save(update_fields=sorted(set(update_fields)) + ["updated_at"])
+```
+
+The poll handler calls `upsert_runner_live_state(runner,
+body.get('status') or {})` after the existing reaper / heartbeat
+update. Pre-observability runners send no snapshot fields and the row
+stays all-NULL / absent. New runners with the feature enabled always
+send `observed_run_id`, so the cloud can clear the row's run binding
+by receiving `null` when the runner goes idle.
+
+#### 4.5.3 Server-side stall watchdog — explicit run-id match
+
+A Celery beat task running every 30s. The watchdog requires both
+that the snapshot's `observed_run_id` matches the run's id **and**
+that the snapshot's `last_event_at` is older than the threshold.
+It also requires a recently-updated `RunnerLiveState.updated_at`, so
+the task only acts on runners that are still actively reporting the
+observability snapshot. This avoids failing a run from a stale row if
+the feature is disabled or a runner downgrades mid-run.
+
+The proactive signal is the difference between two clocks:
+
+- `RunnerLiveState.updated_at` answers "is the runner still polling
+  and reporting this snapshot?"
+- `RunnerLiveState.last_event_at` answers "when did the agent
+  subprocess last produce an event?"
+
+When `updated_at` is fresh but `last_event_at` is stale, the cloud can
+derive "runner alive, agent silent" without waiting for the runner's
+own `STALL_TIMEOUT` branch to emit `RunFailed`.
+
+That match is the difference from the previous draft and the
+reason a separate `RunnerLiveState` row earns its keep — it makes
+"this snapshot belongs to _this_ run" expressible as a join
+condition, not as an inference.
+
+```python
+# apps/api/pi_dash/runner/tasks.py
+@app.task
+def reconcile_stalled_runs():
+    threshold = settings.RUNNER_AGENT_STALL_THRESHOLD_SECS  # default 360
+    snapshot_freshness = settings.RUNNER_AGENT_OBSERVABILITY_STALE_SECS  # default 90
+    now = timezone.now()
+    cutoff = now - timedelta(seconds=threshold)
+    snapshot_cutoff = now - timedelta(seconds=snapshot_freshness)
+
+    # Active BUSY runs whose runner's snapshot:
+    #   (a) currently describes this run (observed_run_id == run.id), AND
+    #   (b) is still being reported by the runner, AND
+    #   (c) hasn't recorded agent activity within the threshold.
+    # NULL last_event_at is excluded by __lt; pre-observability
+    # runners are therefore never reaped by this task.
+    stalled = (
+        AgentRun.objects
+        .filter(status__in=BUSY_STATUSES)
+        .exclude(status__in=(
+            AgentRunStatus.AWAITING_APPROVAL,
+            AgentRunStatus.AWAITING_REAUTH,
+        ))
+        .filter(
+            runner__live_state__observed_run_id=models.F("id"),
+            runner__live_state__updated_at__gte=snapshot_cutoff,
+            runner__live_state__last_event_at__lt=cutoff,
+        )
+    )
+    for run in stalled.select_related("runner"):
+        run_lifecycle.finalize_run_terminal(
+            run.runner, run.id, AgentRunStatus.FAILED,
+            error_detail=f"agent stalled: no events for >{threshold}s",
+        )
+```
+
+This covers the gap left by the existing heartbeat reaper:
+
+- Runner's tokio runtime wedged: heartbeats stop, so the existing
+  heartbeat reaper handles that via runner offline detection. The
+  fresh-`updated_at` guard intentionally keeps this watchdog out of
+  that failure mode.
+- Agent CLI hung in a way that produces no events — the _new_ class
+  this watchdog adds. Today the cloud only learns of these stalls
+  after the runner's own 5-minute internal watchdog fires.
+- Any future failure mode where the runner remains alive but the
+  agent goes silent on a specific run.
+
+Pre-observability runners pass through the watchdog cleanly: their
+`live_state` row either doesn't exist or has all NULL fields, so
+the inner `__lt` clause excludes their runs. Runners that previously
+sent observability but stop sending it are also skipped once
+`updated_at` ages past `RUNNER_AGENT_OBSERVABILITY_STALE_SECS`.
+
+Default threshold: 360s. Configurable via Django settings,
+overrideable per agent kind on the run's runner config.
+
+#### 4.5.4 Web UI surface — observability only, not a second lifecycle
+
+`apps/web/core/components/runners/...` gains a per-run detail
+panel reading from `Runner.live_state` (the `RunnerLiveState` row
+described in §4.5.1) joined with the active `AgentRun`. The panel
+treats this data as **observability only** — it never overrides
+the cloud-side `AgentRunStatus` for run lifecycle transitions, and
+the badge it renders is derived from raw scalars, not from a
+synthetic enum that the cloud has to agree with.
+
+| UI element       | Source field                                                                                                   | NULL render      | Format                                                                  |
+| ---------------- | -------------------------------------------------------------------------------------------------------------- | ---------------- | ----------------------------------------------------------------------- |
+| Activity badge   | derived from `last_event_at` + `agent_subprocess_alive` + `approvals_pending` (CSS rule, not server-side enum) | "unknown" (gray) | green=active, yellow=thinking, red=stalled/dead, blue=awaiting approval |
+| Last activity    | `last_event_at`                                                                                                | "—"              | "12s ago", "2m ago"                                                     |
+| Last event kind  | `last_event_kind`                                                                                              | "—"              | small label (e.g. `tool/exec`)                                          |
+| Agent PID        | `agent_pid`                                                                                                    | "—"              | numeric, with copy button                                               |
+| Subprocess alive | `agent_subprocess_alive`                                                                                       | "—"              | "yes" / "no" / "—"                                                      |
+| Approvals        | `approvals_pending`                                                                                            | "0"              | numeric, with link to approvals view                                    |
+| Tokens           | `total_tokens` (and i/o split)                                                                                 | "—"              | "31.0k"                                                                 |
+| Turn             | `turn_count`                                                                                                   | "—"              | numeric                                                                 |
+| Last event       | `last_event_summary`                                                                                           | hidden           | tooltip                                                                 |
+
+The activity badge is the only place the UI synthesises a state
+label, and it does so on the client from the raw scalars. There is
+no server-side `agent_state` enum to keep coherent with
+`AgentRunStatus` and `RunnerStatus`. This is what Codex's review
+of v2 of this doc was pointing at: keep observability descriptive,
+not authoritative.
+
+This is roughly what Symphony's terminal dashboard renders
+(`status_dashboard.ex:590-633`), translated to a web component —
+but with the lifecycle classification done on the client side
+rather than persisted as state.
+
+## 5. Phasing
+
+### Phase A — Runner-side, no cloud changes
+
+Lands behind a feature flag. Heartbeat carries the new fields if
+the config opts in. Cloud ignores them today.
+
+A.1 `RunnerLiveState`-style scalar fields on `StateHandle::Inner`
+(no `AgentLifecycle` enum).
+A.2 `note_agent_event(ts, kind, summary)` / `set_agent_pid` /
+`set_agent_alive` wired in `pump_events` and bridge spawn.
+A.3 `PollStatus` extended with the optional snapshot fields
+(`AttachBody` is **not** changed).
+A.4 Bridge-owned process-exit notification (§4.4) drives
+`agent_subprocess_alive`; the supervisor subscribes to it but does
+not own `child.wait()` directly.
+A.5 Optional, opt-in: supervisor-side parsing of
+`codex/event/token_count` and `turn/started` from `Raw.method` to
+populate `tokens` / `turn_count`. No `BridgeEvent` API change.
+A.6 `reset_run_snapshot()` invoked from `set_current_run(Some(_))`
+only when the run id changes, so a new run never sends stale fields
+and a same-run re-stamp does not erase live values.
+A.7 Unit tests for the snapshot-reset on new-run boundary, the
+process-exit watcher, and PollStatus serialisation.
+
+Ships behind `agent_observability_v1` config flag, default off.
+
+### Phase B — Cloud-side ingestion
+
+B.1 DB migration: new `RunnerLiveState` table with the
+`(observed_run_id, updated_at, last_event_at)` index for the watchdog.
+B.2 `upsert_runner_live_state(runner, status_entry)` helper called
+from the poll handler **only** (`apply_hello` is unchanged). The
+helper persists a full snapshot wipe on `observed_run_id` change.
+B.3 Server-side stall reconcile Celery task with the explicit
+`observed_run_id == agent_run.id` join.
+B.4 Tests covering: backward compat (no `live_state` row,
+all-NULL row), `observed_run_id` change persists a full wipe before
+applying incoming values, idle/null clears the row's run binding,
+stall watchdog requires run-id match, fresh `updated_at`, and stale
+`last_event_at`, AwaitingApproval/AwaitingReauth excluded.
+
+When B ships, runners can flip the flag on; old runners continue
+to work without the new fields. An old run that completes on a
+now-upgraded fleet does **not** poison the next run's metrics
+because `upsert_runner_live_state` wipes the snapshot the moment
+`observed_run_id` changes.
+
+### Phase C — Operator surface
+
+C.1 Web UI per-run detail panel; activity badge derived
+client-side from raw scalars.
+C.2 Optional JSON observability endpoint
+(`GET /api/v1/runners/<rid>/live-state`) for external dashboards.
+C.3 Status colour in the runs list view, from `last_event_at`
+recency.
+
+## 6. Backward and Forward Compatibility
+
+`RunnerLiveState` columns are nullable end-to-end; `NULL` is the
+canonical "unknown" sentinel for both the watchdog and the UI.
+There is no `default="idle"` and no `default=0` — those would
+silently misrepresent pre-observability runs as "idle, 0 tokens"
+instead of "unknown."
+
+| Direction                        | Effect                                                                                                                                                |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| New runner → old cloud           | Old cloud ignores unknown fields in `PollStatus`; existing reaper still works on `in_flight_run`. `AttachBody` is unchanged.                          |
+| Old runner → new cloud           | Heartbeat carries no snapshot fields; `live_state` row stays NULL or absent; UI renders "—"; stall watchdog skips the run.                            |
+| New runner → new cloud, flag off | Heartbeat carries no snapshot fields; any old `live_state` row ages out via the watchdog's `updated_at` freshness guard.                              |
+| Mixed fleet during rollout       | Each runner is independent. A new run starts by overwriting the snapshot via `observed_run_id` change, blanking the previous run's data in one write. |
+
+Field stability:
+
+- All snapshot fields are descriptive scalars; there is no
+  enum-typed field whose variant set the cloud has to keep current
+  with the runner. New scalars can be added later without breaking
+  parsing on either side.
+- `tokens` / `turn_count` may be NULL during a run (e.g. Claude has
+  no streaming tokens); ingestion preserves the previous non-NULL
+  value rather than blanking it. The exception is the
+  `observed_run_id`-changed wipe, which clears all snapshot fields
+  in one write.
+- A heartbeat that omits the entire snapshot block (old runner, or
+  new runner with the flag off) leaves the `live_state` row
+  unchanged. The watchdog only acts when `updated_at` is fresh, so a
+  stale row from an old/disabled runner ages out instead of failing an
+  active run from old data. The explicit run-id match still protects
+  the normal completed-run case where a previous run's snapshot is
+  present but no longer describes any active run.
+
+## 7. Risks and Follow-up Questions
+
+1. **Threshold tuning.** V1 starts with
+   `RUNNER_AGENT_STALL_THRESHOLD_SECS = 360` and
+   `RUNNER_AGENT_OBSERVABILITY_STALE_SECS = 90`. These values may need
+   deployment tuning for slow-agent flows, but they are no longer an
+   implementation blocker.
+
+2. **Retry instead of fail.** V1 marks cloud-detected stalls
+   `FAILED`, matching the runner's current watchdog behavior. If we
+   later want to retry stalled runs automatically, that belongs in a
+   separate orchestration/retry-policy design.
+
+3. **Privacy of `last_event_summary`.** Must never include prompt
+   text, model output, or file contents. The runner's
+   `summary_of(BridgeEvent)` formatter sanitises by structure: only
+   method name, item id, duration, exit code. Codex tool args
+   containing user input are out of scope — keep at summary level.
+
+4. **PID stability under SSH-driven workers.** Symphony runs codex
+   on remote workers via SSH; the PID it reports is the SSH parent
+   PID, not the codex PID directly. Pi-dash today runs the agent
+   locally, so this isn't an issue. If we add SSH-driven workers
+   later, the PID field needs a host-qualifier.
+
+5. **`approvals_pending` already exists on the runner side
+   (`set_approvals_pending`).** Just wire it through the heartbeat;
+   no new state needed.
+
+6. **Cloud-side stall reconcile cost.** O(active_runs) per 30s
+   tick, with the `(observed_run_id, updated_at, last_event_at)`
+   index keeping the join cheap. Trivial at expected scale (≤ thousands of
+   concurrent runs); revisit if scale changes.
+
+7. **Snapshot stalemate when the runner upgrades mid-run.** If a
+   pre-observability runner runs to completion and then upgrades
+   without finishing, its `live_state` row is empty. After upgrade
+   the next run's first poll writes the new `observed_run_id` and
+   the system is healthy. Old completed runs are never re-evaluated
+   by the watchdog because they aren't in `BUSY_STATUSES`. So this
+   case is benign.
+
+8. **Symphony-style multi-turn continuation.** V1 does not adopt this.
+   Symphony retries the same issue across multiple codex turns up to a
+   `max_turns` cap; pi-dash today treats each assignment as one run.
+   Changing that belongs in a separate orchestration design.
+
+## 8. Open Items for Future Designs
+
+- **Remote operator commands** using `agent_pid`: "interrupt agent",
+  "kill agent", "send signal." Requires a runner-side IPC handler
+  and cloud-side authorization.
+- **Live event streaming**: the existing per-event REST posts could
+  be replaced by an SSE / WebSocket per-run upgrade for verbose runs,
+  reusing the WS protocol kept dormant in
+  `.ai_design/move_to_https/design.md`.
+- **Multi-turn continuation** like Symphony's
+  `do_run_codex_turns` (issue stays active → continuation prompt →
+  next turn). Today pi-dash treats every assignment as one-shot.
+
+## 9. Summary
+
+Today the runner reports a four-bit picture of its state to the
+cloud: alive, busy, on-run-X, idle. That is enough for the cloud to
+reconcile commitment but not for the operator to reason about the
+agent. Symphony's reference implementation shows a richer
+agent-process-management pattern that costs ~250 bytes per heartbeat:
+per-event activity timestamp, agent PID, turn count, token usage, and
+operator-facing status projection. Pi-dash adopts that
+observability/watchdog pattern without adopting Symphony's tracker
+scheduler or lifecycle vocabulary. Bringing the narrowed pattern into
+pi-dash gives:
+
+1. The cloud a way to detect stalled agents without depending on the
+   runner's own internal watchdog.
+2. The web UI enough material to render meaningful per-run status
+   beyond "running" or "failed."
+3. Operators a PID they can act on when a local subprocess
+   misbehaves.
+
+The change is additive on both sides, behind a feature flag, with
+clean fallbacks for mixed fleets.
+
+---
+
+## Appendix A — Symphony reference index
+
+| Pattern                      | Symphony source                                                                       |
+| ---------------------------- | ------------------------------------------------------------------------------------- |
+| Per-run rich state record    | `elixir/lib/symphony_elixir/orchestrator.ex:1172-1199`                                |
+| Server-side stall reconcile  | `elixir/lib/symphony_elixir/orchestrator.ex:448-487`                                  |
+| Process-exit detection       | `elixir/lib/symphony_elixir/codex/app_server.ex:356-357` (Erlang Port `:exit_status`) |
+| Codex frame dispatch         | `elixir/lib/symphony_elixir/codex/app_server.ex:364-438`                              |
+| Token/turn tracking          | `elixir/lib/symphony_elixir/orchestrator.ex:1172-1230`                                |
+| JSON observability shape     | `elixir/lib/symphony_elixir_web/presenter.ex:98-117`                                  |
+| Terminal dashboard rendering | `elixir/lib/symphony_elixir/status_dashboard.ex:590-633`                              |
+
+## Appendix B — Pi-dash insertion-point index
+
+| Component              | File                                                                   | Change                                                                                                                              |
+| ---------------------- | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| State store            | `runner/src/daemon/state.rs`                                           | add scalar fields (no lifecycle enum); `note_agent_event(ts, kind, summary)`; `reset_run_snapshot` invoked only when run id changes |
+| Bridge process handle  | `runner/src/agent/mod.rs::AgentBridge`                                 | expose `process_handle() -> AgentProcessHandle` with PID + exit notification                                                        |
+| Process-exit watcher   | `runner/src/codex/app_server.rs`, `runner/src/claude_code/process.rs`  | bridge-owned wait task updates exit notification; supervisor subscribes and drives `set_agent_alive(false)`                         |
+| Event ingestion        | `runner/src/daemon/supervisor.rs::pump_events`                         | call `note_agent_event` on every `BridgeEvent`; opportunistic `Raw.method` matching for tokens / turn (opt-in)                      |
+| PollStatus (poll only) | `runner/src/cloud/http.rs::PollStatus` (line 757)                      | add the optional snapshot fields. **`AttachBody` is unchanged**                                                                     |
+| Poll handler ingestion | `apps/api/pi_dash/runner/views/sessions.py::RunnerSessionPollEndpoint` | call new `upsert_runner_live_state(runner, body.get("status") or {})`                                                               |
+| Live-state model       | `apps/api/pi_dash/runner/models.py::RunnerLiveState` (new)             | one row per runner, all nullable; keyed to `observed_run_id`; `(observed_run_id, updated_at, last_event_at)` index                  |
+| Stall reconcile        | `apps/api/pi_dash/runner/tasks.py::reconcile_stalled_runs` (new)       | Celery beat; explicit `live_state.observed_run_id == agent_run.id` join + fresh `updated_at` + stale `last_event_at`                |
+| DB migration           | `apps/api/pi_dash/runner/migrations/00XX_runner_live_state.py`         | additive — new table only, no changes to `AgentRun` / `Runner`                                                                      |
+| UI panel               | `apps/web/core/components/runners/RunnerAgentStatusPanel.tsx` (new)    | observability-only; activity badge derived client-side from raw scalars; NULLs render as "—"                                        |

--- a/.ai_design/runner_agent_bridge/tasks.md
+++ b/.ai_design/runner_agent_bridge/tasks.md
@@ -1,0 +1,383 @@
+# Runner ↔ AI Agent Communication: Observability and Health Bridge — Tasks
+
+Purpose: track the implementation of the per-active-run
+observability snapshot, the bridge-owned process-exit notification,
+and the cloud-side stall watchdog described in `design.md`.
+
+Companion docs in this directory:
+
+- `design.md` — architecture, wire shape, ingestion rules, decisions
+
+How to use this file:
+
+- Keep task status in-place with checkboxes.
+- Add PR links or issue ids inline after the task text.
+- Do not delete completed tasks; strike or annotate only if scope
+  changes.
+- Section refs like `design.md §4.5.2` point at the normative spec;
+  treat them as the contract.
+- Phase A and Phase B can ship in either order because the runner
+  fields are gated by `agent_observability_v1` and the cloud
+  ingestion is a no-op when fields are absent. **Phase B must
+  ship before runners enable the flag in production**, so cloud
+  rolls first by convention.
+
+## Milestones
+
+- [ ] Phase A: runner — bridge process-exit notification, runner-
+      side state plumbing, `PollStatus` extension, opt-in token /
+      turn parsing, all gated behind `agent_observability_v1`
+- [ ] Phase B: cloud — `RunnerLiveState` table, poll-handler
+      ingestion, server-side stall watchdog with explicit run-id
+      match
+- [ ] Phase C: operator surface — web UI panel + optional
+      observability JSON endpoint
+- [ ] Roll out: enable `agent_observability_v1=true` per fleet,
+      monitor watchdog firing rate vs. runner-internal stall count
+
+## 1. Phase A — Runner side
+
+### 1.1 Bridge process handle (`design.md` §4.4)
+
+- [ ] Define `AgentProcessHandle` in `runner/src/agent/mod.rs`:
+  - [ ] `pub pid: Option<u32>`
+  - [ ] `pub exit_rx: tokio::sync::watch::Receiver<Option<ExitSnapshot>>`
+- [ ] Define `ExitSnapshot` in the same file:
+  - [ ] `pub status_code: Option<i32>`
+  - [ ] `pub signal: Option<i32>`
+  - [ ] `pub observed_at: chrono::DateTime<Utc>`
+- [ ] Add `AgentBridge::process_handle(&self) -> AgentProcessHandle`
+      enum-dispatched to each concrete bridge.
+
+### 1.2 Codex AppServer refactor — `Child` ownership (`design.md` §4.4 implementation note)
+
+- [ ] In `runner/src/codex/app_server.rs`, replace `child: Child`
+      with `kill_tx: mpsc::Sender<()>` (or oneshot if kill fires
+      exactly once) and store the new `exit_rx`.
+- [ ] Spawn a wait task immediately after `cmd.spawn()`:
+  - [ ] `tokio::spawn` that owns `Child` exclusively.
+  - [ ] `select!` on `kill_rx.recv()` (→ `child.start_kill()`) and
+        `child.wait()` (→ build `ExitSnapshot`, send via
+        `exit_tx`, exit task).
+  - [ ] Capture `child.id()` before moving `Child` into the task —
+        this becomes `AgentProcessHandle.pid`.
+- [ ] Rewrite `AppServer::shutdown(grace)`:
+  - [ ] Send a `KillRequest` via `kill_tx`.
+  - [ ] Await `exit_rx.changed()` with a `tokio::time::timeout`.
+  - [ ] Removes the existing direct calls to `self.child.wait()` /
+        `self.child.start_kill()` at lines 60-72.
+- [ ] Add a unit test that exercises `spawn → kill → exit_rx
+    observed → ExitSnapshot.status_code is Some(<signal-derived>)`.
+
+### 1.3 Claude process refactor — same shape
+
+- [ ] Repeat 1.2 for `runner/src/claude_code/process.rs`. Same
+      `Child`-ownership flip, same `kill_tx` / `exit_rx` exposure.
+- [ ] Verify `claude_code::Bridge` exposes `process_handle()`.
+
+### 1.4 `StateHandle` snapshot fields (`design.md` §4.3)
+
+- [ ] In `runner/src/daemon/state.rs::Inner`, add:
+  - [ ] `last_event_at: Mutex<Option<DateTime<Utc>>>`
+  - [ ] `last_event_kind: Mutex<Option<String>>`
+  - [ ] `last_event_summary: Mutex<Option<String>>`
+  - [ ] `agent_pid: Mutex<Option<u32>>`
+  - [ ] `agent_subprocess_alive: Mutex<Option<bool>>`
+  - [ ] `tokens: Mutex<Option<TokenUsage>>`
+  - [ ] `turn_count: Mutex<Option<u32>>`
+- [ ] Define `TokenUsage { input, output, total: u64 }` in a new
+      module `runner/src/daemon/observability.rs`.
+- [ ] Add `StateHandle` async helpers:
+  - [ ] `note_agent_event(ts, kind, summary)`
+  - [ ] `set_agent_pid(Option<u32>)`
+  - [ ] `set_agent_alive(bool)`
+  - [ ] `set_tokens(TokenUsage)`
+  - [ ] `incr_turn()`
+  - [ ] `reset_run_snapshot()` (wipes all of the above to None)
+- [ ] Modify `set_current_run` per the §4.3 pseudocode: call
+      `reset_run_snapshot()` when `next.run_id != prev.run_id` AND
+      when `prev.is_none() && next.is_some()`. Do **not** call
+      it when the same run id is re-stamped.
+- [ ] Unit tests for `StateHandle`:
+  - [ ] `set_current_run(Some(rid))` twice with same rid → snapshot
+        is **not** reset.
+  - [ ] `set_current_run(Some(rid_a))` then `set_current_run(Some(rid_b))`
+        → snapshot is reset.
+  - [ ] `set_current_run(None)` → snapshot fields preserved
+        (last poll still carries the terminal values).
+  - [ ] `note_agent_event` updates `last_event_at`, `last_event_kind`,
+        `last_event_summary` atomically.
+
+### 1.5 Supervisor wiring (`design.md` §4.3 call sites)
+
+- [ ] In `runner/src/daemon/supervisor.rs::pump_events`, before the
+      existing `match event` body:
+  - [ ] Compute `kind = kind_of(&event)` and `summary = summary_of(&event)`.
+  - [ ] Call `state.note_agent_event(Utc::now(), kind, summary).await`.
+- [ ] After `AgentBridge::spawn_*` returns Ok in the run loop:
+  - [ ] Read `bridge.process_handle()`.
+  - [ ] Call `state.set_agent_pid(handle.pid).await`.
+  - [ ] Call `state.set_agent_alive(true).await`.
+  - [ ] `tokio::spawn` a small task that watches `handle.exit_rx`
+        and calls `state.set_agent_alive(false).await` when the
+        receiver yields `Some(ExitSnapshot)`.
+- [ ] `kind_of(&BridgeEvent)` formatter helper, in
+      `runner/src/daemon/observability.rs`. One match arm per
+      variant. For `Raw { method, .. }` use `method` directly.
+      Result is length-capped at 64 chars.
+- [ ] `summary_of(&BridgeEvent)` formatter helper, same module.
+      Structure-only output: never includes prompt, model output,
+      or file content. For each event variant, surface
+      method-name + identifiers + duration (where available).
+      Length-capped at 200 chars. Add unit tests asserting that
+      a tool/exec event's args do **not** appear in the summary.
+
+### 1.6 Optional, opt-in: token / turn extraction (`design.md` §4.3)
+
+- [ ] Behind a sub-flag of `agent_observability_v1`
+      (`agent_observability_v1.parse_codex_token_count`,
+      default true on Codex):
+  - [ ] In the supervisor's `BridgeEvent::Raw` arm, match
+        `method == "codex/event/token_count"` and call
+        `state.set_tokens(parse_codex_token_count(&params)?)`.
+  - [ ] Match `method == "turn/started"` and call
+        `state.incr_turn()`.
+- [ ] Failures inside `parse_codex_token_count` log at debug and
+      continue — never propagate. Observability shim must not
+      affect run correctness.
+- [ ] No changes to `BridgeEvent` variants. No changes to
+      `runner/src/codex/bridge.rs::BridgeCursor::translate`.
+- [ ] Claude path is a no-op. `tokens` and `turn_count` stay None
+      for Claude during a run; `last_event_summary` will still
+      populate from `Raw.method` like Codex.
+
+### 1.7 Wire shape (`design.md` §4.2)
+
+- [ ] In `runner/src/cloud/http.rs::PollStatus` (line 757), add the
+      new optional fields per §4.2. Order: `observed_run_id` first
+      (always serialized when feature on), then the rest with
+      `#[serde(skip_serializing_if = "Option::is_none")]`.
+- [ ] **Do not** modify `AttachBody`. Add a regression test that
+      asserts `AttachBody`'s serialized field set is unchanged.
+- [ ] Add `PollStatus::from_state(state: &StateHandle, in_flight:
+    Option<Uuid>)` constructor that snapshots the state's
+      mutexes once. `observed_run_id` is set from `in_flight` (=
+      `rx_in_flight`), not from a separate field.
+- [ ] Update the existing poll-time call site
+      (`http.rs::poll_once`, currently constructs `PollStatus::from_wire`):
+      switch to `PollStatus::from_state(...)` so the new fields
+      flow on every poll.
+- [ ] Feature-flag: when `agent_observability_v1=false`, all new
+      fields serialize as absent (including `observed_run_id`).
+      When true, `observed_run_id` is always serialized — possibly
+      `null`.
+- [ ] Unit test: feature off → wire bytes match the v3 (pre-this-
+      design) shape exactly. Feature on, idle → `observed_run_id:
+    null` is present, other fields absent. Feature on, busy →
+      all populated fields present.
+
+### 1.8 Phase A roll-out gate
+
+- [ ] Add `daemon.agent_observability_v1: bool` to
+      `runner/src/config/schema.rs::DaemonConfig`. Default false.
+- [ ] CLI: `pidash status` shows the flag value (so operators can
+      tell whether their fleet is reporting).
+- [ ] Document in `runner/README.md` (one paragraph): the flag,
+      what it costs (~250 bytes per poll), what the cloud needs
+      (Phase B deployed) before turning it on.
+
+## 2. Phase B — Cloud side
+
+### 2.1 `RunnerLiveState` model (`design.md` §4.5.1)
+
+- [ ] Add `RunnerLiveState` model to
+      `apps/api/pi_dash/runner/models.py`:
+  - [ ] `runner = OneToOneField(Runner, on_delete=CASCADE,
+    primary_key=True, related_name="live_state")`
+  - [ ] `observed_run_id = UUIDField(null=True, blank=True)`
+  - [ ] `last_event_at = DateTimeField(null=True, blank=True)`
+  - [ ] `last_event_kind = CharField(max_length=64, null=True, blank=True)`
+  - [ ] `last_event_summary = CharField(max_length=200, null=True, blank=True)`
+  - [ ] `agent_pid = PositiveIntegerField(null=True, blank=True)`
+  - [ ] `agent_subprocess_alive = BooleanField(null=True, blank=True)`
+  - [ ] `approvals_pending = PositiveSmallIntegerField(null=True, blank=True)`
+  - [ ] `input_tokens = BigIntegerField(null=True, blank=True)`
+  - [ ] `output_tokens = BigIntegerField(null=True, blank=True)`
+  - [ ] `total_tokens = BigIntegerField(null=True, blank=True)`
+  - [ ] `turn_count = PositiveIntegerField(null=True, blank=True)`
+  - [ ] `updated_at = DateTimeField(auto_now=True)`
+  - [ ] `Meta.indexes`: `Index(fields=["observed_run_id",
+    "updated_at", "last_event_at"])`
+- [ ] Migration `apps/api/pi_dash/runner/migrations/00XX_runner_live_state.py`:
+      additive only, no data migration, no changes to existing
+      tables. Depends on the latest existing runner migration.
+
+### 2.2 Ingestion helper (`design.md` §4.5.2)
+
+- [ ] Add to `apps/api/pi_dash/runner/services/session_service.py`:
+  - [ ] `SNAPSHOT_FIELDS` tuple (does **not** include
+        `observed_run_id` — that field drives the wipe, it is
+        not a wipe target).
+  - [ ] `parse_optional_uuid(raw)` — returns `None` for
+        `None`/missing, raises `ValueError` for malformed UUIDs.
+  - [ ] `upsert_runner_live_state(runner, status_entry)` per the
+        §4.5.2 listing. Wipe-on-rid-change semantics. Tokens
+        unpacking from nested `tokens.{input,output,total}` to
+        the flat columns.
+- [ ] In `apps/api/pi_dash/runner/views/sessions.py::RunnerSessionPollEndpoint.post`:
+  - [ ] After the existing reaper / heartbeat update, call
+        `upsert_runner_live_state(runner, body.get("status") or {})`.
+- [ ] **Do not** modify `apply_hello`. Add a regression test
+      asserting `apply_hello`'s behaviour is unchanged when the
+      session-open body contains arbitrary extra fields.
+
+### 2.3 Server-side stall watchdog (`design.md` §4.5.3)
+
+- [ ] Add settings to `apps/api/apple_pi_dash/settings/common.py`:
+  - [ ] `RUNNER_AGENT_STALL_THRESHOLD_SECS = 360`
+  - [ ] `RUNNER_AGENT_OBSERVABILITY_STALE_SECS = 90`
+- [ ] Add `reconcile_stalled_runs` Celery task to
+      `apps/api/pi_dash/runner/tasks.py`. Query exactly as in
+      §4.5.3, with the `models.F("id")` cross-join match,
+      fresh-`updated_at` clause, and stale-`last_event_at` clause.
+- [ ] Wire the task into Celery beat at the cadence specified
+      (every 30s) — add to the project's beat schedule
+      configuration.
+- [ ] On stall match, call `run_lifecycle.finalize_run_terminal(
+    run.runner, run.id, AgentRunStatus.FAILED, error_detail=
+    f"agent stalled: no events for >{threshold}s")`. Same
+      lifecycle helper used by other terminal transitions.
+
+### 2.4 Cloud-side tests (`design.md` §5 Phase B.4)
+
+- [ ] `test_upsert_runner_live_state`:
+  - [ ] Pre-observability runner (status_entry empty) → no row
+        written, no exception.
+  - [ ] First snapshot for a runner → row created with the fields
+        present.
+  - [ ] Subsequent snapshot, same `observed_run_id` → only the
+        present fields update; missing fields preserved.
+  - [ ] `observed_run_id` change → all snapshot fields wiped to
+        NULL **before** applying incoming values, in one save.
+  - [ ] Idle clear (`observed_run_id: null`) → wipe persists, row
+        retains the runner FK with NULL run binding.
+  - [ ] Malformed UUID in `observed_run_id` → log warning,
+        skip, do not raise.
+- [ ] `test_reconcile_stalled_runs`:
+  - [ ] Run with no `live_state` row → not reaped.
+  - [ ] Run with `live_state.observed_run_id != run.id` → not
+        reaped (snapshot describes a different run, e.g. previous
+        completed run not yet overwritten).
+  - [ ] Run with matching `observed_run_id` but stale
+        `updated_at` (older than `RUNNER_AGENT_OBSERVABILITY_STALE_SECS`)
+        → not reaped (runner stopped reporting; old data).
+  - [ ] Run with matching `observed_run_id`, fresh `updated_at`,
+        stale `last_event_at` (older than
+        `RUNNER_AGENT_STALL_THRESHOLD_SECS`) → reaped, error
+        message matches.
+  - [ ] Run in `AWAITING_APPROVAL` / `AWAITING_REAUTH` → never
+        reaped even when otherwise stale.
+  - [ ] Pre-observability run with `last_event_at = NULL` → not
+        reaped (NULL excluded by `__lt`).
+- [ ] `test_session_poll_unchanged_for_old_runner`: a poll with
+      no `status` payload (or one that omits all snapshot fields)
+      leaves any pre-existing `live_state` row untouched.
+
+### 2.5 Cloud-side observability metrics (optional)
+
+- [ ] Increment a counter on each stall-watchdog firing for
+      dashboarding (`pidash.runner.stall_reaped`). Tag with
+      `agent_kind` so Codex / Claude rates can be compared.
+
+## 3. Phase C — Operator surface
+
+### 3.1 Web UI panel (`design.md` §4.5.4)
+
+- [ ] Add `apps/web/core/components/runners/RunnerAgentStatusPanel.tsx`.
+      Reads `Runner.live_state` plus the active `AgentRun`
+      via the existing runner-detail query.
+- [ ] Activity badge derivation, client-side only:
+  - [ ] `null` everywhere → gray "unknown".
+  - [ ] `agent_subprocess_alive == false` → red "dead".
+  - [ ] `approvals_pending > 0` → blue "awaiting approval".
+  - [ ] `last_event_at` within last 30s → green "active".
+  - [ ] `last_event_at` 30-180s ago → yellow "thinking".
+  - [ ] `last_event_at` > 180s ago → red "stalled".
+- [ ] Render NULL fields per §4.5.4 table: "—" for scalar
+      observability fields; tooltip hidden if `last_event_summary`
+      is NULL.
+- [ ] Storybook entry covering all six badge states + the
+      all-null pre-observability state.
+
+### 3.2 Read endpoint (optional)
+
+- [ ] `GET /api/v1/runners/<rid>/live-state` returning the
+      serialized snapshot. Auth: same as the existing
+      runner-detail endpoint. Skip if the web UI's existing
+      runner-detail endpoint can be extended instead — pick one
+      surface, not both.
+
+## 4. Test matrix (cross-phase)
+
+End-to-end tests that exercise both runner and cloud against a
+local docker stack:
+
+- [ ] **Healthy run.** Runner accepts an Assign, agent emits
+      events, run completes. Assert: `live_state` row has
+      non-NULL `last_event_at` updated within the run, watchdog
+      never fires, run reaches `AgentRunStatus.COMPLETED`.
+- [ ] **Stalled agent.** Runner accepts Assign, agent process
+      lives but emits no events for > threshold. Assert: cloud
+      watchdog reaps the run with the documented error message;
+      runner's existing internal stall watchdog also fires
+      (overlap is expected and benign).
+- [ ] **Daemon restart mid-run.** Restart `pidash` while a run is
+      in flight. Assert: PR #94's drain step (commit `df687a6`)
+      sends `RunFailed{daemon_restart}` first, the new
+      `live_state` row's `observed_run_id` is cleared at restart's
+      first poll, no spurious stall reap.
+- [ ] **Feature flag off → on.** Boot a runner with
+      `agent_observability_v1=false`, dispatch a run, then
+      hot-reload the daemon with the flag on. Assert: first poll
+      after restart populates `live_state`, watchdog behaves
+      correctly thereafter.
+- [ ] **Mixed fleet.** Two runners on the same connection, one
+      with the flag on, one with the flag off. Assert: only the
+      enabled runner's row is populated; the watchdog only fires
+      on enabled runners.
+
+## 5. Rollout plan
+
+- [ ] Phase B lands first (additive cloud changes; no behavioural
+      effect until runners send fields).
+- [ ] Phase A lands second behind the flag.
+- [ ] Per-cell rollout: enable `agent_observability_v1=true` on
+      one fleet cell; observe `pidash.runner.stall_reaped` rate
+      and the false-positive rate vs. the runner's internal
+      5-minute watchdog firing rate. Tune
+      `RUNNER_AGENT_STALL_THRESHOLD_SECS` if false positives
+      appear.
+- [ ] Phase C ships when at least one production cell has been
+      running with the flag on for a week without watchdog
+      false-positives.
+- [ ] Default-enable the flag once the rollout reaches stable
+      false-positive rate < 1% of stalled runs.
+
+## 6. Disable / rollback plan
+
+If the watchdog over-fires or the runner-side parsing is buggy:
+
+- [ ] Set `agent_observability_v1=false` on affected runners.
+      Existing in-flight runs continue normally; the next poll
+      stops sending snapshot fields. The cloud's `live_state`
+      row ages out via `RUNNER_AGENT_OBSERVABILITY_STALE_SECS`
+      and the watchdog stops acting on those runners.
+- [ ] To disable cloud-side watchdog without redeploying runners:
+      remove the `reconcile_stalled_runs` task from Celery beat,
+      or set `RUNNER_AGENT_STALL_THRESHOLD_SECS` to a very large
+      number. The poll-handler ingestion is harmless to leave
+      running.
+- [ ] Migration is additive only; no rollback migration is
+      needed. The `RunnerLiveState` table can be left in place
+      during a temporary rollback; re-enabling is just flipping
+      the runner flag back on.

--- a/apps/api/pi_dash/celery.py
+++ b/apps/api/pi_dash/celery.py
@@ -7,6 +7,8 @@ import os
 import logging
 
 # Third party imports
+from datetime import timedelta
+
 from celery import Celery
 from pythonjsonlogger.jsonlogger import JsonFormatter
 from celery.signals import after_setup_logger, after_setup_task_logger
@@ -85,6 +87,14 @@ app.conf.beat_schedule = {
     "runner-mark-offline-runners": {
         "task": "runner.mark_offline_runners",
         "schedule": crontab(minute="*/1"),
+    },
+    # Per-active-run agent stall watchdog. Backstop for the runner's own
+    # internal 5-minute stall timer; see
+    # `.ai_design/runner_agent_bridge/design.md` §4.5.3. 30s gives ~12
+    # ticks per stall threshold so we don't oversleep the deadline.
+    "runner-reconcile-stalled-runs": {
+        "task": "runner.reconcile_stalled_runs",
+        "schedule": timedelta(seconds=30),
     },
     # Issue ticking — see .ai_design/issue_ticking_system/design.md §6
     "scan-due-agent-tickers": {

--- a/apps/api/pi_dash/runner/migrations/0012_runner_live_state.py
+++ b/apps/api/pi_dash/runner/migrations/0012_runner_live_state.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Add RunnerLiveState — per-runner volatile observability snapshot.
+
+See ``.ai_design/runner_agent_bridge/design.md`` §4.5.1. This is an
+additive migration: a new table with a one-to-one FK to ``Runner`` and a
+covering index for the stall-watchdog query. No existing tables are
+modified, no data migration is required, and rolling back is safe (the
+table can be left in place during a temporary rollback).
+"""
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("runner", "0011_per_runner_https_transport"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="RunnerLiveState",
+            fields=[
+                (
+                    "runner",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        primary_key=True,
+                        related_name="live_state",
+                        serialize=False,
+                        to="runner.runner",
+                    ),
+                ),
+                ("observed_run_id", models.UUIDField(blank=True, null=True)),
+                ("last_event_at", models.DateTimeField(blank=True, null=True)),
+                (
+                    "last_event_kind",
+                    models.CharField(blank=True, max_length=64, null=True),
+                ),
+                (
+                    "last_event_summary",
+                    models.CharField(blank=True, max_length=200, null=True),
+                ),
+                ("agent_pid", models.PositiveIntegerField(blank=True, null=True)),
+                ("agent_subprocess_alive", models.BooleanField(blank=True, null=True)),
+                (
+                    "approvals_pending",
+                    models.PositiveIntegerField(blank=True, null=True),
+                ),
+                ("input_tokens", models.BigIntegerField(blank=True, null=True)),
+                ("output_tokens", models.BigIntegerField(blank=True, null=True)),
+                ("total_tokens", models.BigIntegerField(blank=True, null=True)),
+                ("turn_count", models.PositiveIntegerField(blank=True, null=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                "db_table": "runner_live_state",
+            },
+        ),
+        migrations.AddIndex(
+            model_name="runnerlivestate",
+            index=models.Index(
+                fields=["observed_run_id", "updated_at", "last_event_at"],
+                name="runner_live_watchdog_idx",
+            ),
+        ),
+    ]

--- a/apps/api/pi_dash/runner/models.py
+++ b/apps/api/pi_dash/runner/models.py
@@ -764,3 +764,65 @@ class ApprovalRequest(models.Model):
         db_table = "agent_run_approval"
         ordering = ("-requested_at",)
         indexes = [models.Index(fields=["agent_run", "status"])]
+
+
+class RunnerLiveState(models.Model):
+    """Volatile per-runner observability snapshot for the active agent run.
+
+    Holds the descriptive scalars the runner emits on every poll
+    (``last_event_at``, ``last_event_kind``, ``last_event_summary``,
+    ``agent_pid``, ``agent_subprocess_alive``, ``approvals_pending``,
+    streaming token counts, ``turn_count``). All fields are nullable;
+    NULL is the canonical "unknown" sentinel for both the watchdog and
+    the UI. See ``.ai_design/runner_agent_bridge/design.md`` §4.5.1.
+
+    Authoritative run state stays on :class:`AgentRun`; this row is
+    overwritten / cleared on each ``observed_run_id`` change. The
+    watchdog (``reconcile_stalled_runs``) only acts when this row's
+    ``observed_run_id`` matches an active ``AgentRun.id`` and
+    ``updated_at`` is fresh.
+    """
+
+    runner = models.OneToOneField(
+        Runner,
+        on_delete=models.CASCADE,
+        primary_key=True,
+        related_name="live_state",
+    )
+    # The run this snapshot describes. NULL when the runner is idle.
+    # The watchdog only acts when this matches a running AgentRun's id —
+    # that join condition is what makes the snapshot unambiguously about
+    # the run we'd otherwise fail.
+    observed_run_id = models.UUIDField(null=True, blank=True)
+    last_event_at = models.DateTimeField(null=True, blank=True)
+    last_event_kind = models.CharField(max_length=64, null=True, blank=True)
+    last_event_summary = models.CharField(max_length=200, null=True, blank=True)
+    agent_pid = models.PositiveIntegerField(null=True, blank=True)
+    agent_subprocess_alive = models.BooleanField(null=True, blank=True)
+    # PositiveIntegerField (Postgres INTEGER, max 2_147_483_647), not
+    # SmallInteger: the runner serialises this as u32. Real-world counts
+    # are tiny so the int32 ceiling is unreachable in practice; the
+    # u32::MAX (4_294_967_295) saturating sentinel the runner uses on
+    # `usize → u32` conversion would still overflow this column, but
+    # producing approvals_pending > 4 billion is not a realistic path.
+    approvals_pending = models.PositiveIntegerField(null=True, blank=True)
+    input_tokens = models.BigIntegerField(null=True, blank=True)
+    output_tokens = models.BigIntegerField(null=True, blank=True)
+    total_tokens = models.BigIntegerField(null=True, blank=True)
+    turn_count = models.PositiveIntegerField(null=True, blank=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        db_table = "runner_live_state"
+        indexes = [
+            # Watchdog query in reconcile_stalled_runs filters on
+            # observed_run_id (run-id match), updated_at (snapshot fresh),
+            # and last_event_at (agent activity stale).
+            models.Index(
+                fields=["observed_run_id", "updated_at", "last_event_at"],
+                name="runner_live_watchdog_idx",
+            ),
+        ]
+
+    def __str__(self) -> str:
+        return f"RunnerLiveState(runner={self.runner_id} observed_run_id={self.observed_run_id})"

--- a/apps/api/pi_dash/runner/serializers.py
+++ b/apps/api/pi_dash/runner/serializers.py
@@ -11,6 +11,7 @@ from pi_dash.runner.models import (
     ApprovalRequest,
     Pod,
     Runner,
+    RunnerLiveState,
 )
 
 
@@ -64,6 +65,33 @@ class PodSerializer(serializers.ModelSerializer):
         return pod.runners.count()
 
 
+class RunnerLiveStateSerializer(serializers.ModelSerializer):
+    """Per-active-run agent observability snapshot.
+
+    See ``.ai_design/runner_agent_bridge/design.md`` §4.5.4. All fields
+    nullable; the UI renders ``null`` as ``"—"`` and derives the activity
+    badge client-side from raw scalars.
+    """
+
+    class Meta:
+        model = RunnerLiveState
+        fields = [
+            "observed_run_id",
+            "last_event_at",
+            "last_event_kind",
+            "last_event_summary",
+            "agent_pid",
+            "agent_subprocess_alive",
+            "approvals_pending",
+            "input_tokens",
+            "output_tokens",
+            "total_tokens",
+            "turn_count",
+            "updated_at",
+        ]
+        read_only_fields = fields
+
+
 class PodMiniSerializer(serializers.ModelSerializer):
     class Meta:
         model = Pod
@@ -73,6 +101,9 @@ class PodMiniSerializer(serializers.ModelSerializer):
 
 class RunnerSerializer(serializers.ModelSerializer):
     pod_detail = PodMiniSerializer(source="pod", read_only=True)
+    # Optional one-to-one observability snapshot. ``None`` when the row
+    # doesn't exist yet (pre-flag runner that has never reported).
+    live_state = RunnerLiveStateSerializer(read_only=True)
 
     class Meta:
         model = Runner
@@ -90,6 +121,7 @@ class RunnerSerializer(serializers.ModelSerializer):
             "owner",
             "pod",
             "pod_detail",
+            "live_state",
             "enrolled_at",
             "revoked_at",
             "revoked_reason",
@@ -107,6 +139,7 @@ class RunnerSerializer(serializers.ModelSerializer):
             "last_heartbeat_at",
             "owner",
             "pod_detail",
+            "live_state",
             "enrolled_at",
             "revoked_at",
             "revoked_reason",

--- a/apps/api/pi_dash/runner/services/session_service.py
+++ b/apps/api/pi_dash/runner/services/session_service.py
@@ -22,6 +22,7 @@ from pi_dash.runner.models import (
     AgentRun,
     AgentRunStatus,
     Runner,
+    RunnerLiveState,
     RunnerStatus,
 )
 
@@ -135,6 +136,118 @@ def reap_stale_busy_runs(runner: Runner, body: Dict[str, Any]) -> None:
             drain_pod_by_id(pid)
 
     transaction.on_commit(_drain_after_commit)
+
+
+# ---------------------------------------------------------------------------
+# Per-active-run observability snapshot ingestion
+# ---------------------------------------------------------------------------
+#
+# Lives on the poll path only (`apply_hello` is unchanged) — see
+# `.ai_design/runner_agent_bridge/design.md` §4.2 / §4.5.2.
+#
+# Wire shape carries one envelope key (`observed_run_id`) plus optional
+# scalar fields. `observed_run_id` *change* triggers a full wipe of the
+# row's snapshot fields before applying the incoming values; missing
+# scalars on a same-run poll are NOT overwritten (a stale poll never NULLs
+# out a known-good value).
+
+# Snapshot fields stored on RunnerLiveState. Does NOT include
+# `observed_run_id` (that field drives the wipe, it is not a wipe target).
+# Tokens travel as a nested `tokens.{input,output,total}` object on the
+# wire; they are unpacked into the three flat columns by the upsert.
+SNAPSHOT_FIELDS = (
+    "last_event_at",
+    "last_event_kind",
+    "last_event_summary",
+    "agent_pid",
+    "agent_subprocess_alive",
+    "approvals_pending",
+    "input_tokens",
+    "output_tokens",
+    "total_tokens",
+    "turn_count",
+)
+
+
+def parse_optional_uuid(raw: Any) -> Optional[UUID]:
+    """Return a UUID for present-and-valid values, ``None`` for missing /
+    explicit-null. Raises ``ValueError`` for malformed UUID strings so the
+    caller can decide to skip the entire poll's observability ingestion.
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, UUID):
+        return raw
+    return UUID(str(raw))
+
+
+def upsert_runner_live_state(
+    runner: Runner, status_entry: Dict[str, Any]
+) -> None:
+    """Apply the volatile observability snapshot from a poll body.
+
+    ``status_entry`` is the dict the poll handler reads as
+    ``body['status']``. Missing fields are left as-is on the existing
+    row — a stale poll never NULLs out a known-good value. A poll that
+    carries a different ``observed_run_id`` than the row's current value
+    persists a full wipe of every snapshot field before applying the
+    incoming values, ensuring no cross-run carryover.
+
+    No-op when the body has no observability fields at all (pre-flag
+    runner). Malformed ``observed_run_id`` values are logged and skipped
+    rather than raised so a buggy runner can't take down the cloud's
+    poll handler.
+    """
+    if not status_entry:
+        return
+    has_snapshot = "observed_run_id" in status_entry or any(
+        key in status_entry for key in (*SNAPSHOT_FIELDS, "tokens")
+    )
+    if not has_snapshot:
+        return
+
+    state, _ = RunnerLiveState.objects.get_or_create(runner=runner)
+
+    try:
+        incoming_run_id = parse_optional_uuid(status_entry.get("observed_run_id"))
+    except (ValueError, TypeError):
+        logger.warning(
+            "ignoring runner live-state update for %s: invalid observed_run_id %r",
+            runner.id,
+            status_entry.get("observed_run_id"),
+        )
+        return
+
+    update_fields: list[str] = []
+
+    if (
+        "observed_run_id" in status_entry
+        and state.observed_run_id != incoming_run_id
+    ):
+        # New run, or idle/null after a completed run. Persist the full
+        # wipe, not just the fields present on this poll.
+        for f in SNAPSHOT_FIELDS:
+            setattr(state, f, None)
+        update_fields.extend(SNAPSHOT_FIELDS)
+        state.observed_run_id = incoming_run_id
+        update_fields.append("observed_run_id")
+
+    for f in SNAPSHOT_FIELDS:
+        if f in status_entry:
+            setattr(state, f, status_entry[f])
+            update_fields.append(f)
+
+    if "tokens" in status_entry:
+        tokens = status_entry["tokens"] or {}
+        state.input_tokens = tokens.get("input")
+        state.output_tokens = tokens.get("output")
+        state.total_tokens = tokens.get("total")
+        update_fields.extend(["input_tokens", "output_tokens", "total_tokens"])
+
+    if update_fields:
+        state.save(
+            update_fields=sorted(set(update_fields)) + ["updated_at"]
+        )
 
 
 def mark_runner_online(runner_id: UUID | str) -> None:

--- a/apps/api/pi_dash/runner/tasks.py
+++ b/apps/api/pi_dash/runner/tasks.py
@@ -15,7 +15,7 @@ from datetime import timedelta
 
 from celery import shared_task
 from django.conf import settings
-from django.db import transaction
+from django.db import models, transaction
 from django.utils import timezone
 
 from pi_dash.runner.models import (
@@ -28,7 +28,7 @@ from pi_dash.runner.models import (
     RunnerSession,
     RunnerStatus,
 )
-from pi_dash.runner.services import outbox
+from pi_dash.runner.services import outbox, run_lifecycle
 from pi_dash.runner.services.pubsub import send_to_runner
 
 logger = logging.getLogger(__name__)
@@ -199,3 +199,92 @@ def sweep_run_message_dedupe() -> int:
     if deleted:
         logger.info("sweep_run_message_dedupe deleted %s row(s)", deleted)
     return deleted
+
+
+# ---- Per-active-run agent stall watchdog ---------------------------------
+#
+# Cloud-side backstop for the runner's own internal stall watchdog —
+# see ``.ai_design/runner_agent_bridge/design.md`` §4.5.3. Fires only on
+# runs where the snapshot's ``observed_run_id`` matches the run id (so we
+# never reap a run from a previous-run snapshot), the snapshot row is
+# *fresh* (so we don't reap when the runner stops reporting altogether —
+# heartbeat-staleness is handled by ``mark_offline_runners`` / etc.), and
+# the agent itself has been silent past the threshold.
+
+@shared_task(name="runner.reconcile_stalled_runs")
+def reconcile_stalled_runs() -> int:
+    """Mark BUSY runs FAILED when the agent subprocess has gone silent.
+
+    Three conjuncts must all hold for a run to be reaped:
+
+    1. ``RunnerLiveState.observed_run_id == AgentRun.id`` — the snapshot
+       describes *this* run, not a previous one whose row hasn't been
+       overwritten yet.
+    2. ``RunnerLiveState.updated_at`` is within
+       ``RUNNER_AGENT_OBSERVABILITY_STALE_SECS`` — the runner is still
+       reporting (we're not reacting to a stale row from a downgraded
+       runner).
+    3. ``RunnerLiveState.last_event_at`` is older than
+       ``RUNNER_AGENT_STALL_THRESHOLD_SECS`` — the agent itself has gone
+       silent.
+
+    Runs in ``AWAITING_APPROVAL`` / ``AWAITING_REAUTH`` are excluded so
+    operator-driven pauses are never failed by the watchdog.
+    Pre-observability runners pass cleanly: their ``last_event_at`` is
+    NULL and ``__lt`` excludes NULL.
+    """
+    threshold = int(getattr(settings, "RUNNER_AGENT_STALL_THRESHOLD_SECS", 360))
+    snapshot_freshness = int(
+        getattr(settings, "RUNNER_AGENT_OBSERVABILITY_STALE_SECS", 90)
+    )
+    now = timezone.now()
+    cutoff = now - timedelta(seconds=threshold)
+    snapshot_cutoff = now - timedelta(seconds=snapshot_freshness)
+
+    # AWAITING_APPROVAL / AWAITING_REAUTH are intentionally excluded
+    # from the active-run set: they're operator-driven pauses, not
+    # silence on the agent's part. The runner's snapshot during those
+    # states will look "stalled" by construction; failing the run from
+    # this watchdog would race the user. Filter directly on the two
+    # active states instead of subtracting from BUSY_STATUSES so a
+    # future status added to BUSY_STATUSES doesn't silently sneak past
+    # the exclusion.
+    active_statuses = (AgentRunStatus.ASSIGNED, AgentRunStatus.RUNNING)
+    stalled = (
+        AgentRun.objects.filter(status__in=active_statuses)
+        .filter(
+            runner__live_state__observed_run_id=models.F("id"),
+            runner__live_state__updated_at__gte=snapshot_cutoff,
+            runner__live_state__last_event_at__lt=cutoff,
+        )
+        .select_related("runner")
+    )
+
+    reaped = 0
+    for run in stalled:
+        if run.runner is None:
+            continue
+        # Per-row guard: a single bad finalize (DB constraint, optimistic-
+        # concurrency conflict, scheduler-hook error) must not abort the
+        # whole sweep — the next 30s tick would then re-walk the same poison
+        # row and never reap the rest. Log + continue.
+        try:
+            run_lifecycle.finalize_run_terminal(
+                run.runner,
+                run.id,
+                AgentRunStatus.FAILED,
+                error_detail=f"agent stalled: no events for >{threshold}s",
+            )
+            reaped += 1
+        except Exception:
+            logger.exception(
+                "reconcile_stalled_runs: failed to reap run %s",
+                run.id,
+            )
+    if reaped:
+        logger.info(
+            "reconcile_stalled_runs reaped %s stalled run(s) (threshold=%ss)",
+            reaped,
+            threshold,
+        )
+    return reaped

--- a/apps/api/pi_dash/runner/views/sessions.py
+++ b/apps/api/pi_dash/runner/views/sessions.py
@@ -258,6 +258,19 @@ class RunnerSessionPollEndpoint(APIView):
         )
         if status_entry:
             session_service.reap_stale_busy_runs(runner, status_entry)
+            # Volatile observability snapshot — see
+            # `.ai_design/runner_agent_bridge/design.md` §4.5.2.
+            # Pre-observability runners send no snapshot fields and the
+            # helper short-circuits. Failures here must never break the
+            # poll path: a malformed snapshot or a transient DB error
+            # would otherwise return 500 and spin the runner's retry loop.
+            try:
+                session_service.upsert_runner_live_state(runner, status_entry)
+            except Exception:
+                logger.exception(
+                    "upsert_runner_live_state failed for runner %s",
+                    runner.id,
+                )
 
         # 5. XACK explicit ids.
         if ack_ids:
@@ -303,6 +316,10 @@ class RunnerSessionPollEndpoint(APIView):
         use_zero: bool,
     ) -> list[dict]:
         if block_ms <= 0:
+            if not use_zero:
+                return []
+            # The initial PEL replay uses STREAMS ... 0 and must remain
+            # nonblocking. The dangerous Redis case is BLOCK 0 with ">".
             return outbox.read_for_session(
                 runner_id=runner_id,
                 session_id=session_id,

--- a/apps/api/pi_dash/settings/common.py
+++ b/apps/api/pi_dash/settings/common.py
@@ -360,6 +360,21 @@ EVENT_BATCH_MAX_AGE_MS = int(os.environ.get("EVENT_BATCH_MAX_AGE_MS", 250))
 EVENT_BATCH_MAX_BYTES = int(os.environ.get("EVENT_BATCH_MAX_BYTES", 65536))
 RUN_MESSAGE_DEDUPE_TTL_SECS = int(os.environ.get("RUN_MESSAGE_DEDUPE_TTL_SECS", 604800))
 RUNNER_PROTOCOL_VERSION = 4
+
+# Per-active-run agent observability watchdog tunables — see
+# ``.ai_design/runner_agent_bridge/design.md`` §4.5.3.
+# 360s is slightly longer than the runner's own 5-minute internal stall
+# watchdog, so the cloud acts as a backstop rather than racing the runner.
+RUNNER_AGENT_STALL_THRESHOLD_SECS = int(
+    os.environ.get("RUNNER_AGENT_STALL_THRESHOLD_SECS", 360)
+)
+# Snapshot-row freshness guard. The watchdog only acts on runners whose
+# poll-driven `RunnerLiveState.updated_at` is newer than this. Covers
+# roughly three missed 25s polls; stale rows from disabled / downgraded
+# runners age out instead of failing active runs.
+RUNNER_AGENT_OBSERVABILITY_STALE_SECS = int(
+    os.environ.get("RUNNER_AGENT_OBSERVABILITY_STALE_SECS", 90)
+)
 # Access-token signing key ring. Each entry: {kid, secret, status} where
 # status ∈ {"active", "verify_only"}. Exactly one key is active.
 # Default to a deterministic per-instance key derived from SECRET_KEY so

--- a/apps/api/pi_dash/tests/unit/runner/test_long_poll_deadline.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_long_poll_deadline.py
@@ -94,3 +94,40 @@ def test_loop_returns_empty_without_calling_redis_when_deadline_expired():
     assert read_calls == [], (
         f"read_for_session must not be called when block_ms=0; got: {read_calls}"
     )
+
+
+@pytest.mark.unit
+def test_initial_pel_replay_still_reads_with_zero_budget():
+    """`use_zero=True` is a nonblocking PEL replay, not a long poll for `>`."""
+    endpoint = RunnerSessionPollEndpoint()
+    runner_id = "11111111-1111-1111-1111-111111111111"
+    session_id = "22222222-2222-2222-2222-222222222222"
+    replayed = [{"stream_id": "1-0", "type": "assign"}]
+    read_calls: list[dict[str, Any]] = []
+
+    def _spy_read_for_session(**kwargs):
+        read_calls.append(kwargs)
+        return replayed
+
+    with patch(
+        "pi_dash.runner.views.sessions.outbox.read_for_session",
+        side_effect=_spy_read_for_session,
+    ):
+        result = endpoint._read_with_eviction_awareness(
+            runner_id=runner_id,
+            session_id=session_id,
+            sid=session_id,
+            block_ms=0,
+            use_zero=True,
+        )
+
+    assert result == replayed
+    assert read_calls == [
+        {
+            "runner_id": runner_id,
+            "session_id": session_id,
+            "block_ms": 0,
+            "count": 100,
+            "use_zero": True,
+        }
+    ]

--- a/apps/api/pi_dash/tests/unit/runner/test_runner_live_state.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_runner_live_state.py
@@ -1,0 +1,414 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Tests for the per-active-run agent observability snapshot.
+
+Covers:
+
+- ``upsert_runner_live_state`` ingestion semantics (new row, same-run
+  update, ``observed_run_id`` change wipe, idle clear, malformed UUID,
+  pre-observability runner is a no-op).
+- ``reconcile_stalled_runs`` watchdog matches only when the snapshot's
+  ``observed_run_id`` equals the run's id, ``updated_at`` is fresh, and
+  ``last_event_at`` is stale.
+- Pre-observability poll bodies leave any pre-existing
+  ``RunnerLiveState`` row untouched.
+
+See ``.ai_design/runner_agent_bridge/design.md`` §4.5.2 / §4.5.3.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+from unittest.mock import patch
+
+import pytest
+from django.test import override_settings
+from django.utils import timezone
+
+from pi_dash.runner.models import (
+    AgentRun,
+    AgentRunStatus,
+    Pod,
+    Runner,
+    RunnerLiveState,
+    RunnerStatus,
+)
+from pi_dash.runner.services.session_service import upsert_runner_live_state
+from pi_dash.runner.tasks import reconcile_stalled_runs
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def pod(project):
+    return Pod.default_for_project(project)
+
+
+def _make_runner(user, workspace, pod, name="r1"):
+    return Runner.objects.create(
+        owner=user,
+        workspace=workspace,
+        pod=pod,
+        name=name,
+        status=RunnerStatus.ONLINE,
+        last_heartbeat_at=timezone.now(),
+    )
+
+
+def _make_run(user, workspace, pod, runner, *, status=AgentRunStatus.RUNNING):
+    return AgentRun.objects.create(
+        workspace=workspace,
+        owner=user,
+        created_by=user,
+        pod=pod,
+        runner=runner,
+        status=status,
+        prompt="test",
+        assigned_at=timezone.now(),
+        started_at=timezone.now(),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _run_on_commit_immediately():
+    with patch(
+        "django.db.transaction.on_commit", side_effect=lambda fn, **kw: fn()
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _stub_send_to_runner():
+    with patch(
+        "pi_dash.runner.services.pubsub.send_to_runner"
+    ) as mock:
+        yield mock
+
+
+# ---------------------------------------------------------------------------
+# upsert_runner_live_state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_upsert_no_op_for_pre_observability_poll(
+    db, create_user, workspace, pod
+):
+    """A poll body with no observability fields must not create a row."""
+    runner = _make_runner(create_user, workspace, pod)
+    # No observed_run_id, no scalar fields, no tokens.
+    upsert_runner_live_state(runner, {"status": "busy", "ts": "2026-01-01T00:00:00Z"})
+    assert not RunnerLiveState.objects.filter(runner=runner).exists()
+
+
+@pytest.mark.unit
+def test_upsert_creates_row_on_first_snapshot(
+    db, create_user, workspace, pod
+):
+    runner = _make_runner(create_user, workspace, pod)
+    rid = uuid.uuid4()
+    now = timezone.now()
+    upsert_runner_live_state(
+        runner,
+        {
+            "observed_run_id": str(rid),
+            "last_event_at": now.isoformat(),
+            "last_event_kind": "codex/event/token_count",
+            "last_event_summary": "tokens 100/200",
+            "agent_pid": 4242,
+            "agent_subprocess_alive": True,
+            "approvals_pending": 0,
+            "tokens": {"input": 100, "output": 200, "total": 300},
+            "turn_count": 1,
+        },
+    )
+    state = RunnerLiveState.objects.get(runner=runner)
+    assert state.observed_run_id == rid
+    assert state.last_event_kind == "codex/event/token_count"
+    assert state.agent_pid == 4242
+    assert state.agent_subprocess_alive is True
+    assert state.approvals_pending == 0
+    assert state.input_tokens == 100
+    assert state.output_tokens == 200
+    assert state.total_tokens == 300
+    assert state.turn_count == 1
+
+
+@pytest.mark.unit
+def test_upsert_partial_update_preserves_unsent_fields(
+    db, create_user, workspace, pod
+):
+    """A poll that omits a field must NOT NULL out the existing value."""
+    runner = _make_runner(create_user, workspace, pod)
+    rid = uuid.uuid4()
+    upsert_runner_live_state(
+        runner,
+        {
+            "observed_run_id": str(rid),
+            "agent_pid": 4242,
+            "tokens": {"input": 100, "output": 200, "total": 300},
+            "turn_count": 1,
+        },
+    )
+    # Subsequent poll updates only turn_count; tokens / pid must persist.
+    upsert_runner_live_state(
+        runner,
+        {
+            "observed_run_id": str(rid),
+            "turn_count": 2,
+        },
+    )
+    state = RunnerLiveState.objects.get(runner=runner)
+    assert state.turn_count == 2
+    assert state.agent_pid == 4242
+    assert state.input_tokens == 100
+    assert state.total_tokens == 300
+
+
+@pytest.mark.unit
+def test_upsert_run_id_change_wipes_snapshot_then_applies_incoming(
+    db, create_user, workspace, pod
+):
+    runner = _make_runner(create_user, workspace, pod)
+    rid_a = uuid.uuid4()
+    upsert_runner_live_state(
+        runner,
+        {
+            "observed_run_id": str(rid_a),
+            "agent_pid": 1111,
+            "turn_count": 5,
+            "tokens": {"input": 10, "output": 20, "total": 30},
+        },
+    )
+    # Run B begins. Carries some new fields; the *unspecified* fields
+    # from run A's row must be wiped, not preserved.
+    rid_b = uuid.uuid4()
+    upsert_runner_live_state(
+        runner,
+        {
+            "observed_run_id": str(rid_b),
+            "agent_pid": 2222,
+            # No turn_count, no tokens — those must NOT carry over.
+        },
+    )
+    state = RunnerLiveState.objects.get(runner=runner)
+    assert state.observed_run_id == rid_b
+    assert state.agent_pid == 2222
+    assert state.turn_count is None
+    assert state.input_tokens is None
+    assert state.output_tokens is None
+    assert state.total_tokens is None
+
+
+@pytest.mark.unit
+def test_upsert_idle_clears_run_binding(
+    db, create_user, workspace, pod
+):
+    """An explicit observed_run_id=null clears the row's run binding."""
+    runner = _make_runner(create_user, workspace, pod)
+    rid = uuid.uuid4()
+    upsert_runner_live_state(
+        runner,
+        {
+            "observed_run_id": str(rid),
+            "agent_pid": 4242,
+            "turn_count": 3,
+        },
+    )
+    upsert_runner_live_state(runner, {"observed_run_id": None})
+    state = RunnerLiveState.objects.get(runner=runner)
+    assert state.observed_run_id is None
+    # All snapshot fields are wiped because the rid changed (Some → None).
+    assert state.agent_pid is None
+    assert state.turn_count is None
+
+
+@pytest.mark.unit
+def test_upsert_malformed_observed_run_id_is_ignored(
+    db, create_user, workspace, pod
+):
+    runner = _make_runner(create_user, workspace, pod)
+    # Pre-existing valid row.
+    valid_rid = uuid.uuid4()
+    upsert_runner_live_state(
+        runner,
+        {"observed_run_id": str(valid_rid), "agent_pid": 4242},
+    )
+    # Bad poll: invalid UUID. Must not raise; must leave the row intact.
+    upsert_runner_live_state(
+        runner,
+        {"observed_run_id": "not-a-uuid", "agent_pid": 9999},
+    )
+    state = RunnerLiveState.objects.get(runner=runner)
+    assert state.observed_run_id == valid_rid
+    assert state.agent_pid == 4242  # unchanged
+
+
+@pytest.mark.unit
+def test_upsert_handles_get_or_create_for_returning_runner(
+    db, create_user, workspace, pod
+):
+    """Subsequent polls keep updating the same row."""
+    runner = _make_runner(create_user, workspace, pod)
+    rid = uuid.uuid4()
+    upsert_runner_live_state(runner, {"observed_run_id": str(rid)})
+    upsert_runner_live_state(
+        runner, {"observed_run_id": str(rid), "agent_pid": 1234}
+    )
+    assert RunnerLiveState.objects.filter(runner=runner).count() == 1
+
+
+# ---------------------------------------------------------------------------
+# reconcile_stalled_runs watchdog
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@override_settings(
+    RUNNER_AGENT_STALL_THRESHOLD_SECS=300,
+    RUNNER_AGENT_OBSERVABILITY_STALE_SECS=90,
+)
+def test_watchdog_reaps_when_all_three_conditions_hold(
+    db, create_user, workspace, pod
+):
+    runner = _make_runner(create_user, workspace, pod)
+    run = _make_run(create_user, workspace, pod, runner)
+    now = timezone.now()
+    # Snapshot says "this run, fresh poll, agent silent for >5min".
+    state = RunnerLiveState.objects.create(
+        runner=runner,
+        observed_run_id=run.id,
+        last_event_at=now - timedelta(seconds=600),
+    )
+    # `auto_now=True` re-stamps `updated_at` on every save(), so we have
+    # to bypass the ORM with a raw UPDATE to set a deterministic value.
+    # The fresh-row state we want IS roughly "now", but pinning it
+    # avoids the slim race where test setup + the watchdog's `now`
+    # straddle a tick boundary.
+    RunnerLiveState.objects.filter(pk=state.pk).update(
+        updated_at=now - timedelta(seconds=10)
+    )
+
+    reaped = reconcile_stalled_runs()
+    assert reaped == 1
+    run.refresh_from_db()
+    assert run.status == AgentRunStatus.FAILED
+    assert "agent stalled" in run.error
+    assert "300s" in run.error
+
+
+@pytest.mark.unit
+@override_settings(RUNNER_AGENT_STALL_THRESHOLD_SECS=300)
+def test_watchdog_does_not_reap_when_observed_run_id_mismatches(
+    db, create_user, workspace, pod
+):
+    """A previous run's snapshot must not fail the *current* run."""
+    runner = _make_runner(create_user, workspace, pod)
+    run = _make_run(create_user, workspace, pod, runner)
+    other_rid = uuid.uuid4()  # snapshot describes a different run
+    RunnerLiveState.objects.create(
+        runner=runner,
+        observed_run_id=other_rid,
+        last_event_at=timezone.now() - timedelta(seconds=600),
+    )
+
+    reaped = reconcile_stalled_runs()
+    assert reaped == 0
+    run.refresh_from_db()
+    assert run.status == AgentRunStatus.RUNNING
+
+
+@pytest.mark.unit
+@override_settings(
+    RUNNER_AGENT_STALL_THRESHOLD_SECS=300,
+    RUNNER_AGENT_OBSERVABILITY_STALE_SECS=90,
+)
+def test_watchdog_does_not_reap_when_snapshot_row_is_stale(
+    db, create_user, workspace, pod
+):
+    """If the runner stops reporting, age-out instead of failing run."""
+    runner = _make_runner(create_user, workspace, pod)
+    run = _make_run(create_user, workspace, pod, runner)
+    now = timezone.now()
+    state = RunnerLiveState.objects.create(
+        runner=runner,
+        observed_run_id=run.id,
+        last_event_at=now - timedelta(seconds=600),
+    )
+    # Force updated_at to be older than the freshness cutoff.
+    RunnerLiveState.objects.filter(pk=state.pk).update(
+        updated_at=now - timedelta(seconds=300)
+    )
+
+    reaped = reconcile_stalled_runs()
+    assert reaped == 0
+
+
+@pytest.mark.unit
+def test_watchdog_does_not_reap_run_without_live_state_row(
+    db, create_user, workspace, pod
+):
+    runner = _make_runner(create_user, workspace, pod)
+    _make_run(create_user, workspace, pod, runner)
+    # No live_state row at all (pre-observability runner).
+    reaped = reconcile_stalled_runs()
+    assert reaped == 0
+
+
+@pytest.mark.unit
+@override_settings(
+    RUNNER_AGENT_STALL_THRESHOLD_SECS=300,
+    RUNNER_AGENT_OBSERVABILITY_STALE_SECS=90,
+)
+def test_watchdog_does_not_reap_awaiting_approval(
+    db, create_user, workspace, pod
+):
+    runner = _make_runner(create_user, workspace, pod)
+    run = _make_run(
+        create_user,
+        workspace,
+        pod,
+        runner,
+        status=AgentRunStatus.AWAITING_APPROVAL,
+    )
+    now = timezone.now()
+    state = RunnerLiveState.objects.create(
+        runner=runner,
+        observed_run_id=run.id,
+        last_event_at=now - timedelta(seconds=600),
+    )
+    # Bypass auto_now=True with a raw UPDATE — see the fresh-row test.
+    RunnerLiveState.objects.filter(pk=state.pk).update(
+        updated_at=now - timedelta(seconds=10)
+    )
+
+    reaped = reconcile_stalled_runs()
+    assert reaped == 0
+    run.refresh_from_db()
+    assert run.status == AgentRunStatus.AWAITING_APPROVAL
+
+
+@pytest.mark.unit
+def test_watchdog_does_not_reap_pre_observability_run_with_null_last_event_at(
+    db, create_user, workspace, pod
+):
+    """NULL last_event_at is excluded by `__lt` — pre-flag runs stay safe."""
+    runner = _make_runner(create_user, workspace, pod)
+    run = _make_run(create_user, workspace, pod, runner)
+    now = timezone.now()
+    # Row exists but last_event_at is NULL.
+    state = RunnerLiveState.objects.create(
+        runner=runner, observed_run_id=run.id, last_event_at=None
+    )
+    # Bypass auto_now=True with a raw UPDATE — see the fresh-row test.
+    RunnerLiveState.objects.filter(pk=state.pk).update(
+        updated_at=now - timedelta(seconds=5)
+    )
+    reaped = reconcile_stalled_runs()
+    assert reaped == 0

--- a/apps/web/app/(all)/[workspaceSlug]/runners/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/page.tsx
@@ -25,6 +25,7 @@ const STATUS_BADGE_VARIANT: Record<TRunnerStatus, TBadgeVariant> = {
   online: "accent-success",
   busy: "accent-primary",
   offline: "accent-neutral",
+  revoked: "accent-warning",
 };
 
 const RunnersListPage = observer(function RunnersListPage() {

--- a/apps/web/core/components/runners/runner-agent-status-panel.tsx
+++ b/apps/web/core/components/runners/runner-agent-status-panel.tsx
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import type { IRunner, IRunnerLiveState } from "@pi-dash/types";
+import { Badge, type TBadgeVariant } from "@pi-dash/ui";
+
+/**
+ * Per-active-run agent observability panel.
+ *
+ * Renders the descriptive scalars that ride on the runner's poll status
+ * (``RunnerLiveState``) and derives an activity badge client-side. There
+ * is intentionally no server-side ``agent_state`` enum — the badge is a
+ * presentation concern, not authoritative lifecycle.
+ *
+ * See ``.ai_design/runner_agent_bridge/design.md`` §4.5.4.
+ */
+
+type ActivityBadgeKey = "active" | "thinking" | "stalled" | "dead" | "awaiting_approval" | "unknown";
+
+interface RunnerAgentStatusPanelProps {
+  runner: Pick<IRunner, "id" | "name" | "status">;
+  liveState: IRunnerLiveState | null | undefined;
+}
+
+const BADGE_VARIANT: Record<ActivityBadgeKey, TBadgeVariant> = {
+  active: "accent-success",
+  thinking: "accent-warning",
+  stalled: "accent-destructive",
+  dead: "accent-destructive",
+  awaiting_approval: "accent-primary",
+  unknown: "accent-neutral",
+};
+
+const BADGE_LABEL: Record<ActivityBadgeKey, string> = {
+  active: "Active",
+  thinking: "Thinking",
+  stalled: "Stalled",
+  dead: "Subprocess dead",
+  awaiting_approval: "Awaiting approval",
+  unknown: "Unknown",
+};
+
+const ACTIVITY_THRESHOLD_SECS = 30;
+const THINKING_THRESHOLD_SECS = 180;
+
+/**
+ * Pure derivation: compute the activity badge from the raw live-state
+ * scalars + a "now" timestamp. Exported for testing.
+ */
+export function deriveActivityBadge(
+  state: IRunnerLiveState | null | undefined,
+  now: number = Date.now()
+): ActivityBadgeKey {
+  if (!state) return "unknown";
+
+  if (state.agent_subprocess_alive === false) return "dead";
+
+  if ((state.approvals_pending ?? 0) > 0) return "awaiting_approval";
+
+  if (!state.last_event_at) return "unknown";
+
+  const ageMs = now - new Date(state.last_event_at).getTime();
+  if (Number.isNaN(ageMs) || ageMs < 0) return "unknown";
+
+  const ageSecs = ageMs / 1000;
+  if (ageSecs <= ACTIVITY_THRESHOLD_SECS) return "active";
+  if (ageSecs <= THINKING_THRESHOLD_SECS) return "thinking";
+  return "stalled";
+}
+
+function formatRelative(ts: string | null): string {
+  if (!ts) return "—";
+  const ms = Date.now() - new Date(ts).getTime();
+  if (Number.isNaN(ms) || ms < 0) return "—";
+  const secs = Math.round(ms / 1000);
+  if (secs < 60) return `${secs}s ago`;
+  if (secs < 3600) return `${Math.round(secs / 60)}m ago`;
+  return `${Math.round(secs / 3600)}h ago`;
+}
+
+function formatNumber(n: number | null): string {
+  if (n === null || n === undefined) return "—";
+  if (n < 1000) return String(n);
+  if (n < 1_000_000) return `${(n / 1000).toFixed(1)}k`;
+  return `${(n / 1_000_000).toFixed(1)}M`;
+}
+
+function formatBoolish(v: boolean | null): string {
+  if (v === null || v === undefined) return "—";
+  return v ? "yes" : "no";
+}
+
+export function RunnerAgentStatusPanel({ runner, liveState }: RunnerAgentStatusPanelProps) {
+  // Re-render every 5s so the relative ages tick forward without needing
+  // a fresh server fetch. Cheap; we only re-derive ageMs / labels.
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick((n) => n + 1), 5_000);
+    return () => clearInterval(id);
+  }, []);
+
+  const activityBadge = useMemo(
+    () => deriveActivityBadge(liveState ?? null, Date.now()),
+    // tick is a placeholder — value isn't read but keeps the badge fresh.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [liveState, tick]
+  );
+
+  const lastEventLabel = formatRelative(liveState?.last_event_at ?? null);
+  const tokensLabel = liveState?.total_tokens != null ? formatNumber(liveState.total_tokens) : "—";
+
+  return (
+    <div className="border-custom-border-200 space-y-3 rounded border p-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <h3 className="text-sm font-medium">Agent</h3>
+          <Badge variant={BADGE_VARIANT[activityBadge]} size="sm">
+            {BADGE_LABEL[activityBadge]}
+          </Badge>
+        </div>
+        <span className="text-xs text-custom-text-300">{runner.name}</span>
+      </div>
+
+      <dl className="text-xs grid grid-cols-2 gap-x-4 gap-y-2">
+        <dt className="text-custom-text-300">Last activity</dt>
+        <dd className="font-mono" title={liveState?.last_event_summary ?? undefined}>
+          {lastEventLabel}
+        </dd>
+
+        <dt className="text-custom-text-300">Last event</dt>
+        <dd className="font-mono truncate">{liveState?.last_event_kind ?? "—"}</dd>
+
+        <dt className="text-custom-text-300">Agent PID</dt>
+        <dd className="font-mono">{liveState?.agent_pid ?? "—"}</dd>
+
+        <dt className="text-custom-text-300">Subprocess alive</dt>
+        <dd>{formatBoolish(liveState?.agent_subprocess_alive ?? null)}</dd>
+
+        <dt className="text-custom-text-300">Approvals</dt>
+        <dd>{liveState?.approvals_pending ?? 0}</dd>
+
+        <dt className="text-custom-text-300">Tokens</dt>
+        <dd className="font-mono">{tokensLabel}</dd>
+
+        <dt className="text-custom-text-300">Turn</dt>
+        <dd className="font-mono">{liveState?.turn_count != null ? liveState.turn_count : "—"}</dd>
+      </dl>
+    </div>
+  );
+}
+
+export default RunnerAgentStatusPanel;

--- a/packages/i18n/src/locales/en/core.ts
+++ b/packages/i18n/src/locales/en/core.ts
@@ -444,6 +444,7 @@ export default {
         online: "online",
         busy: "busy",
         offline: "offline",
+        revoked: "revoked",
       },
       columns_pod: "Pod",
       columns_connection: "Connection",

--- a/packages/types/src/runner.ts
+++ b/packages/types/src/runner.ts
@@ -4,7 +4,7 @@
  * See the LICENSE file for details.
  */
 
-export type TRunnerStatus = "online" | "offline" | "busy";
+export type TRunnerStatus = "online" | "offline" | "busy" | "revoked";
 
 export interface IPodMini {
   id: string;
@@ -28,6 +28,29 @@ export interface IPod {
   updated_at: string;
 }
 
+/** Per-active-run agent observability snapshot.
+ *
+ * All fields nullable; ``null`` is the canonical "unknown" sentinel.
+ * The activity badge is derived client-side from ``last_event_at`` +
+ * ``agent_subprocess_alive`` + ``approvals_pending`` — there is no
+ * server-side ``agent_state`` enum to keep coherent.
+ *
+ * See ``.ai_design/runner_agent_bridge/design.md`` §4.5.4. */
+export interface IRunnerLiveState {
+  observed_run_id: string | null;
+  last_event_at: string | null;
+  last_event_kind: string | null;
+  last_event_summary: string | null;
+  agent_pid: number | null;
+  agent_subprocess_alive: boolean | null;
+  approvals_pending: number | null;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  total_tokens: number | null;
+  turn_count: number | null;
+  updated_at: string;
+}
+
 export interface IRunner {
   id: string;
   name: string;
@@ -43,6 +66,9 @@ export interface IRunner {
   pod_detail: IPodMini | null;
   /** Connection that owns this runner. Required post-refactor. */
   connection: string;
+  /** Volatile per-active-run agent snapshot. Optional / null when the
+   * runner has not yet reported any observability data (pre-flag runner). */
+  live_state?: IRunnerLiveState | null;
   created_at: string;
   updated_at: string;
 }

--- a/runner/src/agent/mod.rs
+++ b/runner/src/agent/mod.rs
@@ -4,12 +4,32 @@
 //! not have to know which underlying CLI is driving a run.
 
 use anyhow::Result;
+use chrono::{DateTime, Utc};
 use std::path::Path;
 use std::time::Duration;
+use tokio::sync::watch;
 use uuid::Uuid;
 
 use crate::cloud::protocol::{ApprovalDecision, ApprovalKind, FailureReason};
 use crate::config::schema::{AgentKind, RunnerConfig};
+
+/// Volatile process-handle the bridge surfaces to the supervisor for
+/// observability. PID is captured at spawn time, `exit_rx` fires once the
+/// child wait task observes termination. See `.ai_design/runner_agent_bridge`
+/// §4.4. The handle carries no ownership of the child — the process wrapper
+/// retains exclusive ownership inside its wait task.
+#[derive(Debug, Clone)]
+pub struct AgentProcessHandle {
+    pub pid: Option<u32>,
+    pub exit_rx: watch::Receiver<Option<ExitSnapshot>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ExitSnapshot {
+    pub status_code: Option<i32>,
+    pub signal: Option<i32>,
+    pub observed_at: DateTime<Utc>,
+}
 
 /// Events the bridge surfaces to the daemon's state machine. Agent-agnostic:
 /// Codex and Claude both translate their native protocols into this shape.
@@ -177,6 +197,17 @@ impl AgentBridge {
         match self {
             AgentBridge::Codex(b) => b.server.shutdown(grace).await,
             AgentBridge::ClaudeCode(b) => b.shutdown(grace).await,
+        }
+    }
+
+    /// Bridge-owned observability handle: the agent subprocess's PID and a
+    /// watch receiver that yields `Some(ExitSnapshot)` once the wait task
+    /// observes termination. Supervisor uses this to drive
+    /// `state.set_agent_pid` / `set_agent_alive`.
+    pub fn process_handle(&self) -> AgentProcessHandle {
+        match self {
+            AgentBridge::Codex(b) => b.server.process_handle(),
+            AgentBridge::ClaudeCode(b) => b.process_handle(),
         }
     }
 }

--- a/runner/src/claude_code/bridge.rs
+++ b/runner/src/claude_code/bridge.rs
@@ -154,6 +154,10 @@ impl Bridge {
     pub async fn shutdown(self, grace: Duration) -> Result<()> {
         self.proc.shutdown(grace).await
     }
+
+    pub fn process_handle(&self) -> crate::agent::AgentProcessHandle {
+        self.proc.process_handle()
+    }
 }
 
 /// Per-run translation state. The `system/init` frame is consumed inside

--- a/runner/src/claude_code/process.rs
+++ b/runner/src/claude_code/process.rs
@@ -3,25 +3,40 @@
 //! instead of JSON-RPC.
 
 use anyhow::{Context, Result};
+use chrono::Utc;
 use std::path::Path;
 use std::process::Stdio;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, Command};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 
+use crate::agent::{AgentProcessHandle, ExitSnapshot};
 use crate::claude_code::schema::StreamEvent;
 use crate::util::shell::{is_benign_login_shell_warning, login_shell_command};
 
 /// Handles the `claude --print --output-format stream-json` subprocess
 /// lifecycle. Owns stdin (so we can push the user turn + signal EOF) and
 /// exposes an mpsc receiver of parsed events coming off stdout.
+///
+/// Mirrors `AppServer`'s child-ownership split: `Child` is owned by an
+/// internal wait task, and `ClaudeProcess` retains side-channels
+/// (`kill_tx`, `exit_rx`). The `pid` is captured at spawn for SIGINT
+/// delivery and observability. See `.ai_design/runner_agent_bridge` §4.4.
 pub struct ClaudeProcess {
-    child: Child,
+    pid: Option<u32>,
     /// `Option` so we can `take()` stdin when the caller wants to half-close
     /// it (signalling end-of-input to Claude, which causes it to process the
     /// queued turn and exit).
     stdin: Option<ChildStdin>,
     pub inbound: mpsc::Receiver<StreamEvent>,
+    kill_tx: mpsc::Sender<KillRequest>,
+    exit_rx: watch::Receiver<Option<ExitSnapshot>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum KillRequest {
+    Graceful,
+    Force,
 }
 
 /// Arguments passed to `claude` for a run. The defaults below match the MVP
@@ -77,15 +92,33 @@ impl ClaudeProcess {
         let stdin = child.stdin.take().context("claude stdin missing")?;
         let stdout = child.stdout.take().context("claude stdout missing")?;
         let stderr = child.stderr.take().context("claude stderr missing")?;
+        let pid = child.id();
 
         let (tx, rx) = mpsc::channel(128);
         tokio::spawn(read_events(stdout, tx.clone()));
         tokio::spawn(drain_stderr(stderr));
+
+        let (kill_tx, kill_rx) = mpsc::channel::<KillRequest>(2);
+        let (exit_tx, exit_rx) = watch::channel::<Option<ExitSnapshot>>(None);
+        tokio::spawn(wait_task(child, kill_rx, exit_tx));
+
         Ok(Self {
-            child,
+            pid,
             stdin: Some(stdin),
             inbound: rx,
+            kill_tx,
+            exit_rx,
         })
+    }
+
+    /// Bridge-owned observability handle. PID was captured at spawn time;
+    /// `exit_rx` yields `Some(ExitSnapshot)` once the wait task observes
+    /// termination.
+    pub fn process_handle(&self) -> AgentProcessHandle {
+        AgentProcessHandle {
+            pid: self.pid,
+            exit_rx: self.exit_rx.clone(),
+        }
     }
 
     /// Send one JSON line (plus a newline) to Claude's stdin.
@@ -104,18 +137,18 @@ impl ClaudeProcess {
     }
 
     /// Best-effort interrupt: send SIGINT if we can, otherwise fall back to
-    /// SIGKILL via `start_kill`. Unlike Codex there's no in-protocol
+    /// SIGKILL via the kill channel. Unlike Codex there's no in-protocol
     /// `turn/interrupt` — the only lever we have is the OS.
     pub async fn interrupt(&mut self) -> Result<()> {
         #[cfg(unix)]
         {
             use nix::sys::signal::{Signal, kill};
             use nix::unistd::Pid;
-            if let Some(pid) = self.child.id() {
-                let pid = Pid::from_raw(pid as i32);
+            if let Some(pid) = self.pid {
+                let pid_t = Pid::from_raw(pid as i32);
                 // SIGINT is usually enough; the kill_on_drop on the child
                 // catches any process that ignores it when we later drop.
-                match kill(pid, Signal::SIGINT) {
+                match kill(pid_t, Signal::SIGINT) {
                     Ok(()) => return Ok(()),
                     Err(e) => {
                         // Reaped, permission denied, PID-namespace mismatch —
@@ -127,25 +160,82 @@ impl ClaudeProcess {
             }
         }
         // Non-unix, pid-already-reaped, or SIGINT failure above.
-        self.child
-            .start_kill()
-            .context("failed to kill claude subprocess")?;
+        self.kill_tx
+            .send(KillRequest::Force)
+            .await
+            .context("failed to send kill request to claude wait task")?;
         Ok(())
     }
 
     pub async fn shutdown(mut self, grace: std::time::Duration) -> Result<()> {
         self.close_stdin();
-        match tokio::time::timeout(grace, self.child.wait()).await {
-            Ok(Ok(status)) => {
-                tracing::debug!(?status, "claude exited gracefully");
+        let _ = self.kill_tx.send(KillRequest::Graceful).await;
+        match tokio::time::timeout(grace, self.exit_rx.changed()).await {
+            Ok(Ok(())) => {
+                let snap = self.exit_rx.borrow().clone();
+                tracing::debug!(?snap, "claude exited gracefully");
             }
             _ => {
                 tracing::warn!("claude did not exit within grace; sending SIGKILL");
-                self.child.start_kill().ok();
-                self.child.wait().await.ok();
+                let _ = self.kill_tx.send(KillRequest::Force).await;
+                let _ = self.exit_rx.changed().await;
             }
         }
         Ok(())
+    }
+}
+
+/// Owns the `Child` exclusively. Awaits either a kill request (force-kill
+/// the subprocess) or the child's natural exit, then publishes an
+/// `ExitSnapshot` and terminates.
+async fn wait_task(
+    mut child: Child,
+    mut kill_rx: mpsc::Receiver<KillRequest>,
+    exit_tx: watch::Sender<Option<ExitSnapshot>>,
+) {
+    let snapshot = loop {
+        tokio::select! {
+            biased;
+            req = kill_rx.recv() => {
+                match req {
+                    Some(KillRequest::Force) => {
+                        let _ = child.start_kill();
+                    }
+                    Some(KillRequest::Graceful) => {
+                        // No-op: wait for natural exit.
+                    }
+                    None => {
+                        // All senders dropped — recv will resolve to None
+                        // synchronously every iteration. Stop polling the
+                        // recv arm and just await natural exit, otherwise
+                        // the biased select! would spin on the closed
+                        // channel without ever polling child.wait().
+                        let res = child.wait().await;
+                        break exit_snapshot_from(res.ok());
+                    }
+                }
+            }
+            res = child.wait() => {
+                break exit_snapshot_from(res.ok());
+            }
+        }
+    };
+    let _ = exit_tx.send(Some(snapshot));
+}
+
+fn exit_snapshot_from(status: Option<std::process::ExitStatus>) -> ExitSnapshot {
+    #[cfg(unix)]
+    let signal = {
+        use std::os::unix::process::ExitStatusExt;
+        status.as_ref().and_then(|s| s.signal())
+    };
+    #[cfg(not(unix))]
+    let signal: Option<i32> = None;
+    let status_code = status.as_ref().and_then(|s| s.code());
+    ExitSnapshot {
+        status_code,
+        signal,
+        observed_at: Utc::now(),
     }
 }
 

--- a/runner/src/cli/connect.rs
+++ b/runner/src/cli/connect.rs
@@ -164,6 +164,7 @@ pub async fn run(args: Args, paths: &Paths) -> Result<()> {
                 cloud_url: args.url.clone(),
                 log_level: "info".to_string(),
                 log_retention_days: 14,
+                agent_observability_v1: false,
             },
             runners: vec![new_runner_block],
         },
@@ -207,11 +208,16 @@ pub async fn run(args: Args, paths: &Paths) -> Result<()> {
         if outcome.ok {
             println!("Service restarted ({}).", outcome.summary);
         } else {
-            println!("Service restart did not complete cleanly: {}", outcome.summary);
+            println!(
+                "Service restart did not complete cleanly: {}",
+                outcome.summary
+            );
             if let Some(detail) = outcome.detail {
                 println!("\n{detail}");
             }
-            println!("\nThe runner config was written successfully. Try `pidash restart` manually.");
+            println!(
+                "\nThe runner config was written successfully. Try `pidash restart` manually."
+            );
             // Don't return Err — the cloud-side enrollment + local
             // config write succeeded; the restart hiccup is recoverable
             // by the operator and doesn't undo the work above.
@@ -292,8 +298,8 @@ fn assert_no_workspace_collision(
     let new_canon = std::fs::canonicalize(new_wd).unwrap_or_else(|_| new_wd.to_path_buf());
     for r in existing {
         let existing_path = &r.workspace.working_dir;
-        let existing_canon = std::fs::canonicalize(existing_path)
-            .unwrap_or_else(|_| existing_path.clone());
+        let existing_canon =
+            std::fs::canonicalize(existing_path).unwrap_or_else(|_| existing_path.clone());
         if existing_canon == new_canon {
             anyhow::bail!(
                 "runner {} ({}) already uses --working-dir {} — two runners cannot share \
@@ -406,12 +412,10 @@ mod tests {
     #[test]
     fn workspace_collision_rejects_new_nested_under_existing() {
         let existing = vec![runner_with_wd("a", PathBuf::from("/tmp/repo"))];
-        let err = assert_no_workspace_collision(
-            &existing,
-            std::path::Path::new("/tmp/repo/subproject"),
-        )
-        .unwrap_err()
-        .to_string();
+        let err =
+            assert_no_workspace_collision(&existing, std::path::Path::new("/tmp/repo/subproject"))
+                .unwrap_err()
+                .to_string();
         assert!(err.contains("nested"));
     }
 
@@ -438,8 +442,6 @@ mod tests {
     #[test]
     fn workspace_collision_allows_first_enrollment() {
         // No existing runners → nothing can collide.
-        assert!(
-            assert_no_workspace_collision(&[], std::path::Path::new("/tmp/repo")).is_ok()
-        );
+        assert!(assert_no_workspace_collision(&[], std::path::Path::new("/tmp/repo")).is_ok());
     }
 }

--- a/runner/src/cli/doctor.rs
+++ b/runner/src/cli/doctor.rs
@@ -344,6 +344,7 @@ mod tests {
                 cloud_url: "http://127.0.0.1:1".into(),
                 log_level: "info".into(),
                 log_retention_days: 14,
+                agent_observability_v1: false,
             },
             runners,
         }

--- a/runner/src/cli/remove.rs
+++ b/runner/src/cli/remove.rs
@@ -9,8 +9,12 @@
 //! 2. Uninstall the service unit (tolerant; no-op if not installed).
 //! 3. Deregister with the cloud (skipped with `--local-only` or if no creds).
 //! 4. Delete local `config.toml` + `credentials.toml`.
+//!
+//! Requires `--all` as an explicit confirmation: this command wipes EVERY
+//! runner on the host plus connection credentials. To drop a single runner
+//! instead, use `pidash runner remove <name>`.
 
-use anyhow::Result;
+use anyhow::{Result, bail};
 use clap::Args as ClapArgs;
 
 use crate::cloud::runners::delete_runner;
@@ -18,6 +22,13 @@ use crate::util::paths::Paths;
 
 #[derive(Debug, ClapArgs)]
 pub struct Args {
+    /// REQUIRED confirmation that you want to wipe ALL runners on this
+    /// host and the connection credentials. Without this flag the
+    /// command refuses to do anything. Use `pidash runner remove <name>`
+    /// to drop a single runner instead.
+    #[arg(long)]
+    pub all: bool,
+
     /// Delete local state without contacting the cloud. The connection
     /// row remains in the cloud UI until the user revokes it there.
     #[arg(long)]
@@ -25,6 +36,34 @@ pub struct Args {
 }
 
 pub async fn run(args: Args, paths: &Paths) -> Result<()> {
+    if !args.all {
+        // Refuse and explain. List what would be removed so the user
+        // sees the blast radius before re-running with --all.
+        eprintln!("pidash remove: refusing to run without --all.");
+        eprintln!();
+        eprintln!("This command wipes EVERY runner on this host AND the connection");
+        eprintln!("credentials. It is not reversible without re-enrolling from scratch.");
+        eprintln!();
+        match crate::config::file::load_all(paths) {
+            Ok((config, _)) => {
+                eprintln!("Runners that would be removed:");
+                for r in &config.runners {
+                    eprintln!("  - {} ({})", r.name, r.runner_id);
+                }
+                if config.runners.is_empty() {
+                    eprintln!("  (no runners configured)");
+                }
+            }
+            Err(_) => {
+                eprintln!("(no local configuration found — nothing to remove)");
+            }
+        }
+        eprintln!();
+        eprintln!("To drop a single runner instead:  pidash runner remove <NAME>");
+        eprintln!("To proceed with the full teardown: pidash remove --all");
+        bail!("--all is required");
+    }
+
     let svc = crate::service::detect();
     if let Err(e) = svc.stop().await {
         tracing::warn!("service stop failed (ok if not running): {e:#}");

--- a/runner/src/cli/runner.rs
+++ b/runner/src/cli/runner.rs
@@ -71,6 +71,12 @@ pub struct RemoveArgs {
     /// Name of the runner to remove. Must match a ``[[runner]]`` in
     /// ``config.toml``.
     pub name: String,
+
+    /// Skip the cloud-side delete and only clean up local config +
+    /// data dir. Use this when the runner is already revoked
+    /// cloud-side, or when the cloud is unreachable.
+    #[arg(long)]
+    pub local_only: bool,
 }
 
 pub async fn run(args: RunnerArgs, paths: &Paths) -> Result<()> {
@@ -122,7 +128,14 @@ pub async fn add(args: AddArgs, paths: &Paths) -> Result<RunnerConfig> {
             version: crate::RUNNER_VERSION.to_string(),
             protocol_version: crate::PROTOCOL_VERSION,
         };
-        match register_runner(&cfg.daemon.cloud_url, &creds.connection_id, &creds.connection_secret, &req).await {
+        match register_runner(
+            &cfg.daemon.cloud_url,
+            &creds.connection_id,
+            &creds.connection_secret,
+            &req,
+        )
+        .await
+        {
             Ok(resp) => break (resp, candidate),
             Err(RunnerCrudError::NameTaken)
                 if !user_supplied && attempts < MAX_AUTO_NAME_RETRIES =>
@@ -206,8 +219,6 @@ pub fn list(paths: &Paths) -> Result<()> {
 }
 
 pub async fn remove(args: RemoveArgs, paths: &Paths) -> Result<()> {
-    let creds = file::load_credentials(paths)
-        .context("no credentials.toml — run `pidash connect` first")?;
     let mut cfg = file::load_config(paths)?;
     let idx = cfg
         .runners
@@ -215,21 +226,47 @@ pub async fn remove(args: RemoveArgs, paths: &Paths) -> Result<()> {
         .position(|r| r.name == args.name)
         .ok_or_else(|| anyhow::anyhow!("no runner named {:?} in config.toml", args.name))?;
     let runner_id = cfg.runners[idx].runner_id;
-    delete_runner(
-        &cfg.daemon.cloud_url,
-        &creds.connection_id,
-        &creds.connection_secret,
-        &runner_id,
-    )
-    .await
-    .context("cloud delete-runner failed")?;
+
+    if !args.local_only {
+        // TODO(cloud-endpoint): the per-runner refactor removed the
+        // `connections/<id>/runners/<rid>/` DELETE route this CLI was
+        // calling. Until a runner-scoped delete endpoint is added under
+        // the machine-token auth surface, this call will 404. Surface a
+        // useful hint pointing at --local-only and the web UI.
+        let creds = file::load_credentials(paths)
+            .context("no credentials.toml — run `pidash connect` first, or pass --local-only")?;
+        if let Err(e) = delete_runner(
+            &cfg.daemon.cloud_url,
+            &creds.connection_id,
+            &creds.connection_secret,
+            &runner_id,
+        )
+        .await
+        {
+            eprintln!("cloud delete-runner failed: {e:#}");
+            eprintln!();
+            eprintln!("To remove this runner from the cloud, use the web UI's");
+            eprintln!("\"Delete\" button on the runners page.");
+            eprintln!("To clean up local state only, re-run with --local-only:");
+            eprintln!("  pidash runner remove {} --local-only", args.name);
+            anyhow::bail!("cloud delete-runner failed");
+        }
+    }
+
     cfg.runners.remove(idx);
     file::write_config(paths, &cfg)?;
     let runner_data = paths.runner_dir(runner_id);
     if runner_data.exists() {
         let _ = std::fs::remove_dir_all(&runner_data);
     }
-    println!("Removed runner {}.", args.name);
+    if args.local_only {
+        println!(
+            "Removed runner {} from local config (cloud row not touched).",
+            args.name
+        );
+    } else {
+        println!("Removed runner {}.", args.name);
+    }
     Ok(())
 }
 
@@ -244,5 +281,12 @@ pub async fn remove_by_id(runner_id: &Uuid, paths: &Paths) -> Result<()> {
         .find(|r| r.runner_id == *runner_id)
         .map(|r| r.name.clone())
         .ok_or_else(|| anyhow::anyhow!("no runner with id {runner_id} in config.toml"))?;
-    remove(RemoveArgs { name }, paths).await
+    remove(
+        RemoveArgs {
+            name,
+            local_only: false,
+        },
+        paths,
+    )
+    .await
 }

--- a/runner/src/cloud/http.rs
+++ b/runner/src/cloud/http.rs
@@ -163,11 +163,7 @@ impl CredentialsHandle {
     /// updates the in-memory copy after a successful fsync. Caller is
     /// expected to hold the runner-cloud-client lock so two refreshes
     /// don't race the same file.
-    pub async fn rotate(
-        &self,
-        new_token: String,
-        new_generation: u64,
-    ) -> Result<()> {
+    pub async fn rotate(&self, new_token: String, new_generation: u64) -> Result<()> {
         let snapshot = {
             let guard = self.state.lock().await;
             RunnerCredentials {
@@ -331,11 +327,7 @@ impl TransportErrorCode {
 }
 
 impl RunnerCloudClient {
-    pub fn new(
-        runner_id: Uuid,
-        creds: CredentialsHandle,
-        transport: SharedHttpTransport,
-    ) -> Self {
+    pub fn new(runner_id: Uuid, creds: CredentialsHandle, transport: SharedHttpTransport) -> Self {
         Self {
             inner: Arc::new(RunnerCloudClientInner {
                 runner_id,
@@ -373,10 +365,9 @@ impl RunnerCloudClient {
         }
         self.refresh().await?;
         let guard = self.inner.state.lock().await;
-        guard
-            .access_token
-            .clone()
-            .ok_or(TransportError::Protocol("no access token after refresh".into()))
+        guard.access_token.clone().ok_or(TransportError::Protocol(
+            "no access token after refresh".into(),
+        ))
     }
 
     /// Single-flight refresh per `RunnerCloudClient`. Concurrent
@@ -393,9 +384,7 @@ impl RunnerCloudClient {
                 let result = self.do_refresh().await;
                 let outcome = match &result {
                     Ok(()) => RefreshOutcome::Done(Ok(())),
-                    Err(err) => {
-                        RefreshOutcome::Done(Err(TransportErrorCode::from(err)))
-                    }
+                    Err(err) => RefreshOutcome::Done(Err(TransportErrorCode::from(err))),
                 };
                 let _ = tx.send(outcome);
                 let mut guard = self.inner.state.lock().await;
@@ -511,10 +500,7 @@ impl RunnerCloudClient {
         let mut state = self.inner.state.lock().await;
         state.session = Some(SessionState {
             session_id: parsed.session_id,
-            server_time: parsed
-                .welcome
-                .server_time
-                .unwrap_or_else(Utc::now),
+            server_time: parsed.welcome.server_time.unwrap_or_else(Utc::now),
         });
         Ok(parsed)
     }
@@ -620,11 +606,13 @@ impl RunnerCloudClient {
             }
             msg @ ClientMsg::Accept { run_id, .. } => {
                 let body = to_value(&msg)?;
-                self.post_run_lifecycle(run_id, "accept", body, &idempotency_key).await
+                self.post_run_lifecycle(run_id, "accept", body, &idempotency_key)
+                    .await
             }
             msg @ ClientMsg::RunStarted { run_id, .. } => {
                 let body = to_value(&msg)?;
-                self.post_run_lifecycle(run_id, "started", body, &idempotency_key).await
+                self.post_run_lifecycle(run_id, "started", body, &idempotency_key)
+                    .await
             }
             msg @ ClientMsg::RunEvent { run_id, .. } => {
                 let body = to_value(&msg)?;
@@ -632,31 +620,38 @@ impl RunnerCloudClient {
             }
             msg @ ClientMsg::ApprovalRequest { run_id, .. } => {
                 let body = to_value(&msg)?;
-                self.post_run_lifecycle(run_id, "approvals", body, &idempotency_key).await
+                self.post_run_lifecycle(run_id, "approvals", body, &idempotency_key)
+                    .await
             }
             msg @ ClientMsg::RunAwaitingReauth { run_id, .. } => {
                 let body = to_value(&msg)?;
-                self.post_run_lifecycle(run_id, "awaiting-reauth", body, &idempotency_key).await
+                self.post_run_lifecycle(run_id, "awaiting-reauth", body, &idempotency_key)
+                    .await
             }
             msg @ ClientMsg::RunCompleted { run_id, .. } => {
                 let body = to_value(&msg)?;
-                self.post_run_lifecycle(run_id, "complete", body, &idempotency_key).await
+                self.post_run_lifecycle(run_id, "complete", body, &idempotency_key)
+                    .await
             }
             msg @ ClientMsg::RunPaused { run_id, .. } => {
                 let body = to_value(&msg)?;
-                self.post_run_lifecycle(run_id, "pause", body, &idempotency_key).await
+                self.post_run_lifecycle(run_id, "pause", body, &idempotency_key)
+                    .await
             }
             msg @ ClientMsg::RunFailed { run_id, .. } => {
                 let body = to_value(&msg)?;
-                self.post_run_lifecycle(run_id, "fail", body, &idempotency_key).await
+                self.post_run_lifecycle(run_id, "fail", body, &idempotency_key)
+                    .await
             }
             msg @ ClientMsg::RunCancelled { run_id, .. } => {
                 let body = to_value(&msg)?;
-                self.post_run_lifecycle(run_id, "cancelled", body, &idempotency_key).await
+                self.post_run_lifecycle(run_id, "cancelled", body, &idempotency_key)
+                    .await
             }
             msg @ ClientMsg::RunResumed { run_id, .. } => {
                 let body = to_value(&msg)?;
-                self.post_run_lifecycle(run_id, "resumed", body, &idempotency_key).await
+                self.post_run_lifecycle(run_id, "resumed", body, &idempotency_key)
+                    .await
             }
         }
     }
@@ -761,6 +756,95 @@ pub struct PollStatus {
     pub status: String,
     pub in_flight_run: Option<Uuid>,
     pub ts: DateTime<Utc>,
+    // ----- per-active-run observability snapshot -----
+    // Optional; only serialised when `agent_observability_v1` is enabled.
+    // `observed_run_id` is the only field that may serialise as `null` on
+    // the wire — that explicit null tells the cloud "this runner is idle,
+    // clear my live-state row's run binding." All other fields are skipped
+    // when None so a stale poll never NULLs out a known-good cloud value.
+    // See `.ai_design/runner_agent_bridge/design.md` §4.2.
+    /// Always serialised when feature is enabled (including null).
+    #[serde(
+        rename = "observed_run_id",
+        default,
+        skip_serializing_if = "PollStatusObservabilityFlag::skip"
+    )]
+    pub observed_run_id_envelope: PollStatusObservabilityFlag,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_event_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_event_kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_event_summary: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_pid: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_subprocess_alive: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approvals_pending: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tokens: Option<TokenUsage>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn_count: Option<u32>,
+}
+
+/// Wire-side wrapper used to express the three states of `observed_run_id`:
+/// absent (feature off), present-and-null (feature on, runner idle), and
+/// present-with-value (feature on, runner busy). Default is `Absent`,
+/// which `skip_serializing_if` drops from the JSON entirely.
+#[derive(Debug, Clone, Default)]
+pub enum PollStatusObservabilityFlag {
+    #[default]
+    Absent,
+    Present(Option<Uuid>),
+}
+
+impl PollStatusObservabilityFlag {
+    pub fn skip(&self) -> bool {
+        matches!(self, Self::Absent)
+    }
+}
+
+impl Serialize for PollStatusObservabilityFlag {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            // The struct field carries `skip_serializing_if = "skip"`,
+            // which intercepts `Absent` before serde reaches this impl.
+            // If a future refactor drops that attribute, this branch
+            // would silently start emitting `null` — a wire change that
+            // looks like "feature on, idle" to the cloud, with no
+            // compile-time warning. Treat reaching it as a bug rather
+            // than papering over it.
+            Self::Absent => Err(serde::ser::Error::custom(
+                "PollStatusObservabilityFlag::Absent reached Serialize; \
+                 skip_serializing_if was bypassed",
+            )),
+            Self::Present(v) => match v {
+                Some(uuid) => serializer.serialize_some(uuid),
+                None => serializer.serialize_none(),
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct TokenUsage {
+    pub input: u64,
+    pub output: u64,
+    pub total: u64,
+}
+
+impl From<crate::daemon::observability::TokenUsage> for TokenUsage {
+    fn from(t: crate::daemon::observability::TokenUsage) -> Self {
+        Self {
+            input: t.input,
+            output: t.output,
+            total: t.total,
+        }
+    }
 }
 
 impl PollStatus {
@@ -769,6 +853,15 @@ impl PollStatus {
             status: "idle".to_string(),
             in_flight_run: None,
             ts: Utc::now(),
+            observed_run_id_envelope: PollStatusObservabilityFlag::Absent,
+            last_event_at: None,
+            last_event_kind: None,
+            last_event_summary: None,
+            agent_pid: None,
+            agent_subprocess_alive: None,
+            approvals_pending: None,
+            tokens: None,
+            turn_count: None,
         }
     }
 
@@ -783,7 +876,45 @@ impl PollStatus {
             status: s.to_string(),
             in_flight_run,
             ts: Utc::now(),
+            observed_run_id_envelope: PollStatusObservabilityFlag::Absent,
+            last_event_at: None,
+            last_event_kind: None,
+            last_event_summary: None,
+            agent_pid: None,
+            agent_subprocess_alive: None,
+            approvals_pending: None,
+            tokens: None,
+            turn_count: None,
         }
+    }
+
+    /// Build a poll status that includes the per-active-run observability
+    /// snapshot when the `agent_observability_v1` flag is enabled. When
+    /// disabled, this is identical to `from_wire`.
+    pub fn from_state(
+        status: WireStatus,
+        in_flight_run: Option<Uuid>,
+        feature_enabled: bool,
+        snapshot: crate::daemon::state::ObservabilitySnapshot,
+        approvals_pending: usize,
+    ) -> Self {
+        let mut me = Self::from_wire(status, in_flight_run);
+        if !feature_enabled {
+            return me;
+        }
+        // observed_run_id is *always* serialised when the feature is on,
+        // including as null when idle. The cloud uses an explicit null to
+        // clear the live-state row's run binding (design §4.5.2).
+        me.observed_run_id_envelope = PollStatusObservabilityFlag::Present(in_flight_run);
+        me.last_event_at = snapshot.last_event_at;
+        me.last_event_kind = snapshot.last_event_kind;
+        me.last_event_summary = snapshot.last_event_summary;
+        me.agent_pid = snapshot.agent_pid;
+        me.agent_subprocess_alive = snapshot.agent_subprocess_alive;
+        me.approvals_pending = Some(u32::try_from(approvals_pending).unwrap_or(u32::MAX));
+        me.tokens = snapshot.tokens.map(TokenUsage::from);
+        me.turn_count = snapshot.turn_count;
+        me
     }
 }
 
@@ -818,6 +949,12 @@ pub struct HttpLoop {
     pub in_flight_rx: watch::Receiver<Option<Uuid>>,
     pub shutdown: Arc<tokio::sync::Notify>,
     pub attach_body: AttachBody,
+    /// Optional handle to the daemon's state. When `Some`, `poll_once`
+    /// builds a `PollStatus::from_state` (carrying the per-active-run
+    /// observability snapshot). When `None`, falls back to `from_wire`,
+    /// which is identical to the v3 wire shape — used by tests and any
+    /// caller that doesn't want to thread state through.
+    pub state: Option<crate::daemon::state::StateHandle>,
     inline_acks: VecDeque<String>,
 }
 
@@ -863,8 +1000,17 @@ impl HttpLoop {
             in_flight_rx,
             shutdown,
             attach_body,
+            state: None,
             inline_acks: VecDeque::new(),
         }
+    }
+
+    /// Attach the daemon's state so `poll_once` can include the
+    /// per-active-run observability snapshot when the
+    /// `agent_observability_v1` flag is enabled.
+    pub fn with_state(mut self, state: crate::daemon::state::StateHandle) -> Self {
+        self.state = Some(state);
+        self
     }
 
     /// Build a fresh `AttachBody` snapshotting the current status and
@@ -1034,7 +1180,16 @@ impl HttpLoop {
         while let Ok(entry) = self.ack_rx.try_recv() {
             acks.push(entry.stream_id);
         }
-        let status = PollStatus::from_wire(*self.status_rx.borrow(), *self.in_flight_rx.borrow());
+        let wire_status = *self.status_rx.borrow();
+        let in_flight = *self.in_flight_rx.borrow();
+        let status = match self.state.as_ref() {
+            Some(state) if state.agent_observability_v1() => {
+                let snapshot = state.observability_snapshot().await;
+                let approvals = state.approvals_pending_value().await;
+                PollStatus::from_state(wire_status, in_flight, true, snapshot, approvals)
+            }
+            _ => PollStatus::from_wire(wire_status, in_flight),
+        };
         let resp = self.client.poll(acks, status).await?;
         for msg in resp.messages {
             self.dispatch(msg).await;
@@ -1081,7 +1236,6 @@ impl HttpLoop {
             }
         }
     }
-
 }
 
 // ---------------------------------------------------------------------------
@@ -1176,10 +1330,7 @@ pub async fn write_runner_credentials(
 ) -> Result<(), TransportError> {
     let handle = CredentialsHandle::new(path, creds.clone());
     handle
-        .rotate(
-            creds.refresh_token.clone(),
-            creds.refresh_token_generation,
-        )
+        .rotate(creds.refresh_token.clone(), creds.refresh_token_generation)
         .await
         .map_err(|e| TransportError::Network(e.to_string()))
 }
@@ -1223,10 +1374,7 @@ mod tests {
     fn auth_error_mapping() {
         let err = map_auth_error(StatusCode::UNAUTHORIZED, "{\"error\":\"runner_revoked\"}");
         assert!(matches!(err, TransportError::RunnerRevoked));
-        let err = map_auth_error(
-            StatusCode::FORBIDDEN,
-            "{\"error\":\"runner_id_mismatch\"}",
-        );
+        let err = map_auth_error(StatusCode::FORBIDDEN, "{\"error\":\"runner_id_mismatch\"}");
         assert!(matches!(err, TransportError::RunnerIdMismatch));
     }
 
@@ -1281,5 +1429,114 @@ mod tests {
         let refreshed = refresh_attach_body(&base, WireStatus::Idle, None);
         assert_eq!(refreshed.in_flight_run, None);
         assert_eq!(refreshed.status, PollStatus::idle().status);
+    }
+
+    #[test]
+    fn attach_body_serialization_unchanged_by_observability_design() {
+        // Regression: AttachBody must NOT carry any observability fields.
+        // The poll path is the single ingestion site for the
+        // per-active-run snapshot; session-open stays a thin
+        // identity/resume body.
+        let body = sample_attach_body();
+        let v = serde_json::to_value(&body).unwrap();
+        let keys: std::collections::BTreeSet<_> = v.as_object().unwrap().keys().cloned().collect();
+        let expected: std::collections::BTreeSet<_> = [
+            "version",
+            "os",
+            "arch",
+            "status",
+            "in_flight_run",
+            "project_slug",
+            "host_label",
+            "agent_versions",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        assert_eq!(
+            keys, expected,
+            "AttachBody serialised key set drifted: {keys:?}"
+        );
+    }
+
+    #[test]
+    fn poll_status_from_wire_omits_observability_fields() {
+        // Pre-observability shape: only status / in_flight_run / ts.
+        let s = PollStatus::from_wire(WireStatus::Idle, None);
+        let v = serde_json::to_value(&s).unwrap();
+        let obj = v.as_object().unwrap();
+        let keys: std::collections::BTreeSet<_> = obj.keys().cloned().collect();
+        let expected: std::collections::BTreeSet<_> = ["status", "in_flight_run", "ts"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert_eq!(
+            keys, expected,
+            "PollStatus::from_wire wire shape drifted: {keys:?}"
+        );
+    }
+
+    #[test]
+    fn poll_status_feature_off_matches_legacy_shape() {
+        let snap = crate::daemon::state::ObservabilitySnapshot::default();
+        let s = PollStatus::from_state(WireStatus::Busy, Some(Uuid::nil()), false, snap, 0);
+        let v = serde_json::to_value(&s).unwrap();
+        let obj = v.as_object().unwrap();
+        // No new fields when feature is off — this is the strict back-compat
+        // guarantee.
+        assert!(!obj.contains_key("observed_run_id"));
+        assert!(!obj.contains_key("last_event_at"));
+        assert!(!obj.contains_key("agent_pid"));
+        assert!(!obj.contains_key("approvals_pending"));
+        assert!(!obj.contains_key("tokens"));
+    }
+
+    #[test]
+    fn poll_status_feature_on_idle_serialises_observed_run_id_null() {
+        let snap = crate::daemon::state::ObservabilitySnapshot::default();
+        let s = PollStatus::from_state(WireStatus::Idle, None, true, snap, 0);
+        let v = serde_json::to_value(&s).unwrap();
+        let obj = v.as_object().unwrap();
+        assert!(obj.contains_key("observed_run_id"));
+        assert_eq!(obj.get("observed_run_id"), Some(&serde_json::Value::Null));
+        // approvals_pending is always populated when feature is on.
+        assert_eq!(obj.get("approvals_pending"), Some(&serde_json::json!(0)));
+        // No event has fired yet — descriptive scalars stay absent.
+        assert!(!obj.contains_key("last_event_at"));
+        assert!(!obj.contains_key("agent_pid"));
+    }
+
+    #[test]
+    fn poll_status_feature_on_busy_serialises_populated_fields() {
+        use crate::daemon::observability::TokenUsage as InnerTokenUsage;
+        let rid = Uuid::new_v4();
+        let snap = crate::daemon::state::ObservabilitySnapshot {
+            last_event_at: Some(Utc::now()),
+            last_event_kind: Some("codex/event/token_count".into()),
+            last_event_summary: Some("running".into()),
+            agent_pid: Some(4242),
+            agent_subprocess_alive: Some(true),
+            tokens: Some(InnerTokenUsage {
+                input: 100,
+                output: 200,
+                total: 300,
+            }),
+            turn_count: Some(2),
+        };
+        let s = PollStatus::from_state(WireStatus::Busy, Some(rid), true, snap, 1);
+        let v = serde_json::to_value(&s).unwrap();
+        let obj = v.as_object().unwrap();
+        assert_eq!(obj.get("observed_run_id"), Some(&serde_json::json!(rid)));
+        assert_eq!(obj.get("agent_pid"), Some(&serde_json::json!(4242)));
+        assert_eq!(
+            obj.get("agent_subprocess_alive"),
+            Some(&serde_json::json!(true))
+        );
+        assert_eq!(obj.get("approvals_pending"), Some(&serde_json::json!(1)));
+        assert_eq!(obj.get("turn_count"), Some(&serde_json::json!(2)));
+        let tokens = obj.get("tokens").unwrap().as_object().unwrap();
+        assert_eq!(tokens.get("input"), Some(&serde_json::json!(100)));
+        assert_eq!(tokens.get("output"), Some(&serde_json::json!(200)));
+        assert_eq!(tokens.get("total"), Some(&serde_json::json!(300)));
     }
 }

--- a/runner/src/codex/app_server.rs
+++ b/runner/src/codex/app_server.rs
@@ -1,20 +1,40 @@
 use anyhow::{Context, Result};
+use chrono::Utc;
 use std::path::Path;
 use std::process::Stdio;
 use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, Command};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 
+use crate::agent::{AgentProcessHandle, ExitSnapshot};
 use crate::codex::jsonrpc::Incoming;
 use crate::util::shell::{is_benign_login_shell_warning, login_shell_command};
 
 /// Handles the `codex app-server` subprocess lifecycle + JSON-RPC wire.
+///
+/// `Child` is owned by an internal wait task spawned in `spawn_command`. The
+/// `AppServer` holds only the side-channels needed to drive it: stdin for
+/// outbound requests, `kill_tx` to request shutdown, and `exit_rx` to observe
+/// exit. This split is required because `tokio::process::Child::wait()` and
+/// `start_kill()` both take `&mut self`, so only one task can hold the child.
+/// See `.ai_design/runner_agent_bridge/design.md` §4.4.
 pub struct AppServer {
-    child: Child,
+    pid: Option<u32>,
     stdin: ChildStdin,
     next_id: AtomicU64,
     pub inbound: mpsc::Receiver<Incoming>,
+    kill_tx: mpsc::Sender<KillRequest>,
+    exit_rx: watch::Receiver<Option<ExitSnapshot>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum KillRequest {
+    /// Polite stdin-drop already happened on the AppServer side; just wait
+    /// for natural exit and force-kill on grace expiry.
+    Graceful,
+    /// Force-kill immediately (used as the grace-window fallback).
+    Force,
 }
 
 impl AppServer {
@@ -36,15 +56,23 @@ impl AppServer {
         let stdin = child.stdin.take().context("codex stdin missing")?;
         let stdout = child.stdout.take().context("codex stdout missing")?;
         let stderr = child.stderr.take().context("codex stderr missing")?;
+        let pid = child.id();
 
         let (tx, rx) = mpsc::channel(128);
         tokio::spawn(read_frames(stdout, tx.clone()));
         tokio::spawn(drain_stderr(stderr));
+
+        let (kill_tx, kill_rx) = mpsc::channel::<KillRequest>(2);
+        let (exit_tx, exit_rx) = watch::channel::<Option<ExitSnapshot>>(None);
+        tokio::spawn(wait_task(child, kill_rx, exit_tx));
+
         Ok(Self {
-            child,
+            pid,
             stdin,
             next_id: AtomicU64::new(1),
             inbound: rx,
+            kill_tx,
+            exit_rx,
         })
     }
 
@@ -59,19 +87,88 @@ impl AppServer {
         Ok(())
     }
 
+    /// Bridge-owned observability handle. PID was captured at spawn time;
+    /// `exit_rx` yields `Some(ExitSnapshot)` once the wait task observes
+    /// termination.
+    pub fn process_handle(&self) -> AgentProcessHandle {
+        AgentProcessHandle {
+            pid: self.pid,
+            exit_rx: self.exit_rx.clone(),
+        }
+    }
+
     pub async fn shutdown(mut self, grace: std::time::Duration) -> Result<()> {
+        // Half-close stdin so codex notices end-of-input.
         drop(self.stdin);
-        match tokio::time::timeout(grace, self.child.wait()).await {
-            Ok(Ok(status)) => {
-                tracing::debug!(?status, "codex exited gracefully");
+        // Tell the wait task to wait for natural exit; if the grace expires
+        // we follow up with Force.
+        let _ = self.kill_tx.send(KillRequest::Graceful).await;
+        match tokio::time::timeout(grace, self.exit_rx.changed()).await {
+            Ok(Ok(())) => {
+                let snap = self.exit_rx.borrow().clone();
+                tracing::debug!(?snap, "codex exited gracefully");
             }
             _ => {
                 tracing::warn!("codex did not exit within grace; sending SIGKILL");
-                self.child.start_kill().ok();
-                self.child.wait().await.ok();
+                let _ = self.kill_tx.send(KillRequest::Force).await;
+                let _ = self.exit_rx.changed().await;
             }
         }
         Ok(())
+    }
+}
+
+/// Owns the `Child` exclusively. Awaits either a kill request (force-kill
+/// the subprocess) or the child's natural exit, then publishes an
+/// `ExitSnapshot` and terminates.
+async fn wait_task(
+    mut child: Child,
+    mut kill_rx: mpsc::Receiver<KillRequest>,
+    exit_tx: watch::Sender<Option<ExitSnapshot>>,
+) {
+    let snapshot = loop {
+        tokio::select! {
+            biased;
+            req = kill_rx.recv() => {
+                match req {
+                    Some(KillRequest::Force) => {
+                        let _ = child.start_kill();
+                    }
+                    Some(KillRequest::Graceful) => {
+                        // No-op: wait for natural exit.
+                    }
+                    None => {
+                        // All senders dropped — recv will resolve to None
+                        // synchronously every iteration. Stop polling the
+                        // recv arm and just await natural exit, otherwise
+                        // the biased select! would spin on the closed
+                        // channel without ever polling child.wait().
+                        let res = child.wait().await;
+                        break exit_snapshot_from(res.ok());
+                    }
+                }
+            }
+            res = child.wait() => {
+                break exit_snapshot_from(res.ok());
+            }
+        }
+    };
+    let _ = exit_tx.send(Some(snapshot));
+}
+
+fn exit_snapshot_from(status: Option<std::process::ExitStatus>) -> ExitSnapshot {
+    #[cfg(unix)]
+    let signal = {
+        use std::os::unix::process::ExitStatusExt;
+        status.as_ref().and_then(|s| s.signal())
+    };
+    #[cfg(not(unix))]
+    let signal: Option<i32> = None;
+    let status_code = status.as_ref().and_then(|s| s.code());
+    ExitSnapshot {
+        status_code,
+        signal,
+        observed_at: Utc::now(),
     }
 }
 

--- a/runner/src/codex/bridge.rs
+++ b/runner/src/codex/bridge.rs
@@ -289,9 +289,7 @@ impl BridgeCursor {
                     // a `turn/completed` with no conclusion right after a
                     // systemError, so the runner reported "completed" on
                     // 400s from OpenAI.
-                    let conclusion = params
-                        .get("conclusion")
-                        .and_then(|v| v.as_str());
+                    let conclusion = params.get("conclusion").and_then(|v| v.as_str());
                     if conclusion == Some("success") {
                         vec![BridgeEvent::Completed {
                             run_id: self.run_id,
@@ -358,9 +356,7 @@ impl BridgeCursor {
                         .get("status")
                         .and_then(|s| s.get("activeFlags"))
                         .and_then(|f| f.as_array())
-                        .map(|arr| {
-                            arr.iter().any(|v| v.as_str() == Some("waitingOnApproval"))
-                        })
+                        .map(|arr| arr.iter().any(|v| v.as_str() == Some("waitingOnApproval")))
                         .unwrap_or(false);
                     if waiting && let Some(pending) = self.pending_command.clone() {
                         // We've already emitted an ApprovalRequest for this
@@ -411,10 +407,8 @@ impl BridgeCursor {
                     // Cache the most recent in-progress commandExecution so
                     // a later `waitingOnApproval` flag can refer to it.
                     if let Some(item) = params.get("item")
-                        && item.get("type").and_then(|v| v.as_str())
-                            == Some("commandExecution")
-                        && item.get("status").and_then(|v| v.as_str())
-                            == Some("inProgress")
+                        && item.get("type").and_then(|v| v.as_str()) == Some("commandExecution")
+                        && item.get("status").and_then(|v| v.as_str()) == Some("inProgress")
                     {
                         let item_id = item
                             .get("id")
@@ -450,8 +444,7 @@ impl BridgeCursor {
                     // The cached command finished; drop the tracking so a
                     // late waitingOnApproval doesn't re-open it.
                     if let Some(item) = params.get("item")
-                        && item.get("type").and_then(|v| v.as_str())
-                            == Some("commandExecution")
+                        && item.get("type").and_then(|v| v.as_str()) == Some("commandExecution")
                     {
                         let same = self
                             .pending_command
@@ -517,10 +510,7 @@ mod translate_tests {
         assert_eq!(evs.len(), 1);
         match &evs[0] {
             BridgeEvent::Failed { detail, .. } => {
-                assert_eq!(
-                    detail.as_deref(),
-                    Some("turn/completed without conclusion")
-                );
+                assert_eq!(detail.as_deref(), Some("turn/completed without conclusion"));
             }
             other => panic!("expected Failed, got {other:?}"),
         }
@@ -602,15 +592,23 @@ mod translate_tests {
             json!({"status": {"activeFlags": ["waitingOnApproval"]}}),
         ));
         match evs.as_slice() {
-            [BridgeEvent::ApprovalRequest {
-                kind,
-                payload,
-                reason,
-                ..
-            }] => {
+            [
+                BridgeEvent::ApprovalRequest {
+                    kind,
+                    payload,
+                    reason,
+                    ..
+                },
+            ] => {
                 assert!(matches!(kind, ApprovalKind::CommandExecution));
-                assert_eq!(payload.get("command").and_then(|v| v.as_str()), Some("rm -rf /tmp/x"));
-                assert_eq!(payload.get("synthesized").and_then(|v| v.as_bool()), Some(true));
+                assert_eq!(
+                    payload.get("command").and_then(|v| v.as_str()),
+                    Some("rm -rf /tmp/x")
+                );
+                assert_eq!(
+                    payload.get("synthesized").and_then(|v| v.as_bool()),
+                    Some(true)
+                );
                 assert!(reason.as_deref().unwrap_or("").contains("rm -rf /tmp/x"));
             }
             other => panic!("expected ApprovalRequest, got {other:?}"),
@@ -639,7 +637,10 @@ mod translate_tests {
             "thread/status/changed",
             json!({"status": {"activeFlags": ["waitingOnApproval"]}}),
         ));
-        assert!(matches!(first.as_slice(), [BridgeEvent::ApprovalRequest { .. }]));
+        assert!(matches!(
+            first.as_slice(),
+            [BridgeEvent::ApprovalRequest { .. }]
+        ));
 
         let second = c.translate(notif(
             "thread/status/changed",

--- a/runner/src/config/file.rs
+++ b/runner/src/config/file.rs
@@ -135,6 +135,7 @@ mod tests {
                 cloud_url: "https://x".into(),
                 log_level: "info".into(),
                 log_retention_days: 14,
+                agent_observability_v1: false,
             },
             runners: vec![sample_runner("t", tmp.path().join("wd"))],
         };

--- a/runner/src/config/schema.rs
+++ b/runner/src/config/schema.rs
@@ -20,6 +20,11 @@ pub struct DaemonConfig {
     pub log_level: String,
     #[serde(default = "default_retention_days")]
     pub log_retention_days: u32,
+    /// Opt into the per-active-run observability snapshot on the poll
+    /// status. Default off; new fields ride only when this is true.
+    /// See `.ai_design/runner_agent_bridge/design.md` §4.2.
+    #[serde(default)]
+    pub agent_observability_v1: bool,
 }
 
 fn default_log_level() -> String {
@@ -36,6 +41,7 @@ impl Default for DaemonConfig {
             cloud_url: String::new(),
             log_level: default_log_level(),
             log_retention_days: default_retention_days(),
+            agent_observability_v1: false,
         }
     }
 }
@@ -434,6 +440,7 @@ mod tests {
                 cloud_url: "https://x".into(),
                 log_level: "info".into(),
                 log_retention_days: 14,
+                agent_observability_v1: false,
             },
             runners,
         }

--- a/runner/src/daemon/mod.rs
+++ b/runner/src/daemon/mod.rs
@@ -1,3 +1,4 @@
+pub mod observability;
 pub mod runner_instance;
 pub mod runner_out;
 pub mod state;

--- a/runner/src/daemon/observability.rs
+++ b/runner/src/daemon/observability.rs
@@ -1,0 +1,242 @@
+//! Observability scalars for the per-active-run snapshot the runner sends
+//! to the cloud on every poll. Designed to be agent-agnostic and
+//! presentation-only; the cloud watchdog and the web UI consume these as
+//! descriptive scalars (`.ai_design/runner_agent_bridge/design.md` §4.1).
+
+use serde::{Deserialize, Serialize};
+
+use crate::agent::BridgeEvent;
+
+/// Streaming token usage parsed opportunistically from a Codex
+/// `codex/event/token_count` Raw frame. Claude does not emit equivalent
+/// streaming counts during a run, so this is left `None` for Claude.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TokenUsage {
+    pub input: u64,
+    pub output: u64,
+    pub total: u64,
+}
+
+/// Maximum length for `last_event_kind` — matches the cloud's
+/// `RunnerLiveState.last_event_kind` column.
+pub const KIND_MAX: usize = 64;
+
+/// Maximum length for `last_event_summary` — matches the cloud's
+/// `RunnerLiveState.last_event_summary` column.
+pub const SUMMARY_MAX: usize = 200;
+
+/// Classify a `BridgeEvent` into a short kind label, for the live-state
+/// `last_event_kind` field. Length-capped to `KIND_MAX`.
+pub fn kind_of(event: &BridgeEvent) -> String {
+    let raw = match event {
+        BridgeEvent::RunStarted { .. } => "run/started".to_string(),
+        BridgeEvent::Raw { method, .. } => method.clone(),
+        BridgeEvent::ApprovalRequest { .. } => "approval/request".to_string(),
+        BridgeEvent::AwaitingReauth { .. } => "auth/awaiting_reauth".to_string(),
+        BridgeEvent::Completed { .. } => "run/completed".to_string(),
+        BridgeEvent::Failed { .. } => "run/failed".to_string(),
+    };
+    truncate(&raw, KIND_MAX)
+}
+
+/// Build a structure-only one-line summary of a `BridgeEvent` for the
+/// live-state `last_event_summary` field. This must NEVER include prompt
+/// text, model output, or file content — only method names, ids,
+/// durations, exit codes. Length-capped to `SUMMARY_MAX`.
+///
+/// Returns `String` rather than `Option<String>` because every variant
+/// produces a non-empty summary today; callers that want to defer
+/// stamping (e.g. on a quiet idle tick) should not call this in the
+/// first place.
+pub fn summary_of(event: &BridgeEvent) -> String {
+    let raw = match event {
+        BridgeEvent::RunStarted { thread_id, .. } => {
+            format!("run started thread={thread_id}")
+        }
+        BridgeEvent::Raw { method, .. } => {
+            // Only the method name and an opaque tag for the params shape.
+            // Never inline `params` content — those carry user prompts and
+            // model output for many codex methods.
+            format!("raw method={method}")
+        }
+        BridgeEvent::ApprovalRequest {
+            approval_id, kind, ..
+        } => {
+            format!("approval request id={approval_id} kind={kind:?}")
+        }
+        BridgeEvent::AwaitingReauth { .. } => "awaiting reauth".to_string(),
+        BridgeEvent::Completed { .. } => "run completed".to_string(),
+        BridgeEvent::Failed { reason, .. } => {
+            format!("run failed reason={reason:?}")
+        }
+    };
+    truncate(&raw, SUMMARY_MAX)
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        return s.to_string();
+    }
+    // Truncate on a char boundary.
+    let mut end = max;
+    while !s.is_char_boundary(end) && end > 0 {
+        end -= 1;
+    }
+    s[..end].to_string()
+}
+
+/// Best-effort parser for a Codex `codex/event/token_count` Raw frame's
+/// params. Returns `None` if the params don't match the expected shape.
+/// Failures are non-fatal — the supervisor logs at debug and continues.
+///
+/// Accepts either of the two shapes seen on the wire:
+///   - `{ "usage": { "input_tokens": ..., "output_tokens": ... } }`
+///   - `{ "input_tokens": ..., "output_tokens": ... }` (flat)
+/// Both shapes must additionally surface `total_tokens` to be accepted —
+/// a frame with only `input_tokens`/`output_tokens` and no `total_tokens`
+/// is treated as not-a-token-count to keep the parser narrow. This
+/// avoids false positives on unrelated frames that happen to carry
+/// numeric fields named `input_tokens` / `output_tokens`.
+pub fn parse_codex_token_count(params: &serde_json::Value) -> Option<TokenUsage> {
+    let usage = params.get("usage").unwrap_or(params);
+    let input = usage.get("input_tokens").and_then(|v| v.as_u64())?;
+    let output = usage.get("output_tokens").and_then(|v| v.as_u64())?;
+    let total = usage.get("total_tokens").and_then(|v| v.as_u64())?;
+    Some(TokenUsage {
+        input,
+        output,
+        total,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cloud::protocol::{ApprovalKind, FailureReason};
+    use serde_json::json;
+    use uuid::Uuid;
+
+    fn run_id() -> Uuid {
+        Uuid::nil()
+    }
+
+    #[test]
+    fn kind_of_uses_raw_method() {
+        let ev = BridgeEvent::Raw {
+            run_id: run_id(),
+            method: "codex/event/token_count".into(),
+            params: json!({}),
+        };
+        assert_eq!(kind_of(&ev), "codex/event/token_count");
+    }
+
+    #[test]
+    fn kind_of_caps_length() {
+        let long = "x".repeat(200);
+        let ev = BridgeEvent::Raw {
+            run_id: run_id(),
+            method: long,
+            params: json!({}),
+        };
+        assert_eq!(kind_of(&ev).len(), KIND_MAX);
+    }
+
+    #[test]
+    fn summary_of_does_not_leak_params() {
+        // Even when params carry user-content, summary_of must never
+        // surface them. We assert the summary contains the method name
+        // but does NOT contain the embedded `prompt` or `output` content.
+        let ev = BridgeEvent::Raw {
+            run_id: run_id(),
+            method: "tool/exec".into(),
+            params: json!({"prompt": "rm -rf /etc", "output": "secret data"}),
+        };
+        let s = summary_of(&ev);
+        assert!(s.contains("method=tool/exec"));
+        assert!(!s.contains("rm -rf"), "summary leaked params content: {s}");
+        assert!(
+            !s.contains("secret data"),
+            "summary leaked params content: {s}"
+        );
+    }
+
+    #[test]
+    fn summary_of_caps_length() {
+        let long = "x".repeat(500);
+        let ev = BridgeEvent::Raw {
+            run_id: run_id(),
+            method: long,
+            params: json!({}),
+        };
+        let s = summary_of(&ev);
+        assert!(s.len() <= SUMMARY_MAX);
+    }
+
+    #[test]
+    fn summary_of_failed_includes_reason_classifier() {
+        let ev = BridgeEvent::Failed {
+            run_id: run_id(),
+            reason: FailureReason::Timeout,
+            detail: Some("user-detail".into()),
+        };
+        let s = summary_of(&ev);
+        assert!(s.contains("Timeout"));
+        // Detail string carries operator-supplied text; we deliberately
+        // do not echo it through, only the classifier.
+        assert!(!s.contains("user-detail"));
+    }
+
+    #[test]
+    fn summary_of_approval_includes_kind() {
+        let ev = BridgeEvent::ApprovalRequest {
+            run_id: run_id(),
+            approval_id: "abc".into(),
+            kind: ApprovalKind::CommandExecution,
+            payload: json!({"cmd": "ls"}),
+            reason: Some("test".into()),
+        };
+        let s = summary_of(&ev);
+        assert!(s.contains("approval request"));
+        assert!(s.contains("kind="));
+        assert!(!s.contains("\"cmd\""));
+    }
+
+    #[test]
+    fn parse_codex_token_count_accepts_usage_block() {
+        let params = json!({
+            "usage": {"input_tokens": 100, "output_tokens": 250, "total_tokens": 350}
+        });
+        let u = parse_codex_token_count(&params).unwrap();
+        assert_eq!(u.input, 100);
+        assert_eq!(u.output, 250);
+        assert_eq!(u.total, 350);
+    }
+
+    #[test]
+    fn parse_codex_token_count_accepts_flat_block_with_total() {
+        let params = json!({
+            "input_tokens": 10,
+            "output_tokens": 20,
+            "total_tokens": 30
+        });
+        let u = parse_codex_token_count(&params).unwrap();
+        assert_eq!(u.input, 10);
+        assert_eq!(u.output, 20);
+        assert_eq!(u.total, 30);
+    }
+
+    #[test]
+    fn parse_codex_token_count_rejects_flat_without_total() {
+        // Defensive: a frame with only input/output and no total is
+        // ambiguous — could be an unrelated event with a similar
+        // numeric field naming. Stay narrow to avoid false positives.
+        let params = json!({"input_tokens": 10, "output_tokens": 20});
+        assert!(parse_codex_token_count(&params).is_none());
+    }
+
+    #[test]
+    fn parse_codex_token_count_returns_none_on_garbage() {
+        let params = json!({"unrelated": true});
+        assert!(parse_codex_token_count(&params).is_none());
+    }
+}

--- a/runner/src/daemon/runner_out.rs
+++ b/runner/src/daemon/runner_out.rs
@@ -53,7 +53,9 @@ impl RunnerOut {
                 .send(env)
                 .await
                 .map_err(|e| anyhow!("cloud sender dropped: {e}")),
-            RunnerOutInner::Http(client) => client.dispatch_client_msg(env).await.map_err(Into::into),
+            RunnerOutInner::Http(client) => {
+                client.dispatch_client_msg(env).await.map_err(Into::into)
+            }
             RunnerOutInner::Offline => Ok(()),
         }
     }
@@ -64,9 +66,9 @@ impl RunnerOut {
                 .send(Envelope::new(body))
                 .await
                 .map_err(|e| anyhow!("cloud sender dropped: {e}")),
-            RunnerOutInner::Http(_) => {
-                Err(anyhow!("connection-scoped frames are unsupported on HTTP transport"))
-            }
+            RunnerOutInner::Http(_) => Err(anyhow!(
+                "connection-scoped frames are unsupported on HTTP transport"
+            )),
             RunnerOutInner::Offline => Ok(()),
         }
     }

--- a/runner/src/daemon/state.rs
+++ b/runner/src/daemon/state.rs
@@ -5,7 +5,26 @@ use uuid::Uuid;
 
 use crate::cloud::protocol::RunnerStatus;
 use crate::config::schema::Config;
+use crate::daemon::observability::TokenUsage;
 use crate::ipc::protocol::{CurrentRunSummary, RunnerStatusSnapshot};
+
+/// Volatile observability fields that ride on `PollStatus`. Doubles as
+/// the in-memory storage shape (held under one `Mutex` inside `Inner`)
+/// AND the wire-snapshot returned by `StateHandle::observability_snapshot()`.
+/// Keeping them in one struct means `reset_run_snapshot()` is a single
+/// `Default::default()` assignment and a new field added here is automatically
+/// included in reset, snapshot read, and rid-change wipe — no enumeration to
+/// keep in sync.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ObservabilitySnapshot {
+    pub last_event_at: Option<DateTime<Utc>>,
+    pub last_event_kind: Option<String>,
+    pub last_event_summary: Option<String>,
+    pub agent_pid: Option<u32>,
+    pub agent_subprocess_alive: Option<bool>,
+    pub tokens: Option<TokenUsage>,
+    pub turn_count: Option<u32>,
+}
 
 #[derive(Clone)]
 pub struct StateHandle {
@@ -30,6 +49,10 @@ struct Inner {
     name: String,
     project_slug: Option<String>,
     pod_id: Option<Uuid>,
+    /// Cached at construction; the daemon doesn't reload `agent_observability_v1`
+    /// at runtime in v1, so reading from `Inner` saves a `Mutex<Config>` lock
+    /// on every poll.
+    agent_observability_v1: bool,
     cloud_url: Mutex<String>,
     started_at: DateTime<Utc>,
     connected: Mutex<bool>,
@@ -37,6 +60,18 @@ struct Inner {
     current_run: Mutex<Option<CurrentRunSummary>>,
     approvals_pending: Mutex<usize>,
     runner_id: Mutex<Option<Uuid>>,
+    /// Per-active-run observability snapshot. One `Mutex` over the whole
+    /// struct (rather than seven `Mutex<Option<T>>` fields) so that:
+    ///   1. `reset_run_snapshot()` is a single assignment — adding a
+    ///      future field cannot silently leak across run boundaries.
+    ///   2. `note_agent_event` stamps `last_event_at` / `last_event_kind`
+    ///      / `last_event_summary` atomically — no concurrent reader can
+    ///      see a partial update.
+    ///   3. `observability_snapshot()` is one lock + one clone instead
+    ///      of seven independent locks.
+    /// Collectively wiped on rid change in `set_current_run` so a freshly
+    /// assigned run never inherits stale metrics.
+    run_snapshot: Mutex<ObservabilitySnapshot>,
 }
 
 impl StateHandle {
@@ -50,12 +85,14 @@ impl StateHandle {
             None => (String::new(), None, None),
         };
         let cloud_url = cfg.daemon.cloud_url.clone();
+        let agent_observability_v1 = cfg.daemon.agent_observability_v1;
         Self {
             inner: Arc::new(Inner {
                 cfg: Mutex::new(cfg),
                 name,
                 project_slug,
                 pod_id,
+                agent_observability_v1,
                 cloud_url: Mutex::new(cloud_url),
                 started_at: Utc::now(),
                 connected: Mutex::new(false),
@@ -63,6 +100,7 @@ impl StateHandle {
                 current_run: Mutex::new(None),
                 approvals_pending: Mutex::new(0),
                 runner_id: Mutex::new(None),
+                run_snapshot: Mutex::new(ObservabilitySnapshot::default()),
             }),
             tx_tick,
             rx_tick,
@@ -79,6 +117,12 @@ impl StateHandle {
 
     pub fn subscribe(&self) -> watch::Receiver<u64> {
         self.rx_tick.clone()
+    }
+
+    /// Whether the runner should serialise the per-active-run observability
+    /// snapshot on its `PollStatus`. Cached at construction.
+    pub fn agent_observability_v1(&self) -> bool {
+        self.inner.agent_observability_v1
     }
 
     pub fn force_reconnect(&self) {
@@ -114,6 +158,21 @@ impl StateHandle {
 
     pub async fn set_current_run(&self, s: Option<CurrentRunSummary>) {
         let next = s.as_ref().map(|r| r.run_id);
+        let prev = *self.tx_in_flight.borrow();
+        // Clear the per-run observability snapshot only on a run-id
+        // *change*. Re-stamping the same run id during startup
+        // (supervisor early-stamp + worker re-stamp at supervisor.rs:803)
+        // must not erase live values.
+        // `set_current_run(None)` on a finished run does NOT reset; the
+        // last-known values remain on the next poll until a new run starts.
+        let must_reset = match (prev, next) {
+            (Some(p), Some(n)) => p != n,
+            (None, Some(_)) => true,
+            _ => false,
+        };
+        if must_reset {
+            self.reset_run_snapshot().await;
+        }
         *self.inner.current_run.lock().await = s;
         let _ = self.tx_in_flight.send(next);
         let status = if next.is_some() {
@@ -123,6 +182,56 @@ impl StateHandle {
         };
         let _ = self.tx_status.send(status);
         self.tick();
+    }
+
+    /// Wipe the per-run observability snapshot. Called by
+    /// `set_current_run` when the in-flight run id changes, and is safe
+    /// to call directly from tests.
+    pub async fn reset_run_snapshot(&self) {
+        *self.inner.run_snapshot.lock().await = ObservabilitySnapshot::default();
+        self.tick();
+    }
+
+    /// Bump `last_event_at` and stamp `kind` / `summary` atomically.
+    /// Called from `pump_events` on every `BridgeEvent` regardless of variant.
+    pub async fn note_agent_event(&self, ts: DateTime<Utc>, kind: String, summary: Option<String>) {
+        let mut snap = self.inner.run_snapshot.lock().await;
+        snap.last_event_at = Some(ts);
+        snap.last_event_kind = Some(kind);
+        if let Some(s) = summary {
+            snap.last_event_summary = Some(s);
+        }
+        drop(snap);
+        self.tick();
+    }
+
+    pub async fn set_agent_pid(&self, pid: Option<u32>) {
+        self.inner.run_snapshot.lock().await.agent_pid = pid;
+        self.tick();
+    }
+
+    pub async fn set_agent_alive(&self, alive: bool) {
+        self.inner.run_snapshot.lock().await.agent_subprocess_alive = Some(alive);
+        self.tick();
+    }
+
+    pub async fn set_tokens(&self, usage: TokenUsage) {
+        self.inner.run_snapshot.lock().await.tokens = Some(usage);
+        self.tick();
+    }
+
+    pub async fn incr_turn(&self) {
+        let mut snap = self.inner.run_snapshot.lock().await;
+        snap.turn_count = Some(snap.turn_count.unwrap_or(0).saturating_add(1));
+        drop(snap);
+        self.tick();
+    }
+
+    /// Snapshot the volatile observability fields for one poll. One lock
+    /// + one clone — adding a new field to `ObservabilitySnapshot`
+    /// automatically participates without touching this method.
+    pub async fn observability_snapshot(&self) -> ObservabilitySnapshot {
+        self.inner.run_snapshot.lock().await.clone()
     }
 
     pub async fn incr_current_run_events(&self) {
@@ -137,6 +246,11 @@ impl StateHandle {
     pub async fn set_approvals_pending(&self, n: usize) {
         *self.inner.approvals_pending.lock().await = n;
         self.tick();
+    }
+
+    /// Read the cached approvals-pending count for the wire snapshot.
+    pub async fn approvals_pending_value(&self) -> usize {
+        *self.inner.approvals_pending.lock().await
     }
 
     pub async fn set_config(&self, cfg: Config) {
@@ -222,6 +336,102 @@ mod tests {
 
         state.set_current_run(None).await;
         assert_eq!(*state.rx_in_flight.borrow(), None);
+    }
+
+    #[tokio::test]
+    async fn re_stamping_same_run_id_preserves_observability_snapshot() {
+        // Supervisor stamps Some(rid) twice (early + worker re-stamp at
+        // supervisor.rs:803). Live observability fields populated between
+        // those two calls must survive the re-stamp.
+        let state = empty_state();
+        let rid = Uuid::new_v4();
+
+        state.set_current_run(Some(summary(rid, "preparing"))).await;
+        state.set_agent_pid(Some(4242)).await;
+        state.set_agent_alive(true).await;
+        state
+            .note_agent_event(Utc::now(), "raw".into(), Some("test".into()))
+            .await;
+
+        // Same rid → must NOT call reset_run_snapshot.
+        state.set_current_run(Some(summary(rid, "starting"))).await;
+        let snap = state.observability_snapshot().await;
+        assert_eq!(snap.agent_pid, Some(4242));
+        assert_eq!(snap.agent_subprocess_alive, Some(true));
+        assert!(snap.last_event_at.is_some());
+        assert_eq!(snap.last_event_kind.as_deref(), Some("raw"));
+    }
+
+    #[tokio::test]
+    async fn run_id_change_resets_observability_snapshot() {
+        let state = empty_state();
+        let rid_a = Uuid::new_v4();
+        let rid_b = Uuid::new_v4();
+
+        state.set_current_run(Some(summary(rid_a, "running"))).await;
+        state.set_agent_pid(Some(1111)).await;
+        state.set_agent_alive(true).await;
+        state
+            .set_tokens(TokenUsage {
+                input: 1,
+                output: 2,
+                total: 3,
+            })
+            .await;
+        state.incr_turn().await;
+        state
+            .note_agent_event(Utc::now(), "raw".into(), Some("a".into()))
+            .await;
+
+        state.set_current_run(Some(summary(rid_b, "running"))).await;
+        let snap = state.observability_snapshot().await;
+        // Whole-struct equality with Default. Any *future* field added to
+        // ObservabilitySnapshot is automatically covered — a new field
+        // can't silently leak across run boundaries without flipping this
+        // test red.
+        assert_eq!(
+            snap,
+            ObservabilitySnapshot::default(),
+            "snapshot leaked across run boundary"
+        );
+    }
+
+    #[tokio::test]
+    async fn set_current_run_none_preserves_terminal_snapshot() {
+        // After a run completes, we keep the last-known scalars on the
+        // wire so the cloud can render the terminal state until a new run
+        // arrives. Reset happens only on the next idle→busy transition.
+        let state = empty_state();
+        let rid = Uuid::new_v4();
+
+        state.set_current_run(Some(summary(rid, "running"))).await;
+        state.set_agent_pid(Some(7777)).await;
+
+        state.set_current_run(None).await;
+        let snap = state.observability_snapshot().await;
+        assert_eq!(snap.agent_pid, Some(7777));
+    }
+
+    #[tokio::test]
+    async fn note_agent_event_atomically_stamps_three_fields() {
+        let state = empty_state();
+        let now = Utc::now();
+        state
+            .note_agent_event(now, "tool/exec".into(), Some("running".into()))
+            .await;
+        let snap = state.observability_snapshot().await;
+        assert_eq!(snap.last_event_at, Some(now));
+        assert_eq!(snap.last_event_kind.as_deref(), Some("tool/exec"));
+        assert_eq!(snap.last_event_summary.as_deref(), Some("running"));
+    }
+
+    #[tokio::test]
+    async fn incr_turn_increments_from_none() {
+        let state = empty_state();
+        state.incr_turn().await;
+        assert_eq!(state.observability_snapshot().await.turn_count, Some(1));
+        state.incr_turn().await;
+        assert_eq!(state.observability_snapshot().await.turn_count, Some(2));
     }
 
     #[tokio::test]

--- a/runner/src/daemon/supervisor.rs
+++ b/runner/src/daemon/supervisor.rs
@@ -89,8 +89,7 @@ impl Supervisor {
             let inst = if let Some(shared) = &transport {
                 let runner_paths = paths.for_runner(runner_cfg.runner_id);
                 let creds = load_runner_credentials(&runner_paths, &runner_cfg.name).await?;
-                let client =
-                    RunnerCloudClient::new(runner_cfg.runner_id, creds, shared.clone());
+                let client = RunnerCloudClient::new(runner_cfg.runner_id, creds, shared.clone());
                 RunnerInstance::new_http(runner_cfg.clone(), &paths, client)
             } else {
                 RunnerInstance::new_offline(runner_cfg.clone(), &paths)
@@ -217,7 +216,8 @@ impl Supervisor {
                     inst.state.rx_in_flight.clone(),
                     inst.state.shutdown_notified(),
                     attach_body_for_instance(inst),
-                );
+                )
+                .with_state(inst.state.clone());
                 let http_handle = tokio::spawn(async move {
                     if let Err(e) = http_loop.run().await {
                         tracing::error!("http loop exited: {e:#}");
@@ -380,12 +380,16 @@ async fn load_runner_credentials(
         .get("refresh")
         .and_then(|v| v.get("token"))
         .and_then(toml::Value::as_str)
-        .ok_or_else(|| anyhow::anyhow!("runner credentials at {path:?} are missing refresh.token"))?;
+        .ok_or_else(|| {
+            anyhow::anyhow!("runner credentials at {path:?} are missing refresh.token")
+        })?;
     let generation = parsed
         .get("refresh")
         .and_then(|v| v.get("generation"))
         .and_then(toml::Value::as_integer)
-        .ok_or_else(|| anyhow::anyhow!("runner credentials at {path:?} are missing refresh.generation"))?;
+        .ok_or_else(|| {
+            anyhow::anyhow!("runner credentials at {path:?} are missing refresh.generation")
+        })?;
     let runner_id = uuid::Uuid::parse_str(runner_id)
         .map_err(|e| anyhow::anyhow!("invalid runner.id in {path:?}: {e}"))?;
     Ok(CredentialsHandle::new(
@@ -409,8 +413,11 @@ fn attach_body_for_instance(inst: &RunnerInstance) -> AttachBody {
         version: crate::RUNNER_VERSION.to_string(),
         os: std::env::consts::OS.to_string(),
         arch: std::env::consts::ARCH.to_string(),
-        status: PollStatus::from_wire(*inst.state.rx_status.borrow(), *inst.state.rx_in_flight.borrow())
-            .status,
+        status: PollStatus::from_wire(
+            *inst.state.rx_status.borrow(),
+            *inst.state.rx_in_flight.borrow(),
+        )
+        .status,
         in_flight_run: *inst.state.rx_in_flight.borrow(),
         project_slug: inst.config.project_slug.clone(),
         host_label: hostname().unwrap_or_else(|| inst.config.name.clone()),
@@ -448,6 +455,46 @@ async fn refresh_loop(client: RunnerCloudClient, state: StateHandle) {
             tracing::error!(runner_id = %client.runner_id(), "scheduled refresh failed: {e:#}");
         }
     }
+}
+
+/// Spawn a small task that flips `agent_subprocess_alive` to false the
+/// moment the bridge-owned wait task observes the agent subprocess
+/// terminating. Independent of stdout-close detection so a `kill -9`
+/// path that double-forks or otherwise keeps stdout open is still
+/// caught for observability.
+///
+/// Scoped to `run_id`: if a new run has taken over the in-flight slot
+/// by the time this task fires, the alive flag is left alone — the new
+/// run's own watcher owns it. Without this guard, run A's exit could
+/// stamp `alive=false` on run B's snapshot.
+fn spawn_exit_watch(
+    state: StateHandle,
+    run_id: uuid::Uuid,
+    mut exit_rx: tokio::sync::watch::Receiver<Option<crate::agent::ExitSnapshot>>,
+) {
+    tokio::spawn(async move {
+        // A freshly-cloned watch::Receiver marks the current value as
+        // "seen", so changed() only fires on values published *after*
+        // we subscribed. Check borrow() first to catch the case where
+        // the wait task already published Some(ExitSnapshot) before we
+        // got here (e.g. agent binary segfaults on startup).
+        let already_exited = exit_rx.borrow().is_some();
+        if !already_exited {
+            if exit_rx.changed().await.is_err() {
+                return;
+            }
+            if exit_rx.borrow().is_none() {
+                return;
+            }
+        }
+        // Guard: only stamp alive=false if the in-flight run is still
+        // ours. A new run may already have taken over and called
+        // set_agent_alive(true); we must not stomp it.
+        if *state.rx_in_flight.borrow() != Some(run_id) {
+            return;
+        }
+        state.set_agent_alive(false).await;
+    });
 }
 
 fn hostname() -> Option<String> {
@@ -933,6 +980,16 @@ impl AssignWorker {
                 return Ok(());
             }
         };
+        // Capture the bridge-owned process handle now that the subprocess
+        // is spawned. Subscribe to its `exit_rx` so the live-state snapshot
+        // flips `agent_subprocess_alive=false` the moment the wait task
+        // observes termination — independent of stdout-close detection.
+        // See `.ai_design/runner_agent_bridge/design.md` §4.4.
+        let process_handle = bridge.process_handle();
+        self.state.set_agent_pid(process_handle.pid).await;
+        self.state.set_agent_alive(true).await;
+        spawn_exit_watch(self.state.clone(), run_id, process_handle.exit_rx.clone());
+
         let payload = RunPayload {
             run_id,
             prompt,
@@ -1119,6 +1176,31 @@ impl AssignWorker {
         workspace_root: &std::path::Path,
     ) -> Result<Option<Outcome>> {
         self.state.incr_current_run_events().await;
+        // Observability: every bridge event bumps last_event_at + stamps
+        // a structure-only kind/summary. The summary is sanitised inside
+        // `summary_of` — never includes prompt or model output.
+        // Opt-in: extract codex token / turn metrics from Raw frames so
+        // operators see them on the runner-status panel.
+        let kind = crate::daemon::observability::kind_of(&ev);
+        let summary = crate::daemon::observability::summary_of(&ev);
+        self.state
+            .note_agent_event(Utc::now(), kind, Some(summary))
+            .await;
+        if let BridgeEvent::Raw { method, params, .. } = &ev {
+            match method.as_str() {
+                "codex/event/token_count" => {
+                    if let Some(usage) =
+                        crate::daemon::observability::parse_codex_token_count(params)
+                    {
+                        self.state.set_tokens(usage).await;
+                    }
+                }
+                "turn/started" => {
+                    self.state.incr_turn().await;
+                }
+                _ => {}
+            }
+        }
         match ev {
             BridgeEvent::RunStarted { .. } => Ok(None),
             BridgeEvent::Raw {
@@ -1322,8 +1404,8 @@ mod tests {
     use super::*;
     use crate::cloud::protocol::Envelope;
     use crate::config::schema::{
-        AgentSection, ApprovalPolicySection, ClaudeCodeSection, CodexSection,
-        RunnerConfig, WorkspaceSection,
+        AgentSection, ApprovalPolicySection, ClaudeCodeSection, CodexSection, RunnerConfig,
+        WorkspaceSection,
     };
     use std::path::PathBuf;
     use tokio::sync::Notify;
@@ -1558,6 +1640,9 @@ mod tests {
         assert_eq!(sent, 0);
         let stray =
             tokio::time::timeout(std::time::Duration::from_millis(100), out_rx.recv()).await;
-        assert!(stray.is_err(), "idle drain produced a stray frame: {stray:?}");
+        assert!(
+            stray.is_err(),
+            "idle drain produced a stray frame: {stray:?}"
+        );
     }
 }

--- a/runner/src/ipc/protocol.rs
+++ b/runner/src/ipc/protocol.rs
@@ -167,10 +167,7 @@ impl StatusSnapshot {
 impl RunnerStatusSnapshot {
     pub fn print_compact(&self) {
         let project = self.project_slug.as_deref().unwrap_or("(no project)");
-        println!(
-            "  {} — {:?} project={}",
-            self.name, self.status, project
-        );
+        println!("  {} — {:?} project={}", self.name, self.status, project);
         if let Some(run) = &self.current_run {
             println!(
                 "    current run: {} ({}); events={}",

--- a/runner/src/ipc/server.rs
+++ b/runner/src/ipc/server.rs
@@ -226,8 +226,7 @@ impl IpcServer {
                 anyhow::bail!("approval not found or already resolved");
             }
             Request::DoctorRun { runner } => {
-                let report =
-                    crate::cli::doctor::execute(&self.paths, runner.as_deref()).await?;
+                let report = crate::cli::doctor::execute(&self.paths, runner.as_deref()).await?;
                 Ok(Response::Doctor(report))
             }
             Request::RunnerReconnect => {
@@ -274,8 +273,7 @@ impl IpcServer {
     }
 
     fn runner_names(&self) -> Vec<String> {
-        let mut names: Vec<String> =
-            self.instances.values().map(|i| i.name.clone()).collect();
+        let mut names: Vec<String> = self.instances.values().map(|i| i.name.clone()).collect();
         names.sort();
         names
     }

--- a/runner/src/tui/app.rs
+++ b/runner/src/tui/app.rs
@@ -36,12 +36,7 @@ pub enum Tab {
 
 impl Tab {
     pub fn all() -> [Tab; 4] {
-        [
-            Tab::General,
-            Tab::RunnerStatus,
-            Tab::Runs,
-            Tab::Approvals,
-        ]
+        [Tab::General, Tab::RunnerStatus, Tab::Runs, Tab::Approvals]
     }
 
     pub fn label(&self) -> &'static str {
@@ -64,8 +59,8 @@ impl Tab {
         let s = raw.trim().to_ascii_lowercase();
         match s.as_str() {
             "general" | "1" => Some(Tab::General),
-            "runners" | "runner" | "runner-status" | "runner_status" | "status"
-            | "config" | "2" => Some(Tab::RunnerStatus),
+            "runners" | "runner" | "runner-status" | "runner_status" | "status" | "config"
+            | "2" => Some(Tab::RunnerStatus),
             "runs" | "3" => Some(Tab::Runs),
             "approvals" | "4" => Some(Tab::Approvals),
             _ => None,
@@ -635,9 +630,7 @@ async fn handle_event(ev: Event, state: &mut AppState) {
                 .as_ref()
                 .is_some_and(|f| f.active_picker.is_some());
             if picker_open {
-                if key.code == KeyCode::Char('c')
-                    && key.modifiers.contains(KeyModifiers::CONTROL)
-                {
+                if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
                     state.confirm_exit = true;
                     state.confirm_exit_yes = true;
                     return;
@@ -945,9 +938,7 @@ async fn handle_event(ev: Event, state: &mut AppState) {
             // Tab toggles which card on the Runners tab owns input.
             // Shift+Tab does the same flip (only two cards). Anywhere
             // else it's a no-op so global keys aren't surprised.
-            (KeyCode::Tab, _) | (KeyCode::BackTab, _)
-                if state.tab == Tab::RunnerStatus =>
-            {
+            (KeyCode::Tab, _) | (KeyCode::BackTab, _) if state.tab == Tab::RunnerStatus => {
                 state.runner_tab_focus = match state.runner_tab_focus {
                     RunnerTabFocus::RunnerList => RunnerTabFocus::Settings,
                     RunnerTabFocus::Settings => RunnerTabFocus::RunnerList,
@@ -1036,26 +1027,17 @@ async fn handle_event(ev: Event, state: &mut AppState) {
             // wherever a per-runner cursor matters — that's every tab
             // except General now.
             (KeyCode::Char('<') | KeyCode::Char(','), _)
-                if matches!(
-                    state.tab,
-                    Tab::RunnerStatus | Tab::Runs | Tab::Approvals
-                ) =>
+                if matches!(state.tab, Tab::RunnerStatus | Tab::Runs | Tab::Approvals) =>
             {
                 move_picker(state, -1).await;
             }
             (KeyCode::Char('>') | KeyCode::Char('.'), _)
-                if matches!(
-                    state.tab,
-                    Tab::RunnerStatus | Tab::Runs | Tab::Approvals
-                ) =>
+                if matches!(state.tab, Tab::RunnerStatus | Tab::Runs | Tab::Approvals) =>
             {
                 move_picker(state, 1).await;
             }
             (KeyCode::Char(c @ '1'..='9'), KeyModifiers::ALT)
-                if matches!(
-                    state.tab,
-                    Tab::RunnerStatus | Tab::Runs | Tab::Approvals
-                ) =>
+                if matches!(state.tab, Tab::RunnerStatus | Tab::Runs | Tab::Approvals) =>
             {
                 if let Some(d) = c.to_digit(10) {
                     jump_picker(state, (d as usize).saturating_sub(1)).await;
@@ -1104,8 +1086,7 @@ fn start_or_apply_config_field(state: &mut AppState) {
         cfg_view::FieldKind::Bool => cfg_view::toggle_bool(cfg, spec.id, runner_idx),
         cfg_view::FieldKind::Enum(_) => cfg_view::cycle_enum(cfg, spec.id, runner_idx),
         cfg_view::FieldKind::Text | cfg_view::FieldKind::U32 => {
-            state.config_edit_buffer =
-                Some(cfg_view::display_value(cfg, spec.id, runner_idx));
+            state.config_edit_buffer = Some(cfg_view::display_value(cfg, spec.id, runner_idx));
         }
     }
 }
@@ -1314,8 +1295,7 @@ async fn submit_add_runner_form(state: &mut AppState) {
     state.add_runner_form = None;
     // Restart the daemon so the new RunnerInstance is hosted; outcome
     // surfaces in the General tab's banner.
-    state.reload_outcome =
-        Some(crate::service::reload::restart_and_verify(&state.paths).await);
+    state.reload_outcome = Some(crate::service::reload::restart_and_verify(&state.paths).await);
     refresh(state).await;
     // Aim the picker at the freshly-added runner so Config / Runs land
     // on it right away.
@@ -1338,7 +1318,10 @@ async fn submit_remove_runner(state: &mut AppState) {
     let Some(name) = state.remove_runner_confirm.take() else {
         return;
     };
-    let args = crate::cli::runner::RemoveArgs { name: name.clone() };
+    let args = crate::cli::runner::RemoveArgs {
+        name: name.clone(),
+        local_only: false,
+    };
     match crate::cli::runner::remove(args, &state.paths).await {
         Ok(_) => {
             state.reload_outcome =
@@ -1415,13 +1398,7 @@ async fn submit_register_form(state: &mut AppState) {
             return;
         }
     };
-    let resp = match crate::cloud::http::enroll_runner(
-        &transport,
-        &token,
-        &host_label,
-        None,
-    )
-    .await
+    let resp = match crate::cloud::http::enroll_runner(&transport, &token, &host_label, None).await
     {
         Ok(r) => r,
         Err(e) => {
@@ -1439,6 +1416,7 @@ async fn submit_register_form(state: &mut AppState) {
             cloud_url: cloud_url.clone(),
             log_level: "info".to_string(),
             log_retention_days: 14,
+            agent_observability_v1: false,
         },
         runners: vec![crate::config::schema::RunnerConfig {
             name: resp.runner_name.clone(),
@@ -1740,11 +1718,7 @@ fn render_add_runner_form(f: &mut ratatui::Frame<'_>, form: &AddRunnerForm) {
         modal_field_line("Working dir ", &form.working_dir, form.focus == 3),
         Line::raw(""),
     ];
-    let submit_label = if form.busy {
-        " Adding… "
-    } else {
-        " Submit "
-    };
+    let submit_label = if form.busy { " Adding… " } else { " Submit " };
     let submit_style = if form.focus == 4 {
         Style::default()
             .fg(ratatui::style::Color::Black)
@@ -1759,10 +1733,7 @@ fn render_add_runner_form(f: &mut ratatui::Frame<'_>, form: &AddRunnerForm) {
         Span::raw("   "),
         Span::styled(submit_label.to_string(), submit_style),
         Span::raw("   "),
-        Span::styled(
-            "Esc cancel",
-            Style::default().add_modifier(Modifier::DIM),
-        ),
+        Span::styled("Esc cancel", Style::default().add_modifier(Modifier::DIM)),
     ]));
     if let Some(e) = &form.error {
         lines.push(Line::raw(""));
@@ -1773,11 +1744,7 @@ fn render_add_runner_form(f: &mut ratatui::Frame<'_>, form: &AddRunnerForm) {
     }
 
     let p = Paragraph::new(lines)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .title(" Add runner "),
-        )
+        .block(Block::default().borders(Borders::ALL).title(" Add runner "))
         .wrap(ratatui::widgets::Wrap { trim: false });
     f.render_widget(p, area);
 }

--- a/runner/src/tui/views/config.rs
+++ b/runner/src/tui/views/config.rs
@@ -147,10 +147,7 @@ fn runner_at(cfg: &Config, idx: usize) -> Option<&crate::config::schema::RunnerC
     cfg.runners.get(i)
 }
 
-fn runner_at_mut(
-    cfg: &mut Config,
-    idx: usize,
-) -> Option<&mut crate::config::schema::RunnerConfig> {
+fn runner_at_mut(cfg: &mut Config, idx: usize) -> Option<&mut crate::config::schema::RunnerConfig> {
     if cfg.runners.is_empty() {
         return None;
     }
@@ -312,11 +309,8 @@ pub fn cycle_enum(cfg: &mut Config, id: FieldId, runner_idx: usize) {
 /// before. Keys: `<`/`>` cycle, `Alt+1`–`Alt+9` jump.
 pub fn runner_picker_bar(state: &AppState) -> Paragraph<'static> {
     let Some(working) = state.config_working.as_ref() else {
-        return Paragraph::new(Line::raw("")).block(
-            Block::default()
-                .borders(Borders::ALL)
-                .title(" Runners "),
-        );
+        return Paragraph::new(Line::raw(""))
+            .block(Block::default().borders(Borders::ALL).title(" Runners "));
     };
     let total = working.runners.len();
     let picked = state.runner_picker_idx.min(total.saturating_sub(1));
@@ -338,11 +332,11 @@ pub fn runner_picker_bar(state: &AppState) -> Paragraph<'static> {
         "   [<] prev  [>] next  [Alt+1..9] jump".to_string(),
         Style::default().add_modifier(Modifier::DIM),
     ));
-    Paragraph::new(Line::from(spans)).block(
-        Block::default()
-            .borders(Borders::ALL)
-            .title(format!(" Runners ({}/{}) ", picked + 1, total)),
-    )
+    Paragraph::new(Line::from(spans)).block(Block::default().borders(Borders::ALL).title(format!(
+        " Runners ({}/{}) ",
+        picked + 1,
+        total
+    )))
 }
 
 pub fn register_form_lines(state: &AppState) -> Vec<Line<'static>> {
@@ -432,11 +426,7 @@ fn form_field_line(label: &str, value: &str, focused: bool) -> Line<'static> {
 }
 
 fn form_button_line(focused: bool, busy: bool) -> Line<'static> {
-    let label = if busy {
-        " Connecting… "
-    } else {
-        " Connect "
-    };
+    let label = if busy { " Connecting… " } else { " Connect " };
     let style = if focused {
         Style::default()
             .fg(Color::Black)
@@ -581,8 +571,7 @@ fn render_editable_row(
     let modified = loaded
         .as_ref()
         .map(|l| {
-            display_value(l, spec.id, runner_idx)
-                != display_value(working, spec.id, runner_idx)
+            display_value(l, spec.id, runner_idx) != display_value(working, spec.id, runner_idx)
         })
         .unwrap_or(true);
 

--- a/runner/src/tui/views/general.rs
+++ b/runner/src/tui/views/general.rs
@@ -118,10 +118,7 @@ fn connection_card(state: &AppState) -> Paragraph<'_> {
             )]),
             Line::from(format!("Cloud URL: {}", s.daemon.cloud_url)),
             Line::from(format!("Uptime:    {}s", s.daemon.uptime_secs)),
-            Line::from(format!(
-                "Runners:   {} configured",
-                s.runners.len(),
-            )),
+            Line::from(format!("Runners:   {} configured", s.runners.len(),)),
         ],
         None => vec![Line::from(Span::styled(
             "Daemon IPC unreachable.",
@@ -129,11 +126,7 @@ fn connection_card(state: &AppState) -> Paragraph<'_> {
         ))],
     };
     Paragraph::new(lines)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .title(" Connection "),
-        )
+        .block(Block::default().borders(Borders::ALL).title(" Connection "))
         .wrap(Wrap { trim: true })
 }
 
@@ -159,10 +152,7 @@ fn daemon_settings_card(state: &AppState) -> Paragraph<'_> {
         Style::default().fg(Color::Gray)
     };
     let retention_value = if editing {
-        format!(
-            "{}▊",
-            state.config_edit_buffer.as_deref().unwrap_or("")
-        )
+        format!("{}▊", state.config_edit_buffer.as_deref().unwrap_or(""))
     } else {
         cfg.daemon.log_retention_days.to_string()
     };
@@ -180,7 +170,10 @@ fn daemon_settings_card(state: &AppState) -> Paragraph<'_> {
     let marker = |on: bool| if on { "▶" } else { " " };
     lines.push(Line::from(vec![
         Span::styled(
-            format!(" {} log_level         ", marker(state.tab_general_field == GeneralField::LogLevel)),
+            format!(
+                " {} log_level         ",
+                marker(state.tab_general_field == GeneralField::LogLevel)
+            ),
             Style::default().fg(Color::Cyan),
         ),
         Span::styled(cfg.daemon.log_level.clone(), log_level_style),
@@ -195,7 +188,10 @@ fn daemon_settings_card(state: &AppState) -> Paragraph<'_> {
     ]));
     lines.push(Line::from(vec![
         Span::styled(
-            format!(" {} log_retention_days ", marker(state.tab_general_field == GeneralField::LogRetentionDays)),
+            format!(
+                " {} log_retention_days ",
+                marker(state.tab_general_field == GeneralField::LogRetentionDays)
+            ),
             Style::default().fg(Color::Cyan),
         ),
         Span::styled(retention_value, retention_style),

--- a/runner/src/tui/views/runner_status.rs
+++ b/runner/src/tui/views/runner_status.rs
@@ -238,4 +238,3 @@ fn hotkeys_card() -> Paragraph<'static> {
     ]))
     .block(Block::default().borders(Borders::ALL).title(" Controls "))
 }
-

--- a/runner/src/tui/widgets/picker.rs
+++ b/runner/src/tui/widgets/picker.rs
@@ -197,7 +197,12 @@ impl Picker {
             ])
             .split(popup);
 
-        let title = format!(" {} ({} of {}) ", self.title, self.filtered.len(), self.rows.len());
+        let title = format!(
+            " {} ({} of {}) ",
+            self.title,
+            self.filtered.len(),
+            self.rows.len()
+        );
         let filter_line = if self.filter.is_empty() {
             Line::from(Span::styled(
                 "type to filter — ↑/↓ move — Enter select — Esc cancel",
@@ -233,10 +238,7 @@ impl Picker {
             })
             .collect();
         let list = List::new(items)
-            .block(
-                Block::default()
-                    .borders(Borders::BOTTOM | Borders::LEFT | Borders::RIGHT),
-            )
+            .block(Block::default().borders(Borders::BOTTOM | Borders::LEFT | Borders::RIGHT))
             // Leading symbol + REVERSED + BOLD so the cursor is
             // unambiguous on every terminal theme — REVERSED-only is
             // hard to spot against some palettes.


### PR DESCRIPTION
Cherry-pick of PR #98's squash commit. Originally merged into feat/move-to-https because its base hadn't auto-retargeted when #94 landed; this brings the same content to main as a single commit against the post-#94 squash.