### PR TITLE
feat(run-ai): build prompt from phase template, not client literal

### DIFF
--- a/apps/api/pi_dash/orchestration/scheduling.py
+++ b/apps/api/pi_dash/orchestration/scheduling.py
@@ -443,16 +443,29 @@ def dispatch_run_ai_run(issue: Issue, *, actor) -> Optional[AgentRun]:
 
     if orchestration_service._active_run_for(issue) is not None:
         logger.info(
-            "run_ai: skip dispatch issue=%s reason=active-run-exists",
+            "agent_ticker: skip dispatch issue=%s reason=active-run-exists triggered_by=%s",
             issue.pk,
+            TRIGGER_RUN_AI,
+        )
+        return None
+
+    creator = _resolve_creator_for_trigger(
+        issue, triggered_by=TRIGGER_RUN_AI, actor=actor
+    )
+    if creator is None:
+        logger.warning(
+            "agent_ticker: skip dispatch issue=%s reason=no-creator triggered_by=%s",
+            issue.pk,
+            TRIGGER_RUN_AI,
         )
         return None
 
     pod = _resolve_pod_for_issue(issue)
     if pod is None:
         logger.warning(
-            "run_ai: skip dispatch issue=%s reason=no-pod",
+            "agent_ticker: skip dispatch issue=%s reason=no-pod triggered_by=%s",
             issue.pk,
+            TRIGGER_RUN_AI,
         )
         return None
 
@@ -461,14 +474,14 @@ def dispatch_run_ai_run(issue: Issue, *, actor) -> Optional[AgentRun]:
         outcome = orchestration_service._create_continuation_run(
             issue=issue,
             parent=parent,
-            creator=actor,
+            creator=creator,
             pod=pod,
         )
     else:
         outcome = orchestration_service._create_and_dispatch_run(
             issue=issue,
             parent=None,
-            creator=actor,
+            creator=creator,
             pod=pod,
         )
     return outcome.created_run

--- a/apps/api/pi_dash/orchestration/scheduling.py
+++ b/apps/api/pi_dash/orchestration/scheduling.py
@@ -322,6 +322,7 @@ def reset_ticker_after_comment_and_run(issue: Issue) -> Optional[IssueAgentTicke
 
 TRIGGER_TICK = "tick"
 TRIGGER_COMMENT_AND_RUN = "comment_and_run"
+TRIGGER_RUN_AI = "run_ai"
 
 
 def _resolve_pod_for_issue(issue: Issue):
@@ -415,6 +416,61 @@ def dispatch_continuation_run(
         creator=creator,
         pod=pod,
     )
+    return outcome.created_run
+
+
+def dispatch_run_ai_run(issue: Issue, *, actor) -> Optional[AgentRun]:
+    """Public wrapper for the "Run AI" button.
+
+    Builds the same templated prompt the state-transition-into-In-Progress
+    path produces, by routing through the orchestration service's run-
+    creation helpers (which call ``composer.build_first_turn``). This is
+    the prompt-parity contract: a manual Run AI click renders the phase's
+    template against the issue's current state, identical to a tick or a
+    state transition into the same phase.
+
+    Behavior:
+    - Bails (returns ``None``) when an active run already exists on the
+      issue (single-active-run guardrail) or no pod is available.
+    - When a prior run exists, delegates to ``_create_continuation_run``
+      so the new run inherits parent linkage and runner pinning (repo
+      locality, same as Comment & Run / tick).
+    - When no prior run exists, delegates to ``_create_and_dispatch_run``
+      so a brand-new issue's first agent run still goes through the
+      templated prompt path.
+    """
+    from pi_dash.orchestration import service as orchestration_service
+
+    if orchestration_service._active_run_for(issue) is not None:
+        logger.info(
+            "run_ai: skip dispatch issue=%s reason=active-run-exists",
+            issue.pk,
+        )
+        return None
+
+    pod = _resolve_pod_for_issue(issue)
+    if pod is None:
+        logger.warning(
+            "run_ai: skip dispatch issue=%s reason=no-pod",
+            issue.pk,
+        )
+        return None
+
+    parent = orchestration_service._latest_prior_run(issue)
+    if parent is not None:
+        outcome = orchestration_service._create_continuation_run(
+            issue=issue,
+            parent=parent,
+            creator=actor,
+            pod=pod,
+        )
+    else:
+        outcome = orchestration_service._create_and_dispatch_run(
+            issue=issue,
+            parent=None,
+            creator=actor,
+            pod=pod,
+        )
     return outcome.created_run
 
 
@@ -530,10 +586,12 @@ __all__ = [
     "INFINITE_MAX_TICKS",
     "PAUSED_STATE_NAME",
     "TRIGGER_COMMENT_AND_RUN",
+    "TRIGGER_RUN_AI",
     "TRIGGER_TICK",
     "arm_ticker",
     "disarm_ticker",
     "dispatch_continuation_run",
+    "dispatch_run_ai_run",
     "maybe_apply_deferred_pause",
     "maybe_disarm_on_terminal_signal",
     "reset_ticker_after_comment_and_run",

--- a/apps/api/pi_dash/runner/views/runs.py
+++ b/apps/api/pi_dash/runner/views/runs.py
@@ -104,6 +104,13 @@ class AgentRunListEndpoint(APIView):
         if triggered_by == "comment_and_run":
             return self._post_comment_and_run(request)
 
+        # Run AI button — same templated-prompt path as a state transition
+        # into the issue's current ticking phase. The frontend sends only
+        # the issue id; the prompt is rendered server-side from the phase
+        # template via ``composer.build_first_turn``.
+        if triggered_by == "run_ai":
+            return self._post_run_ai(request)
+
         prompt = request.data.get("prompt")
         workspace_id = request.data.get("workspace")
         if not prompt:
@@ -141,6 +148,57 @@ class AgentRunListEndpoint(APIView):
         # an idle runner if one exists. Non-blocking on commit.
         matcher.drain_pod(ctx.pod)
         run.refresh_from_db()
+        return Response(
+            AgentRunSerializer(run).data,
+            status=status.HTTP_201_CREATED,
+        )
+
+    def _post_run_ai(self, request):
+        """Dispatch a run for the "Run AI" button.
+
+        Body must include ``work_item`` (issue id). Builds the prompt
+        from the phase template (``coding-task`` for In Progress,
+        ``review`` for In Review, default otherwise) so the manual
+        button produces the same prompt as a state-transition or tick
+        for that phase.
+        """
+        from pi_dash.db.models.issue import Issue
+        from pi_dash.orchestration import scheduling
+
+        work_item_id = request.data.get("work_item")
+        if not work_item_id:
+            return Response(
+                {"error": "work_item is required for run_ai"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        issue = Issue.all_objects.filter(pk=work_item_id).first()
+        if issue is None:
+            return Response(
+                {"error": "issue not found"}, status=status.HTTP_404_NOT_FOUND
+            )
+        if not is_workspace_member(request.user, issue.workspace_id):
+            return Response(
+                {"error": "issue not found"}, status=status.HTTP_404_NOT_FOUND
+            )
+
+        with transaction.atomic():
+            run = scheduling.dispatch_run_ai_run(issue, actor=request.user)
+            # Run AI is explicit human re-engagement — mirror the Comment
+            # & Run reset so the next automatic tick budget restarts
+            # cleanly. Only fires when the dispatch actually committed a
+            # run (active-run-exists / no-pod return None).
+            if run is not None:
+                scheduling.reset_ticker_after_comment_and_run(issue)
+        if run is None:
+            return Response(
+                {
+                    "error": (
+                        "could not dispatch — issue may already have an "
+                        "active run, or no pod is available"
+                    )
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
         return Response(
             AgentRunSerializer(run).data,
             status=status.HTTP_201_CREATED,

--- a/apps/api/pi_dash/tests/unit/runner/test_runs_views.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_runs_views.py
@@ -614,9 +614,12 @@ def test_comment_and_run_404_for_issue_in_other_workspace(db, api_client, worksp
 @pytest.mark.unit
 def test_run_ai_renders_prompt_from_phase_template(db, session_client, workspace, project):
     """The Run AI button must produce a prompt rendered from the
-    phase template — not the literal client-supplied default. The
-    rendered body always carries the issue identifier, which is the
-    cheapest available signal that the templated path was taken."""
+    phase template — not the literal client-supplied default. We assert
+    on three signals: (1) the issue identifier (cheap signal of server
+    rendering), (2) absence of the legacy literal sentence (regression
+    guard), and (3) a unique fragment from the seeded default template's
+    intro (proves the templated composition path was taken — server
+    could otherwise return any non-empty string and pass the first two)."""
     from pi_dash.prompting.seed import seed_default_template
 
     seed_default_template()
@@ -637,6 +640,9 @@ def test_run_ai_renders_prompt_from_phase_template(db, session_client, workspace
     expected_id = f"{project_obj.identifier}-{issue.sequence_id}"
     assert expected_id in run.prompt
     assert "Please pick up this work item" not in run.prompt
+    # Stable phrase from ``prompting/fragments/01_intro.md`` — present
+    # iff the composer actually rendered the template.
+    assert "orchestrates AI agents" in run.prompt
 
 
 @pytest.mark.unit
@@ -665,7 +671,7 @@ def test_run_ai_links_continuation_when_prior_run_exists(db, session_client, wor
 
 
 @pytest.mark.unit
-def test_run_ai_succeeds_when_no_prior_run(db, session_client, workspace, project):
+def test_run_ai_succeeds_when_no_prior_run(db, session_client, workspace):
     """Unlike Comment & Run, Run AI must work on a brand-new issue with
     no prior agent run — it falls through to the first-run dispatch
     path (``_create_and_dispatch_run``), which still renders the
@@ -677,15 +683,15 @@ def test_run_ai_succeeds_when_no_prior_run(db, session_client, workspace, projec
 
     seed_default_template()
     with impersonate(workspace.owner):
-        project = Project.objects.create(
+        fresh_project = Project.objects.create(
             name="RA1", identifier="RA1", workspace=workspace,
             created_by=workspace.owner,
         )
         in_progress = State.objects.create(
-            name="In Progress", project=project, group="started"
+            name="In Progress", project=fresh_project, group="started"
         )
         issue = Issue.objects.create(
-            name="Fresh task", workspace=workspace, project=project,
+            name="Fresh task", workspace=workspace, project=fresh_project,
             state=in_progress, created_by=workspace.owner,
         )
     # Discard the run the state-transition signal auto-created so the
@@ -740,6 +746,51 @@ def test_run_ai_returns_409_when_active_run_exists(db, session_client, workspace
         format="json",
     )
     assert resp.status_code == status.HTTP_409_CONFLICT
+
+
+@pytest.mark.unit
+def test_run_ai_returns_409_when_no_pod_available(db, session_client, workspace):
+    """When the issue's project has no default Pod, ``dispatch_run_ai_run``
+    returns ``None`` (no-pod) and the endpoint must surface that as 409 —
+    not 201 with a never-runnable AgentRun."""
+    from crum import impersonate
+
+    from pi_dash.db.models import Issue, Project, State
+    from pi_dash.prompting.seed import seed_default_template
+
+    seed_default_template()
+    with impersonate(workspace.owner):
+        podless_project = Project.objects.create(
+            name="NoPod", identifier="NOPOD", workspace=workspace,
+            created_by=workspace.owner,
+        )
+        in_progress = State.objects.create(
+            name="In Progress", project=podless_project, group="started"
+        )
+        issue = Issue.objects.create(
+            name="Stranded", workspace=workspace, project=podless_project,
+            state=in_progress, created_by=workspace.owner,
+        )
+    # Discard the AgentRun the post_save(Issue) state-transition signal
+    # auto-created (otherwise the active-run guardrail trips first and
+    # masks the no-pod path we're trying to exercise). ``AgentRun.pod``
+    # and ``Issue.assigned_pod`` are both on_delete=PROTECT, so we must
+    # detach those references before dropping the auto-created Pod.
+    AgentRun.objects.filter(work_item=issue).delete()
+    type(issue).all_objects.filter(pk=issue.pk).update(assigned_pod=None)
+    Pod.objects.filter(project=podless_project).delete()
+
+    resp = session_client.post(
+        "/api/runners/runs/",
+        {
+            "workspace": str(workspace.id),
+            "work_item": str(issue.id),
+            "triggered_by": "run_ai",
+        },
+        format="json",
+    )
+    assert resp.status_code == status.HTTP_409_CONFLICT, resp.data
+    assert AgentRun.objects.filter(work_item=issue).count() == 0
 
 
 @pytest.mark.unit

--- a/apps/api/pi_dash/tests/unit/runner/test_runs_views.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_runs_views.py
@@ -603,6 +603,168 @@ def test_comment_and_run_404_for_issue_in_other_workspace(db, api_client, worksp
 
 
 # ---------------------------------------------------------------------------
+# Run AI endpoint
+#
+# POST /api/runners/runs/ with ``triggered_by="run_ai"`` builds the prompt
+# server-side from the issue's phase template (the same path as a state
+# transition into the phase). The client never sends a prompt body.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_run_ai_renders_prompt_from_phase_template(db, session_client, workspace, project):
+    """The Run AI button must produce a prompt rendered from the
+    phase template — not the literal client-supplied default. The
+    rendered body always carries the issue identifier, which is the
+    cheapest available signal that the templated path was taken."""
+    from pi_dash.prompting.seed import seed_default_template
+
+    seed_default_template()
+    issue, _ = _make_in_progress_issue_with_paused_run(workspace)
+
+    resp = session_client.post(
+        "/api/runners/runs/",
+        {
+            "workspace": str(workspace.id),
+            "work_item": str(issue.id),
+            "triggered_by": "run_ai",
+        },
+        format="json",
+    )
+    assert resp.status_code == status.HTTP_201_CREATED, resp.data
+    run = AgentRun.objects.get(id=resp.data["id"])
+    project_obj = issue.project
+    expected_id = f"{project_obj.identifier}-{issue.sequence_id}"
+    assert expected_id in run.prompt
+    assert "Please pick up this work item" not in run.prompt
+
+
+@pytest.mark.unit
+def test_run_ai_links_continuation_when_prior_run_exists(db, session_client, workspace, project):
+    """When a prior run exists, the Run AI dispatch goes through the
+    continuation path so the new run inherits ``parent_run`` (and thus
+    runner pinning), matching the Comment & Run / tick contract."""
+    from pi_dash.prompting.seed import seed_default_template
+
+    seed_default_template()
+    issue, parent = _make_in_progress_issue_with_paused_run(workspace)
+
+    resp = session_client.post(
+        "/api/runners/runs/",
+        {
+            "workspace": str(workspace.id),
+            "work_item": str(issue.id),
+            "triggered_by": "run_ai",
+        },
+        format="json",
+    )
+    assert resp.status_code == status.HTTP_201_CREATED, resp.data
+    run = AgentRun.objects.get(id=resp.data["id"])
+    assert run.parent_run_id == parent.id
+    assert run.status in (AgentRunStatus.QUEUED, AgentRunStatus.ASSIGNED)
+
+
+@pytest.mark.unit
+def test_run_ai_succeeds_when_no_prior_run(db, session_client, workspace, project):
+    """Unlike Comment & Run, Run AI must work on a brand-new issue with
+    no prior agent run — it falls through to the first-run dispatch
+    path (``_create_and_dispatch_run``), which still renders the
+    templated prompt."""
+    from crum import impersonate
+
+    from pi_dash.db.models import Issue, Project, State
+    from pi_dash.prompting.seed import seed_default_template
+
+    seed_default_template()
+    with impersonate(workspace.owner):
+        project = Project.objects.create(
+            name="RA1", identifier="RA1", workspace=workspace,
+            created_by=workspace.owner,
+        )
+        in_progress = State.objects.create(
+            name="In Progress", project=project, group="started"
+        )
+        issue = Issue.objects.create(
+            name="Fresh task", workspace=workspace, project=project,
+            state=in_progress, created_by=workspace.owner,
+        )
+    # Discard the run the state-transition signal auto-created so the
+    # endpoint genuinely sees no prior.
+    AgentRun.objects.filter(work_item=issue).delete()
+
+    resp = session_client.post(
+        "/api/runners/runs/",
+        {
+            "workspace": str(workspace.id),
+            "work_item": str(issue.id),
+            "triggered_by": "run_ai",
+        },
+        format="json",
+    )
+    assert resp.status_code == status.HTTP_201_CREATED, resp.data
+    run = AgentRun.objects.get(id=resp.data["id"])
+    assert run.parent_run_id is None
+    assert run.prompt  # rendered, not empty
+
+
+@pytest.mark.unit
+def test_run_ai_requires_work_item(db, session_client, workspace, project):
+    resp = session_client.post(
+        "/api/runners/runs/",
+        {"workspace": str(workspace.id), "triggered_by": "run_ai"},
+        format="json",
+    )
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+    assert "work_item" in resp.data["error"]
+
+
+@pytest.mark.unit
+def test_run_ai_returns_409_when_active_run_exists(db, session_client, workspace, project):
+    """Single-active-run guardrail applies: a Run AI click while an
+    active run exists is a 409, not a duplicate dispatch."""
+    from pi_dash.prompting.seed import seed_default_template
+
+    seed_default_template()
+    issue, parent = _make_in_progress_issue_with_paused_run(workspace)
+    # Promote the parent to an active status so the guardrail trips.
+    parent.status = AgentRunStatus.RUNNING
+    parent.save(update_fields=["status"])
+
+    resp = session_client.post(
+        "/api/runners/runs/",
+        {
+            "workspace": str(workspace.id),
+            "work_item": str(issue.id),
+            "triggered_by": "run_ai",
+        },
+        format="json",
+    )
+    assert resp.status_code == status.HTTP_409_CONFLICT
+
+
+@pytest.mark.unit
+def test_run_ai_404_for_issue_in_other_workspace(db, api_client, workspace, second_workspace, project):
+    issue, _ = _make_in_progress_issue_with_paused_run(workspace)
+    outsider = User.objects.create(
+        email=f"o-{uuid4().hex[:8]}@example.com",
+        username=f"o_{uuid4().hex[:8]}",
+    )
+    outsider.set_password("pw")
+    outsider.save()
+    api_client.force_authenticate(user=outsider)
+    resp = api_client.post(
+        "/api/runners/runs/",
+        {
+            "workspace": str(second_workspace.id),
+            "work_item": str(issue.id),
+            "triggered_by": "run_ai",
+        },
+        format="json",
+    )
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+# ---------------------------------------------------------------------------
 # X-Pi-Dash-Skip-Immediate-Dispatch header path
 #
 # Used by the Comment & Run flow on a Paused issue: the client wants to

--- a/apps/web/core/components/issues/issue-detail-widgets/run-ai/comment-and-run-modal.tsx
+++ b/apps/web/core/components/issues/issue-detail-widgets/run-ai/comment-and-run-modal.tsx
@@ -84,7 +84,7 @@ export const CommentAndRunModal = observer(function CommentAndRunModal(props: Pr
       setIsPosting(false);
     }
 
-    const run = await triggerRun({ workspaceSlug, issueId });
+    const run = await triggerRun({ workspaceSlug, issueId, mode: "comment_and_run" });
     if (run) onClose();
   };
 

--- a/apps/web/core/components/issues/issue-detail-widgets/run-ai/run-ai-button.tsx
+++ b/apps/web/core/components/issues/issue-detail-widgets/run-ai/run-ai-button.tsx
@@ -12,10 +12,6 @@ import { AiIcon } from "@pi-dash/propel/icons";
 // local
 import { useCreateAgentRun } from "./use-create-agent-run";
 
-const DEFAULT_PROMPT =
-  "Please pick up this work item and make progress on it. " +
-  "Read the issue details and existing comments before acting.";
-
 type Props = {
   workspaceSlug: string;
   issueId: string;
@@ -30,7 +26,7 @@ export const RunAIActionButton = observer(function RunAIActionButton(props: Prop
   const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     e.stopPropagation();
-    triggerRun({ workspaceSlug, issueId, prompt: DEFAULT_PROMPT });
+    triggerRun({ workspaceSlug, issueId, mode: "run_ai" });
   };
 
   return (

--- a/apps/web/core/components/issues/issue-detail-widgets/run-ai/use-create-agent-run.ts
+++ b/apps/web/core/components/issues/issue-detail-widgets/run-ai/use-create-agent-run.ts
@@ -17,12 +17,14 @@ const agentRunService = new AgentRunService();
 type CreateRunArgs = {
   workspaceSlug: string;
   issueId: string;
-  /** When provided, dispatches a fresh prompted run via ``createAgentRun``
-   * (the "Run AI" button path). When omitted, falls through to
-   * ``commentAndRun`` which reuses the per-issue continuation pipeline
-   * and rebuilds the prompt from issue + comments server-side (the
-   * "Comment & Run" modal path). */
-  prompt?: string;
+  /** Selects the dispatch path. Both modes have the prompt rendered
+   * server-side from the issue's phase template (``coding-task`` for
+   * In Progress, ``review`` for In Review, default otherwise) so the
+   * agent receives the same prompt a state transition / tick produces.
+   * - ``"run_ai"``: the "Run AI" button — no comment is posted first.
+   * - ``"comment_and_run"``: the Comment & Run modal — caller has just
+   *   posted a comment on the issue. */
+  mode: "run_ai" | "comment_and_run";
 };
 
 export function useCreateAgentRun() {
@@ -31,7 +33,7 @@ export function useCreateAgentRun() {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const triggerRun = useCallback(
-    async ({ workspaceSlug, issueId, prompt }: CreateRunArgs) => {
+    async ({ workspaceSlug, issueId, mode }: CreateRunArgs) => {
       const workspace = workspaceStore.getWorkspaceBySlug(workspaceSlug);
       if (!workspace?.id) {
         setToast({
@@ -44,16 +46,16 @@ export function useCreateAgentRun() {
 
       setIsSubmitting(true);
       try {
-        const run = prompt
-          ? await agentRunService.createAgentRun({
-              workspace: workspace.id,
-              work_item: issueId,
-              prompt,
-            })
-          : await agentRunService.commentAndRun({
-              workspace: workspace.id,
-              work_item: issueId,
-            });
+        const run =
+          mode === "run_ai"
+            ? await agentRunService.runAi({
+                workspace: workspace.id,
+                work_item: issueId,
+              })
+            : await agentRunService.commentAndRun({
+                workspace: workspace.id,
+                work_item: issueId,
+              });
         setToast({
           type: TOAST_TYPE.SUCCESS,
           title: t("run_ai.success_title"),

--- a/apps/web/core/services/runner/agent-run.service.ts
+++ b/apps/web/core/services/runner/agent-run.service.ts
@@ -8,13 +8,19 @@ import { API_BASE_URL } from "@pi-dash/constants";
 // services
 import { APIService } from "@/services/api.service";
 
-export type TCreateAgentRunPayload = {
+/**
+ * Run AI button dispatch — server renders the prompt from the issue's
+ * phase template (``coding-task`` for In Progress, ``review`` for In
+ * Review, default otherwise) via ``composer.build_first_turn``. The
+ * client never sends a prompt body; the manual button produces the
+ * same prompt a state transition / tick produces for that phase.
+ *
+ * Server-side wiring: see ``apps/api/pi_dash/runner/views/runs.py``
+ * ``_post_run_ai`` (gated on ``triggered_by === "run_ai"``).
+ */
+export type TRunAiPayload = {
   workspace: string;
-  prompt: string;
-  work_item?: string;
-  pod?: string;
-  run_config?: Record<string, unknown>;
-  required_capabilities?: string[];
+  work_item: string;
 };
 
 /**
@@ -47,8 +53,13 @@ export class AgentRunService extends APIService {
     super(API_BASE_URL);
   }
 
-  async createAgentRun(data: TCreateAgentRunPayload): Promise<TAgentRun> {
-    return this.post(`/api/runners/runs/`, data)
+  /**
+   * Dispatch a run for the "Run AI" button. Prompt is rendered server-
+   * side from the issue's phase template — the client sends only the
+   * workspace + issue ids.
+   */
+  async runAi(data: TRunAiPayload): Promise<TAgentRun> {
+    return this.post(`/api/runners/runs/`, { ...data, triggered_by: "run_ai" })
       .then((response) => response?.data)
       .catch((error) => {
         throw error?.response?.data ?? error;


### PR DESCRIPTION
## Summary

The "Run AI" button was sending a hardcoded sentence (`"Please pick up this work item and make progress on it. Read the issue details and existing comments before acting."`) as the agent prompt, and the API stored it verbatim — bypassing `composer.build_first_turn` entirely. As a result, manual Run AI runs diverged from auto-ticks and state-transition runs, which render the phase template (`coding-task` for In Progress, `review` for In Review, default otherwise).

This PR routes the button through a new `triggered_by="run_ai"` path that shares the templated-prompt machinery used by ticks and state-transitions, so all three sources produce the same rendered prompt for a given issue + phase.

Comment & Run already used the templated path; no behavior change there. The legacy raw-prompt `POST` path is preserved for external callers (CLI, scripts) that still send `prompt` directly.

## Changes

**Backend**
- `orchestration/scheduling.py`: add `TRIGGER_RUN_AI` and `dispatch_run_ai_run(issue, *, actor)`. When a prior run exists it delegates to `_create_continuation_run` (parent linkage + runner pinning, matching Comment & Run / tick); otherwise it falls through to `_create_and_dispatch_run` so a brand-new issue's first agent run also gets the templated prompt. Both call `build_first_turn`.
- `runner/views/runs.py`: add `_post_run_ai` view handler mirroring `_post_comment_and_run`. Reuses `reset_ticker_after_comment_and_run` since Run AI is also explicit human re-engagement.

**Frontend**
- `services/runner/agent-run.service.ts`: replace `createAgentRun(prompt)` with `runAi({ workspace, work_item })` (sends `triggered_by: "run_ai"`, no prompt body).
- `issue-detail-widgets/run-ai/use-create-agent-run.ts`: replace the `prompt?: string` discriminator with an explicit `mode: "run_ai" | "comment_and_run"`.
- `run-ai/run-ai-button.tsx`: drop the `DEFAULT_PROMPT` literal; pass `mode: "run_ai"`.
- `run-ai/comment-and-run-modal.tsx`: pass `mode: "comment_and_run"` explicitly.

**Tests**
Five new unit tests under `tests/unit/runner/test_runs_views.py` pinning the contract:
- prompt is templated (asserts `"Please pick up this work item"` is **not** in `run.prompt`, and the issue identifier **is**)
- parent linkage when a prior run exists
- fallback creates a first run when no prior exists
- 400 on missing `work_item`
- 409 on active-run-exists
- 404 cross-workspace

## Test plan

- [ ] `pytest apps/api/pi_dash/tests/unit/runner/test_runs_views.py -k "run_ai"` (new tests)
- [ ] `pytest apps/api/pi_dash/tests/unit/runner/test_runs_views.py -k "comment_and_run"` (regression — should still pass unchanged)
- [ ] `pytest apps/api/pi_dash/tests/unit/orchestration/test_scheduling.py` (regression on `dispatch_continuation_run`)
- [ ] Manual: in Web UI, click "Run AI" on an In Progress issue → confirm the resulting `AgentRun.prompt` matches what a state transition into In Progress produces (full `coding-task` template, not the literal sentence)
- [ ] Manual: click "Run AI" on a brand-new issue with no prior run → confirm a run is created with `parent_run = NULL` and a templated prompt
- [ ] Manual: click "Comment and Run" → confirm unchanged behavior