### PR TITLE
PDASHOSS01-1 Add a new agent field in add runner dialogue

### DIFF
--- a/apps/web/core/components/runners/add-runner-modal.tsx
+++ b/apps/web/core/components/runners/add-runner-modal.tsx
@@ -29,12 +29,19 @@ type Props = {
   onCreated: () => void;
 };
 
+// Mirrors the runner CLI's ``--agent`` value-enum (kebab-case). Keep in
+// sync with runner/src/config/schema.rs:AgentKind.
+const AGENT_OPTIONS = ["claude-code", "codex"] as const;
+type TAgent = (typeof AGENT_OPTIONS)[number];
+const DEFAULT_AGENT: TAgent = "claude-code";
+
 interface FormValues {
   projectIdentifier: string;
   podName: string;
   name: string;
   hostLabel: string;
   workingDir: string;
+  agent: TAgent;
 }
 
 const DEFAULT_VALUES: FormValues = {
@@ -43,6 +50,7 @@ const DEFAULT_VALUES: FormValues = {
   name: "",
   hostLabel: "",
   workingDir: "",
+  agent: DEFAULT_AGENT,
 };
 
 const runnerService = new RunnerService();
@@ -124,6 +132,12 @@ export const AddRunnerModal = observer(function AddRunnerModal(props: Props) {
 
   const hostLabelInput = watch("hostLabel");
   const workingDirInput = watch("workingDir");
+  const agentInput = watch("agent");
+
+  const agentOptionLabel = (value: TAgent): string =>
+    value === "claude-code"
+      ? t("runners.add_modal.agent_options.claude_code")
+      : t("runners.add_modal.agent_options.codex");
 
   const onSubmit: SubmitHandler<FormValues> = async (values) => {
     try {
@@ -282,6 +296,36 @@ export const AddRunnerModal = observer(function AddRunnerModal(props: Props) {
             <p className="text-12 text-secondary">{t("runners.add_modal.working_dir_help")}</p>
           </div>
 
+          <div className="flex flex-col gap-1">
+            <label htmlFor="add-runner-agent" className="text-13 font-medium text-primary">
+              {t("runners.add_modal.agent_label")}
+            </label>
+            <Controller
+              control={control}
+              name="agent"
+              render={({ field }) => (
+                <CustomSelect
+                  value={field.value}
+                  label={agentOptionLabel(field.value)}
+                  onChange={(v: TAgent) => field.onChange(v)}
+                  buttonClassName="border border-subtle"
+                  input
+                  maxHeight="lg"
+                  placement="bottom-start"
+                >
+                  <>
+                    {AGENT_OPTIONS.map((opt) => (
+                      <CustomSelect.Option key={opt} value={opt}>
+                        {agentOptionLabel(opt)}
+                      </CustomSelect.Option>
+                    ))}
+                  </>
+                </CustomSelect>
+              )}
+            />
+            <p className="text-12 text-secondary">{t("runners.add_modal.agent_help")}</p>
+          </div>
+
           <div className="flex justify-end gap-2">
             <Button variant="secondary" onClick={onClose} disabled={isSubmitting}>
               {t("runners.add_modal.cancel")}
@@ -302,7 +346,12 @@ export const AddRunnerModal = observer(function AddRunnerModal(props: Props) {
             </p>
           </div>
 
-          <RunnerEnrollmentCommand invite={invite} hostLabel={hostLabelInput} workingDir={workingDirInput} />
+          <RunnerEnrollmentCommand
+            invite={invite}
+            hostLabel={hostLabelInput}
+            workingDir={workingDirInput}
+            agent={agentInput}
+          />
 
           <div className="flex justify-end">
             <Button onClick={onClose}>{t("runners.add_modal.done")}</Button>

--- a/apps/web/core/components/runners/runner-enrollment-command.tsx
+++ b/apps/web/core/components/runners/runner-enrollment-command.tsx
@@ -14,10 +14,14 @@ import type { IRunnerInvite } from "@pi-dash/types";
 type Props = {
   invite: IRunnerInvite;
   /** Optional CLI flags surfaced for parity with the create-runner modal.
-   * The host_label / working_dir flags don't change anything server-side
-   * — they're CLI-only, so we keep the input simple here. */
+   * The host_label / working_dir / agent flags don't change anything
+   * server-side — they're CLI-only, so we keep the input simple here. */
   hostLabel?: string;
   workingDir?: string;
+  /** Agent kind in the runner CLI's kebab-case value-enum spelling
+   * (``codex`` or ``claude-code``). Omitted from the rendered command
+   * when unset. */
+  agent?: string;
 };
 
 /**
@@ -26,7 +30,7 @@ type Props = {
  * and the revive flow so both surface the same install instructions.
  */
 export function RunnerEnrollmentCommand(props: Props) {
-  const { invite, hostLabel, workingDir } = props;
+  const { invite, hostLabel, workingDir, agent } = props;
   const { t } = useTranslation();
   const [origin, setOrigin] = useState("");
   const [justCopied, setJustCopied] = useState(false);
@@ -42,6 +46,7 @@ export function RunnerEnrollmentCommand(props: Props) {
     const optionalArgs: string[] = [];
     if (hostLabel?.trim()) optionalArgs.push(`  --host-label ${hostLabel.trim()}`);
     if (workingDir?.trim()) optionalArgs.push(`  --working-dir ${workingDir.trim()}`);
+    if (agent?.trim()) optionalArgs.push(`  --agent ${agent.trim()}`);
     if (optionalArgs.length > 0) {
       lines[lines.length - 1] += " \\";
       for (let i = 0; i < optionalArgs.length; i += 1) {
@@ -50,7 +55,7 @@ export function RunnerEnrollmentCommand(props: Props) {
       }
     }
     return lines.join("\n");
-  }, [invite.enrollment_token, apiOrigin, hostLabel, workingDir]);
+  }, [invite.enrollment_token, apiOrigin, hostLabel, workingDir, agent]);
 
   const copy = async () => {
     if (!enrollmentCommand) return;

--- a/packages/i18n/src/locales/en/core.ts
+++ b/packages/i18n/src/locales/en/core.ts
@@ -543,6 +543,12 @@ export default {
       working_dir_help:
         "Local path the daemon runs the agent CLI in — usually the project repo on disk. Defaults to a sandbox under the runner's data dir, which is rarely what you want.",
       working_dir_placeholder: "local dev machine project working dir",
+      agent_label: "Agent",
+      agent_help: "Which AI agent CLI this runner will drive. Baked into the displayed ``pidash connect`` command.",
+      agent_options: {
+        claude_code: "Claude Code",
+        codex: "Codex",
+      },
       submit: "Mint enrollment token",
       submitting: "Minting…",
       cancel: "Cancel",

--- a/runner/src/cli/connect.rs
+++ b/runner/src/cli/connect.rs
@@ -21,7 +21,9 @@ use crate::cloud::http::{
     RunnerCredentials, SharedHttpTransport, TransportError, enroll_runner, write_runner_credentials,
 };
 use crate::config::file;
-use crate::config::schema::{Config, Credentials, DaemonConfig, RunnerConfig, WorkspaceSection};
+use crate::config::schema::{
+    AgentKind, AgentSection, Config, Credentials, DaemonConfig, RunnerConfig, WorkspaceSection,
+};
 use crate::util::paths::Paths;
 
 #[derive(Debug, ClapArgs)]
@@ -46,6 +48,11 @@ pub struct Args {
     /// fine for sandbox runs but not what most operators want.
     #[arg(long)]
     pub working_dir: Option<PathBuf>,
+
+    /// Which agent CLI this runner drives (``codex`` or ``claude-code``).
+    /// Defaults to ``AgentKind::default()`` when omitted.
+    #[arg(long, value_enum)]
+    pub agent: Option<AgentKind>,
 
     /// Skip the post-enroll doctor + service install. Useful in CI.
     #[arg(long)]
@@ -176,7 +183,9 @@ pub async fn run(args: Args, paths: &Paths) -> Result<()> {
         project_slug: Some(resp.project_identifier.clone()),
         pod_id: None,
         workspace: WorkspaceSection { working_dir },
-        agent: Default::default(),
+        agent: AgentSection {
+            kind: args.agent.unwrap_or_default(),
+        },
         codex: Default::default(),
         claude_code: Default::default(),
         approval_policy: Default::default(),


### PR DESCRIPTION
## Summary

- Adds an **Agent** picker (Claude Code / Codex; default Claude Code) to the add-runner modal.
- Appends `--agent <value>` to the displayed `pidash connect` command so the user's pick is baked into the one-liner they paste on the runner host.
- Wires `--agent` (optional, defaults to `AgentKind::default()`) through `pidash connect` so the new flag the UI surfaces actually takes effect, populating the new runner block's `agent.kind` instead of always falling back to the default.

Closes PDASHOSS01-1.

## Test plan

- [ ] `cargo test -p pidash --lib connect::` — passes locally.
- [ ] `cargo test --test pidash_cli_contract` / `pidash_cli_structure` — passes locally.
- [ ] `cargo clippy --no-deps --all-targets` — clean.
- [ ] `pnpm turbo run check:types --filter=@pi-dash/i18n` — clean.
- [ ] Manual: open the add-runner dialog; the new Agent field defaults to "Claude Code"; toggling to "Codex" updates the rendered command to `--agent codex`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
