### PR TITLE
feat(cli): add `pidash issue create`

### DIFF
--- a/runner/src/cli/issue.rs
+++ b/runner/src/cli/issue.rs
@@ -111,6 +111,9 @@ async fn cmd_get(client: &ApiClient, identifier: &str) -> Result<(), CliError> {
 }
 
 async fn cmd_create(client: &ApiClient, args: CreateArgs) -> Result<(), CliError> {
+    if args.project.trim().is_empty() {
+        return Err(CliError::new(EXIT_INVALID, "--project must not be empty"));
+    }
     if args.title.trim().is_empty() {
         return Err(CliError::new(EXIT_INVALID, "--title must not be empty"));
     }

--- a/runner/src/cli/issue.rs
+++ b/runner/src/cli/issue.rs
@@ -27,8 +27,35 @@ pub enum IssueCommand {
         /// Project-scoped identifier, e.g. `ENG-42`.
         identifier: String,
     },
+    /// Create a new work item under a project. `--project` is required — the CLI
+    /// is machine-global and intentionally has no default project, so the caller
+    /// must always name one (slug like `ENG` or a project UUID).
+    Create(CreateArgs),
     /// Update fields on a work item. Pass only the fields you want to change.
     Patch(PatchArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct CreateArgs {
+    /// Project identifier (slug like `ENG`) or project UUID.
+    #[arg(long)]
+    pub project: String,
+
+    /// Title (required).
+    #[arg(long)]
+    pub title: String,
+
+    /// Description (plain text or markdown).
+    #[arg(long)]
+    pub description: Option<String>,
+
+    /// Priority: `none|low|medium|high|urgent`.
+    #[arg(long)]
+    pub priority: Option<String>,
+
+    /// Initial state — exact state name (case-insensitive) or a state UUID.
+    #[arg(long)]
+    pub state: Option<String>,
 }
 
 #[derive(Debug, Args)]
@@ -65,6 +92,7 @@ pub async fn run(args: IssueArgs, paths: &crate::util::paths::Paths) -> i32 {
 
     let result = match args.command {
         IssueCommand::Get { identifier } => cmd_get(&client, &identifier).await,
+        IssueCommand::Create(a) => cmd_create(&client, a).await,
         IssueCommand::Patch(p) => cmd_patch(&client, p).await,
     };
     match result {
@@ -78,6 +106,45 @@ async fn cmd_get(client: &ApiClient, identifier: &str) -> Result<(), CliError> {
     println!(
         "{}",
         serde_json::to_string(&issue.raw).expect("serialize JSON value")
+    );
+    Ok(())
+}
+
+async fn cmd_create(client: &ApiClient, args: CreateArgs) -> Result<(), CliError> {
+    if args.title.trim().is_empty() {
+        return Err(CliError::new(EXIT_INVALID, "--title must not be empty"));
+    }
+
+    // Pass `--project` straight through. The backend accepts either a UUID or
+    // a workspace-scoped slug in the URL path, so the CLI no longer pre-resolves
+    // it. The same value seeds the state-name resolution URL below.
+    let project_ref = args.project.as_str();
+
+    let mut body: Map<String, Value> = Map::new();
+    body.insert("name".into(), Value::String(args.title));
+    if let Some(desc) = args.description {
+        body.insert("description".into(), Value::String(desc));
+    }
+    if let Some(prio) = args.priority {
+        body.insert("priority".into(), Value::String(prio));
+    }
+    if let Some(state) = args.state {
+        let uuid = if looks_like_uuid(&state) {
+            state
+        } else {
+            resolve_state_name(client, project_ref, &state).await?
+        };
+        body.insert("state".into(), Value::String(uuid));
+    }
+
+    let path = format!(
+        "workspaces/{}/projects/{}/work-items/",
+        client.env.workspace_slug, project_ref
+    );
+    let resp = client.post(&path, &Value::Object(body)).await?;
+    println!(
+        "{}",
+        serde_json::to_string(&resp).expect("serialize JSON value")
     );
     Ok(())
 }

--- a/runner/src/cli/resolve.rs
+++ b/runner/src/cli/resolve.rs
@@ -16,6 +16,10 @@ use serde_json::Value;
 
 use crate::api_client::{ApiClient, CliError, EXIT_INVALID, EXIT_NOT_FOUND, EXIT_SERVER};
 
+// Note: there is no `resolve_project` helper. Project-scoped REST routes
+// accept either a UUID or the workspace-scoped slug ("ENG") in the URL path,
+// so callers pass the user-supplied `--project` value straight through.
+
 /// Issue resolved from a `<PROJ>-<num>` identifier.
 #[derive(Debug, Clone)]
 pub struct ResolvedIssue {


### PR DESCRIPTION
## Summary
- Adds `pidash issue create --project <SLUG|UUID> --title "..." [--description] [--priority] [--state]` to create a project-scoped work item from the CLI.
- `--project` is required — the CLI is machine-global and intentionally has no default project, so callers must always name one.
- `--state` reuses the existing `resolve_state_name(client, project_ref, ...)` helper, so name-or-UUID works the same as on `issue patch`.
- Adds a short note in `resolve.rs` explaining why there's no `resolve_project` helper: project-scoped REST routes accept either a UUID or the workspace-scoped slug, so the CLI passes `--project` straight through.

## Stacked on #112
This PR is **stacked on top of #112** (`feat(api): accept project slug or UUID across all project-scoped routes`).

- Base: `api/project-slug-or-id` (will auto-retarget to `main` once #112 merges).
- The diff shown here is only the Rust CLI delta; the Python API changes belong to #112.
- `--project <SLUG>` requires #112 to be merged. `--project <UUID>` works against `main` today.

**Merge order: #112 first, then this.**

## Test plan
- [ ] `cargo build -p pi-dash-runner`
- [ ] Manual: `pidash issue create --project <UUID> --title "smoke"` returns the created work-item JSON on stdout, exit 0
- [ ] Manual: `--title ""` exits with `EXIT_INVALID` and an error on stderr
- [ ] Manual: `--state "In Progress"` resolves to a UUID via `resolve_state_name` and is sent in the body
- [ ] After #112 merges: re-run with `--project ENG` and confirm slug routing works