### PR TITLE
feat(runner): revoke + revive without losing the runner row

### DIFF
--- a/apps/api/pi_dash/runner/services/permissions.py
+++ b/apps/api/pi_dash/runner/services/permissions.py
@@ -52,3 +52,15 @@ def is_at_least_member(user, workspace_id) -> bool:
     """True if ``user`` is at least Member role (>=15) — not Guest."""
     role = workspace_role(user, workspace_id)
     return role is not None and role >= ROLE_MEMBER
+
+
+def can_manage_runner(user, runner) -> bool:
+    """True if ``user`` owns the runner or is admin of its workspace.
+
+    Shared by the runner views so revoke/revive/delete/patch all gate on
+    the same rule. Duck-typed on ``runner.owner_id`` / ``runner.workspace_id``
+    to avoid an import-time dependency on the Runner model.
+    """
+    return runner.owner_id == user.id or is_workspace_admin(
+        user, runner.workspace_id
+    )

--- a/apps/api/pi_dash/runner/views/__init__.py
+++ b/apps/api/pi_dash/runner/views/__init__.py
@@ -9,6 +9,7 @@ from .enrollment import (
     RunnerEnrollEndpoint,
     RunnerInviteEndpoint,
     RunnerRefreshEndpoint,
+    RunnerReviveEndpoint,
     RunnerSelfRevokeEndpoint,
 )
 from .metrics import MetricsEndpoint
@@ -28,7 +29,11 @@ from .run_endpoints import (
     RunStartedEndpoint,
     RunStreamUpgradeEndpoint,
 )
-from .runners import RunnerDetailEndpoint, RunnerListEndpoint
+from .runners import (
+    RunnerDetailEndpoint,
+    RunnerListEndpoint,
+    RunnerRevokeEndpoint,
+)
 from .runs import (
     AgentRunCancelEndpoint,
     AgentRunDetailEndpoint,
@@ -49,6 +54,8 @@ __all__ = [
     "RunnerEnrollEndpoint",
     "RunnerInviteEndpoint",
     "RunnerRefreshEndpoint",
+    "RunnerReviveEndpoint",
+    "RunnerRevokeEndpoint",
     "RunnerSelfRevokeEndpoint",
     "HealthEndpoint",
     "MetricsEndpoint",

--- a/apps/api/pi_dash/runner/views/enrollment.py
+++ b/apps/api/pi_dash/runner/views/enrollment.py
@@ -35,13 +35,17 @@ from pi_dash.runner.models import (
     Pod,
     Runner,
     RunnerForceRefresh,
+    RunnerStatus,
 )
 from pi_dash.runner.serializers import (
     RunnerEnrollRequestSerializer,
     RunnerEnrollmentInviteSerializer,
 )
 from pi_dash.runner.services import tokens
-from pi_dash.runner.services.permissions import is_workspace_member
+from pi_dash.runner.services.permissions import (
+    is_workspace_admin,
+    is_workspace_member,
+)
 from pi_dash.runner.services.pubsub import close_runner_session, send_to_runner
 
 logger = logging.getLogger(__name__)
@@ -378,6 +382,101 @@ class RunnerRefreshEndpoint(APIView):
                 "refresh_token_generation": runner.refresh_token_generation,
             }
         )
+
+
+class RunnerReviveEndpoint(APIView):
+    """``POST /api/runners/<runner_id>/revive/`` — mint a fresh enrollment token.
+
+    Two recovery cases the legacy invite flow cannot serve without
+    spawning a duplicate Runner row:
+
+    - **Stale PENDING**: ``RunnerInviteEndpoint`` minted a token, the
+      operator lost it before running ``pidash connect``. The row sits
+      in PENDING (``enrolled_at IS NULL``) with a hash nobody holds the
+      preimage for.
+    - **Revoked**: an active runner was revoked (manual or replay) and
+      the operator wants to reuse the same name / pod / id rather than
+      start over.
+
+    Either case resets the row to PENDING and returns a fresh
+    enrollment-token payload identical to ``RunnerInviteEndpoint`` so
+    the web UI can reuse the same install-command panel. Refuses
+    actively-enrolled runners — revoke first, then revive.
+    """
+
+    authentication_classes = [BaseSessionAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, runner_id):
+        with transaction.atomic():
+            runner = (
+                Runner.objects.select_for_update()
+                .select_related("workspace", "pod__project")
+                .filter(pk=runner_id)
+                .first()
+            )
+            if runner is None:
+                return Response(
+                    {"error": "not found"}, status=status.HTTP_404_NOT_FOUND
+                )
+            if runner.owner_id != request.user.id and not is_workspace_admin(
+                request.user, runner.workspace_id
+            ):
+                return Response(
+                    {"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN
+                )
+            if runner.revoked_at is None and runner.enrolled_at is not None:
+                return Response(
+                    {"error": "runner is currently active; revoke it first"},
+                    status=status.HTTP_409_CONFLICT,
+                )
+
+            enrollment = tokens.mint_enrollment_token()
+            runner.enrollment_token_hash = enrollment.hashed
+            runner.enrollment_token_fingerprint = enrollment.fingerprint
+            runner.enrolled_at = None
+            runner.refresh_token_hash = ""
+            runner.refresh_token_fingerprint = ""
+            runner.previous_refresh_token_hash = ""
+            runner.refresh_token_generation = 0
+            runner.revoked_at = None
+            runner.revoked_reason = ""
+            runner.status = RunnerStatus.OFFLINE
+            runner.save(
+                update_fields=[
+                    "enrollment_token_hash",
+                    "enrollment_token_fingerprint",
+                    "enrolled_at",
+                    "refresh_token_hash",
+                    "refresh_token_fingerprint",
+                    "previous_refresh_token_hash",
+                    "refresh_token_generation",
+                    "revoked_at",
+                    "revoked_reason",
+                    "status",
+                    "updated_at",
+                ]
+            )
+            # Drop any leftover force-refresh directive — we are at rtg=0.
+            RunnerForceRefresh.objects.filter(runner=runner).delete()
+
+        project_identifier = (
+            runner.pod.project.identifier
+            if runner.pod and runner.pod.project_id
+            else ""
+        )
+        body = RunnerEnrollmentInviteSerializer(
+            {
+                "runner_id": runner.id,
+                "name": runner.name,
+                "workspace_slug": runner.workspace.slug,
+                "project_identifier": project_identifier,
+                "pod_id": runner.pod_id,
+                "enrollment_token": enrollment.raw,
+                "enrollment_expires_at": enrollment.expires_at.isoformat(),
+            }
+        ).data
+        return Response(body, status=status.HTTP_201_CREATED)
 
 
 class RunnerSelfRevokeEndpoint(APIView):

--- a/apps/api/pi_dash/runner/views/enrollment.py
+++ b/apps/api/pi_dash/runner/views/enrollment.py
@@ -43,7 +43,7 @@ from pi_dash.runner.serializers import (
 )
 from pi_dash.runner.services import tokens
 from pi_dash.runner.services.permissions import (
-    is_workspace_admin,
+    can_manage_runner,
     is_workspace_member,
 )
 from pi_dash.runner.services.pubsub import close_runner_session, send_to_runner
@@ -419,9 +419,7 @@ class RunnerReviveEndpoint(APIView):
                 return Response(
                     {"error": "not found"}, status=status.HTTP_404_NOT_FOUND
                 )
-            if runner.owner_id != request.user.id and not is_workspace_admin(
-                request.user, runner.workspace_id
-            ):
+            if not can_manage_runner(request.user, runner):
                 return Response(
                     {"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN
                 )

--- a/apps/api/pi_dash/runner/views/runners.py
+++ b/apps/api/pi_dash/runner/views/runners.py
@@ -12,14 +12,10 @@ from pi_dash.authentication.session import BaseSessionAuthentication
 from pi_dash.runner.models import Pod, Runner
 from pi_dash.runner.serializers import RunnerSerializer
 from pi_dash.runner.services.permissions import (
-    is_workspace_admin,
+    can_manage_runner,
     is_workspace_member,
 )
 from pi_dash.runner.services.pubsub import close_runner_session, send_to_runner
-
-
-def _can_manage_runner(user, runner: Runner) -> bool:
-    return runner.owner_id == user.id or is_workspace_admin(user, runner.workspace_id)
 
 
 class RunnerListEndpoint(APIView):
@@ -81,7 +77,7 @@ class RunnerDetailEndpoint(APIView):
             return Response({"error": "not found"}, status=status.HTTP_404_NOT_FOUND)
         if runner is False:
             return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
-        if not _can_manage_runner(request.user, runner):
+        if not can_manage_runner(request.user, runner):
             return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
 
         updates: list[str] = []
@@ -130,7 +126,7 @@ class RunnerDetailEndpoint(APIView):
         runner = Runner.objects.filter(pk=runner_id).first()
         if runner is None:
             return Response({"error": "not found"}, status=status.HTTP_404_NOT_FOUND)
-        if not _can_manage_runner(request.user, runner):
+        if not can_manage_runner(request.user, runner):
             return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
         runner_pk = runner.pk
         runner.revoke()
@@ -150,8 +146,9 @@ class RunnerRevokeEndpoint(APIView):
     """``POST /api/runners/<runner_id>/revoke/`` — hard-revoke without delete.
 
     Cascades to sessions, in-flight runs, and pinned follow-ups via
-    ``Runner.revoke()``. Idempotent: revoking an already-revoked runner
-    re-emits the control frame and returns 200 with the current row.
+    ``Runner.revoke()``. Idempotent: a second call on an already-revoked
+    row returns 200 with the current state without re-emitting the
+    revoke control frame or re-closing the (already closed) session.
     Use this when an operator wants to stop a runner permanently but
     keep its history visible in the list — paired with the ``revive``
     endpoint that mints a fresh enrollment token on the same row.
@@ -161,17 +158,31 @@ class RunnerRevokeEndpoint(APIView):
     permission_classes = [IsAuthenticated]
 
     def post(self, request, runner_id):
-        runner = Runner.objects.filter(pk=runner_id).first()
-        if runner is None:
-            return Response({"error": "not found"}, status=status.HTTP_404_NOT_FOUND)
-        if not _can_manage_runner(request.user, runner):
-            return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
-        runner_pk = runner.pk
-        runner.revoke(reason="manual_revoke")
-        send_to_runner(
-            runner_pk,
-            {"type": "revoke", "reason": "revoked by user"},
-        )
-        close_runner_session(runner_pk)
-        runner.refresh_from_db()
+        # Hold the row lock across the read-then-revoke window so two
+        # concurrent operator clicks don't both see ``revoked_at IS NULL``
+        # and both fire the cascade + control frame.
+        with transaction.atomic():
+            runner = (
+                Runner.objects.select_for_update().filter(pk=runner_id).first()
+            )
+            if runner is None:
+                return Response(
+                    {"error": "not found"}, status=status.HTTP_404_NOT_FOUND
+                )
+            if not can_manage_runner(request.user, runner):
+                return Response(
+                    {"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN
+                )
+            already_revoked = runner.revoked_at is not None
+            runner_pk = runner.pk
+            if not already_revoked:
+                runner.revoke(reason="manual_revoke")
+
+        if not already_revoked:
+            send_to_runner(
+                runner_pk,
+                {"type": "revoke", "reason": "revoked by user"},
+            )
+            close_runner_session(runner_pk)
+            runner.refresh_from_db()
         return Response(RunnerSerializer(runner).data)

--- a/apps/api/pi_dash/runner/views/runners.py
+++ b/apps/api/pi_dash/runner/views/runners.py
@@ -144,3 +144,34 @@ class RunnerDetailEndpoint(APIView):
         close_runner_session(runner_pk)
         Runner.objects.filter(pk=runner_pk).delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class RunnerRevokeEndpoint(APIView):
+    """``POST /api/runners/<runner_id>/revoke/`` — hard-revoke without delete.
+
+    Cascades to sessions, in-flight runs, and pinned follow-ups via
+    ``Runner.revoke()``. Idempotent: revoking an already-revoked runner
+    re-emits the control frame and returns 200 with the current row.
+    Use this when an operator wants to stop a runner permanently but
+    keep its history visible in the list — paired with the ``revive``
+    endpoint that mints a fresh enrollment token on the same row.
+    """
+
+    authentication_classes = [BaseSessionAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, runner_id):
+        runner = Runner.objects.filter(pk=runner_id).first()
+        if runner is None:
+            return Response({"error": "not found"}, status=status.HTTP_404_NOT_FOUND)
+        if not _can_manage_runner(request.user, runner):
+            return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
+        runner_pk = runner.pk
+        runner.revoke(reason="manual_revoke")
+        send_to_runner(
+            runner_pk,
+            {"type": "revoke", "reason": "revoked by user"},
+        )
+        close_runner_session(runner_pk)
+        runner.refresh_from_db()
+        return Response(RunnerSerializer(runner).data)

--- a/apps/api/pi_dash/runner/web_urls.py
+++ b/apps/api/pi_dash/runner/web_urls.py
@@ -20,6 +20,8 @@ from pi_dash.runner.views import (
     RunnerDetailEndpoint,
     RunnerInviteEndpoint,
     RunnerListEndpoint,
+    RunnerReviveEndpoint,
+    RunnerRevokeEndpoint,
 )
 
 urlpatterns = [
@@ -40,6 +42,16 @@ urlpatterns = [
         "<uuid:runner_id>/",
         RunnerDetailEndpoint.as_view(),
         name="runner-detail",
+    ),
+    path(
+        "<uuid:runner_id>/revoke/",
+        RunnerRevokeEndpoint.as_view(),
+        name="runner-revoke",
+    ),
+    path(
+        "<uuid:runner_id>/revive/",
+        RunnerReviveEndpoint.as_view(),
+        name="runner-revive",
     ),
     # Pods
     path("pods/", PodListEndpoint.as_view(), name="pod-list"),

--- a/apps/api/pi_dash/tests/unit/runner/test_runner_revoke_revive.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_runner_revoke_revive.py
@@ -1,0 +1,180 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Tests for the runner revoke + revive web endpoints.
+
+These two endpoints close the gap left by ``RunnerInviteEndpoint``,
+which only ever creates a brand-new Runner row. ``revoke`` keeps the
+row visible while killing its credentials; ``revive`` mints a fresh
+enrollment token on the same row so the operator can re-enroll the
+daemon without losing pod / name / id continuity.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pi_dash.runner.models import Pod, Runner, RunnerForceRefresh, RunnerStatus
+from pi_dash.runner.services import tokens
+
+
+@pytest.fixture
+def pod(project):
+    return Pod.default_for_project(project)
+
+
+@pytest.fixture
+def pending_runner(db, create_user, workspace, pod):
+    enrollment = tokens.mint_enrollment_token()
+    return (
+        Runner.objects.create(
+            owner=create_user,
+            workspace=workspace,
+            pod=pod,
+            name="agent-x",
+            enrollment_token_hash=enrollment.hashed,
+            enrollment_token_fingerprint=enrollment.fingerprint,
+        ),
+        enrollment,
+    )
+
+
+@pytest.fixture
+def enrolled_runner(db, api_client, pending_runner):
+    runner, enrollment = pending_runner
+    resp = api_client.post(
+        "/api/v1/runner/runners/enroll/",
+        {"enrollment_token": enrollment.raw, "host_label": "host"},
+        format="json",
+    )
+    assert resp.status_code == 201, resp.data
+    runner.refresh_from_db()
+    return runner
+
+
+@pytest.mark.unit
+def test_revoke_keeps_row_and_marks_revoked(
+    db, session_client, enrolled_runner
+):
+    resp = session_client.post(f"/api/runners/{enrolled_runner.id}/revoke/")
+    assert resp.status_code == 200, resp.data
+    assert resp.data["status"] == RunnerStatus.REVOKED
+    assert resp.data["revoked_at"] is not None
+    # Row not deleted — historic context preserved.
+    assert Runner.objects.filter(pk=enrolled_runner.id).exists()
+
+
+@pytest.mark.unit
+def test_revoke_is_idempotent(db, session_client, enrolled_runner):
+    first = session_client.post(f"/api/runners/{enrolled_runner.id}/revoke/")
+    assert first.status_code == 200
+    second = session_client.post(f"/api/runners/{enrolled_runner.id}/revoke/")
+    assert second.status_code == 200
+    assert second.data["status"] == RunnerStatus.REVOKED
+
+
+@pytest.mark.unit
+def test_revoke_404_for_unknown_runner(db, session_client):
+    import uuid
+
+    resp = session_client.post(f"/api/runners/{uuid.uuid4()}/revoke/")
+    assert resp.status_code == 404
+
+
+@pytest.mark.unit
+def test_revive_pending_mints_new_enrollment_token(
+    db, session_client, pending_runner
+):
+    runner, original = pending_runner
+    original_hash = runner.enrollment_token_hash
+    resp = session_client.post(f"/api/runners/{runner.id}/revive/")
+    assert resp.status_code == 201, resp.data
+    new_token = resp.data["enrollment_token"]
+    assert new_token and new_token != original.raw
+    runner.refresh_from_db()
+    assert runner.enrollment_token_hash != original_hash
+    assert runner.enrollment_token_hash == tokens.hash_token(new_token)
+    # Same row, same name — that's the whole point.
+    assert resp.data["runner_id"] == str(runner.id)
+    assert resp.data["name"] == runner.name
+
+
+@pytest.mark.unit
+def test_revive_revoked_runner_resets_state(
+    db, api_client, session_client, enrolled_runner
+):
+    # Revoke first, then revive.
+    revoke = session_client.post(f"/api/runners/{enrolled_runner.id}/revoke/")
+    assert revoke.status_code == 200
+    enrolled_runner.refresh_from_db()
+    assert enrolled_runner.refresh_token_hash != ""
+    assert enrolled_runner.revoked_at is not None
+
+    resp = session_client.post(f"/api/runners/{enrolled_runner.id}/revive/")
+    assert resp.status_code == 201, resp.data
+    enrolled_runner.refresh_from_db()
+    assert enrolled_runner.revoked_at is None
+    assert enrolled_runner.revoked_reason == ""
+    assert enrolled_runner.enrolled_at is None
+    assert enrolled_runner.refresh_token_hash == ""
+    assert enrolled_runner.refresh_token_generation == 0
+    assert enrolled_runner.status == RunnerStatus.OFFLINE
+
+    # And the freshly minted enrollment token actually works against the
+    # public enroll endpoint — meaning the same row gets re-enrolled
+    # rather than a new Runner being created.
+    new_token = resp.data["enrollment_token"]
+    enroll = api_client.post(
+        "/api/v1/runner/runners/enroll/",
+        {"enrollment_token": new_token, "host_label": "host-2"},
+        format="json",
+    )
+    assert enroll.status_code == 201, enroll.data
+    assert enroll.data["runner_id"] == str(enrolled_runner.id)
+
+
+@pytest.mark.unit
+def test_revive_rejects_active_runner(db, session_client, enrolled_runner):
+    resp = session_client.post(f"/api/runners/{enrolled_runner.id}/revive/")
+    assert resp.status_code == 409, resp.data
+
+
+@pytest.mark.unit
+def test_revive_clears_force_refresh_directive(
+    db, session_client, enrolled_runner
+):
+    RunnerForceRefresh.objects.create(runner=enrolled_runner, min_rtg=99)
+    session_client.post(f"/api/runners/{enrolled_runner.id}/revoke/")
+    resp = session_client.post(f"/api/runners/{enrolled_runner.id}/revive/")
+    assert resp.status_code == 201
+    assert not RunnerForceRefresh.objects.filter(runner=enrolled_runner).exists()
+
+
+@pytest.mark.unit
+def test_revoke_forbidden_for_non_owner_non_admin(
+    db, api_client, create_user, enrolled_runner
+):
+    from pi_dash.db.models import User
+
+    other = User.objects.create(email="other@example.com")
+    other.set_password("x")
+    other.save()
+    api_client.force_authenticate(user=other)
+    resp = api_client.post(f"/api/runners/{enrolled_runner.id}/revoke/")
+    assert resp.status_code == 403
+
+
+@pytest.mark.unit
+def test_revive_forbidden_for_non_owner_non_admin(
+    db, api_client, pending_runner
+):
+    from pi_dash.db.models import User
+
+    runner, _ = pending_runner
+    other = User.objects.create(email="other2@example.com")
+    other.set_password("x")
+    other.save()
+    api_client.force_authenticate(user=other)
+    resp = api_client.post(f"/api/runners/{runner.id}/revive/")
+    assert resp.status_code == 403

--- a/apps/api/pi_dash/tests/unit/runner/test_runner_revoke_revive.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_runner_revoke_revive.py
@@ -83,6 +83,14 @@ def test_revoke_404_for_unknown_runner(db, session_client):
 
 
 @pytest.mark.unit
+def test_revive_404_for_unknown_runner(db, session_client):
+    import uuid
+
+    resp = session_client.post(f"/api/runners/{uuid.uuid4()}/revive/")
+    assert resp.status_code == 404
+
+
+@pytest.mark.unit
 def test_revive_pending_mints_new_enrollment_token(
     db, session_client, pending_runner
 ):

--- a/apps/web/app/(all)/[workspaceSlug]/runners/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/page.tsx
@@ -11,11 +11,13 @@ import useSWR from "swr";
 import { useTranslation } from "@pi-dash/i18n";
 import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
 import { PodService, RunnerService } from "@pi-dash/services";
-import type { IPod, IRunner, TRunnerStatus } from "@pi-dash/types";
+import { EModalPosition, EModalWidth, ModalCore } from "@pi-dash/ui";
+import type { IPod, IRunner, IRunnerInvite, TRunnerStatus } from "@pi-dash/types";
 import type { TBadgeVariant } from "@pi-dash/ui";
 import { AlertModalCore, Badge, Button, Tooltip } from "@pi-dash/ui";
 import { PageHead } from "@/components/core/page-title";
 import { AddRunnerModal } from "@/components/runners/add-runner-modal";
+import { RunnerEnrollmentCommand } from "@/components/runners/runner-enrollment-command";
 import { useWorkspace } from "@/hooks/store/use-workspace";
 
 const service = new RunnerService();
@@ -27,6 +29,17 @@ const STATUS_BADGE_VARIANT: Record<TRunnerStatus, TBadgeVariant> = {
   offline: "accent-neutral",
   revoked: "accent-warning",
 };
+
+// A runner is "revivable" when it has never enrolled or has been
+// revoked — i.e., it's not currently holding live credentials.
+// ``revoke`` is the inverse: only meaningful when the runner is
+// active (enrolled and not yet revoked).
+function isRevivable(r: IRunner): boolean {
+  return r.status === "revoked" || r.enrolled_at === null;
+}
+function isRevocable(r: IRunner): boolean {
+  return r.status !== "revoked" && r.enrolled_at !== null;
+}
 
 const RunnersListPage = observer(function RunnersListPage() {
   const { currentWorkspace } = useWorkspace();
@@ -52,6 +65,10 @@ const RunnersListPage = observer(function RunnersListPage() {
   const [addOpen, setAddOpen] = useState(false);
   const [deleteRunner, setDeleteRunner] = useState<IRunner | null>(null);
   const [deleting, setDeleting] = useState(false);
+  const [revokeRunner, setRevokeRunner] = useState<IRunner | null>(null);
+  const [revoking, setRevoking] = useState(false);
+  const [reviving, setReviving] = useState<string | null>(null);
+  const [reviveInvite, setReviveInvite] = useState<IRunnerInvite | null>(null);
 
   async function confirmDeleteRunner() {
     if (!deleteRunner) return;
@@ -69,6 +86,43 @@ const RunnersListPage = observer(function RunnersListPage() {
       });
     } finally {
       setDeleting(false);
+    }
+  }
+
+  async function confirmRevokeRunner() {
+    if (!revokeRunner) return;
+    setRevoking(true);
+    try {
+      await service.revokeRunner(revokeRunner.id);
+      setRevokeRunner(null);
+      mutateRunners();
+    } catch (e: unknown) {
+      const err = e as { error?: string } | null;
+      setToast({
+        type: TOAST_TYPE.ERROR,
+        title: t("runners.toast.error_title"),
+        message: err?.error ?? t("runners.list.revoke_failed"),
+      });
+    } finally {
+      setRevoking(false);
+    }
+  }
+
+  async function reviveRunner(runner: IRunner) {
+    setReviving(runner.id);
+    try {
+      const invite = await service.reviveRunner(runner.id);
+      setReviveInvite(invite);
+      mutateRunners();
+    } catch (e: unknown) {
+      const err = e as { error?: string } | null;
+      setToast({
+        type: TOAST_TYPE.ERROR,
+        title: t("runners.toast.error_title"),
+        message: err?.error ?? t("runners.list.revive_failed"),
+      });
+    } finally {
+      setReviving(null);
     }
   }
 
@@ -166,9 +220,27 @@ const RunnersListPage = observer(function RunnersListPage() {
                     {r.last_heartbeat_at ? new Date(r.last_heartbeat_at).toLocaleString() : "—"}
                   </td>
                   <td className="px-3 py-2 text-right">
-                    <Button variant="tertiary-danger" size="sm" onClick={() => setDeleteRunner(r)}>
-                      {t("runners.list.delete")}
-                    </Button>
+                    <div className="flex justify-end gap-2">
+                      {isRevivable(r) && (
+                        <Button
+                          variant="neutral-primary"
+                          size="sm"
+                          onClick={() => reviveRunner(r)}
+                          disabled={reviving === r.id}
+                          loading={reviving === r.id}
+                        >
+                          {t("runners.list.revive")}
+                        </Button>
+                      )}
+                      {isRevocable(r) && (
+                        <Button variant="outline-danger" size="sm" onClick={() => setRevokeRunner(r)}>
+                          {t("runners.list.revoke")}
+                        </Button>
+                      )}
+                      <Button variant="tertiary-danger" size="sm" onClick={() => setDeleteRunner(r)}>
+                        {t("runners.list.delete")}
+                      </Button>
+                    </div>
                   </td>
                 </tr>
               ))}
@@ -202,6 +274,39 @@ const RunnersListPage = observer(function RunnersListPage() {
         content={t("runners.list.delete_confirm_body")}
         primaryButtonText={{ default: t("runners.list.delete"), loading: t("runners.list.delete") }}
       />
+      <AlertModalCore
+        isOpen={!!revokeRunner}
+        handleClose={() => (revoking ? null : setRevokeRunner(null))}
+        handleSubmit={confirmRevokeRunner}
+        isSubmitting={revoking}
+        title={t("runners.list.revoke_confirm_title")}
+        content={t("runners.list.revoke_confirm_body")}
+        primaryButtonText={{ default: t("runners.list.revoke"), loading: t("runners.list.revoke") }}
+      />
+      <ModalCore
+        isOpen={!!reviveInvite}
+        handleClose={() => setReviveInvite(null)}
+        position={EModalPosition.CENTER}
+        width={EModalWidth.XXL}
+      >
+        {reviveInvite && (
+          <div className="flex flex-col gap-4 p-5">
+            <div>
+              <div className="text-18 font-medium text-primary">{t("runners.list.revive_modal_title")}</div>
+              <p className="mt-1 text-13 text-secondary">
+                {t("runners.add_modal.runner_id_label")}: <code className="text-12">{reviveInvite.runner_id}</code>
+                <br />
+                {reviveInvite.name}
+              </p>
+              <p className="mt-2 text-13 text-secondary">{t("runners.list.revive_modal_body")}</p>
+            </div>
+            <RunnerEnrollmentCommand invite={reviveInvite} />
+            <div className="flex justify-end">
+              <Button onClick={() => setReviveInvite(null)}>{t("runners.add_modal.done")}</Button>
+            </div>
+          </div>
+        )}
+      </ModalCore>
     </div>
   );
 });

--- a/apps/web/core/components/runners/add-runner-modal.tsx
+++ b/apps/web/core/components/runners/add-runner-modal.tsx
@@ -10,7 +10,6 @@ import type { SubmitHandler } from "react-hook-form";
 import { Controller, useForm } from "react-hook-form";
 import useSWR from "swr";
 // pi dash imports
-import { API_BASE_URL } from "@pi-dash/constants";
 import { useTranslation } from "@pi-dash/i18n";
 import { Button } from "@pi-dash/propel/button";
 import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
@@ -18,6 +17,7 @@ import { PodService, RunnerService } from "@pi-dash/services";
 import type { IPod, IRunnerInvite, TPartialProject } from "@pi-dash/types";
 import { CustomSelect, EModalPosition, EModalWidth, Input, ModalCore } from "@pi-dash/ui";
 // app
+import { RunnerEnrollmentCommand } from "@/components/runners/runner-enrollment-command";
 import { ProjectService } from "@/services/project";
 
 type Props = {
@@ -63,8 +63,6 @@ export const AddRunnerModal = observer(function AddRunnerModal(props: Props) {
   } = useForm<FormValues>({ defaultValues: DEFAULT_VALUES });
 
   const [invite, setInvite] = useState<IRunnerInvite | null>(null);
-  const [origin, setOrigin] = useState("");
-  const [justCopied, setJustCopied] = useState(false);
 
   // Reset everything on close→open. State persists between consecutive
   // opens otherwise (RHF + local invite state would carry the stale
@@ -72,9 +70,7 @@ export const AddRunnerModal = observer(function AddRunnerModal(props: Props) {
   useEffect(() => {
     if (!isOpen) return;
     setInvite(null);
-    setJustCopied(false);
     reset(DEFAULT_VALUES);
-    if (typeof window !== "undefined") setOrigin(window.location.origin);
   }, [isOpen, reset]);
 
   // Project picker + pod picker load whenever the modal is open. Pod
@@ -126,28 +122,8 @@ export const AddRunnerModal = observer(function AddRunnerModal(props: Props) {
     if (!stillFits) setValue("podName", "");
   }, [selectedProject, selectedPodName, podsForPicker, setValue]);
 
-  const apiOrigin = API_BASE_URL || origin;
-
-  const enrollmentCommand = useMemo(() => {
-    if (!invite) return "";
-    const hostLabelArg = watch("hostLabel").trim();
-    const workingDirArg = watch("workingDir").trim();
-    const lines = [`pidash connect \\`, `  --url ${apiOrigin} \\`, `  --token ${invite.enrollment_token}`];
-    // host-label / working-dir are CLI-only flags; they don't go to the
-    // invite endpoint. Append each on its own continuation line so the
-    // generated command stays readable and copy-pasteable.
-    const optionalArgs: string[] = [];
-    if (hostLabelArg) optionalArgs.push(`  --host-label ${hostLabelArg}`);
-    if (workingDirArg) optionalArgs.push(`  --working-dir ${workingDirArg}`);
-    if (optionalArgs.length > 0) {
-      lines[lines.length - 1] += " \\";
-      for (let i = 0; i < optionalArgs.length; i += 1) {
-        const isLast = i === optionalArgs.length - 1;
-        lines.push(isLast ? optionalArgs[i] : `${optionalArgs[i]} \\`);
-      }
-    }
-    return lines.join("\n");
-  }, [invite, apiOrigin, watch]);
+  const hostLabelInput = watch("hostLabel");
+  const workingDirInput = watch("workingDir");
 
   const onSubmit: SubmitHandler<FormValues> = async (values) => {
     try {
@@ -165,21 +141,6 @@ export const AddRunnerModal = observer(function AddRunnerModal(props: Props) {
         type: TOAST_TYPE.ERROR,
         title: t("runners.toast.error_title"),
         message: err?.error ?? t("runners.add_modal.errors.create_failed"),
-      });
-    }
-  };
-
-  const copyCommand = async () => {
-    if (!enrollmentCommand) return;
-    try {
-      await navigator.clipboard.writeText(enrollmentCommand);
-      setJustCopied(true);
-      window.setTimeout(() => setJustCopied(false), 2000);
-    } catch {
-      setToast({
-        type: TOAST_TYPE.ERROR,
-        title: t("runners.toast.error_title"),
-        message: t("runners.list.copy_failed"),
       });
     }
   };
@@ -341,18 +302,7 @@ export const AddRunnerModal = observer(function AddRunnerModal(props: Props) {
             </p>
           </div>
 
-          <div className="border-amber-500/40 bg-amber-500/10 rounded border p-3 text-13 text-primary">
-            <div className="font-medium">{t("runners.add_modal.token_warning")}</div>
-            <p className="mt-2 text-secondary">{t("runners.add_modal.token_instructions")}</p>
-            <pre className="font-mono mt-1 rounded border border-subtle bg-layer-1 p-2 text-11 whitespace-pre-wrap text-primary select-all">
-              {enrollmentCommand}
-            </pre>
-            <div className="mt-2">
-              <Button size="sm" onClick={copyCommand}>
-                {justCopied ? t("runners.add_modal.copied") : t("runners.add_modal.copy_command")}
-              </Button>
-            </div>
-          </div>
+          <RunnerEnrollmentCommand invite={invite} hostLabel={hostLabelInput} workingDir={workingDirInput} />
 
           <div className="flex justify-end">
             <Button onClick={onClose}>{t("runners.add_modal.done")}</Button>

--- a/apps/web/core/components/runners/runner-enrollment-command.tsx
+++ b/apps/web/core/components/runners/runner-enrollment-command.tsx
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { API_BASE_URL } from "@pi-dash/constants";
+import { useTranslation } from "@pi-dash/i18n";
+import { Button } from "@pi-dash/propel/button";
+import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
+import type { IRunnerInvite } from "@pi-dash/types";
+
+type Props = {
+  invite: IRunnerInvite;
+  /** Optional CLI flags surfaced for parity with the create-runner modal.
+   * The host_label / working_dir flags don't change anything server-side
+   * — they're CLI-only, so we keep the input simple here. */
+  hostLabel?: string;
+  workingDir?: string;
+};
+
+/**
+ * Displays the ``pidash connect --url ... --token ...`` command for a
+ * freshly minted enrollment token. Shared between the add-runner flow
+ * and the revive flow so both surface the same install instructions.
+ */
+export function RunnerEnrollmentCommand(props: Props) {
+  const { invite, hostLabel, workingDir } = props;
+  const { t } = useTranslation();
+  const [origin, setOrigin] = useState("");
+  const [justCopied, setJustCopied] = useState(false);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") setOrigin(window.location.origin);
+  }, []);
+
+  const apiOrigin = API_BASE_URL || origin;
+
+  const enrollmentCommand = useMemo(() => {
+    const lines = [`pidash connect \\`, `  --url ${apiOrigin} \\`, `  --token ${invite.enrollment_token}`];
+    const optionalArgs: string[] = [];
+    if (hostLabel?.trim()) optionalArgs.push(`  --host-label ${hostLabel.trim()}`);
+    if (workingDir?.trim()) optionalArgs.push(`  --working-dir ${workingDir.trim()}`);
+    if (optionalArgs.length > 0) {
+      lines[lines.length - 1] += " \\";
+      for (let i = 0; i < optionalArgs.length; i += 1) {
+        const isLast = i === optionalArgs.length - 1;
+        lines.push(isLast ? optionalArgs[i] : `${optionalArgs[i]} \\`);
+      }
+    }
+    return lines.join("\n");
+  }, [invite.enrollment_token, apiOrigin, hostLabel, workingDir]);
+
+  const copy = async () => {
+    if (!enrollmentCommand) return;
+    try {
+      await navigator.clipboard.writeText(enrollmentCommand);
+      setJustCopied(true);
+      window.setTimeout(() => setJustCopied(false), 2000);
+    } catch {
+      setToast({
+        type: TOAST_TYPE.ERROR,
+        title: t("runners.toast.error_title"),
+        message: t("runners.list.copy_failed"),
+      });
+    }
+  };
+
+  return (
+    <div className="border-amber-500/40 bg-amber-500/10 rounded border p-3 text-13 text-primary">
+      <div className="font-medium">{t("runners.add_modal.token_warning")}</div>
+      <p className="mt-2 text-secondary">{t("runners.add_modal.token_instructions")}</p>
+      <pre className="font-mono mt-1 rounded border border-subtle bg-layer-1 p-2 text-11 whitespace-pre-wrap text-primary select-all">
+        {enrollmentCommand}
+      </pre>
+      <div className="mt-2">
+        <Button size="sm" onClick={copy}>
+          {justCopied ? t("runners.add_modal.copied") : t("runners.add_modal.copy_command")}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/i18n/src/locales/en/core.ts
+++ b/packages/i18n/src/locales/en/core.ts
@@ -440,6 +440,16 @@ export default {
       delete_confirm_body:
         "The runner row is removed and the daemon is forced offline. Historic runs are preserved with a null runner reference.",
       delete_failed: "Failed to delete runner",
+      revoke: "Revoke",
+      revoke_confirm_title: "Revoke runner?",
+      revoke_confirm_body:
+        "The runner's credentials are invalidated and any in-flight runs are cancelled, but the row stays in the list. You can revive it later to mint a fresh enrollment token on the same row.",
+      revoke_failed: "Failed to revoke runner",
+      revive: "Revive",
+      revive_failed: "Failed to revive runner",
+      revive_modal_title: "New enrollment token",
+      revive_modal_body:
+        "Run the command below on the host that should pick up this runner. Copy it now — the token will not be shown again.",
       status: {
         online: "online",
         busy: "busy",

--- a/packages/services/src/runner/runner.service.ts
+++ b/packages/services/src/runner/runner.service.ts
@@ -42,6 +42,30 @@ export class RunnerService extends APIService {
       });
   }
 
+  /** ``POST /api/runners/<id>/revoke/`` — hard-revoke without removing
+   * the row. Cascades to sessions, in-flight runs, and pinned follow-ups
+   * via the model's ``revoke()``. Idempotent. */
+  async revokeRunner(runnerId: string): Promise<IRunner> {
+    return this.post(`/api/runners/${runnerId}/revoke/`, {})
+      .then((r) => r?.data)
+      .catch((e) => {
+        throw e?.response?.data;
+      });
+  }
+
+  /** ``POST /api/runners/<id>/revive/`` — mint a fresh enrollment token
+   * on an existing PENDING-or-REVOKED runner row. The response payload
+   * is identical to ``createRunnerInvite`` so the same install-command
+   * panel can render it. 409 if the runner is currently active — revoke
+   * it first. */
+  async reviveRunner(runnerId: string): Promise<IRunnerInvite> {
+    return this.post(`/api/runners/${runnerId}/revive/`, {})
+      .then((r) => r?.data)
+      .catch((e) => {
+        throw e?.response?.data;
+      });
+  }
+
   /** Move a runner to a different pod (same workspace). Owner or admin only. */
   async move(runnerId: string, podId: string, name?: string): Promise<IRunner> {
     const body: Record<string, unknown> = { pod: podId };

--- a/packages/types/src/runner.ts
+++ b/packages/types/src/runner.ts
@@ -69,6 +69,14 @@ export interface IRunner {
   /** Volatile per-active-run agent snapshot. Optional / null when the
    * runner has not yet reported any observability data (pre-flag runner). */
   live_state?: IRunnerLiveState | null;
+  /** Set the first time the daemon successfully exchanges its enrollment
+   * token for a refresh token. Null = PENDING (still needs to enroll). */
+  enrolled_at: string | null;
+  /** Set when the runner is hard-revoked (manual, replay, membership
+   * change). The row stays visible; `revive` clears this and mints a
+   * fresh enrollment token on the same row. */
+  revoked_at: string | null;
+  revoked_reason: string;
   created_at: string;
   updated_at: string;
 }

--- a/runner/src/cli/connect.rs
+++ b/runner/src/cli/connect.rs
@@ -127,6 +127,38 @@ pub async fn run(args: Args, paths: &Paths) -> Result<()> {
     .await
     .context("writing runner credentials failed")?;
 
+    // Re-enrollment after revive: the cloud reused the same Runner row
+    // and minted a fresh refresh token. The local config already has a
+    // matching `[[runner]]` block; rotating credentials.toml above is
+    // the only thing required, and appending another block would create
+    // a duplicate runner_id that the supervisor would reject. Skip the
+    // append and the rest of the first-enrollment scaffolding.
+    let already_configured = existing_config
+        .as_ref()
+        .map(|cfg| cfg.runners.iter().any(|r| r.runner_id == resp.runner_id))
+        .unwrap_or(false);
+    if already_configured {
+        println!(
+            "Re-enrolled runner {} ({}) — local config left as-is, refresh token rotated.",
+            resp.runner_name, resp.runner_id
+        );
+        println!("Restarting service to pick up the new credentials…");
+        let outcome = crate::service::reload::restart_and_verify(paths).await;
+        if outcome.ok {
+            println!("Service restarted ({}).", outcome.summary);
+        } else {
+            println!(
+                "Service restart did not complete cleanly: {}",
+                outcome.summary
+            );
+            if let Some(detail) = outcome.detail {
+                println!("\n{detail}");
+            }
+            println!("\nThe new credentials were written. Try `pidash restart` manually.");
+        }
+        return Ok(());
+    }
+
     // working_dir falls back to a per-runner sandbox under
     // data_dir/runners/<rid>/workspace when the operator didn't pass
     // ``--working-dir``. The sandbox path runs but is rarely what
@@ -438,6 +470,13 @@ pub async fn enroll_additional_runner(
     )
     .await
     .map_err(|e| EnrollAdditionalError::WriteCredentials(format!("{e:#}")))?;
+
+    // Re-enrollment of an existing runner row (cloud-side ``revive``):
+    // credentials.toml has already been rotated above. Return the
+    // existing config block instead of pushing a duplicate.
+    if let Some(existing) = cfg.runners.iter().find(|r| r.runner_id == resp.runner_id) {
+        return Ok(existing.clone());
+    }
 
     let working_dir = working_dir.unwrap_or_else(|| paths.runner_dir(resp.runner_id).join("workspace"));
     let new_runner = RunnerConfig {


### PR DESCRIPTION
## Summary

Closes the gap left by `RunnerInviteEndpoint`, which only ever creates a fresh `Runner` row. After this PR, an operator can recover from an expired/lost enrollment token or a revoked runner without spawning a duplicate row.

- **Revoke** (`POST /api/runners/<id>/revoke/`) — hard-revoke without removing the row. Cascades sessions / in-flight runs / pinned follow-ups via `Runner.revoke()`. Idempotent.
- **Revive** (`POST /api/runners/<id>/revive/`) — mint a fresh enrollment token on a PENDING or REVOKED row. Clears `revoked_at`, resets refresh-token state, returns the same payload shape as the invite endpoint so the existing install-command panel renders unchanged. Returns 409 on actively-enrolled rows (revoke first).
- **CLI**: `pidash connect --token <new>` is now idempotent — when the enroll response's `runner_id` already exists in `config.toml`, credentials.toml is rotated in place instead of appending a duplicate `[[runner]]` block. Same idempotency applied to the TUI's `enroll_additional_runner` helper.
- **Web**: runners list grows **Revive** + **Revoke** buttons next to Delete. Revive opens the existing enrollment-command modal pre-populated with the freshly minted token.
- Refactored the post-enroll command panel into a shared `RunnerEnrollmentCommand` component used by both the add-runner modal and the new revive modal. `IRunner` now exposes `enrolled_at`, `revoked_at`, `revoked_reason` (already serialised server-side; just plumbed through the type).

## Test plan

- [ ] Backend: `pytest apps/api/pi_dash/tests/unit/runner/test_runner_revoke_revive.py` — 9 new unit tests cover revoke idempotency, revoke 404, revive on PENDING, revive on revoked (end-to-end including re-enroll against the new token), revive 409 on active, force-refresh cleanup, and owner/admin permission checks.
- [ ] Backend: full unit suite still green.
- [ ] CLI: `cargo test --lib cli::connect` (already verified locally — 7/7 pass).
- [ ] Web typecheck: `pnpm --filter=web check:types` — no new errors in any of the touched files.
- [ ] Manual: mint a runner invite, let the enrollment token go stale, click **Revive** in the UI, confirm the same `runner_id` appears in the response, run `pidash connect --token <new>` and verify the daemon enrolls without producing a duplicate `[[runner]]` block.
- [ ] Manual: revoke an active runner from the UI, confirm sessions close and runs cancel, then revive and re-enroll on the same row.