### PR TITLE
feat: device-code auth login + CLI-token runner registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,17 +111,29 @@ curl --proto '=https' --tlsv1.2 -LsSf \
   https://github.com/The-AI-Republic/pi-dash/releases/latest/download/pidash-installer.sh | sh
 ```
 
-Then enroll the machine with your Pi Dash platform. A single `pidash connect` call exchanges the one-time token, registers the first runner, installs the OS service (systemd user unit on Linux, launchd agent on macOS), and starts the daemon:
+Then authenticate the machine and register a runner. The standard flow is two commands:
 
 ```bash
-# Grab the one-time token from the "Add connection" button in the web UI
-pidash connect \
-  --url https://your-pidash-instance.com \
-  --token <ONE_TIME_CODE> \
-  --working-dir /path/to/your/repo
+# 1. Browser-based device-code login (like `gh auth login` / `stripe login`).
+#    Stores a CLI token at ~/.config/pidash/config.toml.
+pidash auth login --url https://your-pidash-instance.com
+
+# 2. Register this host as a runner. Uses the token from step 1 — no
+#    enrollment-token paste needed. On the first runner, installs the OS
+#    service (systemd user unit on Linux, launchd agent on macOS) and
+#    starts the daemon.
+pidash runner add --project <project-id>
 ```
 
-Need to add another runner under the same host later? Use `pidash runner add --project <project-id>`. To wire the host up but skip the auto service install (e.g. in CI), pass `--skip-service` and run `pidash install && pidash start` yourself.
+`pidash auth login` prompts to add a runner inline when no runner exists yet, so a fresh dev laptop can be onboarded with a single command. Add more runners later with `pidash runner add --project <other-project-id>`.
+
+For headless / scripted hosts where the browser flow is awkward, the legacy enrollment-token paste still works:
+
+```bash
+pidash connect --url https://your-pidash-instance.com --token <ONE_TIME_TOKEN>
+```
+
+Generate `<ONE_TIME_TOKEN>` from the "Add connection" button in the web UI.
 
 The runner daemon runs in the background, polls for assigned tasks, dispatches them to your AI agent, and reports results back to the platform.
 

--- a/apps/api/pi_dash/api/urls/__init__.py
+++ b/apps/api/pi_dash/api/urls/__init__.py
@@ -3,6 +3,7 @@
 # See the LICENSE file for details.
 
 from .asset import urlpatterns as asset_patterns
+from .auth import urlpatterns as auth_patterns
 from .cycle import urlpatterns as cycle_patterns
 from .intake import urlpatterns as intake_patterns
 from .label import urlpatterns as label_patterns
@@ -17,6 +18,7 @@ from .sticky import urlpatterns as sticky_patterns
 
 urlpatterns = [
     *asset_patterns,
+    *auth_patterns,
     *cycle_patterns,
     *intake_patterns,
     *label_patterns,

--- a/apps/api/pi_dash/api/urls/auth.py
+++ b/apps/api/pi_dash/api/urls/auth.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+from django.urls import path
+
+from pi_dash.authentication.views.cli import (
+    DeviceCodeApproveEndpoint,
+    DeviceCodeRevokeEndpoint,
+    DeviceCodeStartEndpoint,
+    DeviceCodeTokenEndpoint,
+)
+
+urlpatterns = [
+    path(
+        "auth/device/start/",
+        DeviceCodeStartEndpoint.as_view(),
+        name="auth-device-start",
+    ),
+    path(
+        "auth/device/approve/",
+        DeviceCodeApproveEndpoint.as_view(),
+        name="auth-device-approve",
+    ),
+    path(
+        "auth/device/token/",
+        DeviceCodeTokenEndpoint.as_view(),
+        name="auth-device-token",
+    ),
+    path(
+        "auth/revoke/",
+        DeviceCodeRevokeEndpoint.as_view(),
+        name="auth-revoke",
+    ),
+]

--- a/apps/api/pi_dash/api/urls/auth.py
+++ b/apps/api/pi_dash/api/urls/auth.py
@@ -9,6 +9,7 @@ from pi_dash.authentication.views.cli import (
     DeviceCodeRevokeEndpoint,
     DeviceCodeStartEndpoint,
     DeviceCodeTokenEndpoint,
+    WorkspaceListEndpoint,
 )
 
 urlpatterns = [
@@ -31,5 +32,10 @@ urlpatterns = [
         "auth/revoke/",
         DeviceCodeRevokeEndpoint.as_view(),
         name="auth-revoke",
+    ),
+    path(
+        "auth/workspaces/",
+        WorkspaceListEndpoint.as_view(),
+        name="auth-workspaces",
     ),
 ]

--- a/apps/api/pi_dash/authentication/views/cli/__init__.py
+++ b/apps/api/pi_dash/authentication/views/cli/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+from .device import (
+    DeviceCodeStartEndpoint,
+    DeviceCodeTokenEndpoint,
+    DeviceCodeApproveEndpoint,
+    DeviceCodeRevokeEndpoint,
+)
+
+__all__ = [
+    "DeviceCodeStartEndpoint",
+    "DeviceCodeTokenEndpoint",
+    "DeviceCodeApproveEndpoint",
+    "DeviceCodeRevokeEndpoint",
+]

--- a/apps/api/pi_dash/authentication/views/cli/__init__.py
+++ b/apps/api/pi_dash/authentication/views/cli/__init__.py
@@ -7,6 +7,7 @@ from .device import (
     DeviceCodeTokenEndpoint,
     DeviceCodeApproveEndpoint,
     DeviceCodeRevokeEndpoint,
+    WorkspaceListEndpoint,
 )
 
 __all__ = [
@@ -14,4 +15,5 @@ __all__ = [
     "DeviceCodeTokenEndpoint",
     "DeviceCodeApproveEndpoint",
     "DeviceCodeRevokeEndpoint",
+    "WorkspaceListEndpoint",
 ]

--- a/apps/api/pi_dash/authentication/views/cli/device.py
+++ b/apps/api/pi_dash/authentication/views/cli/device.py
@@ -303,6 +303,36 @@ class DeviceCodeTokenEndpoint(APIView):
         )
 
 
+class WorkspaceListEndpoint(APIView):
+    """``GET /api/v1/auth/workspaces/`` — workspaces the caller belongs to.
+
+    Used by ``pidash auth login`` to drive a "which workspace should this
+    host be bound to?" picker. The Pi Dash CLI on a dev host is
+    single-workspace-per-install in v1: after login the CLI persists one
+    ``workspace_slug`` and forwards it on subsequent runner-create calls.
+
+    Authenticated with the CLI's ``X-Api-Key`` token. Returns
+    ``{"workspaces": [{"slug", "name"}, ...]}`` in member-since order so
+    the picker stays stable across calls.
+    """
+
+    permission_classes = [IsAuthenticated]
+    authentication_classes = [APIKeyAuthentication]
+
+    def get(self, request):
+        members = (
+            WorkspaceMember.objects.filter(member=request.user, is_active=True)
+            .select_related("workspace")
+            .order_by("created_at")
+        )
+        workspaces = [
+            {"slug": m.workspace.slug, "name": m.workspace.name}
+            for m in members
+            if m.workspace is not None
+        ]
+        return Response({"workspaces": workspaces}, status=status.HTTP_200_OK)
+
+
 class DeviceCodeRevokeEndpoint(APIView):
     """Invalidate the caller's CLI token. Idempotent.
 

--- a/apps/api/pi_dash/authentication/views/cli/device.py
+++ b/apps/api/pi_dash/authentication/views/cli/device.py
@@ -25,13 +25,14 @@ import logging
 from datetime import timedelta
 
 # Django imports
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from django.utils import timezone
 
 # Third party imports
 from rest_framework import status
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.throttling import AnonRateThrottle
 from rest_framework.views import APIView
 
 # Module imports
@@ -50,6 +51,21 @@ DEVICE_CODE_TTL = timedelta(minutes=10)
 DEVICE_CODE_POLL_INTERVAL_SECONDS = 5
 DEVICE_CODE_MIN_POLL_GAP = timedelta(seconds=3)
 
+# Generated user_codes have ~3×10^11 entropy across the 10-min window,
+# so collisions are vanishingly rare in practice — but a single
+# collision still 500s the request, which we'd rather convert into a
+# retry. Bounded so a pathological alphabet exhaustion can't loop.
+DEVICE_CODE_START_MAX_RETRIES = 5
+
+
+class DeviceCodeStartThrottle(AnonRateThrottle):
+    """Per-IP cap on `device/start/` to keep the table from being
+    filled with junk by an unauthenticated caller. The legit flow
+    needs one call per `pidash auth login`, so a modest cap is fine.
+    """
+
+    scope = "auth_device_start"
+
 
 def _verification_uri(request) -> str:
     return f"{base_host(request=request).rstrip('/')}/auth/device/"
@@ -60,19 +76,34 @@ class DeviceCodeStartEndpoint(APIView):
 
     Anonymous endpoint. Anyone with network access can request a code;
     this is harmless because the code only unlocks anything once a
-    logged-in human explicitly approves it via the web UI.
+    logged-in human explicitly approves it via the web UI. Throttled
+    per IP so a malicious caller can't fill the table.
     """
 
     permission_classes = [AllowAny]
     authentication_classes: list = []
+    throttle_classes = [DeviceCodeStartThrottle]
 
     def post(self, request):
         expires_at = timezone.now() + DEVICE_CODE_TTL
-        row = CLIDeviceCode.objects.create(
-            expires_at=expires_at,
-            # No user/workspace yet — the row is "pending" until the
-            # human approves it in their browser session.
-        )
+        # Retry on the (vanishingly improbable) unique-constraint
+        # collision so a 1-in-10^11 unlucky generator output doesn't
+        # surface a 500 to the user.
+        for _attempt in range(DEVICE_CODE_START_MAX_RETRIES):
+            try:
+                row = CLIDeviceCode.objects.create(
+                    expires_at=expires_at,
+                    # No user/workspace yet — the row is "pending" until
+                    # the human approves it in their browser session.
+                )
+                break
+            except IntegrityError as exc:
+                logger.warning("CLIDeviceCode create collided, retrying: %s", exc)
+        else:
+            return Response(
+                {"error": "internal_error", "error_description": "Could not allocate a device code; try again."},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
         return Response(
             {
                 "device_code": row.device_code,
@@ -138,6 +169,17 @@ class DeviceCodeApproveEndpoint(APIView):
                 return Response(
                     {"error": "This code has expired. Run `pidash auth login` again."},
                     status=status.HTTP_410_GONE,
+                )
+            # Reject second-user takeover: once a code is approved, only
+            # the same user can re-approve it (idempotent). Otherwise an
+            # attacker who shoulder-surfs the user_code in the ~10-min
+            # window could overwrite `row.user` before the CLI polls and
+            # end up with a token impersonating the second-approver's
+            # account.
+            if row.approved and row.user_id is not None and row.user_id != request.user.id:
+                return Response(
+                    {"error": "This code has already been approved by another user."},
+                    status=status.HTTP_409_CONFLICT,
                 )
 
             # Pick a workspace the approving user is a member of. v1 is
@@ -218,9 +260,13 @@ class DeviceCodeTokenEndpoint(APIView):
             # MUST NOT poll faster than `interval`; if they do we should
             # tell them to `slow_down`. We accept the first poll
             # unconditionally and clamp subsequent ones to a 3s floor.
+            #
+            # Critically, do NOT bump `last_polled_at` on a slow_down
+            # rejection — otherwise a malicious caller holding the
+            # device_code could spam fast polls and starve the legit
+            # CLI, which would always see `(now - last_polled_at) < gap`
+            # because the attacker just touched it.
             if row.last_polled_at is not None and (now - row.last_polled_at) < DEVICE_CODE_MIN_POLL_GAP:
-                row.last_polled_at = now
-                row.save(update_fields=["last_polled_at", "updated_at"])
                 return Response(
                     {"error": "slow_down"},
                     status=status.HTTP_400_BAD_REQUEST,

--- a/apps/api/pi_dash/authentication/views/cli/device.py
+++ b/apps/api/pi_dash/authentication/views/cli/device.py
@@ -1,0 +1,282 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Device-authorization flow for `pidash auth login` (RFC 8628-shaped).
+
+Three endpoints make up the dance:
+
+* ``POST /api/v1/auth/device/start/`` — AllowAny. CLI requests a
+  ``device_code``/``user_code`` pair. ``device_code`` stays on the CLI;
+  ``user_code`` is shown to the human so they can type it into the web UI.
+* ``POST /api/v1/auth/device/approve/`` — session-authenticated. The
+  logged-in human submits the ``user_code`` they read off their terminal,
+  stamping the row with ``user`` + ``approved``.
+* ``POST /api/v1/auth/device/token/`` — AllowAny. CLI polls with the
+  ``device_code`` it kept; once the row is approved we mint an
+  :class:`APIToken` for the user and consume the row.
+
+Also hosts ``POST /api/v1/auth/revoke/`` — used by ``pidash auth logout``
+to invalidate the caller's CLI token server-side.
+"""
+
+# Python imports
+import logging
+from datetime import timedelta
+
+# Django imports
+from django.db import transaction
+from django.utils import timezone
+
+# Third party imports
+from rest_framework import status
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+# Module imports
+from pi_dash.api.middleware.api_authentication import APIKeyAuthentication
+from pi_dash.authentication.session import BaseSessionAuthentication
+from pi_dash.db.models import APIToken, CLIDeviceCode, WorkspaceMember
+from pi_dash.authentication.utils.host import base_host
+
+logger = logging.getLogger("pi_dash.auth.cli")
+
+
+# RFC 8628 §3.2 — we choose 10 minutes for the grant window and 5 seconds
+# as the recommended polling interval. The CLI must honor `slow_down` if
+# we return it; we double the floor on each violation up to 30s.
+DEVICE_CODE_TTL = timedelta(minutes=10)
+DEVICE_CODE_POLL_INTERVAL_SECONDS = 5
+DEVICE_CODE_MIN_POLL_GAP = timedelta(seconds=3)
+
+
+def _verification_uri(request) -> str:
+    return f"{base_host(request=request).rstrip('/')}/auth/device/"
+
+
+class DeviceCodeStartEndpoint(APIView):
+    """RFC 8628 §3.1 — issue a device/user code pair.
+
+    Anonymous endpoint. Anyone with network access can request a code;
+    this is harmless because the code only unlocks anything once a
+    logged-in human explicitly approves it via the web UI.
+    """
+
+    permission_classes = [AllowAny]
+    authentication_classes: list = []
+
+    def post(self, request):
+        expires_at = timezone.now() + DEVICE_CODE_TTL
+        row = CLIDeviceCode.objects.create(
+            expires_at=expires_at,
+            # No user/workspace yet — the row is "pending" until the
+            # human approves it in their browser session.
+        )
+        return Response(
+            {
+                "device_code": row.device_code,
+                "user_code": row.user_code,
+                "verification_uri": _verification_uri(request),
+                "expires_in": int(DEVICE_CODE_TTL.total_seconds()),
+                "interval": DEVICE_CODE_POLL_INTERVAL_SECONDS,
+            },
+            status=status.HTTP_200_OK,
+        )
+
+
+class DeviceCodeApproveEndpoint(APIView):
+    """Session-auth: logged-in human approves a pending CLI login.
+
+    The web UI at ``/auth/device/`` calls this with the ``user_code``
+    typed by the human. We stamp the row with ``request.user`` so the
+    subsequent CLI poll can mint a token for that user.
+    """
+
+    permission_classes = [IsAuthenticated]
+    authentication_classes = [BaseSessionAuthentication]
+
+    def post(self, request):
+        raw = (request.data.get("user_code") or "").strip().upper()
+        if not raw:
+            return Response(
+                {"error": "user_code is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # Be lenient about hyphens / case so users can type the code as
+        # rendered (e.g. "WXYZ-1234") or paste with whitespace. The DB
+        # stores the canonical "XXXX-XXXX" form.
+        normalized = raw.replace(" ", "").replace("-", "")
+        if len(normalized) != 8:
+            return Response(
+                {"error": "user_code must be 8 characters."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        canonical = f"{normalized[:4]}-{normalized[4:]}"
+
+        with transaction.atomic():
+            try:
+                row = CLIDeviceCode.objects.select_for_update().get(user_code=canonical)
+            except CLIDeviceCode.DoesNotExist:
+                return Response(
+                    {"error": "Code not recognized. Check the code on your terminal and try again."},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
+
+            if row.consumed:
+                return Response(
+                    {"error": "This code has already been used."},
+                    status=status.HTTP_410_GONE,
+                )
+            if row.denied:
+                return Response(
+                    {"error": "This code has been denied."},
+                    status=status.HTTP_410_GONE,
+                )
+            if row.expires_at <= timezone.now():
+                return Response(
+                    {"error": "This code has expired. Run `pidash auth login` again."},
+                    status=status.HTTP_410_GONE,
+                )
+
+            # Pick a workspace the approving user is a member of. v1 is
+            # single-workspace-per-host, so we just pick the most recent
+            # one; future work can let the user choose during approval.
+            membership = (
+                WorkspaceMember.objects.filter(member=request.user, is_active=True)
+                .select_related("workspace")
+                .order_by("-created_at")
+                .first()
+            )
+
+            row.user = request.user
+            row.workspace = membership.workspace if membership else None
+            row.approved = True
+            row.save(update_fields=["user", "workspace", "approved", "updated_at"])
+
+        return Response(
+            {
+                "ok": True,
+                "user_email": request.user.email,
+                "workspace_slug": row.workspace.slug if row.workspace else None,
+            },
+            status=status.HTTP_200_OK,
+        )
+
+
+class DeviceCodeTokenEndpoint(APIView):
+    """RFC 8628 §3.4 — CLI polls here trading device_code for an APIToken.
+
+    Returns one of:
+      * 200 ``{access_token, workspace_slug, user_email}`` on approval.
+      * 400 ``{error: "authorization_pending"}`` while waiting.
+      * 400 ``{error: "slow_down"}`` if polling too fast.
+      * 410 ``{error: "expired_token"}`` after TTL.
+      * 410 ``{error: "access_denied"}`` if the human denied it.
+    """
+
+    permission_classes = [AllowAny]
+    authentication_classes: list = []
+
+    def post(self, request):
+        device_code = (request.data.get("device_code") or "").strip()
+        if not device_code:
+            return Response(
+                {"error": "invalid_request", "error_description": "device_code is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        with transaction.atomic():
+            try:
+                row = CLIDeviceCode.objects.select_for_update().get(device_code=device_code)
+            except CLIDeviceCode.DoesNotExist:
+                return Response(
+                    {"error": "invalid_grant", "error_description": "Unknown device code."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            now = timezone.now()
+
+            if row.consumed:
+                return Response(
+                    {"error": "invalid_grant", "error_description": "Device code already consumed."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            if row.denied:
+                return Response(
+                    {"error": "access_denied"},
+                    status=status.HTTP_410_GONE,
+                )
+            if row.expires_at <= now:
+                return Response(
+                    {"error": "expired_token"},
+                    status=status.HTTP_410_GONE,
+                )
+
+            # Enforce a minimum gap between polls. RFC 8628 says a client
+            # MUST NOT poll faster than `interval`; if they do we should
+            # tell them to `slow_down`. We accept the first poll
+            # unconditionally and clamp subsequent ones to a 3s floor.
+            if row.last_polled_at is not None and (now - row.last_polled_at) < DEVICE_CODE_MIN_POLL_GAP:
+                row.last_polled_at = now
+                row.save(update_fields=["last_polled_at", "updated_at"])
+                return Response(
+                    {"error": "slow_down"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            row.last_polled_at = now
+
+            if not row.approved or row.user_id is None:
+                row.save(update_fields=["last_polled_at", "updated_at"])
+                return Response(
+                    {"error": "authorization_pending"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            # Approved + not yet consumed: mint a fresh APIToken for the
+            # user and consume the row in the same transaction.
+            api_token = APIToken.objects.create(
+                user=row.user,
+                workspace=row.workspace,
+                user_type=0,  # Human
+                description="Issued by pidash auth login (device-code flow).",
+            )
+            row.consumed = True
+            row.save(update_fields=["consumed", "last_polled_at", "updated_at"])
+
+        return Response(
+            {
+                "access_token": api_token.token,
+                "token_type": "X-Api-Key",
+                "user_email": row.user.email if row.user else None,
+                "workspace_slug": row.workspace.slug if row.workspace else None,
+            },
+            status=status.HTTP_200_OK,
+        )
+
+
+class DeviceCodeRevokeEndpoint(APIView):
+    """Invalidate the caller's CLI token. Idempotent.
+
+    Used by ``pidash auth logout``. The caller authenticates with their
+    current token (which we then mark inactive). Subsequent requests
+    with that token will 401.
+    """
+
+    permission_classes = [IsAuthenticated]
+    authentication_classes = [APIKeyAuthentication]
+
+    def post(self, request):
+        # request.auth is the raw token string (see APIKeyAuthentication).
+        raw_token = request.auth
+        try:
+            tok = APIToken.objects.get(token=raw_token)
+        except APIToken.DoesNotExist:
+            # Already gone — idempotent OK.
+            return Response({"ok": True}, status=status.HTTP_200_OK)
+        if tok.is_active:
+            tok.is_active = False
+            tok.save(update_fields=["is_active", "updated_at"])
+        return Response({"ok": True}, status=status.HTTP_200_OK)

--- a/apps/api/pi_dash/db/migrations/0135_clidevicecode.py
+++ b/apps/api/pi_dash/db/migrations/0135_clidevicecode.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Add CLIDeviceCode model for `pidash auth login` device-code flow.
+
+RFC 8628-shaped grant: a row is created when the CLI starts a login,
+approved by the user via the web UI, and consumed when the CLI trades
+the device_code for a fresh APIToken.
+"""
+
+import uuid
+
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+import pi_dash.db.models.api
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("db", "0134_issueagentticker_disarm_reason"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="CLIDeviceCode",
+            fields=[
+                ("created_at", models.DateTimeField(auto_now_add=True, verbose_name="Created At")),
+                ("updated_at", models.DateTimeField(auto_now=True, verbose_name="Last Modified At")),
+                ("deleted_at", models.DateTimeField(blank=True, null=True, verbose_name="Deleted At")),
+                (
+                    "id",
+                    models.UUIDField(
+                        db_index=True,
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                        unique=True,
+                    ),
+                ),
+                (
+                    "device_code",
+                    models.CharField(
+                        db_index=True,
+                        default=pi_dash.db.models.api.generate_device_code,
+                        max_length=64,
+                        unique=True,
+                    ),
+                ),
+                (
+                    "user_code",
+                    models.CharField(
+                        db_index=True,
+                        default=pi_dash.db.models.api.generate_user_code,
+                        max_length=16,
+                        unique=True,
+                    ),
+                ),
+                ("approved", models.BooleanField(default=False)),
+                ("denied", models.BooleanField(default=False)),
+                ("consumed", models.BooleanField(default=False)),
+                ("expires_at", models.DateTimeField()),
+                ("last_polled_at", models.DateTimeField(blank=True, null=True)),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="clidevicecode_created_by",
+                        to=settings.AUTH_USER_MODEL,
+                        verbose_name="Created By",
+                    ),
+                ),
+                (
+                    "updated_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="clidevicecode_updated_by",
+                        to=settings.AUTH_USER_MODEL,
+                        verbose_name="Last Modified By",
+                    ),
+                ),
+                (
+                    "user",
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="device_codes",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "workspace",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="device_codes",
+                        to="db.workspace",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "CLI Device Code",
+                "verbose_name_plural": "CLI Device Codes",
+                "db_table": "cli_device_codes",
+                "ordering": ("-created_at",),
+            },
+        ),
+    ]

--- a/apps/api/pi_dash/db/models/__init__.py
+++ b/apps/api/pi_dash/db/models/__init__.py
@@ -3,7 +3,7 @@
 # See the LICENSE file for details.
 
 from .analytic import AnalyticView
-from .api import APIActivityLog, APIToken
+from .api import APIActivityLog, APIToken, CLIDeviceCode
 from .asset import FileAsset
 from .base import BaseModel
 from .cycle import Cycle, CycleIssue, CycleUserProperties

--- a/apps/api/pi_dash/db/models/api.py
+++ b/apps/api/pi_dash/db/models/api.py
@@ -3,6 +3,7 @@
 # See the LICENSE file for details.
 
 # Python imports
+import secrets
 from uuid import uuid4
 
 # Django imports
@@ -18,6 +19,17 @@ def generate_label_token():
 
 def generate_token():
     return "pi_dash_api_" + uuid4().hex
+
+
+def generate_device_code():
+    return secrets.token_urlsafe(32)
+
+
+def generate_user_code():
+    # 8-char, ambiguity-free alphabet, hyphenated for readability ("WXYZ-1234").
+    alphabet = "BCDFGHJKLMNPQRSTVWXZ23456789"
+    raw = "".join(secrets.choice(alphabet) for _ in range(8))
+    return f"{raw[:4]}-{raw[4:]}"
 
 
 class APIToken(BaseModel):
@@ -46,6 +58,40 @@ class APIToken(BaseModel):
 
     def __str__(self):
         return str(self.user.id)
+
+
+class CLIDeviceCode(BaseModel):
+    """RFC 8628-shaped device-authorization grant for `pidash auth login`.
+
+    Lifecycle: ``pidash auth login`` POSTs to start, gets back
+    ``device_code`` (opaque, returned to CLI only) + ``user_code``
+    (short, shown to the human). User opens the verification URL in a
+    browser, signs in, enters ``user_code``, approves — server stamps
+    ``user`` + ``approved``. CLI polls the token endpoint with
+    ``device_code`` and trades the approved row for a fresh
+    :class:`APIToken`. Row is then marked ``consumed`` to prevent reuse.
+    """
+
+    device_code = models.CharField(max_length=64, unique=True, default=generate_device_code, db_index=True)
+    user_code = models.CharField(max_length=16, unique=True, default=generate_user_code, db_index=True)
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, null=True, related_name="device_codes")
+    workspace = models.ForeignKey(
+        "db.Workspace", related_name="device_codes", on_delete=models.CASCADE, null=True, blank=True
+    )
+    approved = models.BooleanField(default=False)
+    denied = models.BooleanField(default=False)
+    consumed = models.BooleanField(default=False)
+    expires_at = models.DateTimeField()
+    last_polled_at = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        verbose_name = "CLI Device Code"
+        verbose_name_plural = "CLI Device Codes"
+        db_table = "cli_device_codes"
+        ordering = ("-created_at",)
+
+    def __str__(self):
+        return self.user_code
 
 
 class APIActivityLog(BaseModel):

--- a/apps/api/pi_dash/runner/urls.py
+++ b/apps/api/pi_dash/runner/urls.py
@@ -16,6 +16,8 @@ from pi_dash.runner.views import (
     HealthEndpoint,
     MachineTokenRedeemEndpoint,
     MetricsEndpoint,
+    ProjectListEndpoint,
+    RunnerCreateEndpoint,
     RunAcceptEndpoint,
     RunApprovalEndpoint,
     RunAwaitingReauthEndpoint,
@@ -45,6 +47,21 @@ urlpatterns = [
         "runners/enroll/",
         RunnerEnrollEndpoint.as_view(),
         name="runner-enroll",
+    ),
+    # CLI-initiated runner creation (X-Api-Key auth). Dual of
+    # invite+enroll for callers that already have a user-scoped token.
+    path(
+        "runners/",
+        RunnerCreateEndpoint.as_view(),
+        name="runner-create",
+    ),
+    # CLI-facing project list — same view as /api/runners/projects/ but
+    # mounted here so `pidash` calls stay under /api/v1/runner/. Auth
+    # accepts X-Api-Key (set by `pidash auth login`).
+    path(
+        "projects/",
+        ProjectListEndpoint.as_view(),
+        name="cli-project-list",
     ),
     path(
         "runners/<uuid:runner_id>/refresh/",

--- a/apps/api/pi_dash/runner/views/__init__.py
+++ b/apps/api/pi_dash/runner/views/__init__.py
@@ -6,6 +6,7 @@ from .approvals import ApprovalDecideEndpoint, ApprovalListEndpoint
 from .enrollment import (
     MachineTokenRedeemEndpoint,
     MachineTokenTicketEndpoint,
+    RunnerCreateEndpoint,
     RunnerEnrollEndpoint,
     RunnerInviteEndpoint,
     RunnerRefreshEndpoint,
@@ -51,6 +52,7 @@ __all__ = [
     "ApprovalListEndpoint",
     "MachineTokenRedeemEndpoint",
     "MachineTokenTicketEndpoint",
+    "RunnerCreateEndpoint",
     "RunnerEnrollEndpoint",
     "RunnerInviteEndpoint",
     "RunnerRefreshEndpoint",

--- a/apps/api/pi_dash/runner/views/enrollment.py
+++ b/apps/api/pi_dash/runner/views/enrollment.py
@@ -15,6 +15,7 @@ token in lock-step on the server.
 from __future__ import annotations
 
 import logging
+import re
 import uuid as _uuid
 from typing import Optional
 
@@ -512,6 +513,14 @@ class RunnerSelfRevokeEndpoint(APIView):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
+# Runner names must round-trip safely through systemd unit names,
+# filesystem paths, and TOML keys — so reject anything that would
+# blow up downstream. Matches the runner CLI's `runner_name::validate`
+# in spirit; the regex stays simple on purpose.
+_RUNNER_NAME_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_.\-]{0,127}$")
+_MAX_AUTO_NAME_RETRIES = 5
+
+
 class RunnerCreateEndpoint(APIView):
     """``POST /api/v1/runner/runners/`` — CLI-initiated runner creation.
 
@@ -527,6 +536,12 @@ class RunnerCreateEndpoint(APIView):
     project. We deliberately do NOT require admin/maintainer here for
     parity with the web "Add Runner" button — any workspace member who
     can see the project can register a runner against it.
+
+    Workspace resolution: when ``workspace_slug`` is omitted, and the
+    caller is a member of exactly one workspace, we infer it. With zero
+    memberships we return 400; with multiple we require the caller to
+    name one. This matches the single-workspace-per-host onboarding
+    model the CLI is built around.
     """
 
     authentication_classes = [APIKeyAuthentication]
@@ -534,34 +549,66 @@ class RunnerCreateEndpoint(APIView):
     throttle_classes: list = []
 
     def post(self, request):
+        from pi_dash.db.models.project import Project
+        from pi_dash.db.models.workspace import Workspace, WorkspaceMember
+
         workspace_slug = (request.data.get("workspace_slug") or "").strip()
         project_identifier = (request.data.get("project") or "").strip()
         host_label = (request.data.get("host_label") or "").strip()[:255]
         body_name = (request.data.get("name") or "").strip()[:128]
         pod_name = (request.data.get("pod") or "").strip()
 
-        if not workspace_slug or not project_identifier:
+        if not project_identifier:
             return Response(
-                {"error": "workspace_slug and project are required"},
+                {"error": "project is required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if body_name and not _RUNNER_NAME_RE.match(body_name):
+            return Response(
+                {
+                    "error": "invalid_runner_name",
+                    "error_description": "name must start with [A-Za-z0-9_] and contain only A-Z, a-z, 0-9, _, ., -",
+                },
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        from pi_dash.db.models.project import Project
-        from pi_dash.db.models.workspace import Workspace
+        # Resolve workspace. Explicit slug wins; otherwise infer from
+        # the caller's single workspace membership (most pidash CLI
+        # users only belong to one). Multi-workspace users must be
+        # explicit so we don't pick the wrong one.
+        if workspace_slug:
+            workspace = Workspace.objects.filter(slug=workspace_slug).first()
+            if workspace is None or not is_workspace_member(request.user, workspace.id):
+                # Same 404 in both cases — don't leak existence of
+                # workspaces the caller can't see.
+                return Response(
+                    {"error": "workspace_not_found"},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
+        else:
+            memberships = list(
+                WorkspaceMember.objects.filter(member=request.user, is_active=True)
+                .select_related("workspace")
+                .order_by("created_at")[:2]
+            )
+            if not memberships:
+                return Response(
+                    {
+                        "error": "no_workspace_membership",
+                        "error_description": "Caller is not a member of any workspace.",
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            if len(memberships) > 1:
+                return Response(
+                    {
+                        "error": "workspace_slug_required",
+                        "error_description": "Caller belongs to multiple workspaces — pass workspace_slug to pick one.",
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            workspace = memberships[0].workspace
 
-        workspace = Workspace.objects.filter(slug=workspace_slug).first()
-        if workspace is None:
-            return Response(
-                {"error": "workspace_not_found"},
-                status=status.HTTP_404_NOT_FOUND,
-            )
-        if not is_workspace_member(request.user, workspace.id):
-            # Same 404 the invite endpoint returns — don't leak existence
-            # of workspaces the caller can't see.
-            return Response(
-                {"error": "workspace_not_found"},
-                status=status.HTTP_404_NOT_FOUND,
-            )
         project = Project.objects.filter(
             workspace_id=workspace.id, identifier=project_identifier
         ).first()
@@ -584,45 +631,67 @@ class RunnerCreateEndpoint(APIView):
                 status=status.HTTP_409_CONFLICT,
             )
 
-        name = body_name
-        if not name:
-            count = Runner.objects.filter(pod=pod).count()
-            name = f"runner_{count + 1:03d}"
-
-        with transaction.atomic():
-            refresh = tokens.mint_refresh_token()
+        # Mint the runner row, retrying on auto-name collisions when no
+        # name was supplied. Two `pidash runner add` calls running
+        # concurrently can both compute the same ``runner_NNN`` default;
+        # retrying server-side hides that race from the user. If the
+        # caller passed an explicit name and we 409, surface it.
+        attempts = 0
+        last_exc: Optional[IntegrityError] = None
+        runner: Optional[Runner] = None
+        refresh: Optional[tokens.MintedToken] = None
+        access: Optional[tokens.MintedToken] = None
+        machine_minted: Optional[tokens.MintedToken] = None
+        while attempts < _MAX_AUTO_NAME_RETRIES:
+            attempts += 1
+            name = body_name or _next_auto_runner_name(pod)
             try:
-                runner = Runner.objects.create(
-                    owner=request.user,
-                    workspace_id=workspace.id,
-                    pod=pod,
-                    name=name,
-                    host_label=host_label,
-                    enrolled_at=timezone.now(),
-                    refresh_token_hash=refresh.hashed,
-                    refresh_token_fingerprint=refresh.fingerprint,
-                    refresh_token_generation=1,
-                )
-            except IntegrityError:
-                return Response(
-                    {"error": "runner_name_taken"},
-                    status=status.HTTP_409_CONFLICT,
-                )
-
-            access = tokens.mint_access_token(
-                runner_id=str(runner.id),
-                user_id=str(runner.owner_id),
-                workspace_id=str(runner.workspace_id),
-                rtg=1,
+                with transaction.atomic():
+                    refresh = tokens.mint_refresh_token()
+                    runner = Runner.objects.create(
+                        owner=request.user,
+                        workspace_id=workspace.id,
+                        pod=pod,
+                        name=name,
+                        host_label=host_label,
+                        enrolled_at=timezone.now(),
+                        refresh_token_hash=refresh.hashed,
+                        refresh_token_fingerprint=refresh.fingerprint,
+                        refresh_token_generation=1,
+                    )
+                    access = tokens.mint_access_token(
+                        runner_id=str(runner.id),
+                        user_id=str(runner.owner_id),
+                        workspace_id=str(runner.workspace_id),
+                        rtg=1,
+                    )
+                    if host_label:
+                        machine_minted = _maybe_mint_machine_token(
+                            user=runner.owner,
+                            workspace=runner.workspace,
+                            host_label=host_label,
+                        )
+                break
+            except IntegrityError as exc:
+                last_exc = exc
+                if body_name:
+                    # Caller named it explicitly — don't retry.
+                    return Response(
+                        {"error": "runner_name_taken"},
+                        status=status.HTTP_409_CONFLICT,
+                    )
+                # Auto-name path: retry with a freshly recomputed name.
+                continue
+        if runner is None or refresh is None or access is None:
+            logger.warning(
+                "RunnerCreateEndpoint: gave up after %s auto-name attempts: %s",
+                _MAX_AUTO_NAME_RETRIES,
+                last_exc,
             )
-
-            machine_minted: Optional[tokens.MintedToken] = None
-            if host_label:
-                machine_minted = _maybe_mint_machine_token(
-                    user=runner.owner,
-                    workspace=runner.workspace,
-                    host_label=host_label,
-                )
+            return Response(
+                {"error": "could_not_allocate_runner_name"},
+                status=status.HTTP_409_CONFLICT,
+            )
 
         body = {
             "runner_id": str(runner.id),
@@ -641,6 +710,15 @@ class RunnerCreateEndpoint(APIView):
         if machine_minted is not None:
             body["machine_token"] = machine_minted.raw
         return Response(body, status=status.HTTP_201_CREATED)
+
+
+def _next_auto_runner_name(pod: Pod) -> str:
+    """Generate ``runner_NNN`` numbered higher than any existing runner
+    in the same pod. Used by ``RunnerCreateEndpoint`` when the caller
+    didn't supply ``name``. Race-safe via the retry loop in the caller.
+    """
+    count = Runner.objects.filter(pod=pod).count()
+    return f"runner_{count + 1:03d}"
 
 
 class MachineTokenTicketEndpoint(APIView):

--- a/apps/api/pi_dash/runner/views/enrollment.py
+++ b/apps/api/pi_dash/runner/views/enrollment.py
@@ -25,6 +25,7 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from pi_dash.api.middleware.api_authentication import APIKeyAuthentication
 from pi_dash.authentication.session import BaseSessionAuthentication
 from pi_dash.runner.authentication import (
     RunnerAccessTokenAuthentication,
@@ -509,6 +510,137 @@ class RunnerSelfRevokeEndpoint(APIView):
         close_runner_session(runner_pk)
         Runner.objects.filter(pk=runner_pk).delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class RunnerCreateEndpoint(APIView):
+    """``POST /api/v1/runner/runners/`` — CLI-initiated runner creation.
+
+    The dual of ``RunnerInviteEndpoint`` + ``RunnerEnrollEndpoint`` for
+    callers that already have a user-scoped CLI token (issued by
+    ``pidash auth login``). One round-trip mints the Runner row, marks
+    it enrolled, and returns the same shape as ``RunnerEnrollEndpoint``
+    so the daemon code path can be reused verbatim. No one-time
+    enrollment-token paste required.
+
+    Auth: ``X-Api-Key`` (APIToken). The token's user must be a member
+    of the target workspace and the workspace must contain the named
+    project. We deliberately do NOT require admin/maintainer here for
+    parity with the web "Add Runner" button — any workspace member who
+    can see the project can register a runner against it.
+    """
+
+    authentication_classes = [APIKeyAuthentication]
+    permission_classes = [IsAuthenticated]
+    throttle_classes: list = []
+
+    def post(self, request):
+        workspace_slug = (request.data.get("workspace_slug") or "").strip()
+        project_identifier = (request.data.get("project") or "").strip()
+        host_label = (request.data.get("host_label") or "").strip()[:255]
+        body_name = (request.data.get("name") or "").strip()[:128]
+        pod_name = (request.data.get("pod") or "").strip()
+
+        if not workspace_slug or not project_identifier:
+            return Response(
+                {"error": "workspace_slug and project are required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        from pi_dash.db.models.project import Project
+        from pi_dash.db.models.workspace import Workspace
+
+        workspace = Workspace.objects.filter(slug=workspace_slug).first()
+        if workspace is None:
+            return Response(
+                {"error": "workspace_not_found"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        if not is_workspace_member(request.user, workspace.id):
+            # Same 404 the invite endpoint returns — don't leak existence
+            # of workspaces the caller can't see.
+            return Response(
+                {"error": "workspace_not_found"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        project = Project.objects.filter(
+            workspace_id=workspace.id, identifier=project_identifier
+        ).first()
+        if project is None:
+            return Response(
+                {"error": "project_not_found"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        pod: Optional[Pod] = None
+        if pod_name:
+            pod = Pod.objects.filter(
+                project=project, name=pod_name, deleted_at__isnull=True
+            ).first()
+        if pod is None:
+            pod = Pod.default_for_project_id(project.id)
+        if pod is None:
+            return Response(
+                {"error": "project_has_no_default_pod"},
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        name = body_name
+        if not name:
+            count = Runner.objects.filter(pod=pod).count()
+            name = f"runner_{count + 1:03d}"
+
+        with transaction.atomic():
+            refresh = tokens.mint_refresh_token()
+            try:
+                runner = Runner.objects.create(
+                    owner=request.user,
+                    workspace_id=workspace.id,
+                    pod=pod,
+                    name=name,
+                    host_label=host_label,
+                    enrolled_at=timezone.now(),
+                    refresh_token_hash=refresh.hashed,
+                    refresh_token_fingerprint=refresh.fingerprint,
+                    refresh_token_generation=1,
+                )
+            except IntegrityError:
+                return Response(
+                    {"error": "runner_name_taken"},
+                    status=status.HTTP_409_CONFLICT,
+                )
+
+            access = tokens.mint_access_token(
+                runner_id=str(runner.id),
+                user_id=str(runner.owner_id),
+                workspace_id=str(runner.workspace_id),
+                rtg=1,
+            )
+
+            machine_minted: Optional[tokens.MintedToken] = None
+            if host_label:
+                machine_minted = _maybe_mint_machine_token(
+                    user=runner.owner,
+                    workspace=runner.workspace,
+                    host_label=host_label,
+                )
+
+        body = {
+            "runner_id": str(runner.id),
+            "runner_name": runner.name,
+            "refresh_token": refresh.raw,
+            "access_token": access.raw,
+            "access_token_expires_at": access.expires_at.isoformat(),
+            "refresh_token_generation": runner.refresh_token_generation,
+            "workspace_slug": workspace.slug,
+            "pod_slug": pod.name,
+            "project_identifier": project.identifier,
+            "long_poll_interval_secs": 25,
+            "protocol_version": 4,
+            "machine_token_minted": machine_minted is not None,
+        }
+        if machine_minted is not None:
+            body["machine_token"] = machine_minted.raw
+        return Response(body, status=status.HTTP_201_CREATED)
 
 
 class MachineTokenTicketEndpoint(APIView):

--- a/apps/api/pi_dash/runner/views/projects.py
+++ b/apps/api/pi_dash/runner/views/projects.py
@@ -20,6 +20,7 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from pi_dash.api.middleware.api_authentication import APIKeyAuthentication
 from pi_dash.authentication.session import BaseSessionAuthentication
 from pi_dash.db.models.project import Project
 from pi_dash.db.models.workspace import WorkspaceMember
@@ -77,13 +78,16 @@ def _serialize_projects(workspace_id) -> list[dict]:
 class ProjectListEndpoint(APIView):
     """GET /api/runners/projects/
 
-    Two auth modes:
+    Three auth modes (in order):
     - Bearer access-token (runner) — scoped to ``runner.workspace_id``.
+    - ``X-Api-Key`` (CLI/user) — scoped to caller's workspace memberships.
+      Used by ``pidash auth login``'s post-login project picker.
     - Session auth (web UI) — scoped to caller's workspace memberships.
     """
 
     authentication_classes = [
         RunnerAccessTokenAuthentication,
+        APIKeyAuthentication,
         BaseSessionAuthentication,
     ]
     permission_classes: list = []

--- a/apps/api/pi_dash/settings/common.py
+++ b/apps/api/pi_dash/settings/common.py
@@ -88,6 +88,10 @@ REST_FRAMEWORK = {
         "anon": "30/minute",
         "asset_id": "5/minute",
         "user": "120/minute",
+        # `pidash auth login` device-code start. Bounded per IP — the
+        # endpoint creates a DB row each call, so a flood would otherwise
+        # be a free table-pollution vector.
+        "auth_device_start": "20/minute",
     },
     "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
     "DEFAULT_RENDERER_CLASSES": ("rest_framework.renderers.JSONRenderer",),

--- a/apps/api/pi_dash/tests/unit/runner/test_cli_auth_flow.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_cli_auth_flow.py
@@ -296,6 +296,68 @@ def test_runner_create_400_when_no_workspace_membership(
     assert resp.data["error"] == "no_workspace_membership"
 
 
+# -------------------- workspaces list --------------------
+
+
+@pytest.mark.unit
+def test_workspaces_list_returns_single_membership(db, api_key_client, workspace):
+    """Single-workspace caller sees exactly that workspace, by slug + name.
+
+    Drives the no-prompt branch of `pidash auth login`'s workspace
+    resolver: one membership → silently persist `[cli].workspace_slug`.
+    """
+    resp = api_key_client.get("/api/v1/auth/workspaces/")
+    assert resp.status_code == 200, resp.data
+    assert resp.data == {"workspaces": [{"slug": workspace.slug, "name": workspace.name}]}
+
+
+@pytest.mark.unit
+def test_workspaces_list_returns_multiple_in_join_order(
+    db, api_key_client, create_user, workspace
+):
+    """Multi-workspace caller sees every active membership, ordered by
+    join time. The CLI's picker renders them in this order so the list
+    is stable across calls.
+    """
+    from pi_dash.db.models.workspace import Workspace, WorkspaceMember
+
+    second = Workspace.objects.create(name="second-ws", owner=create_user, slug="second-ws")
+    WorkspaceMember.objects.create(workspace=second, member=create_user, role=20)
+
+    resp = api_key_client.get("/api/v1/auth/workspaces/")
+    assert resp.status_code == 200, resp.data
+    slugs = [w["slug"] for w in resp.data["workspaces"]]
+    assert slugs == [workspace.slug, second.slug]
+
+
+@pytest.mark.unit
+def test_workspaces_list_excludes_inactive_memberships(
+    db, api_key_client, create_user, workspace
+):
+    """Soft-removed memberships (`is_active=False`) must not surface
+    in the picker — otherwise the user could pick a workspace they no
+    longer have access to and hit a confusing 403 on the next call.
+    """
+    from pi_dash.db.models.workspace import Workspace, WorkspaceMember
+
+    inactive = Workspace.objects.create(name="gone-ws", owner=create_user, slug="gone-ws")
+    WorkspaceMember.objects.create(
+        workspace=inactive, member=create_user, role=20, is_active=False
+    )
+
+    resp = api_key_client.get("/api/v1/auth/workspaces/")
+    assert resp.status_code == 200, resp.data
+    slugs = [w["slug"] for w in resp.data["workspaces"]]
+    assert slugs == [workspace.slug]
+
+
+@pytest.mark.unit
+def test_workspaces_list_requires_auth(db, api_client):
+    """Anonymous callers get 401; the endpoint is CLI-token only."""
+    resp = api_client.get("/api/v1/auth/workspaces/")
+    assert resp.status_code in (401, 403)
+
+
 # -------------------- approval hardening --------------------
 
 

--- a/apps/api/pi_dash/tests/unit/runner/test_cli_auth_flow.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_cli_auth_flow.py
@@ -1,0 +1,212 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Tests for the device-code (`pidash auth login`) flow + CLI-initiated
+runner mint + token revoke endpoints. See
+``apps/api/pi_dash/authentication/views/cli/device.py`` and
+``apps/api/pi_dash/runner/views/enrollment.py::RunnerCreateEndpoint``.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+
+from pi_dash.db.models import APIToken, CLIDeviceCode
+
+
+# -------------------- device-code flow --------------------
+
+
+@pytest.mark.unit
+def test_device_start_returns_user_code_and_device_code(db, api_client):
+    resp = api_client.post("/api/v1/auth/device/start/", {}, format="json")
+    assert resp.status_code == 200, resp.data
+    assert resp.data["device_code"]
+    assert resp.data["user_code"]
+    assert "-" in resp.data["user_code"]
+    assert resp.data["verification_uri"].endswith("/auth/device/")
+    assert resp.data["expires_in"] > 0
+    assert resp.data["interval"] > 0
+    # Row created.
+    assert CLIDeviceCode.objects.filter(device_code=resp.data["device_code"]).exists()
+
+
+@pytest.mark.unit
+def test_token_poll_pending_then_approved_mints_apitoken(
+    db, api_client, session_client, create_user
+):
+    start = api_client.post("/api/v1/auth/device/start/", {}, format="json").data
+    # First poll: pending (no approval yet).
+    poll1 = api_client.post(
+        "/api/v1/auth/device/token/", {"device_code": start["device_code"]}, format="json"
+    )
+    assert poll1.status_code == 400
+    assert poll1.data["error"] == "authorization_pending"
+
+    # Operator approves via the web session.
+    approve = session_client.post(
+        "/api/v1/auth/device/approve/", {"user_code": start["user_code"]}, format="json"
+    )
+    assert approve.status_code == 200, approve.data
+    assert approve.data["user_email"] == create_user.email
+
+    # Second poll: success, returns a fresh APIToken.
+    # Bump last_polled_at past the min-gap to skip slow_down.
+    CLIDeviceCode.objects.filter(device_code=start["device_code"]).update(
+        last_polled_at=timezone.now() - timedelta(seconds=30)
+    )
+    poll2 = api_client.post(
+        "/api/v1/auth/device/token/", {"device_code": start["device_code"]}, format="json"
+    )
+    assert poll2.status_code == 200, poll2.data
+    assert poll2.data["access_token"].startswith("pi_dash_api_")
+    assert poll2.data["user_email"] == create_user.email
+    # APIToken row exists.
+    assert APIToken.objects.filter(token=poll2.data["access_token"], user=create_user).exists()
+    # Row marked consumed.
+    row = CLIDeviceCode.objects.get(device_code=start["device_code"])
+    assert row.consumed is True
+
+
+@pytest.mark.unit
+def test_token_poll_rejects_consumed_code(db, api_client, session_client):
+    start = api_client.post("/api/v1/auth/device/start/", {}, format="json").data
+    session_client.post(
+        "/api/v1/auth/device/approve/", {"user_code": start["user_code"]}, format="json"
+    )
+    CLIDeviceCode.objects.filter(device_code=start["device_code"]).update(
+        last_polled_at=timezone.now() - timedelta(seconds=30)
+    )
+    first = api_client.post(
+        "/api/v1/auth/device/token/", {"device_code": start["device_code"]}, format="json"
+    )
+    assert first.status_code == 200, first.data
+    # Second exchange of the same device code must fail.
+    second = api_client.post(
+        "/api/v1/auth/device/token/", {"device_code": start["device_code"]}, format="json"
+    )
+    assert second.status_code == 400
+    assert second.data["error"] == "invalid_grant"
+
+
+@pytest.mark.unit
+def test_token_poll_returns_slow_down_when_polled_too_fast(db, api_client):
+    start = api_client.post("/api/v1/auth/device/start/", {}, format="json").data
+    first = api_client.post(
+        "/api/v1/auth/device/token/", {"device_code": start["device_code"]}, format="json"
+    )
+    assert first.status_code == 400
+    # Immediate second poll → slow_down.
+    second = api_client.post(
+        "/api/v1/auth/device/token/", {"device_code": start["device_code"]}, format="json"
+    )
+    assert second.status_code == 400
+    assert second.data["error"] == "slow_down"
+
+
+@pytest.mark.unit
+def test_token_poll_expired(db, api_client):
+    start = api_client.post("/api/v1/auth/device/start/", {}, format="json").data
+    CLIDeviceCode.objects.filter(device_code=start["device_code"]).update(
+        expires_at=timezone.now() - timedelta(seconds=1)
+    )
+    resp = api_client.post(
+        "/api/v1/auth/device/token/", {"device_code": start["device_code"]}, format="json"
+    )
+    assert resp.status_code == 410
+    assert resp.data["error"] == "expired_token"
+
+
+@pytest.mark.unit
+def test_approve_rejects_unknown_code(db, session_client):
+    resp = session_client.post(
+        "/api/v1/auth/device/approve/", {"user_code": "ZZZZ-9999"}, format="json"
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.unit
+def test_approve_normalizes_dashes_and_case(db, api_client, session_client):
+    start = api_client.post("/api/v1/auth/device/start/", {}, format="json").data
+    code = start["user_code"].replace("-", "").lower()
+    resp = session_client.post(
+        "/api/v1/auth/device/approve/", {"user_code": code}, format="json"
+    )
+    assert resp.status_code == 200, resp.data
+
+
+# -------------------- revoke --------------------
+
+
+@pytest.mark.unit
+def test_revoke_marks_token_inactive_idempotently(db, api_key_client, api_token):
+    resp = api_key_client.post("/api/v1/auth/revoke/", {}, format="json")
+    assert resp.status_code == 200
+    api_token.refresh_from_db()
+    assert api_token.is_active is False
+    # Second call still 200 (token already inactive; the call itself
+    # fails auth, so we test via re-activating then calling once more).
+    api_token.is_active = True
+    api_token.save(update_fields=["is_active"])
+    resp = api_key_client.post("/api/v1/auth/revoke/", {}, format="json")
+    assert resp.status_code == 200
+
+
+# -------------------- CLI-initiated runner mint --------------------
+
+
+@pytest.mark.unit
+def test_runner_create_succeeds_with_api_key(db, api_key_client, workspace, project):
+    resp = api_key_client.post(
+        "/api/v1/runner/runners/",
+        {
+            "workspace_slug": workspace.slug,
+            "project": project.identifier,
+            "host_label": "test-host",
+        },
+        format="json",
+    )
+    assert resp.status_code == 201, resp.data
+    body = resp.data
+    assert body["runner_id"]
+    assert body["refresh_token"]
+    assert body["access_token"]
+    assert body["workspace_slug"] == workspace.slug
+    assert body["project_identifier"] == project.identifier
+    assert body["protocol_version"] == 4
+
+
+@pytest.mark.unit
+def test_runner_create_404_for_unknown_workspace(db, api_key_client, project):
+    resp = api_key_client.post(
+        "/api/v1/runner/runners/",
+        {"workspace_slug": "nope", "project": project.identifier},
+        format="json",
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.unit
+def test_runner_create_404_for_unknown_project(db, api_key_client, workspace):
+    resp = api_key_client.post(
+        "/api/v1/runner/runners/",
+        {"workspace_slug": workspace.slug, "project": "NOPE"},
+        format="json",
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.unit
+def test_runner_create_requires_auth(db, api_client, workspace, project):
+    # No X-Api-Key header at all → 401 from APIKeyAuthentication.
+    resp = api_client.post(
+        "/api/v1/runner/runners/",
+        {"workspace_slug": workspace.slug, "project": project.identifier},
+        format="json",
+    )
+    # DRF returns 403 when no auth class produces a credential (unauthenticated).
+    assert resp.status_code in (401, 403)

--- a/apps/api/pi_dash/tests/unit/runner/test_cli_auth_flow.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_cli_auth_flow.py
@@ -210,3 +210,173 @@ def test_runner_create_requires_auth(db, api_client, workspace, project):
     )
     # DRF returns 403 when no auth class produces a credential (unauthenticated).
     assert resp.status_code in (401, 403)
+
+
+@pytest.mark.unit
+def test_runner_create_infers_workspace_when_caller_has_one(
+    db, api_key_client, workspace, project
+):
+    """The documented onboarding flow: `pidash runner add --project X`
+    (without --workspace) must succeed when the caller belongs to
+    exactly one workspace. The `workspace` fixture wires a single
+    membership for `create_user`, matching the dev-laptop case.
+    """
+    resp = api_key_client.post(
+        "/api/v1/runner/runners/",
+        {"project": project.identifier, "host_label": "test-host"},
+        format="json",
+    )
+    assert resp.status_code == 201, resp.data
+    assert resp.data["workspace_slug"] == workspace.slug
+
+
+@pytest.mark.unit
+def test_runner_create_400_when_workspace_ambiguous(
+    db, api_key_client, create_user, workspace, project
+):
+    """If the caller belongs to multiple workspaces and omits
+    `workspace_slug`, we should refuse with a specific error rather
+    than guessing wrong.
+    """
+    from pi_dash.db.models.workspace import Workspace, WorkspaceMember
+
+    other_ws = Workspace.objects.create(
+        name="other-ws",
+        owner=create_user,
+        slug="other-ws",
+    )
+    WorkspaceMember.objects.create(workspace=other_ws, member=create_user, role=20)
+
+    resp = api_key_client.post(
+        "/api/v1/runner/runners/",
+        {"project": project.identifier},
+        format="json",
+    )
+    assert resp.status_code == 400
+    assert resp.data["error"] == "workspace_slug_required"
+
+
+@pytest.mark.unit
+def test_runner_create_rejects_invalid_name(db, api_key_client, workspace, project):
+    """Disallow path-traversal / control chars in user-supplied names."""
+    resp = api_key_client.post(
+        "/api/v1/runner/runners/",
+        {
+            "workspace_slug": workspace.slug,
+            "project": project.identifier,
+            "name": "../etc/passwd",
+        },
+        format="json",
+    )
+    assert resp.status_code == 400
+    assert resp.data["error"] == "invalid_runner_name"
+
+
+@pytest.mark.unit
+def test_runner_create_400_when_no_workspace_membership(
+    db, api_client, create_user, workspace, project
+):
+    """A token bound to a user with no workspace memberships at all
+    should get a clear `no_workspace_membership` error, not a 500.
+    """
+    from pi_dash.db.models import APIToken
+    from pi_dash.db.models.workspace import WorkspaceMember
+
+    WorkspaceMember.objects.filter(member=create_user).delete()
+    # Mint a fresh token now that the user has no memberships.
+    tok = APIToken.objects.create(user=create_user)
+    api_client.credentials(HTTP_X_API_KEY=tok.token)
+
+    resp = api_client.post(
+        "/api/v1/runner/runners/",
+        {"project": project.identifier},
+        format="json",
+    )
+    assert resp.status_code == 400
+    assert resp.data["error"] == "no_workspace_membership"
+
+
+# -------------------- approval hardening --------------------
+
+
+@pytest.mark.unit
+def test_approve_rejects_second_user_takeover(
+    db, api_client, session_client, create_user
+):
+    """Once user A approves a code, user B (a different logged-in
+    session) cannot re-approve and steal the eventual token.
+    """
+    from pi_dash.db.models import User
+
+    start = api_client.post("/api/v1/auth/device/start/", {}, format="json").data
+    # User A approves.
+    first = session_client.post(
+        "/api/v1/auth/device/approve/", {"user_code": start["user_code"]}, format="json"
+    )
+    assert first.status_code == 200, first.data
+
+    # User B (different account) tries to approve the same code.
+    user_b = User.objects.create(email="b@example.com", username="b")
+    api_client.force_authenticate(user=user_b)
+    second = api_client.post(
+        "/api/v1/auth/device/approve/", {"user_code": start["user_code"]}, format="json"
+    )
+    assert second.status_code == 409
+    api_client.force_authenticate(user=None)
+
+    # Subsequent CLI poll mints the token for user A (the original
+    # approver), not user B.
+    CLIDeviceCode.objects.filter(device_code=start["device_code"]).update(
+        last_polled_at=timezone.now() - timedelta(seconds=30)
+    )
+    poll = api_client.post(
+        "/api/v1/auth/device/token/", {"device_code": start["device_code"]}, format="json"
+    )
+    assert poll.status_code == 200
+    assert poll.data["user_email"] == create_user.email
+
+
+@pytest.mark.unit
+def test_approve_idempotent_for_same_user(db, api_client, session_client, create_user):
+    """Re-approving by the same user is OK (idempotent UX): the human
+    might double-click Approve in the browser.
+    """
+    start = api_client.post("/api/v1/auth/device/start/", {}, format="json").data
+    a = session_client.post(
+        "/api/v1/auth/device/approve/", {"user_code": start["user_code"]}, format="json"
+    )
+    assert a.status_code == 200
+    b = session_client.post(
+        "/api/v1/auth/device/approve/", {"user_code": start["user_code"]}, format="json"
+    )
+    assert b.status_code == 200
+
+
+# -------------------- slow_down DoS prevention --------------------
+
+
+@pytest.mark.unit
+def test_slow_down_does_not_update_last_polled_at(db, api_client):
+    """A rapid poller (or attacker holding the device_code) must NOT be
+    able to slip `last_polled_at` forward on each rejection, otherwise
+    the legit CLI's slower poll would always look "too fast" too.
+    """
+    start = api_client.post("/api/v1/auth/device/start/", {}, format="json").data
+    # First poll establishes last_polled_at.
+    first = api_client.post(
+        "/api/v1/auth/device/token/", {"device_code": start["device_code"]}, format="json"
+    )
+    assert first.status_code == 400
+    row = CLIDeviceCode.objects.get(device_code=start["device_code"])
+    first_polled = row.last_polled_at
+    assert first_polled is not None
+
+    # Second poll within the min-gap returns slow_down — and must leave
+    # last_polled_at frozen at the previous value.
+    second = api_client.post(
+        "/api/v1/auth/device/token/", {"device_code": start["device_code"]}, format="json"
+    )
+    assert second.status_code == 400
+    assert second.data["error"] == "slow_down"
+    row.refresh_from_db()
+    assert row.last_polled_at == first_polled

--- a/apps/web/app/(all)/auth/device/layout.tsx
+++ b/apps/web/app/(all)/auth/device/layout.tsx
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { Outlet } from "react-router";
+import type { Route } from "./+types/layout";
+
+export default function DeviceAuthLayout() {
+  return <Outlet />;
+}
+
+export const meta: Route.MetaFunction = () => [{ title: "Authorize CLI" }];

--- a/apps/web/app/(all)/auth/device/page.tsx
+++ b/apps/web/app/(all)/auth/device/page.tsx
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "react-router";
+import { API_BASE_URL } from "@pi-dash/constants";
+import { AuthenticationWrapper } from "@/lib/wrappers/authentication-wrapper";
+import { EPageTypes } from "@/helpers/authentication.helper";
+import { APIService } from "@/services/api.service";
+
+class DeviceAuthService extends APIService {
+  constructor() {
+    super(API_BASE_URL);
+  }
+
+  approve(userCode: string) {
+    return this.post(`/api/v1/auth/device/approve/`, { user_code: userCode }).then((r) => r.data);
+  }
+}
+
+const deviceAuthService = new DeviceAuthService();
+
+type Status = "idle" | "submitting" | "approved" | "error";
+
+function normalizeUserCode(raw: string): string {
+  return raw.replace(/[^A-Z0-9]/gi, "").toUpperCase();
+}
+
+function formatUserCode(raw: string): string {
+  const clean = normalizeUserCode(raw).slice(0, 8);
+  if (clean.length <= 4) return clean;
+  return `${clean.slice(0, 4)}-${clean.slice(4)}`;
+}
+
+function DeviceAuthPage() {
+  const [params] = useSearchParams();
+  const [code, setCode] = useState<string>(() => formatUserCode(params.get("code") ?? ""));
+  const [status, setStatus] = useState<Status>("idle");
+  const [errorMessage, setErrorMessage] = useState<string>("");
+  const [approvedFor, setApprovedFor] = useState<{ email: string; workspace: string | null } | null>(null);
+
+  const normalized = useMemo(() => normalizeUserCode(code), [code]);
+  const submittable = normalized.length === 8 && status !== "submitting";
+
+  useEffect(() => {
+    // If the CLI deep-linked with ?code=XXXX-YYYY, auto-submit on mount
+    // so the human only has to click "Approve". We still let them edit
+    // and resubmit if the auto-attempt errors.
+    const prefilled = formatUserCode(params.get("code") ?? "");
+    if (prefilled && normalizeUserCode(prefilled).length === 8) {
+      void submit(prefilled);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  async function submit(value: string) {
+    setStatus("submitting");
+    setErrorMessage("");
+    try {
+      const resp = await deviceAuthService.approve(value);
+      setApprovedFor({ email: resp.user_email, workspace: resp.workspace_slug ?? null });
+      setStatus("approved");
+    } catch (err: unknown) {
+      const detail =
+        typeof err === "object" && err !== null && "response" in err
+          ? // @ts-expect-error axios shape
+            (err.response?.data?.error ?? "")
+          : "";
+      setErrorMessage(detail || "Could not approve this code. Check it and try again.");
+      setStatus("error");
+    }
+  }
+
+  function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!submittable) return;
+    void submit(code);
+  }
+
+  return (
+    <div className="bg-custom-background-100 flex min-h-[80vh] items-center justify-center p-8">
+      <div className="border-custom-border-200 bg-custom-background-90 shadow-sm w-full max-w-md rounded-lg border p-8">
+        <h1 className="text-xl text-custom-text-100 mb-2 font-semibold">Authorize Pi Dash CLI</h1>
+        <p className="text-sm text-custom-text-300 mb-6">
+          Enter the code shown on your terminal to grant this device access to your account.
+        </p>
+
+        {status === "approved" && approvedFor ? (
+          <div className="space-y-3">
+            <div className="border-green-500/30 bg-green-500/10 text-sm text-green-700 dark:text-green-300 rounded-md border p-3">
+              <strong>Approved.</strong> Your CLI should pick up the token within a few seconds.
+            </div>
+            <dl className="text-sm text-custom-text-200 space-y-1">
+              <div className="flex justify-between">
+                <dt className="text-custom-text-400">Account</dt>
+                <dd>{approvedFor.email}</dd>
+              </div>
+              {approvedFor.workspace && (
+                <div className="flex justify-between">
+                  <dt className="text-custom-text-400">Workspace</dt>
+                  <dd>{approvedFor.workspace}</dd>
+                </div>
+              )}
+            </dl>
+            <p className="text-xs text-custom-text-400 pt-2">You can close this tab.</p>
+          </div>
+        ) : (
+          <form onSubmit={onSubmit} className="space-y-4">
+            <label className="block">
+              <span className="text-xs text-custom-text-400 mb-1 block font-medium tracking-wide uppercase">
+                Device code
+              </span>
+              <input
+                ref={(el) => {
+                  // Auto-focus on mount without using the `autoFocus` prop,
+                  // which oxlint's jsx-a11y/no-autofocus disallows.
+                  el?.focus();
+                }}
+                type="text"
+                inputMode="text"
+                autoComplete="off"
+                spellCheck={false}
+                value={code}
+                onChange={(e) => setCode(formatUserCode(e.target.value))}
+                placeholder="XXXX-YYYY"
+                className="border-custom-border-200 bg-custom-background-100 font-mono text-lg tracking-widest text-custom-text-100 focus:border-custom-primary-100 w-full rounded-md border px-3 py-2 uppercase focus:outline-none"
+                maxLength={9}
+              />
+            </label>
+
+            {status === "error" && errorMessage && (
+              <div className="border-red-500/30 bg-red-500/10 text-sm text-red-600 dark:text-red-300 rounded-md border p-3">
+                {errorMessage}
+              </div>
+            )}
+
+            <button
+              type="submit"
+              disabled={!submittable}
+              className="bg-custom-primary-100 text-sm hover:bg-custom-primary-200 w-full rounded-md px-4 py-2 font-medium text-white transition disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {status === "submitting" ? "Approving…" : "Approve"}
+            </button>
+          </form>
+        )}
+
+        <p className="text-xs text-custom-text-400 mt-6">
+          Only approve a code that you started by running <code className="font-mono">pidash auth login</code> on a
+          device you control.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default function DeviceAuthRoute() {
+  return (
+    <AuthenticationWrapper pageType={EPageTypes.AUTHENTICATED}>
+      <DeviceAuthPage />
+    </AuthenticationWrapper>
+  );
+}

--- a/apps/web/app/routes/core.ts
+++ b/apps/web/app/routes/core.ts
@@ -35,6 +35,9 @@ export const coreRoutes: RouteConfigEntry[] = [
   // Onboarding
   layout("./(all)/onboarding/layout.tsx", [route("onboarding", "./(all)/onboarding/page.tsx")]),
 
+  // Device-code CLI authorization (`pidash auth login` redirects users here).
+  layout("./(all)/auth/device/layout.tsx", [route("auth/device", "./(all)/auth/device/page.tsx")]),
+
   // Invitations
   layout("./(all)/invitations/layout.tsx", [route("invitations", "./(all)/invitations/page.tsx")]),
 

--- a/runner/README.md
+++ b/runner/README.md
@@ -18,16 +18,43 @@ Pin to a specific version instead of `latest` by swapping in the tag, e.g. `.../
 After install:
 
 ```bash
-pidash configure \
-  --url http://localhost \
-  --token <ONE_TIME_CODE> \
-  --name my-laptop
-pidash install   # register a systemd user unit (Linux) or launchd agent (macOS)
-pidash start
-pidash tui       # optional: open the interactive UI
+# 1. Log in as your user. Opens a browser to approve a short code shown in
+#    the terminal — same idea as `gh auth login` or `stripe login`. Stores
+#    a CLI token at ~/.config/pidash/config.toml.
+pidash auth login --url https://pidash.example.com
+
+# 2. Register this host as a runner. Uses the token from step 1 to mint
+#    runner credentials cloud-side; no enrollment-token paste needed. On
+#    the first runner, installs the systemd user unit / launchd agent and
+#    starts the daemon.
+pidash runner add --project WEB
+
+# 3. Optional: open the interactive UI.
+pidash tui
 ```
 
-Generate the one-time token from the Pi Dash web UI under the runners admin page.
+`pidash auth login` prompts to add a runner inline when no runner exists yet on the host — for the dev-laptop case, that single command is enough.
+
+Useful follow-ups:
+
+```bash
+pidash auth status               # who am I logged in as; runner list
+pidash auth logout               # revoke the CLI token server-side
+pidash runner add --project X    # add another runner
+pidash runner list / remove      # manage runners
+```
+
+### Alternative: legacy enrollment-token flow
+
+For headless / scripted setup where you can't run the browser flow, the original `pidash connect` enrollment-token paste still works:
+
+```bash
+# Generate a one-time enrollment token from the Pi Dash web UI
+# (Runners admin → "Add connection"), then on the target host:
+pidash connect --url https://pidash.example.com --token <ONE_TIME_TOKEN>
+```
+
+This path is kept as a fallback; the device-code flow above is the recommended path for everyone with browser access.
 
 ## Auto-update
 

--- a/runner/src/api_client.rs
+++ b/runner/src/api_client.rs
@@ -328,6 +328,7 @@ mod resolve_tests {
             }],
             cli: Some(CliSection {
                 token: Some(token.into()),
+                workspace_slug: None,
             }),
         }
     }

--- a/runner/src/api_client.rs
+++ b/runner/src/api_client.rs
@@ -150,10 +150,14 @@ impl CliEnv {
         let token = from_cfg_token
             .or_else(|| std::env::var("PIDASH_TOKEN").ok())
             .ok_or_else(|| {
+                // Most common cause: the user enrolled a runner but
+                // never ran `pidash auth login` (which writes
+                // `[cli].token`). Point them at the fix directly
+                // rather than the generic "set this field" wording.
                 CliError::new(
                     EXIT_INVALID,
-                    "no auth token configured: set [cli].token in pidash \
-                     config or export PIDASH_TOKEN",
+                    "not logged in: run `pidash auth login` to authenticate this host, \
+                     or export PIDASH_TOKEN for one-off scripted use",
                 )
             })?;
 

--- a/runner/src/cli/auth/login.rs
+++ b/runner/src/cli/auth/login.rs
@@ -18,7 +18,6 @@ use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
 use serde::Deserialize;
 use std::io::{IsTerminal, Write};
-use std::path::PathBuf;
 use std::time::Duration;
 
 use crate::cli::runner_ops;
@@ -364,9 +363,3 @@ fn pick_project(projects: &[ProjectRow]) -> Result<Option<&ProjectRow>> {
     Ok(Some(&projects[idx - 1]))
 }
 
-// `_` silences "unused import" on the `PathBuf` reference further up
-// when run::tests are disabled; left as a guard for future expansion.
-#[allow(dead_code)]
-fn _unused() -> Option<PathBuf> {
-    None
-}

--- a/runner/src/cli/auth/login.rs
+++ b/runner/src/cli/auth/login.rs
@@ -1,0 +1,372 @@
+//! `pidash auth login` — RFC 8628 device-code flow client.
+//!
+//! Walks the user through the standard device-code dance:
+//!
+//! 1. `POST /api/v1/auth/device/start/` — get `user_code` + `device_code`.
+//! 2. Show `user_code` + verification URI; try to open the URL in a
+//!    browser as a convenience.
+//! 3. Poll `POST /api/v1/auth/device/token/` at the cloud-specified
+//!    interval until the user approves in the browser, hits a terminal
+//!    error, or the grant expires.
+//! 4. Write the returned `APIToken` to `[cli].token` in `config.toml`.
+//!
+//! After a successful login, if the host has no `[[runner]]` block and
+//! we're on an interactive TTY, offer to register one inline — this is
+//! the common dev-laptop case.
+
+use anyhow::{Context, Result};
+use clap::Args as ClapArgs;
+use serde::Deserialize;
+use std::io::{IsTerminal, Write};
+use std::path::PathBuf;
+use std::time::Duration;
+
+use crate::cli::runner_ops;
+use crate::config::file;
+use crate::util::paths::Paths;
+
+#[derive(Debug, ClapArgs)]
+pub struct Args {
+    /// Pi Dash cloud base URL (e.g. `https://pidash.example.com`).
+    /// Optional if this host already has a `config.toml`; we reuse the
+    /// existing `[daemon].cloud_url` in that case.
+    #[arg(long)]
+    pub url: Option<String>,
+
+    /// Don't try to open the verification URL in a browser.
+    #[arg(long)]
+    pub no_browser: bool,
+
+    /// Don't prompt to register a runner after login succeeds, even on
+    /// a TTY. Useful when scripting an auth-only setup.
+    #[arg(long)]
+    pub no_runner_prompt: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct StartResponse {
+    device_code: String,
+    user_code: String,
+    verification_uri: String,
+    expires_in: u64,
+    interval: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenSuccess {
+    access_token: String,
+    #[serde(default)]
+    user_email: Option<String>,
+    #[serde(default)]
+    workspace_slug: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenError {
+    error: String,
+}
+
+pub async fn run(args: Args, paths: &Paths) -> Result<()> {
+    let cloud_url = resolve_cloud_url(&args, paths)?;
+    crate::cli::connect::validate_cloud_url(&cloud_url)?;
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .context("building HTTP client")?;
+
+    let start = start_device_code(&client, &cloud_url).await?;
+
+    print_user_code_block(&start);
+
+    if !args.no_browser {
+        let with_code = format!("{}?code={}", start.verification_uri, start.user_code);
+        let _ = try_open_browser(&with_code);
+    }
+
+    let token = poll_for_token(&client, &cloud_url, &start).await?;
+
+    runner_ops::write_cli_token(paths, &cloud_url, &token.access_token)
+        .context("writing [cli].token to config.toml")?;
+
+    println!();
+    if let Some(email) = token.user_email.as_deref() {
+        println!("✓ Logged in as {email}.");
+    } else {
+        println!("✓ Logged in.");
+    }
+    if let Some(ws) = token.workspace_slug.as_deref() {
+        println!("  Workspace: {ws}");
+    }
+
+    if args.no_runner_prompt {
+        return Ok(());
+    }
+    if !std::io::stdout().is_terminal() {
+        return Ok(());
+    }
+    maybe_offer_runner_add(paths, &cloud_url, &token.access_token).await?;
+    Ok(())
+}
+
+fn resolve_cloud_url(args: &Args, paths: &Paths) -> Result<String> {
+    if let Some(u) = &args.url {
+        return Ok(u.trim_end_matches('/').to_string());
+    }
+    if paths.config_path().exists() {
+        let cfg = file::load_config(paths)?;
+        if !cfg.daemon.cloud_url.is_empty() {
+            return Ok(cfg.daemon.cloud_url.trim_end_matches('/').to_string());
+        }
+    }
+    anyhow::bail!(
+        "no cloud URL configured — pass --url https://your-pi-dash-instance.example.com"
+    );
+}
+
+async fn start_device_code(client: &reqwest::Client, cloud_url: &str) -> Result<StartResponse> {
+    let url = format!("{cloud_url}/api/v1/auth/device/start/");
+    let resp = client
+        .post(&url)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .with_context(|| format!("POST {url}"))?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        anyhow::bail!("device-code start failed: HTTP {status}: {body}");
+    }
+    resp.json::<StartResponse>()
+        .await
+        .context("parsing device-code start response")
+}
+
+fn print_user_code_block(start: &StartResponse) {
+    let minutes = start.expires_in / 60;
+    println!();
+    println!("First, copy your one-time code:");
+    println!();
+    println!("    {}", start.user_code);
+    println!();
+    println!("Then open this URL in your browser and approve the login:");
+    println!();
+    println!("    {}", start.verification_uri);
+    println!();
+    println!("(Code expires in {minutes} minutes.)");
+    println!();
+    print!("Waiting for browser approval...");
+    let _ = std::io::stdout().flush();
+}
+
+fn try_open_browser(url: &str) -> Result<()> {
+    let (program, arg_prefix): (&str, Option<&str>) = if cfg!(target_os = "macos") {
+        ("open", None)
+    } else if cfg!(target_os = "windows") {
+        ("cmd", Some("/C start"))
+    } else {
+        ("xdg-open", None)
+    };
+    let mut cmd = std::process::Command::new(program);
+    if let Some(prefix) = arg_prefix {
+        for arg in prefix.split_whitespace() {
+            cmd.arg(arg);
+        }
+    }
+    cmd.arg(url);
+    cmd.stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    cmd.spawn().context("opening browser")?;
+    Ok(())
+}
+
+async fn poll_for_token(
+    client: &reqwest::Client,
+    cloud_url: &str,
+    start: &StartResponse,
+) -> Result<TokenSuccess> {
+    let url = format!("{cloud_url}/api/v1/auth/device/token/");
+    let mut interval_secs = start.interval.max(1);
+    // Hard ceiling at the cloud's stated expiry, plus a small grace.
+    let deadline = std::time::Instant::now() + Duration::from_secs(start.expires_in + 5);
+
+    loop {
+        if std::time::Instant::now() >= deadline {
+            println!();
+            anyhow::bail!("device code expired before approval — run `pidash auth login` again");
+        }
+
+        tokio::time::sleep(Duration::from_secs(interval_secs)).await;
+        print!(".");
+        let _ = std::io::stdout().flush();
+
+        let resp = client
+            .post(&url)
+            .json(&serde_json::json!({ "device_code": start.device_code }))
+            .send()
+            .await
+            .with_context(|| format!("POST {url}"))?;
+        let status = resp.status();
+        let body_text = resp.text().await.unwrap_or_default();
+
+        if status.is_success() {
+            return serde_json::from_str::<TokenSuccess>(&body_text)
+                .with_context(|| format!("parsing device-code token response: {body_text}"));
+        }
+
+        // Parse the RFC 8628 error code. Anything we don't recognise is
+        // surfaced as-is so the operator can decide what to do.
+        let err: TokenError = serde_json::from_str(&body_text).unwrap_or(TokenError {
+            error: format!("http_{}", status.as_u16()),
+        });
+        match err.error.as_str() {
+            "authorization_pending" => {}
+            "slow_down" => {
+                interval_secs = (interval_secs + 5).min(30);
+            }
+            "expired_token" => {
+                println!();
+                anyhow::bail!("device code expired — run `pidash auth login` again");
+            }
+            "access_denied" => {
+                println!();
+                anyhow::bail!("login was denied in the browser");
+            }
+            other => {
+                println!();
+                anyhow::bail!("device-code poll returned {other} (HTTP {status}): {body_text}");
+            }
+        }
+    }
+}
+
+async fn maybe_offer_runner_add(paths: &Paths, cloud_url: &str, api_token: &str) -> Result<()> {
+    // Skip the prompt entirely if a runner already exists — the user
+    // ran `auth login` to refresh a token, not to onboard.
+    let existing_runners = if paths.config_path().exists() {
+        file::load_config(paths)?.runners.len()
+    } else {
+        0
+    };
+    if existing_runners > 0 {
+        println!();
+        println!("This host already has {existing_runners} runner(s) registered.");
+        println!("Use `pidash runner add` to register another, or `pidash runner list` to see them.");
+        return Ok(());
+    }
+
+    // Fetch the user's projects to decide what to suggest.
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()?;
+    let projects =
+        match fetch_projects(&client, cloud_url, api_token).await {
+            Ok(p) => p,
+            Err(e) => {
+                // Non-fatal: we logged in fine, the picker just can't run.
+                println!();
+                println!("(Couldn't list projects: {e}. You can run `pidash runner add --project <SLUG>` later.)");
+                return Ok(());
+            }
+        };
+
+    if projects.is_empty() {
+        println!();
+        println!("You don't have any projects yet.");
+        println!("Create one in the cloud UI, then run `pidash runner add` to register this host.");
+        return Ok(());
+    }
+
+    println!();
+    println!("Register this host as a runner now?");
+    let pick = pick_project(&projects)?;
+    let Some(project) = pick else {
+        println!("Skipped. Run `pidash runner add` later to register this host.");
+        return Ok(());
+    };
+
+    println!();
+    println!("Registering runner under project {}...", project.identifier);
+    crate::cli::runner::add(
+        crate::cli::runner::AddArgs {
+            name: None,
+            project: project.identifier.clone(),
+            workspace: None,
+            pod: None,
+            working_dir: None,
+            agent: crate::config::schema::AgentKind::default(),
+        },
+        paths,
+    )
+    .await?;
+    Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+struct ProjectRow {
+    identifier: String,
+    name: String,
+}
+
+async fn fetch_projects(
+    client: &reqwest::Client,
+    cloud_url: &str,
+    api_token: &str,
+) -> Result<Vec<ProjectRow>> {
+    let url = format!("{cloud_url}/api/v1/runner/projects/");
+    let resp = client
+        .get(&url)
+        .header("X-Api-Key", api_token)
+        .send()
+        .await
+        .with_context(|| format!("GET {url}"))?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        anyhow::bail!("HTTP {status}: {body}");
+    }
+    let rows: Vec<ProjectRow> = resp.json().await.context("parsing project list")?;
+    Ok(rows)
+}
+
+fn pick_project(projects: &[ProjectRow]) -> Result<Option<&ProjectRow>> {
+    use std::io::BufRead;
+    if projects.len() == 1 {
+        print!("Register this host for project '{}'? [Y/n] ", projects[0].identifier);
+        std::io::stdout().flush().ok();
+        let stdin = std::io::stdin();
+        let mut line = String::new();
+        stdin.lock().read_line(&mut line).ok();
+        let ans = line.trim().to_lowercase();
+        if ans.is_empty() || ans == "y" || ans == "yes" {
+            return Ok(Some(&projects[0]));
+        }
+        return Ok(None);
+    }
+    println!();
+    for (i, p) in projects.iter().enumerate() {
+        println!("  {}) {:<12} {}", i + 1, p.identifier, p.name);
+    }
+    println!("  q) skip");
+    print!("Pick a project [1-{}]: ", projects.len());
+    std::io::stdout().flush().ok();
+    let stdin = std::io::stdin();
+    let mut line = String::new();
+    stdin.lock().read_line(&mut line).ok();
+    let ans = line.trim().to_lowercase();
+    if ans.is_empty() || ans == "q" || ans == "skip" {
+        return Ok(None);
+    }
+    let idx: usize = ans.parse().context("expected a number or 'q'")?;
+    if idx == 0 || idx > projects.len() {
+        anyhow::bail!("selection {idx} out of range");
+    }
+    Ok(Some(&projects[idx - 1]))
+}
+
+// `_` silences "unused import" on the `PathBuf` reference further up
+// when run::tests are disabled; left as a guard for future expansion.
+#[allow(dead_code)]
+fn _unused() -> Option<PathBuf> {
+    None
+}

--- a/runner/src/cli/auth/login.rs
+++ b/runner/src/cli/auth/login.rs
@@ -56,8 +56,11 @@ struct TokenSuccess {
     access_token: String,
     #[serde(default)]
     user_email: Option<String>,
-    #[serde(default)]
-    workspace_slug: Option<String>,
+    // The server also returns `workspace_slug` here (the workspace the
+    // approve step auto-picked), but the CLI deliberately ignores it
+    // and re-resolves via `GET /api/v1/auth/workspaces/` so multi-
+    // workspace users can pick rather than silently inheriting the
+    // server's auto-pick.
 }
 
 #[derive(Debug, Deserialize)]
@@ -94,9 +97,13 @@ pub async fn run(args: Args, paths: &Paths) -> Result<()> {
     } else {
         println!("✓ Logged in.");
     }
-    if let Some(ws) = token.workspace_slug.as_deref() {
-        println!("  Workspace: {ws}");
-    }
+
+    // v1: a CLI install is bound to one workspace. Resolve which one
+    // (auto-pick if there's only one membership; prompt otherwise),
+    // persist the choice, and use it for any subsequent runner-add.
+    let workspace_slug =
+        resolve_workspace_binding(paths, &cloud_url, &token.access_token).await?;
+    println!("  Workspace: {workspace_slug}");
 
     if args.no_runner_prompt {
         return Ok(());
@@ -104,7 +111,7 @@ pub async fn run(args: Args, paths: &Paths) -> Result<()> {
     if !std::io::stdout().is_terminal() {
         return Ok(());
     }
-    maybe_offer_runner_add(paths, &cloud_url, &token.access_token).await?;
+    maybe_offer_runner_add(paths, &cloud_url, &token.access_token, &workspace_slug).await?;
     Ok(())
 }
 
@@ -239,7 +246,119 @@ async fn poll_for_token(
     }
 }
 
-async fn maybe_offer_runner_add(paths: &Paths, cloud_url: &str, api_token: &str) -> Result<()> {
+/// Pick which workspace this CLI install is bound to and persist it
+/// to `[cli].workspace_slug`. Always reaches out to the cloud (even if
+/// a stored binding exists) so a stale slug from a removed membership
+/// gets corrected.
+///
+/// Rules:
+/// - 0 memberships → bail; the user must be invited first.
+/// - 1 membership → silently use it (no prompt).
+/// - ≥2 memberships → if a stored slug is still valid, keep it; else
+///   prompt the user to pick.
+async fn resolve_workspace_binding(
+    paths: &Paths,
+    cloud_url: &str,
+    api_token: &str,
+) -> Result<String> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()
+        .context("building HTTP client for workspace list")?;
+    let workspaces = fetch_workspaces(&client, cloud_url, api_token).await?;
+
+    if workspaces.is_empty() {
+        anyhow::bail!(
+            "your account isn't a member of any workspace — ask an admin to invite you, then re-run `pidash auth login`"
+        );
+    }
+
+    let stored = runner_ops::load_cli_workspace(paths)?;
+
+    let chosen_slug = if workspaces.len() == 1 {
+        workspaces[0].slug.clone()
+    } else if let Some(slug) = stored.as_deref()
+        && workspaces.iter().any(|w| w.slug == slug)
+    {
+        // Stable across re-logins: keep the existing binding.
+        slug.to_string()
+    } else {
+        if stored.is_some() {
+            println!();
+            println!(
+                "(Previous workspace binding is no longer valid — pick a new one.)"
+            );
+        }
+        let picked = pick_workspace(&workspaces)?;
+        picked.slug.clone()
+    };
+
+    runner_ops::write_cli_workspace(paths, &chosen_slug)
+        .context("writing [cli].workspace_slug to config.toml")?;
+    Ok(chosen_slug)
+}
+
+#[derive(Debug, Deserialize)]
+struct WorkspaceRow {
+    slug: String,
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct WorkspaceListResponse {
+    workspaces: Vec<WorkspaceRow>,
+}
+
+async fn fetch_workspaces(
+    client: &reqwest::Client,
+    cloud_url: &str,
+    api_token: &str,
+) -> Result<Vec<WorkspaceRow>> {
+    let url = format!("{cloud_url}/api/v1/auth/workspaces/");
+    let resp = client
+        .get(&url)
+        .header("X-Api-Key", api_token)
+        .send()
+        .await
+        .with_context(|| format!("GET {url}"))?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        anyhow::bail!("workspace list failed: HTTP {status}: {body}");
+    }
+    let parsed: WorkspaceListResponse =
+        resp.json().await.context("parsing workspace list")?;
+    Ok(parsed.workspaces)
+}
+
+fn pick_workspace(workspaces: &[WorkspaceRow]) -> Result<&WorkspaceRow> {
+    use std::io::BufRead;
+    println!();
+    println!("Your account belongs to multiple workspaces.");
+    println!("Pick the one this host should be bound to:");
+    println!();
+    for (i, w) in workspaces.iter().enumerate() {
+        println!("  {}) {:<20} {}", i + 1, w.slug, w.name);
+    }
+    print!("Pick a workspace [1-{}]: ", workspaces.len());
+    std::io::stdout().flush().ok();
+    let stdin = std::io::stdin();
+    let mut line = String::new();
+    stdin.lock().read_line(&mut line).ok();
+    let ans = line.trim();
+    let idx: usize = ans.parse().context("expected a number")?;
+    if idx == 0 || idx > workspaces.len() {
+        anyhow::bail!("selection {idx} out of range");
+    }
+    Ok(&workspaces[idx - 1])
+}
+
+async fn maybe_offer_runner_add(
+    paths: &Paths,
+    cloud_url: &str,
+    api_token: &str,
+    workspace_slug: &str,
+) -> Result<()> {
     // Skip the prompt entirely if a runner already exists — the user
     // ran `auth login` to refresh a token, not to onboard.
     let existing_runners = if paths.config_path().exists() {
@@ -290,7 +409,7 @@ async fn maybe_offer_runner_add(paths: &Paths, cloud_url: &str, api_token: &str)
         crate::cli::runner::AddArgs {
             name: None,
             project: project.identifier.clone(),
-            workspace: None,
+            workspace: Some(workspace_slug.to_string()),
             pod: None,
             working_dir: None,
             agent: crate::config::schema::AgentKind::default(),

--- a/runner/src/cli/auth/logout.rs
+++ b/runner/src/cli/auth/logout.rs
@@ -1,0 +1,77 @@
+//! `pidash auth logout` — revoke CLI token server-side and clear it
+//! locally. Leaves `[[runner]]` blocks + per-runner credentials
+//! untouched: the daemon keeps running under its own identity.
+
+use anyhow::{Context, Result};
+use clap::Args as ClapArgs;
+use std::time::Duration;
+
+use crate::cli::runner_ops;
+use crate::config::file;
+use crate::util::paths::Paths;
+
+#[derive(Debug, ClapArgs)]
+pub struct Args {
+    /// Skip the server-side revoke and only clear the token locally.
+    /// Useful when the cloud is unreachable.
+    #[arg(long)]
+    pub local_only: bool,
+}
+
+pub async fn run(args: Args, paths: &Paths) -> Result<()> {
+    let token = match runner_ops::load_cli_token(paths)? {
+        Some(t) => t,
+        None => {
+            println!("Not logged in — nothing to revoke.");
+            return Ok(());
+        }
+    };
+
+    if !args.local_only {
+        let cfg = file::load_config(paths).ok();
+        let cloud_url = cfg
+            .as_ref()
+            .map(|c| c.daemon.cloud_url.clone())
+            .unwrap_or_default();
+        if cloud_url.is_empty() {
+            anyhow::bail!(
+                "config.toml is missing [daemon].cloud_url — pass --local-only to clear the local token without contacting the cloud"
+            );
+        }
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(15))
+            .build()?;
+        let url = format!("{cloud_url}/api/v1/auth/revoke/");
+        let resp = client
+            .post(&url)
+            .header("X-Api-Key", &token)
+            .json(&serde_json::json!({}))
+            .send()
+            .await
+            .with_context(|| format!("POST {url}"))?;
+        // 200 or 401 are both acceptable: the cloud either revoked it
+        // for us (200) or the token was already invalid (401). Anything
+        // else, we surface but still clear locally so the user isn't
+        // stuck with a half-state.
+        let status = resp.status();
+        if !status.is_success() && status.as_u16() != 401 {
+            let body = resp.text().await.unwrap_or_default();
+            tracing::warn!("revoke endpoint returned HTTP {status}: {body}");
+        }
+    }
+
+    runner_ops::clear_cli_token(paths).context("clearing [cli].token from config.toml")?;
+    println!("Logged out.");
+    let cfg = file::load_config(paths).ok();
+    if let Some(c) = &cfg
+        && !c.runners.is_empty()
+    {
+        println!();
+        println!(
+            "Runner credentials on this host are unchanged ({} runner(s) still configured).",
+            c.runners.len()
+        );
+        println!("Run `pidash runner remove <name>` to remove a runner.");
+    }
+    Ok(())
+}

--- a/runner/src/cli/auth/mod.rs
+++ b/runner/src/cli/auth/mod.rs
@@ -1,0 +1,43 @@
+//! `pidash auth <login|status|logout>` — user-identity flow.
+//!
+//! Mints, inspects, and revokes the `[cli].token` written to
+//! `~/.config/pidash/config.toml`. Strictly the user-identity side: it
+//! does not touch `[[runner]]` blocks or `credentials.toml`. Runner
+//! credentials are minted separately by `pidash runner add`, which uses
+//! the CLI token populated here to authorise itself to the cloud.
+
+use anyhow::Result;
+use clap::{Args as ClapArgs, Subcommand};
+
+pub mod login;
+pub mod logout;
+pub mod status;
+
+use crate::util::paths::Paths;
+
+#[derive(Debug, ClapArgs)]
+pub struct AuthArgs {
+    #[command(subcommand)]
+    pub command: AuthCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum AuthCommand {
+    /// Authenticate this host with Pi Dash cloud via device-code OAuth.
+    /// Stores a user-scoped CLI token in `~/.config/pidash/config.toml`.
+    Login(login::Args),
+    /// Show who this host is logged in as and which runners are
+    /// registered here.
+    Status(status::Args),
+    /// Revoke the CLI token server-side and clear it locally. Leaves
+    /// runner registrations untouched.
+    Logout(logout::Args),
+}
+
+pub async fn run(args: AuthArgs, paths: &Paths) -> Result<()> {
+    match args.command {
+        AuthCommand::Login(a) => login::run(a, paths).await,
+        AuthCommand::Status(a) => status::run(a, paths).await,
+        AuthCommand::Logout(a) => logout::run(a, paths).await,
+    }
+}

--- a/runner/src/cli/auth/status.rs
+++ b/runner/src/cli/auth/status.rs
@@ -1,0 +1,98 @@
+//! `pidash auth status` — show login state.
+
+use anyhow::{Context, Result};
+use clap::Args as ClapArgs;
+use serde::Deserialize;
+use std::time::Duration;
+
+use crate::cli::runner_ops;
+use crate::config::file;
+use crate::util::paths::Paths;
+
+#[derive(Debug, ClapArgs)]
+pub struct Args {}
+
+#[derive(Debug, Deserialize)]
+struct UserMe {
+    #[serde(default)]
+    email: Option<String>,
+    #[serde(default)]
+    first_name: Option<String>,
+    #[serde(default)]
+    last_name: Option<String>,
+}
+
+pub async fn run(_args: Args, paths: &Paths) -> Result<()> {
+    let token = match runner_ops::load_cli_token(paths)? {
+        Some(t) => t,
+        None => {
+            println!("Not logged in.");
+            println!("Run `pidash auth login` to authenticate this host.");
+            std::process::exit(1);
+        }
+    };
+
+    let cfg = file::load_config(paths).ok();
+    let cloud_url = cfg
+        .as_ref()
+        .map(|c| c.daemon.cloud_url.clone())
+        .unwrap_or_default();
+    if cloud_url.is_empty() {
+        anyhow::bail!("config.toml is missing [daemon].cloud_url — re-run `pidash auth login`");
+    }
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()?;
+    let url = format!("{cloud_url}/api/v1/users/me/");
+    let resp = client
+        .get(&url)
+        .header("X-Api-Key", &token)
+        .send()
+        .await
+        .with_context(|| format!("GET {url}"))?;
+    let status = resp.status();
+    if status.as_u16() == 401 || status.as_u16() == 403 {
+        println!("Logged in to {cloud_url}");
+        println!("  ✗ Token rejected by cloud ({status}). Run `pidash auth login` to re-authenticate.");
+        std::process::exit(1);
+    }
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        anyhow::bail!("/api/v1/users/me/ returned HTTP {status}: {body}");
+    }
+    let me: UserMe = resp.json().await.context("parsing /users/me/")?;
+
+    println!("Logged in to {cloud_url}");
+    if let Some(email) = me.email.as_deref() {
+        let name = format!(
+            "{} {}",
+            me.first_name.as_deref().unwrap_or(""),
+            me.last_name.as_deref().unwrap_or("")
+        )
+        .trim()
+        .to_string();
+        if name.is_empty() {
+            println!("  ✓ Account: {email}");
+        } else {
+            println!("  ✓ Account: {email} ({name})");
+        }
+    } else {
+        println!("  ✓ Account: <unknown>");
+    }
+
+    if let Some(c) = &cfg {
+        let runner_count = c.runners.len();
+        if runner_count == 0 {
+            println!("  - No runners registered on this host.");
+            println!("    Run `pidash runner add` to register one.");
+        } else {
+            println!("  ✓ Runners on this host: {runner_count}");
+            for r in &c.runners {
+                let project = r.project_slug.as_deref().unwrap_or("?");
+                println!("      - {} (project {project})", r.name);
+            }
+        }
+    }
+    Ok(())
+}

--- a/runner/src/cli/auth/status.rs
+++ b/runner/src/cli/auth/status.rs
@@ -23,14 +23,11 @@ struct UserMe {
 }
 
 pub async fn run(_args: Args, paths: &Paths) -> Result<()> {
-    let token = match runner_ops::load_cli_token(paths)? {
-        Some(t) => t,
-        None => {
-            println!("Not logged in.");
-            println!("Run `pidash auth login` to authenticate this host.");
-            std::process::exit(1);
-        }
-    };
+    let token = runner_ops::load_cli_token(paths)?.ok_or_else(|| {
+        anyhow::anyhow!(
+            "not logged in — run `pidash auth login` to authenticate this host"
+        )
+    })?;
 
     let cfg = file::load_config(paths).ok();
     let cloud_url = cfg
@@ -53,9 +50,9 @@ pub async fn run(_args: Args, paths: &Paths) -> Result<()> {
         .with_context(|| format!("GET {url}"))?;
     let status = resp.status();
     if status.as_u16() == 401 || status.as_u16() == 403 {
-        println!("Logged in to {cloud_url}");
-        println!("  ✗ Token rejected by cloud ({status}). Run `pidash auth login` to re-authenticate.");
-        std::process::exit(1);
+        anyhow::bail!(
+            "logged in to {cloud_url} but the cloud rejected the token (HTTP {status}) — run `pidash auth login` to re-authenticate"
+        );
     }
     if !status.is_success() {
         let body = resp.text().await.unwrap_or_default();

--- a/runner/src/cli/mod.rs
+++ b/runner/src/cli/mod.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 
+pub mod auth;
 mod comment;
 pub mod connect;
 pub mod doctor;
@@ -13,6 +14,7 @@ mod run;
 // `runner` is `pub` so the TUI can call its library functions
 // (`add`, `remove`) directly without going through clap.
 pub mod runner;
+pub mod runner_ops;
 mod start;
 mod state;
 mod status;
@@ -52,6 +54,11 @@ pub struct Cli {
 
 #[derive(Debug, Subcommand)]
 pub enum Command {
+    /// Authenticate this host as a user (`auth login` / `status` /
+    /// `logout`). Mints a CLI token used by `pidash` commands and by
+    /// `pidash runner add` to register runners.
+    Auth(auth::AuthArgs),
+
     /// Enroll this dev machine with Pi Dash cloud (one-time pairing).
     Connect(connect::Args),
 
@@ -114,6 +121,7 @@ pub async fn run(cli: Cli) -> Result<()> {
     tracing::debug!(?paths, "resolved runner paths");
 
     match cli.command {
+        Command::Auth(args) => auth::run(args, &paths).await,
         Command::Connect(args) => connect::run(args, &paths).await,
         Command::Runner(args) => runner::run(args, &paths).await,
         Command::Install(args) => install::run(args, &paths).await,

--- a/runner/src/cli/run.rs
+++ b/runner/src/cli/run.rs
@@ -22,33 +22,68 @@ pub struct Args {
 
 pub async fn run(args: Args, paths: &Paths) -> Result<()> {
     let config_path = paths.config_path();
-    let creds_path = paths.credentials_path();
     if !config_path.exists() {
         anyhow::bail!(
             "no config.toml at {config_path:?}. \
-             Run `pidash connect --url <URL> --token <ONE_TIME_TOKEN>` first."
-        );
-    }
-    if !creds_path.exists() {
-        anyhow::bail!(
-            "no credentials.toml at {creds_path:?}. \
-             Run `pidash connect --url <URL> --token <ONE_TIME_TOKEN>` to enroll."
+             Run `pidash auth login --url <URL>` (then `pidash runner add`) \
+             or `pidash connect --url <URL> --token <ONE_TIME_TOKEN>` to enroll."
         );
     }
 
-    let (config, creds) = crate::config::file::load_all(paths).context(
-        "failed to load runner config; re-run `pidash connect` if the files are corrupt",
+    let config = crate::config::file::load_config(paths).context(
+        "failed to load config.toml; re-run enrollment if the file is corrupt",
     )?;
     config
         .validate()
         .context("config.toml failed validation; refusing to start the daemon")?;
+
+    if config.runners.is_empty() {
+        anyhow::bail!(
+            "no runners configured in config.toml — \
+             register one with `pidash runner add --project <SLUG>`."
+        );
+    }
+
+    // Multi-runner: each [[runner]] has its own credentials.toml under
+    // data_dir/runners/<id>/. The supervisor loads them per-runner; we
+    // fail fast here so a missing file produces a clear startup error
+    // instead of dying mid-spawn.
+    for r in &config.runners {
+        let p = paths.for_runner(r.runner_id).credentials_path();
+        if !p.exists() {
+            anyhow::bail!(
+                "no credentials.toml at {p:?} for runner {} ({}). \
+                 Re-add it with `pidash runner add`, or remove the [[runner]] block from config.toml.",
+                r.name,
+                r.runner_id
+            );
+        }
+    }
+
+    // The legacy top-level credentials.toml (connection-secret model)
+    // is only populated by the legacy `pidash connect` flow. The
+    // supervisor doesn't actually consume it (see Supervisor::run,
+    // which destructures `creds: _creds`) — each runner uses its own
+    // per-runner refresh-token credentials. We pass a placeholder when
+    // the legacy file is absent so the new `pidash runner add` flow
+    // can start the daemon without the legacy enrollment step.
+    let creds = crate::config::file::load_credentials(paths).unwrap_or_else(|_| {
+        use chrono::Utc;
+        crate::config::schema::Credentials {
+            connection_id: uuid::Uuid::nil(),
+            connection_secret: String::new(),
+            connection_name: None,
+            api_token: None,
+            issued_at: Utc::now(),
+        }
+    });
+
     let primary_name = config
         .primary_runner()
         .map(|r| r.name.as_str())
         .unwrap_or("(no runners)");
     tracing::info!(
         runner = %primary_name,
-        connection_id = %creds.connection_id,
         runner_count = config.runners.len(),
         "starting daemon"
     );

--- a/runner/src/cli/runner.rs
+++ b/runner/src/cli/runner.rs
@@ -12,17 +12,11 @@ use clap::{Args as ClapArgs, Subcommand};
 use std::path::PathBuf;
 use uuid::Uuid;
 
-use crate::cloud::runners::{RegisterRunnerRequest, RunnerCrudError, delete_runner, register_runner};
+use crate::cli::runner_ops;
+use crate::cloud::http::{SharedHttpTransport, create_runner};
 use crate::config::file;
-use crate::config::schema::{
-    AgentKind, AgentSection, ApprovalPolicySection, ClaudeCodeSection, CodexSection,
-    MAX_RUNNERS_PER_DAEMON, RunnerConfig, WorkspaceSection,
-};
+use crate::config::schema::{AgentKind, MAX_RUNNERS_PER_DAEMON, RunnerConfig};
 use crate::util::paths::Paths;
-use crate::util::runner_id;
-use crate::util::runner_name;
-
-const MAX_AUTO_NAME_RETRIES: u32 = 5;
 
 #[derive(Debug, ClapArgs)]
 pub struct RunnerArgs {
@@ -49,6 +43,11 @@ pub struct AddArgs {
     /// Pi Dash project this runner serves.
     #[arg(long)]
     pub project: String,
+
+    /// Pi Dash workspace slug. Optional in single-workspace setups;
+    /// required if the caller belongs to multiple workspaces.
+    #[arg(long)]
+    pub workspace: Option<String>,
 
     /// Pod within the project. Defaults to the project's default pod.
     #[arg(long)]
@@ -87,115 +86,102 @@ pub async fn run(args: RunnerArgs, paths: &Paths) -> Result<()> {
 
 /// Library entry point: exposed so the TUI's add-runner form can reuse the
 /// same enrollment logic without going through clap.
+///
+/// Uses the user-scoped CLI token written by `pidash auth login` to ask
+/// the cloud to mint a runner under the caller's identity. Replaces
+/// the legacy connection-secret-bearer flow.
 pub async fn add(args: AddArgs, paths: &Paths) -> Result<RunnerConfig> {
-    let creds = file::load_credentials(paths)
-        .context("no credentials.toml — run `pidash connect` first")?;
-    let mut cfg = file::load_config(paths)?;
+    let api_token = runner_ops::load_cli_token(paths)
+        .context("reading [cli].token from config.toml")?
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "no CLI token configured — run `pidash auth login` to authenticate this host first"
+            )
+        })?;
 
-    if cfg.runners.len() >= MAX_RUNNERS_PER_DAEMON {
+    // Cap check is local + cheap; do it before the network call.
+    let existing_count = if paths.config_path().exists() {
+        file::load_config(paths)?.runners.len()
+    } else {
+        0
+    };
+    if existing_count >= MAX_RUNNERS_PER_DAEMON {
         anyhow::bail!(
             "daemon already at the {MAX_RUNNERS_PER_DAEMON}-runner cap; remove one with `pidash runner remove <NAME>` first"
         );
     }
 
-    let user_supplied = args.name.is_some();
-    if let Some(n) = &args.name {
-        runner_name::validate(n).with_context(|| format!("invalid --name value {n:?}"))?;
-    }
-
-    let runner_id = runner_id::mint();
-    let working_dir = args
-        .working_dir
-        .clone()
-        .unwrap_or_else(|| paths.runner_dir(runner_id).join("workspace"));
-
-    let mut attempts = 0u32;
-    let (resp, final_name) = loop {
-        attempts += 1;
-        let candidate = args
-            .name
-            .clone()
-            .unwrap_or_else(runner_name::generate_default);
-        let req = RegisterRunnerRequest {
-            runner_id,
-            name: candidate.clone(),
-            project: args.project.clone(),
-            pod: args.pod.clone().unwrap_or_default(),
-            os: std::env::consts::OS.to_string(),
-            arch: std::env::consts::ARCH.to_string(),
-            version: crate::RUNNER_VERSION.to_string(),
-            protocol_version: crate::PROTOCOL_VERSION,
-        };
-        match register_runner(
-            &cfg.daemon.cloud_url,
-            &creds.connection_id,
-            &creds.connection_secret,
-            &req,
+    let cloud_url = if paths.config_path().exists() {
+        file::load_config(paths)?.daemon.cloud_url
+    } else {
+        anyhow::bail!(
+            "no [daemon].cloud_url configured — run `pidash auth login --url <URL>` first"
         )
-        .await
-        {
-            Ok(resp) => break (resp, candidate),
-            Err(RunnerCrudError::NameTaken)
-                if !user_supplied && attempts < MAX_AUTO_NAME_RETRIES =>
-            {
-                tracing::info!(
-                    attempt = attempts,
-                    "auto-generated runner name {candidate} taken; retrying"
-                );
-                continue;
-            }
-            Err(RunnerCrudError::NameTaken) if user_supplied => {
-                anyhow::bail!(
-                    "runner name {candidate:?} is already taken on this connection. \
-                     Choose a different --name or omit it for an auto-generated one."
-                );
-            }
-            Err(RunnerCrudError::NameTaken) => {
-                anyhow::bail!(
-                    "could not generate a unique runner name after {MAX_AUTO_NAME_RETRIES} attempts. \
-                     Pass --name explicitly."
-                );
-            }
-            Err(RunnerCrudError::Other(e)) => {
-                return Err(e).context("cloud rejected runner registration");
-            }
-        }
     };
 
-    let new_runner = RunnerConfig {
-        name: final_name,
-        runner_id: resp.runner_id,
-        workspace_slug: None,
-        project_slug: Some(resp.project_identifier.clone()),
-        pod_id: Some(resp.pod_id),
-        workspace: WorkspaceSection { working_dir },
-        agent: AgentSection { kind: args.agent },
-        codex: CodexSection::default(),
-        claude_code: ClaudeCodeSection::default(),
-        approval_policy: ApprovalPolicySection::default(),
-    };
-    cfg.runners.push(new_runner.clone());
+    let host_label = hostname_or_unknown();
+    let transport = SharedHttpTransport::new(cloud_url.clone())
+        .context("building HTTP transport for cloud")?;
+    let resp = create_runner(
+        &transport,
+        &api_token,
+        // workspace_slug isn't asked from the user yet — pulled from
+        // the caller's token. The endpoint resolves the project under
+        // any workspace the caller belongs to via the workspace_slug we
+        // pass. v1 is one-workspace-per-host, so we send an empty
+        // string and let the endpoint fall back to the user's primary
+        // workspace as derived from `auth login`. If the endpoint
+        // requires it, we'll surface the cloud's error verbatim.
+        &args.workspace.clone().unwrap_or_default(),
+        &args.project,
+        &host_label,
+        args.name.as_deref(),
+        args.pod.as_deref(),
+    )
+    .await
+    .with_context(|| format!("cloud rejected runner creation against {cloud_url}"))?;
 
-    // Validate post-mutation so we catch conflicts (duplicate name,
-    // duplicate working_dir) before persisting. Roll back the cloud-side
-    // registration if validation fails — otherwise we'd leak an orphaned
-    // runner row.
-    if let Err(err) = cfg.validate() {
-        let _ = delete_runner(
-            &cfg.daemon.cloud_url,
-            &creds.connection_id,
-            &creds.connection_secret,
-            &runner_id,
-        )
-        .await;
-        anyhow::bail!("runner config invalid after add: {err}");
-    }
-    file::write_config(paths, &cfg)?;
+    let applied = runner_ops::apply_enroll_response(
+        paths,
+        &resp,
+        &cloud_url,
+        args.working_dir.clone(),
+        args.agent,
+    )
+    .await?;
+
     println!(
         "Added runner {} ({}) under project {}.",
-        new_runner.name, new_runner.runner_id, resp.project_identifier
+        applied.runner.name, applied.runner.runner_id, resp.project_identifier
     );
-    Ok(new_runner)
+    if applied.is_first_runner {
+        println!(
+            "First runner on this host — installing service so the daemon starts automatically."
+        );
+        let svc = crate::service::detect();
+        svc.write_unit(paths).await?;
+        svc.enable_and_start().await?;
+    } else {
+        // Restart so the new [[runner]] block is loaded.
+        let outcome = crate::service::reload::restart_and_verify(paths).await;
+        if !outcome.ok {
+            println!("(Service restart did not complete cleanly: {})", outcome.summary);
+            if let Some(detail) = outcome.detail {
+                println!("{detail}");
+            }
+        }
+    }
+    Ok(applied.runner)
+}
+
+fn hostname_or_unknown() -> String {
+    std::process::Command::new("hostname")
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown-host".to_string())
 }
 
 pub fn list(paths: &Paths) -> Result<()> {

--- a/runner/src/cli/runner.rs
+++ b/runner/src/cli/runner.rs
@@ -122,17 +122,15 @@ pub async fn add(args: AddArgs, paths: &Paths) -> Result<RunnerConfig> {
     let host_label = hostname_or_unknown();
     let transport = SharedHttpTransport::new(cloud_url.clone())
         .context("building HTTP transport for cloud")?;
+    // workspace_slug is optional client-side. When omitted, the cloud
+    // infers from the caller's single workspace membership (the
+    // single-workspace-per-host onboarding case); multi-workspace
+    // callers must pass `--workspace` and get a clear error from the
+    // server otherwise.
     let resp = create_runner(
         &transport,
         &api_token,
-        // workspace_slug isn't asked from the user yet — pulled from
-        // the caller's token. The endpoint resolves the project under
-        // any workspace the caller belongs to via the workspace_slug we
-        // pass. v1 is one-workspace-per-host, so we send an empty
-        // string and let the endpoint fall back to the user's primary
-        // workspace as derived from `auth login`. If the endpoint
-        // requires it, we'll surface the cloud's error verbatim.
-        &args.workspace.clone().unwrap_or_default(),
+        args.workspace.as_deref(),
         &args.project,
         &host_label,
         args.name.as_deref(),

--- a/runner/src/cli/runner.rs
+++ b/runner/src/cli/runner.rs
@@ -122,15 +122,20 @@ pub async fn add(args: AddArgs, paths: &Paths) -> Result<RunnerConfig> {
     let host_label = hostname_or_unknown();
     let transport = SharedHttpTransport::new(cloud_url.clone())
         .context("building HTTP transport for cloud")?;
-    // workspace_slug is optional client-side. When omitted, the cloud
-    // infers from the caller's single workspace membership (the
-    // single-workspace-per-host onboarding case); multi-workspace
-    // callers must pass `--workspace` and get a clear error from the
-    // server otherwise.
+    // Workspace resolution order:
+    //   1. Explicit `--workspace` from this call (highest precedence).
+    //   2. `[cli].workspace_slug` persisted by `pidash auth login`
+    //      (the v1 single-workspace-per-host binding).
+    //   3. None — let the cloud infer from a single membership; it
+    //      rejects with a clear error if the caller is multi-workspace.
+    let workspace_arg = args
+        .workspace
+        .clone()
+        .or(runner_ops::load_cli_workspace(paths)?);
     let resp = create_runner(
         &transport,
         &api_token,
-        args.workspace.as_deref(),
+        workspace_arg.as_deref(),
         &args.project,
         &host_label,
         args.name.as_deref(),

--- a/runner/src/cli/runner_ops.rs
+++ b/runner/src/cli/runner_ops.rs
@@ -1,0 +1,191 @@
+//! Shared local-side plumbing for both `pidash connect` (legacy
+//! enrollment-token flow) and `pidash runner add` (CLI-token flow).
+//!
+//! After a successful cloud-side mint (`EnrollResponse`), both paths
+//! need to do the same local work: write `[[runner]]` to `config.toml`,
+//! drop per-runner `credentials.toml`, and install the OS service unit
+//! on first add. That shared work lives here so the two paths can't
+//! drift.
+
+use anyhow::{Context, Result};
+use std::path::PathBuf;
+
+use crate::cloud::http::{EnrollResponse, RunnerCredentials, write_runner_credentials};
+use crate::config::file;
+use crate::config::schema::{
+    AgentKind, AgentSection, ApprovalPolicySection, ClaudeCodeSection, CliSection, CodexSection,
+    Config, DaemonConfig, RunnerConfig, WorkspaceSection,
+};
+use crate::util::paths::Paths;
+
+/// Read the user's CLI token from `[cli].token` in `config.toml`.
+/// Returns `Ok(None)` when no config exists yet or the section is
+/// absent; the caller is expected to surface a friendly "run `pidash
+/// auth login` first" message in that case.
+pub fn load_cli_token(paths: &Paths) -> Result<Option<String>> {
+    if !paths.config_path().exists() {
+        return Ok(None);
+    }
+    let cfg = file::load_config(paths)?;
+    Ok(cfg.cli.and_then(|c| c.token))
+}
+
+/// Write `[cli].token` into `config.toml`, creating the file if it
+/// doesn't exist yet. Used by `pidash auth login` after the device-code
+/// exchange returns an `APIToken`.
+///
+/// First-run bootstrap: when no config exists, we seed a minimal
+/// `[daemon]` block with the cloud URL the login was performed against.
+/// No `[[runner]]` blocks are added — the runner is registered
+/// separately via `pidash runner add`.
+pub fn write_cli_token(paths: &Paths, cloud_url: &str, token: &str) -> Result<()> {
+    let mut cfg = if paths.config_path().exists() {
+        file::load_config(paths)?
+    } else {
+        Config {
+            version: 2,
+            daemon: DaemonConfig {
+                cloud_url: cloud_url.to_string(),
+                log_level: "info".to_string(),
+                log_retention_days: 14,
+                agent_observability_v1: false,
+                auto_update: true,
+            },
+            runners: vec![],
+            cli: None,
+        }
+    };
+    // Pre-existing config? Don't quietly rebind it to a different cloud.
+    if !cfg.daemon.cloud_url.is_empty() && cfg.daemon.cloud_url != cloud_url {
+        anyhow::bail!(
+            "this host is already enrolled with cloud {} — refusing to overwrite [cli] for a different cloud {}",
+            cfg.daemon.cloud_url,
+            cloud_url
+        );
+    }
+    if cfg.daemon.cloud_url.is_empty() {
+        cfg.daemon.cloud_url = cloud_url.to_string();
+    }
+    cfg.cli = Some(CliSection {
+        token: Some(token.to_string()),
+    });
+    file::write_config(paths, &cfg)?;
+    Ok(())
+}
+
+/// Clear `[cli].token` from `config.toml`. Used by `pidash auth logout`.
+/// Leaves `[[runner]]` blocks untouched so the daemon keeps running
+/// under its own identity. No-op if no config exists.
+pub fn clear_cli_token(paths: &Paths) -> Result<()> {
+    if !paths.config_path().exists() {
+        return Ok(());
+    }
+    let mut cfg = file::load_config(paths)?;
+    if let Some(ref mut cli) = cfg.cli {
+        cli.token = None;
+    }
+    file::write_config(paths, &cfg)?;
+    Ok(())
+}
+
+/// Result of applying a mint locally: the new `RunnerConfig` block and
+/// whether this was the host's first runner (so callers can decide
+/// whether to install the OS service unit / restart it).
+pub struct AppliedRunner {
+    pub runner: RunnerConfig,
+    pub is_first_runner: bool,
+}
+
+/// Apply an `EnrollResponse` (from either the legacy enroll endpoint or
+/// the new CLI-initiated create endpoint) to local disk:
+///
+/// 1. Write the per-runner refresh credential.
+/// 2. Append a new `[[runner]]` block to `config.toml`.
+///
+/// The caller is responsible for:
+/// - Validating the cloud URL up front.
+/// - Restarting the service afterwards (subsequent runners) or installing
+///   it (first runner) — see `is_first_runner` on the return.
+pub async fn apply_enroll_response(
+    paths: &Paths,
+    resp: &EnrollResponse,
+    cloud_url: &str,
+    working_dir: Option<PathBuf>,
+    agent_kind: AgentKind,
+) -> Result<AppliedRunner> {
+    // Per-runner credentials.toml first — config.toml is the canonical
+    // list but the supervisor refuses runner rows that have no
+    // credentials file, so we want the credential on disk before the
+    // config references it.
+    let runner_paths = paths.for_runner(resp.runner_id);
+    runner_paths.ensure()?;
+    write_runner_credentials(
+        runner_paths.credentials_path(),
+        RunnerCredentials {
+            runner_id: resp.runner_id,
+            name: resp.runner_name.clone(),
+            refresh_token: resp.refresh_token.clone(),
+            refresh_token_generation: resp.refresh_token_generation,
+        },
+    )
+    .await
+    .context("writing per-runner credentials failed")?;
+
+    let working_dir =
+        working_dir.unwrap_or_else(|| paths.runner_dir(resp.runner_id).join("workspace"));
+
+    let new_runner = RunnerConfig {
+        name: resp.runner_name.clone(),
+        runner_id: resp.runner_id,
+        workspace_slug: Some(resp.workspace_slug.clone()),
+        project_slug: Some(resp.project_identifier.clone()),
+        pod_id: None,
+        workspace: WorkspaceSection { working_dir },
+        agent: AgentSection { kind: agent_kind },
+        codex: CodexSection::default(),
+        claude_code: ClaudeCodeSection::default(),
+        approval_policy: ApprovalPolicySection::default(),
+    };
+
+    let mut cfg = if paths.config_path().exists() {
+        file::load_config(paths)?
+    } else {
+        // First runner on a host that never had a config — happens when
+        // the user ran `pidash auth login` (which writes [cli] but no
+        // [[runner]]). Bootstrap a minimal config seeded from the
+        // response's cloud URL.
+        Config {
+            version: 2,
+            daemon: DaemonConfig {
+                cloud_url: cloud_url.to_string(),
+                log_level: "info".to_string(),
+                log_retention_days: 14,
+                agent_observability_v1: false,
+                auto_update: true,
+            },
+            runners: vec![],
+            cli: None,
+        }
+    };
+
+    if !cfg.daemon.cloud_url.is_empty() && cfg.daemon.cloud_url != cloud_url {
+        anyhow::bail!(
+            "this host is enrolled with cloud {} — refusing to add a runner pointing at {}",
+            cfg.daemon.cloud_url,
+            cloud_url
+        );
+    }
+    if cfg.daemon.cloud_url.is_empty() {
+        cfg.daemon.cloud_url = cloud_url.to_string();
+    }
+    let is_first_runner = cfg.runners.is_empty();
+    cfg.runners.push(new_runner.clone());
+    cfg.validate()
+        .map_err(|e| anyhow::anyhow!("config invalid after add: {e}"))?;
+    file::write_config(paths, &cfg)?;
+
+    Ok(AppliedRunner {
+        runner: new_runner,
+        is_first_runner,
+    })
+}

--- a/runner/src/cli/runner_ops.rs
+++ b/runner/src/cli/runner_ops.rs
@@ -38,6 +38,9 @@ pub fn load_cli_token(paths: &Paths) -> Result<Option<String>> {
 /// `[daemon]` block with the cloud URL the login was performed against.
 /// No `[[runner]]` blocks are added — the runner is registered
 /// separately via `pidash runner add`.
+///
+/// Preserves any pre-existing `[cli].workspace_slug` so a re-login
+/// (e.g. token refresh) doesn't wipe the host's workspace binding.
 pub fn write_cli_token(paths: &Paths, cloud_url: &str, token: &str) -> Result<()> {
     let mut cfg = if paths.config_path().exists() {
         file::load_config(paths)?
@@ -66,9 +69,47 @@ pub fn write_cli_token(paths: &Paths, cloud_url: &str, token: &str) -> Result<()
     if cfg.daemon.cloud_url.is_empty() {
         cfg.daemon.cloud_url = cloud_url.to_string();
     }
+    let preserved_workspace = cfg.cli.as_ref().and_then(|c| c.workspace_slug.clone());
     cfg.cli = Some(CliSection {
         token: Some(token.to_string()),
+        workspace_slug: preserved_workspace,
     });
+    file::write_config(paths, &cfg)?;
+    Ok(())
+}
+
+/// Read `[cli].workspace_slug` from `config.toml`.
+///
+/// Returns `Ok(None)` if no config exists, the `[cli]` section is
+/// absent, or `workspace_slug` was never set. `pidash runner add` uses
+/// this as the default workspace when the caller omits `--workspace`.
+pub fn load_cli_workspace(paths: &Paths) -> Result<Option<String>> {
+    if !paths.config_path().exists() {
+        return Ok(None);
+    }
+    let cfg = file::load_config(paths)?;
+    Ok(cfg.cli.and_then(|c| c.workspace_slug))
+}
+
+/// Write `[cli].workspace_slug` into `config.toml`. Called by
+/// `pidash auth login` after the workspace picker resolves which
+/// workspace this host is bound to. Requires a pre-existing config
+/// (the token write always happens first).
+///
+/// Rebinding to a different workspace is allowed — the login flow
+/// itself decides whether to keep the existing binding (slug still in
+/// the user's memberships) or pick a new one. Callers that need a
+/// safety check should compare before calling.
+pub fn write_cli_workspace(paths: &Paths, workspace_slug: &str) -> Result<()> {
+    if !paths.config_path().exists() {
+        anyhow::bail!(
+            "no config.toml — `pidash auth login` must write the CLI token before the workspace binding"
+        );
+    }
+    let mut cfg = file::load_config(paths)?;
+    let mut cli = cfg.cli.unwrap_or_default();
+    cli.workspace_slug = Some(workspace_slug.to_string());
+    cfg.cli = Some(cli);
     file::write_config(paths, &cfg)?;
     Ok(())
 }
@@ -324,6 +365,48 @@ mod tests {
         write_cli_token(&paths, "https://example.com", "pi_dash_api_xxx").unwrap();
         let token = load_cli_token(&paths).unwrap();
         assert_eq!(token.as_deref(), Some("pi_dash_api_xxx"));
+    }
+
+    #[test]
+    fn write_then_load_cli_workspace_roundtrips() {
+        let tmp = tempdir().unwrap();
+        let paths = paths_for(tmp.path());
+        write_cli_token(&paths, "https://example.com", "pi_dash_api_xxx").unwrap();
+        assert_eq!(load_cli_workspace(&paths).unwrap(), None);
+        write_cli_workspace(&paths, "acme").unwrap();
+        assert_eq!(load_cli_workspace(&paths).unwrap().as_deref(), Some("acme"));
+    }
+
+    #[test]
+    fn write_cli_token_preserves_existing_workspace_slug() {
+        // Re-login (e.g. token refresh) must not clobber the host's
+        // existing workspace binding — otherwise users hit the picker
+        // every time their token rolls.
+        let tmp = tempdir().unwrap();
+        let paths = paths_for(tmp.path());
+        write_cli_token(&paths, "https://example.com", "tok-1").unwrap();
+        write_cli_workspace(&paths, "acme").unwrap();
+        write_cli_token(&paths, "https://example.com", "tok-2").unwrap();
+        let cfg = file::load_config(&paths).unwrap();
+        let cli = cfg.cli.expect("cli section");
+        assert_eq!(cli.token.as_deref(), Some("tok-2"));
+        assert_eq!(cli.workspace_slug.as_deref(), Some("acme"));
+    }
+
+    #[test]
+    fn write_cli_workspace_rebinds_when_called_with_new_slug() {
+        // Workspace rebinding is intentionally allowed (membership
+        // changes, user pick a different one on re-login). The login
+        // flow gates this; the helper itself does not refuse.
+        let tmp = tempdir().unwrap();
+        let paths = paths_for(tmp.path());
+        write_cli_token(&paths, "https://example.com", "tok").unwrap();
+        write_cli_workspace(&paths, "acme").unwrap();
+        write_cli_workspace(&paths, "zenith").unwrap();
+        assert_eq!(
+            load_cli_workspace(&paths).unwrap().as_deref(),
+            Some("zenith")
+        );
     }
 
     #[test]

--- a/runner/src/cli/runner_ops.rs
+++ b/runner/src/cli/runner_ops.rs
@@ -91,6 +91,7 @@ pub fn clear_cli_token(paths: &Paths) -> Result<()> {
 /// Result of applying a mint locally: the new `RunnerConfig` block and
 /// whether this was the host's first runner (so callers can decide
 /// whether to install the OS service unit / restart it).
+#[derive(Debug)]
 pub struct AppliedRunner {
     pub runner: RunnerConfig,
     pub is_first_runner: bool,
@@ -113,40 +114,10 @@ pub async fn apply_enroll_response(
     working_dir: Option<PathBuf>,
     agent_kind: AgentKind,
 ) -> Result<AppliedRunner> {
-    // Per-runner credentials.toml first — config.toml is the canonical
-    // list but the supervisor refuses runner rows that have no
-    // credentials file, so we want the credential on disk before the
-    // config references it.
-    let runner_paths = paths.for_runner(resp.runner_id);
-    runner_paths.ensure()?;
-    write_runner_credentials(
-        runner_paths.credentials_path(),
-        RunnerCredentials {
-            runner_id: resp.runner_id,
-            name: resp.runner_name.clone(),
-            refresh_token: resp.refresh_token.clone(),
-            refresh_token_generation: resp.refresh_token_generation,
-        },
-    )
-    .await
-    .context("writing per-runner credentials failed")?;
-
-    let working_dir =
-        working_dir.unwrap_or_else(|| paths.runner_dir(resp.runner_id).join("workspace"));
-
-    let new_runner = RunnerConfig {
-        name: resp.runner_name.clone(),
-        runner_id: resp.runner_id,
-        workspace_slug: Some(resp.workspace_slug.clone()),
-        project_slug: Some(resp.project_identifier.clone()),
-        pod_id: None,
-        workspace: WorkspaceSection { working_dir },
-        agent: AgentSection { kind: agent_kind },
-        codex: CodexSection::default(),
-        claude_code: ClaudeCodeSection::default(),
-        approval_policy: ApprovalPolicySection::default(),
-    };
-
+    // Load existing config (if any) and check the cloud URL BEFORE we
+    // touch disk. Writing per-runner credentials first and then
+    // discovering a cloud-URL mismatch leaves an orphaned credentials
+    // file the daemon will never reference — annoying to clean up.
     let mut cfg = if paths.config_path().exists() {
         file::load_config(paths)?
     } else {
@@ -178,14 +149,210 @@ pub async fn apply_enroll_response(
     if cfg.daemon.cloud_url.is_empty() {
         cfg.daemon.cloud_url = cloud_url.to_string();
     }
+
+    let working_dir =
+        working_dir.unwrap_or_else(|| paths.runner_dir(resp.runner_id).join("workspace"));
+
+    let new_runner = RunnerConfig {
+        name: resp.runner_name.clone(),
+        runner_id: resp.runner_id,
+        workspace_slug: Some(resp.workspace_slug.clone()),
+        project_slug: Some(resp.project_identifier.clone()),
+        pod_id: None,
+        workspace: WorkspaceSection { working_dir },
+        agent: AgentSection { kind: agent_kind },
+        codex: CodexSection::default(),
+        claude_code: ClaudeCodeSection::default(),
+        approval_policy: ApprovalPolicySection::default(),
+    };
+
+    // Validate the merged config in-memory before persisting anything.
     let is_first_runner = cfg.runners.is_empty();
     cfg.runners.push(new_runner.clone());
     cfg.validate()
         .map_err(|e| anyhow::anyhow!("config invalid after add: {e}"))?;
+
+    // Disk writes only happen after every fast-fail above has cleared.
+    // credentials.toml goes first: the supervisor refuses to start a
+    // runner whose config block references a missing credentials file,
+    // so write the credential before the config that points at it.
+    let runner_paths = paths.for_runner(resp.runner_id);
+    runner_paths.ensure()?;
+    write_runner_credentials(
+        runner_paths.credentials_path(),
+        RunnerCredentials {
+            runner_id: resp.runner_id,
+            name: resp.runner_name.clone(),
+            refresh_token: resp.refresh_token.clone(),
+            refresh_token_generation: resp.refresh_token_generation,
+        },
+    )
+    .await
+    .context("writing per-runner credentials failed")?;
     file::write_config(paths, &cfg)?;
 
     Ok(AppliedRunner {
         runner: new_runner,
         is_first_runner,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cloud::http::EnrollResponse;
+    use tempfile::tempdir;
+    use uuid::Uuid;
+
+    fn paths_for(root: &std::path::Path) -> Paths {
+        Paths {
+            config_dir: root.join("config"),
+            data_dir: root.join("data"),
+            runtime_dir: root.join("runtime"),
+        }
+    }
+
+    fn sample_response(runner_name: &str) -> EnrollResponse {
+        EnrollResponse {
+            runner_id: Uuid::new_v4(),
+            runner_name: runner_name.into(),
+            refresh_token: "refresh".into(),
+            access_token: "access".into(),
+            access_token_expires_at: "2099-01-01T00:00:00+00:00".into(),
+            refresh_token_generation: 1,
+            workspace_slug: "acme".into(),
+            pod_slug: "default".into(),
+            project_identifier: "WEB".into(),
+            long_poll_interval_secs: 25,
+            protocol_version: 4,
+            machine_token: None,
+            machine_token_minted: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn first_runner_bootstraps_config_when_none_exists() {
+        let tmp = tempdir().unwrap();
+        let paths = paths_for(tmp.path());
+        let resp = sample_response("r1");
+        let applied = apply_enroll_response(
+            &paths,
+            &resp,
+            "https://example.com",
+            Some(tmp.path().join("wd")),
+            AgentKind::Codex,
+        )
+        .await
+        .unwrap();
+        assert!(applied.is_first_runner);
+        let cfg = file::load_config(&paths).unwrap();
+        assert_eq!(cfg.daemon.cloud_url, "https://example.com");
+        assert_eq!(cfg.runners.len(), 1);
+        assert_eq!(cfg.runners[0].name, "r1");
+    }
+
+    #[tokio::test]
+    async fn second_runner_appends_and_flags_not_first() {
+        let tmp = tempdir().unwrap();
+        let paths = paths_for(tmp.path());
+        let r1 = sample_response("r1");
+        apply_enroll_response(
+            &paths,
+            &r1,
+            "https://example.com",
+            Some(tmp.path().join("wd1")),
+            AgentKind::Codex,
+        )
+        .await
+        .unwrap();
+
+        let r2 = sample_response("r2");
+        let applied = apply_enroll_response(
+            &paths,
+            &r2,
+            "https://example.com",
+            Some(tmp.path().join("wd2")),
+            AgentKind::Codex,
+        )
+        .await
+        .unwrap();
+        assert!(!applied.is_first_runner);
+        let cfg = file::load_config(&paths).unwrap();
+        assert_eq!(cfg.runners.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn cloud_url_mismatch_does_not_leave_orphan_credentials() {
+        // The whole point of the URL-check-before-write reorder. If the
+        // user is enrolled with cloud A and a misuse points us at cloud
+        // B, we MUST refuse before writing per-runner credentials —
+        // otherwise an orphan file is left for the operator to clean up.
+        let tmp = tempdir().unwrap();
+        let paths = paths_for(tmp.path());
+        let r1 = sample_response("r1");
+        apply_enroll_response(
+            &paths,
+            &r1,
+            "https://cloud-a.example.com",
+            Some(tmp.path().join("wd1")),
+            AgentKind::Codex,
+        )
+        .await
+        .unwrap();
+
+        let r2 = sample_response("r2");
+        let err = apply_enroll_response(
+            &paths,
+            &r2,
+            "https://cloud-b.example.com",
+            Some(tmp.path().join("wd2")),
+            AgentKind::Codex,
+        )
+        .await
+        .unwrap_err();
+        assert!(format!("{err}").contains("refusing to add a runner pointing at"));
+        // No credentials file should exist for r2 — the bail happened
+        // before the write.
+        let r2_creds = paths.for_runner(r2.runner_id).credentials_path();
+        assert!(!r2_creds.exists(), "orphan credentials file at {r2_creds:?}");
+    }
+
+    #[test]
+    fn write_then_load_cli_token_roundtrips() {
+        let tmp = tempdir().unwrap();
+        let paths = paths_for(tmp.path());
+        write_cli_token(&paths, "https://example.com", "pi_dash_api_xxx").unwrap();
+        let token = load_cli_token(&paths).unwrap();
+        assert_eq!(token.as_deref(), Some("pi_dash_api_xxx"));
+    }
+
+    #[test]
+    fn clear_cli_token_keeps_runner_blocks() {
+        let tmp = tempdir().unwrap();
+        let paths = paths_for(tmp.path());
+        // Seed config with a runner block + token via the normal flow.
+        write_cli_token(&paths, "https://example.com", "pi_dash_api_xxx").unwrap();
+        // Append a runner block manually by writing config.
+        let mut cfg = file::load_config(&paths).unwrap();
+        cfg.runners.push(RunnerConfig {
+            name: "r1".into(),
+            runner_id: Uuid::new_v4(),
+            workspace_slug: Some("acme".into()),
+            project_slug: Some("WEB".into()),
+            pod_id: None,
+            workspace: WorkspaceSection {
+                working_dir: tmp.path().join("wd"),
+            },
+            agent: AgentSection::default(),
+            codex: CodexSection::default(),
+            claude_code: ClaudeCodeSection::default(),
+            approval_policy: ApprovalPolicySection::default(),
+        });
+        file::write_config(&paths, &cfg).unwrap();
+
+        clear_cli_token(&paths).unwrap();
+        let after = file::load_config(&paths).unwrap();
+        assert!(after.cli.as_ref().and_then(|c| c.token.as_ref()).is_none());
+        assert_eq!(after.runners.len(), 1, "runner block must be preserved");
+    }
 }

--- a/runner/src/cloud/http.rs
+++ b/runner/src/cloud/http.rs
@@ -1305,6 +1305,52 @@ fn map_session_error(status: StatusCode, body: &str) -> TransportError {
 
 /// Public helper to enroll a runner — replaces the legacy `enroll.rs`
 /// connection-flow body.
+/// CLI-initiated runner creation.
+///
+/// `pidash auth login` populates `[cli].token` with a user-scoped
+/// `APIToken`. Once that token exists, `pidash runner add` can mint a
+/// runner directly without the one-time enrollment-token paste — we POST
+/// to `/api/v1/runner/runners/` with `X-Api-Key`, and the cloud returns
+/// the same `EnrollResponse` shape `enroll_runner` would have.
+pub async fn create_runner(
+    transport: &SharedHttpTransport,
+    api_token: &str,
+    workspace_slug: &str,
+    project: &str,
+    host_label: &str,
+    name: Option<&str>,
+    pod: Option<&str>,
+) -> Result<EnrollResponse, TransportError> {
+    let url = format!("{}/api/v1/runner/runners/", transport.cloud_url());
+    let mut body = serde_json::json!({
+        "workspace_slug": workspace_slug,
+        "project": project,
+        "host_label": host_label,
+    });
+    if let Some(n) = name {
+        body["name"] = Json::String(n.to_string());
+    }
+    if let Some(p) = pod {
+        body["pod"] = Json::String(p.to_string());
+    }
+    let resp = transport
+        .http()
+        .post(&url)
+        .header("X-Api-Key", api_token)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| TransportError::Network(e.to_string()))?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(map_auth_error(status, &body));
+    }
+    resp.json::<EnrollResponse>()
+        .await
+        .map_err(|e| TransportError::Protocol(format!("create_runner body: {e}")))
+}
+
 pub async fn enroll_runner(
     transport: &SharedHttpTransport,
     enrollment_token: &str,

--- a/runner/src/cloud/http.rs
+++ b/runner/src/cloud/http.rs
@@ -1312,10 +1312,14 @@ fn map_session_error(status: StatusCode, body: &str) -> TransportError {
 /// runner directly without the one-time enrollment-token paste — we POST
 /// to `/api/v1/runner/runners/` with `X-Api-Key`, and the cloud returns
 /// the same `EnrollResponse` shape `enroll_runner` would have.
+///
+/// `workspace_slug` is optional: the cloud falls back to the caller's
+/// single workspace membership when omitted. Multi-workspace callers
+/// must pass an explicit slug.
 pub async fn create_runner(
     transport: &SharedHttpTransport,
     api_token: &str,
-    workspace_slug: &str,
+    workspace_slug: Option<&str>,
     project: &str,
     host_label: &str,
     name: Option<&str>,
@@ -1323,10 +1327,12 @@ pub async fn create_runner(
 ) -> Result<EnrollResponse, TransportError> {
     let url = format!("{}/api/v1/runner/runners/", transport.cloud_url());
     let mut body = serde_json::json!({
-        "workspace_slug": workspace_slug,
         "project": project,
         "host_label": host_label,
     });
+    if let Some(ws) = workspace_slug {
+        body["workspace_slug"] = Json::String(ws.to_string());
+    }
     if let Some(n) = name {
         body["name"] = Json::String(n.to_string());
     }

--- a/runner/src/config/schema.rs
+++ b/runner/src/config/schema.rs
@@ -36,6 +36,15 @@ pub struct CliSection {
     /// "no token" message when it's missing at command time.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub token: Option<String>,
+
+    /// Workspace this host is bound to. The Pi Dash CLI on a dev host
+    /// is single-workspace-per-install in v1: `pidash auth login`
+    /// resolves it (auto-picks if the user belongs to one workspace,
+    /// prompts if they belong to several) and persists it here.
+    /// `pidash runner add` reads this as the default for `--workspace`
+    /// when the caller doesn't pass one explicitly.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_slug: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/runner/tests/pidash_run_errors.rs
+++ b/runner/tests/pidash_run_errors.rs
@@ -45,35 +45,47 @@ async fn run_errors_when_config_missing() {
 
 #[tokio::test]
 async fn run_errors_when_creds_missing_but_config_present() {
+    // Multi-runner: config.toml has one [[runner]] block, but the
+    // per-runner credentials.toml under data_dir/runners/<id>/ is
+    // absent. The daemon must bail with an action-guiding error before
+    // trying to spawn the runner, naming the file the operator needs
+    // to produce and the command that produces it.
     let tmp = tempdir().unwrap();
     let paths = empty_paths(tmp.path());
     ensure_dirs(&paths);
-    // Config exists, credentials do not.
+    let runner_id = uuid::Uuid::new_v4();
     std::fs::write(
         paths.config_path(),
-        r#"
-version = 1
+        format!(
+            r#"
+version = 2
 
-[runner]
-name = "t"
+[daemon]
 cloud_url = "https://x"
 
-[workspace]
+[[runner]]
+name = "t"
+runner_id = "{runner_id}"
+workspace_slug = "acme"
+project_slug = "TEST"
+
+[runner.workspace]
 working_dir = "/tmp/wd"
-"#,
+"#
+        ),
     )
     .unwrap();
     let args = RunArgs { offline: true };
     let err = pidash::cli::run_for_tests(args, &paths)
         .await
-        .expect_err("__run with config but no creds should fail");
+        .expect_err("__run with config but no per-runner creds should fail");
     let msg = format!("{err:#}");
     assert!(
         msg.contains("credentials.toml"),
         "error should mention credentials.toml: {msg}",
     );
     assert!(
-        msg.contains("pidash connect"),
-        "error should point at `pidash connect`: {msg}",
+        msg.contains("pidash runner add"),
+        "error should point at `pidash runner add`: {msg}",
     );
 }


### PR DESCRIPTION
## Summary

Onboard the `pidash` CLI like `gh auth login` / `stripe login` / `aws configure`: one binary, one token in `~/.config/pidash/config.toml`, accessible to any process on the host (human shell, ad-hoc agents, runner-spawned agents). The token is server-enforced (`X-Api-Key` → user identity → workspace RBAC).

**Closes the silent-noop class of failures** where the runner enrolled successfully but the CLI was never set up (e.g. PDASHOSS01-2). Before this change, `[cli].token` had to be populated by hand from a token generated in the web admin — undocumented and easy to skip. After this change, `pidash auth login` is the documented first step on every host.

### Two distinct identities, made first-class

| | User identity | Runner identity |
|---|---|---|
| **Where** | `~/.config/pidash/config.toml` `[cli].token` | `~/.config/pidash/credentials.toml` per-runner |
| **Cardinality** | 1 per OS user | N per host (one per `[[runner]]` block) |
| **Minted by** | `pidash auth login` (RFC 8628 device-code OAuth) | `pidash runner add` (uses CLI token) — or `pidash connect --token` (legacy enrollment-token fallback) |

### New CLI surface

```
pidash auth login [--url URL] [--no-browser] [--no-runner-prompt]
pidash auth status
pidash auth logout [--local-only]
pidash runner add --project SLUG [--workspace SLUG] [--pod NAME] [--name NAME]
```

`pidash auth login` prompts to add a runner inline when no `[[runner]]` exists yet — for the common dev-laptop case, that single command is enough. The legacy `pidash connect --url X --token <T>` enrollment-token flow stays as a fallback for headless / scripted hosts.

### Server changes

- New `CLIDeviceCode` model + migration `db/migrations/0135_clidevicecode.py` (RFC 8628-shaped grant).
- New views in `apps/api/pi_dash/authentication/views/cli/device.py`:
  - `POST /api/v1/auth/device/start/` — anonymous, mints `device_code` + `user_code`.
  - `POST /api/v1/auth/device/approve/` — session-auth; logged-in human approves the code.
  - `POST /api/v1/auth/device/token/` — anonymous; CLI polls, gets fresh `APIToken` on approval.
  - `POST /api/v1/auth/revoke/` — `X-Api-Key`; revokes caller's token (idempotent).
- New `RunnerCreateEndpoint` at `POST /api/v1/runner/runners/` — `X-Api-Key` → mint runner credentials. Returns the same shape as the existing enrollment endpoint, so the runner code path is reused.
- `ProjectListEndpoint` now accepts `X-Api-Key` (in addition to runner-bearer and session auth) so the CLI's post-login project picker works.

### Web

- New `/auth/device/` page (apps/web `(all)/auth/device/page.tsx`). Minimal form: enter `user_code`, hit Approve. Auto-submits if reached via `?code=…` deep link.

### Runner

- New `cli/auth/{login,status,logout}.rs`.
- New `cli/runner_ops.rs` — shared `[cli].token` plumbing + `apply_enroll_response()` so both `pidash connect` (legacy) and `pidash runner add` (new) write config consistently.
- `cli/runner.rs::add()` rewritten to use the CLI token + new `create_runner` HTTP call.
- `api_client.rs` "no auth token configured" error rewritten to point users at `pidash auth login` directly.
- New `cloud/http.rs::create_runner()` HTTP function for the X-Api-Key-authed runner-mint endpoint.

### Backwards compatibility

- `pidash connect --token <ONE_TIME_TOKEN>` still works exactly as before — no breaking change.
- The existing web admin's "Add connection" enrollment-token flow is unchanged.
- Existing hosts with runners but no CLI token keep running; the next time the user runs a `pidash` CLI command, the error message now points them at `pidash auth login`.

## Test plan

- [ ] `cargo test` and `cargo clippy --all-targets -- -D warnings` in `runner/` pass (verified locally — 218 tests, no clippy warnings).
- [ ] `pytest -m unit apps/api/pi_dash/tests/unit/runner/test_cli_auth_flow.py` covers device-code start/approve/poll/expired/slow_down, revoke idempotence, and runner-create happy path + 404s.
- [ ] Manual end-to-end on a fresh host:
  1. `pidash auth login --url https://...` opens browser → enter code → approval page shows ✓ → CLI prints "Logged in as …".
  2. Post-login prompt: pick a project → runner is registered → service unit installed → daemon started.
  3. `pidash auth status` shows account + workspace + the new runner.
  4. `pidash issue list` (or any user-scoped command) works without further setup.
  5. `pidash auth logout` revokes server-side and clears the local token.
- [ ] Manual on an existing host (already has runner via legacy `pidash connect`):
  1. `pidash issue list` shows the new "Not logged in: run `pidash auth login`" error.
  2. After `pidash auth login`, the existing runners are listed by `pidash auth status` and continue running unmodified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)