### PR TITLE
feat(services): expose axios-instance setup seam for downstream builds

### DIFF
--- a/packages/services/src/_axios-setup.ts
+++ b/packages/services/src/_axios-setup.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+// Lives in its own module — not on `api.service` — so the side-effect
+// seam at `api.service` → `./ee/init` doesn't cycle back through
+// `api.service` to look up the registry. A `const` registry on
+// `api.service` would be in the TDZ at the moment `ee/init` evaluates,
+// throwing `ReferenceError: Cannot access 'axiosSetups' before
+// initialization` at module load. Putting the registry here breaks the
+// cycle: `ee/init` imports from this file directly, which finishes
+// initializing before `ee/init`'s body runs.
+
+import type { AxiosInstance } from "axios";
+
+export type AxiosInstanceSetup = (instance: AxiosInstance) => void;
+
+const axiosSetups: AxiosInstanceSetup[] = [];
+
+/**
+ * Register a function that runs against every new axios instance created
+ * by an `APIService` subclass. Must be called before the first service
+ * is constructed — the intended path is the `./ee/init` side-effect
+ * seam that `api.service` imports at the top of its module.
+ */
+export function registerAxiosSetup(setup: AxiosInstanceSetup): void {
+  axiosSetups.push(setup);
+}
+
+/** Apply every registered setup to a freshly-created axios instance. */
+export function applyAxiosSetups(instance: AxiosInstance): void {
+  for (const setup of axiosSetups) setup(instance);
+}

--- a/packages/services/src/api.service.ts
+++ b/packages/services/src/api.service.ts
@@ -6,25 +6,19 @@
 
 import type { AxiosInstance, AxiosRequestConfig } from "axios";
 import axios from "axios";
+// `_axios-setup` first so its registry is fully initialized before
+// `./ee/init` runs and (in cloud builds) registers an interceptor.
+import { applyAxiosSetups } from "./_axios-setup";
 // Side-effect import: lets builds plug per-instance axios setup (eg. an auth
 // refresh interceptor) into every APIService without forking this file.
-// The OSS build ships an empty stub; ee-overlay builds replace it.
+// The OSS build ships an empty stub; ee-overlay builds replace it. The
+// stub/replacement must import its `registerAxiosSetup` from
+// `../_axios-setup` (not from this file) to avoid a circular-import TDZ.
 // eslint-disable-next-line import/no-unassigned-import
 import "./ee/init";
 
-export type AxiosInstanceSetup = (instance: AxiosInstance) => void;
-
-const axiosSetups: AxiosInstanceSetup[] = [];
-
-/**
- * Register a function that runs against every new axios instance created by
- * an APIService subclass. Must be called before the first service is
- * constructed — typically from a module imported very early in the app boot
- * (or via the `./ee/init` side-effect seam).
- */
-export function registerAxiosSetup(setup: AxiosInstanceSetup): void {
-  axiosSetups.push(setup);
-}
+export type { AxiosInstanceSetup } from "./_axios-setup";
+export { registerAxiosSetup } from "./_axios-setup";
 
 /**
  * Abstract base class for making HTTP requests using axios
@@ -44,7 +38,7 @@ export abstract class APIService {
       baseURL,
       withCredentials: true,
     });
-    for (const setup of axiosSetups) setup(this.axiosInstance);
+    applyAxiosSetups(this.axiosInstance);
   }
 
   /**

--- a/packages/services/src/api.service.ts
+++ b/packages/services/src/api.service.ts
@@ -6,6 +6,25 @@
 
 import type { AxiosInstance, AxiosRequestConfig } from "axios";
 import axios from "axios";
+// Side-effect import: lets builds plug per-instance axios setup (eg. an auth
+// refresh interceptor) into every APIService without forking this file.
+// The OSS build ships an empty stub; ee-overlay builds replace it.
+// eslint-disable-next-line import/no-unassigned-import
+import "./ee/init";
+
+export type AxiosInstanceSetup = (instance: AxiosInstance) => void;
+
+const axiosSetups: AxiosInstanceSetup[] = [];
+
+/**
+ * Register a function that runs against every new axios instance created by
+ * an APIService subclass. Must be called before the first service is
+ * constructed — typically from a module imported very early in the app boot
+ * (or via the `./ee/init` side-effect seam).
+ */
+export function registerAxiosSetup(setup: AxiosInstanceSetup): void {
+  axiosSetups.push(setup);
+}
 
 /**
  * Abstract base class for making HTTP requests using axios
@@ -25,6 +44,7 @@ export abstract class APIService {
       baseURL,
       withCredentials: true,
     });
+    for (const setup of axiosSetups) setup(this.axiosInstance);
   }
 
   /**

--- a/packages/services/src/ee/init.ts
+++ b/packages/services/src/ee/init.ts
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+// Empty in OSS. Cloud (or other distributions) replace this file via
+// build-time overlay to call `registerAxiosSetup(...)` from
+// `../api.service` and install per-instance interceptors (eg. a 401 →
+// refresh-token retry handler). Keep this file side-effect-only.

--- a/packages/services/src/ee/init.ts
+++ b/packages/services/src/ee/init.ts
@@ -6,5 +6,15 @@
 
 // Empty in OSS. Cloud (or other distributions) replace this file via
 // build-time overlay to call `registerAxiosSetup(...)` from
-// `../api.service` and install per-instance interceptors (eg. a 401 →
+// `../_axios-setup` and install per-instance interceptors (eg. a 401 →
 // refresh-token retry handler). Keep this file side-effect-only.
+//
+// Important: import `registerAxiosSetup` from `../_axios-setup`, NOT
+// from `../api.service`. Importing from `api.service` re-enters its
+// evaluation while it is awaiting this very side-effect import, and
+// the registry `const` would be in the TDZ.
+
+// Type-only export so this file is a valid ES module (and `import
+// "./ee/init"` from `api.service` resolves). Erased at compile time;
+// nothing ships in the OSS bundle.
+export type _Stub = never;


### PR DESCRIPTION
## Summary

- Add a tiny registration mechanism so downstream distributions can install per-instance axios interceptors (eg. a 401 → refresh-token retry handler) without forking `api.service.ts`.
- `APIService` now walks a registry of setup callbacks on every new instance it creates, and side-effect-imports `./ee/init` to give consumers a stable hook to register from.
- OSS ships `packages/services/src/ee/init.ts` as an empty stub. Cloud (or other distributions) replace it via build-time overlay.

## Motivation

The cloud build has session JWTs that expire every 15 min and a `/api/auth/refresh/` endpoint that rotates them. Today the SPA has no client-side refresh logic, so users get bounced to a sign-in card every 15 min. The cloud needs to install a 401 → refresh → retry axios interceptor — but because `APIService` calls `axios.create()` per subclass, a "global" interceptor isn't possible without a hook point in this file. This adds the minimum hook: a `registerAxiosSetup(fn)` registry plus a `./ee/init` side-effect import. OSS behaviour is unchanged (the stub is empty).

## Test plan

- [ ] `pnpm --filter @pi-dash/services exec tsc --noEmit` passes
- [ ] `pnpm exec oxlint packages/services/src/` passes
- [ ] `pnpm exec oxfmt --check packages/services/src/` passes
- [ ] OSS-only build/run unchanged — empty stub is a no-op
- [ ] Cloud overlay (separate PR in private-pi-dash) successfully calls `registerAxiosSetup` from its replacement `ee/init.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)