### PR TITLE
PDASHOSS01-2 Add "Scheduler" item under the project in left panel of UI

### DIFF
--- a/apps/api/pi_dash/api/serializers/project.py
+++ b/apps/api/pi_dash/api/serializers/project.py
@@ -84,6 +84,7 @@ class ProjectCreateSerializer(BaseSerializer):
             "issue_views_view",
             "page_view",
             "intake_view",
+            "scheduler_view",
             "guest_view_all_features",
             "members_can_edit_states",
             "archive_in",

--- a/apps/api/pi_dash/app/views/project/base.py
+++ b/apps/api/pi_dash/app/views/project/base.py
@@ -182,6 +182,7 @@ class ProjectViewSet(BaseViewSet):
             "module_view",
             "page_view",
             "inbox_view",
+            "scheduler_view",
             "guest_view_all_features",
             "project_lead",
             "network",

--- a/apps/api/pi_dash/db/migrations/0135_project_scheduler_view.py
+++ b/apps/api/pi_dash/db/migrations/0135_project_scheduler_view.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("db", "0134_issueagentticker_disarm_reason"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="project",
+            name="scheduler_view",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/apps/api/pi_dash/db/models/project.py
+++ b/apps/api/pi_dash/db/models/project.py
@@ -97,6 +97,7 @@ class Project(BaseModel):
     issue_views_view = models.BooleanField(default=False)
     page_view = models.BooleanField(default=True)
     intake_view = models.BooleanField(default=False)
+    scheduler_view = models.BooleanField(default=False)
     is_time_tracking_enabled = models.BooleanField(default=False)
     is_issue_type_enabled = models.BooleanField(default=False)
     guest_view_all_features = models.BooleanField(default=False)

--- a/apps/web/app/(all)/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/schedulers/header.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/schedulers/header.tsx
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { observer } from "mobx-react";
+import { useParams } from "next/navigation";
+// pi dash imports
+import { useTranslation } from "@pi-dash/i18n";
+import { CalendarAfterIcon } from "@pi-dash/propel/icons";
+import { Breadcrumbs, Header } from "@pi-dash/ui";
+// components
+import { BreadcrumbLink } from "@/components/common/breadcrumb-link";
+// hooks
+import { useProject } from "@/hooks/store/use-project";
+// pi dash web imports
+import { CommonProjectBreadcrumbs } from "@/pi-dash-web/components/breadcrumbs/common";
+
+export const ProjectSchedulersHeader = observer(function ProjectSchedulersHeader() {
+  const { workspaceSlug, projectId } = useParams();
+  const { t } = useTranslation();
+  const { loader: currentProjectDetailsLoader } = useProject();
+
+  return (
+    <Header>
+      <Header.LeftItem>
+        <div className="flex flex-grow items-center gap-4">
+          <Breadcrumbs isLoading={currentProjectDetailsLoader === "init-loader"}>
+            <CommonProjectBreadcrumbs workspaceSlug={workspaceSlug?.toString()} projectId={projectId?.toString()} />
+            <Breadcrumbs.Item
+              component={
+                <BreadcrumbLink
+                  label={t("scheduler_bindings.tab_label")}
+                  href={`/${workspaceSlug}/projects/${projectId}/schedulers/`}
+                  icon={<CalendarAfterIcon className="h-4 w-4 text-tertiary" />}
+                  isLast
+                />
+              }
+              isLast
+            />
+          </Breadcrumbs>
+        </div>
+      </Header.LeftItem>
+    </Header>
+  );
+});

--- a/apps/web/app/(all)/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/schedulers/layout.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/schedulers/layout.tsx
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { Outlet } from "react-router";
+// components
+import { AppHeader } from "@/components/core/app-header";
+import { ContentWrapper } from "@/components/core/content-wrapper";
+import { ProjectSchedulersHeader } from "./header";
+
+export default function ProjectSchedulersLayout() {
+  return (
+    <>
+      <AppHeader header={<ProjectSchedulersHeader />} />
+      <ContentWrapper>
+        <Outlet />
+      </ContentWrapper>
+    </>
+  );
+}

--- a/apps/web/app/(all)/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/schedulers/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/schedulers/page.tsx
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { observer } from "mobx-react";
+// pi dash imports
+import { EUserPermissionsLevel } from "@pi-dash/constants";
+import { useTranslation } from "@pi-dash/i18n";
+import { EUserProjectRoles } from "@pi-dash/types";
+// components
+import { NotAuthorizedView } from "@/components/auth-screens/not-authorized-view";
+import { PageHead } from "@/components/core/page-title";
+import { ProjectSchedulerBindingsList } from "@/components/project/scheduler-bindings/binding-list";
+// hooks
+import { useProject } from "@/hooks/store/use-project";
+import { useUserPermissions } from "@/hooks/store/user";
+import { useAppRouter } from "@/hooks/use-app-router";
+import type { Route } from "./+types/page";
+
+function ProjectSchedulersPage({ params }: Route.ComponentProps) {
+  const { workspaceSlug, projectId } = params;
+  const router = useAppRouter();
+  const { t } = useTranslation();
+  const { currentProjectDetails } = useProject();
+  const { workspaceUserInfo, allowPermissions } = useUserPermissions();
+
+  // Project admin only — matches the existing settings → schedulers gate
+  // and the backend's project-admin gate on binding mutations.
+  const canManage = allowPermissions(
+    [EUserProjectRoles.ADMIN],
+    EUserPermissionsLevel.PROJECT,
+    workspaceSlug,
+    projectId
+  );
+
+  const pageTitle = currentProjectDetails?.name
+    ? `${currentProjectDetails.name} · ${t("scheduler_bindings.title")}`
+    : t("scheduler_bindings.title");
+
+  // Feature disabled at the project level — bounce admins to the
+  // features settings page so they can flip the toggle back on.
+  if (currentProjectDetails && currentProjectDetails.scheduler_view === false) {
+    return (
+      <div className="flex h-full w-full items-center justify-center">
+        <div className="max-w-md p-6 text-center">
+          <h1 className="text-16 font-semibold text-primary">{t("scheduler_bindings.title")}</h1>
+          <p className="mt-2 text-13 text-secondary">{t("scheduler_bindings.subtitle")}</p>
+          <button
+            type="button"
+            className="mt-4 text-13 font-medium text-primary underline"
+            onClick={() => router.push(`/${workspaceSlug}/settings/projects/${projectId}/`)}
+            disabled={!canManage}
+          >
+            {t("settings")}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (workspaceUserInfo && !canManage) {
+    return <NotAuthorizedView section="settings" isProjectView className="h-auto" />;
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <PageHead title={pageTitle} />
+      <div className="h-full w-full overflow-y-auto p-6">
+        <ProjectSchedulerBindingsList workspaceSlug={workspaceSlug} projectId={projectId} />
+      </div>
+    </div>
+  );
+}
+
+export default observer(ProjectSchedulersPage);

--- a/apps/web/app/(all)/[workspaceSlug]/(settings)/settings/projects/[projectId]/schedulers/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/(settings)/settings/projects/[projectId]/schedulers/page.tsx
@@ -4,30 +4,20 @@
  * See the LICENSE file for details.
  */
 
-import { useState } from "react";
 import { observer } from "mobx-react";
 import { useParams } from "react-router";
-import useSWR from "swr";
 // pi dash imports
 import { EUserPermissions, EUserPermissionsLevel } from "@pi-dash/constants";
 import { useTranslation } from "@pi-dash/i18n";
-import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
-import type { IScheduler, ISchedulerBinding } from "@pi-dash/services";
-import { SchedulerService } from "@pi-dash/services";
-import { Button, ToggleSwitch } from "@pi-dash/ui";
 // components
 import { NotAuthorizedView } from "@/components/auth-screens/not-authorized-view";
 import { PageHead } from "@/components/core/page-title";
-import { EditSchedulerBindingModal } from "@/components/project/scheduler-bindings/edit-binding-modal";
-import { InstallSchedulerBindingModal } from "@/components/project/scheduler-bindings/install-binding-modal";
-import { UninstallSchedulerBindingModal } from "@/components/project/scheduler-bindings/uninstall-binding-modal";
+import { ProjectSchedulerBindingsList } from "@/components/project/scheduler-bindings/binding-list";
 import { SettingsContentWrapper } from "@/components/settings/content-wrapper";
 // hooks
 import { useProject } from "@/hooks/store/use-project";
 import { useUserPermissions } from "@/hooks/store/user";
 import { SchedulersProjectSettingsHeader } from "./header";
-
-const schedulerService = new SchedulerService();
 
 const SchedulerBindingsSettingsPage = observer(function SchedulerBindingsSettingsPage() {
   const { workspaceSlug, projectId } = useParams<{ workspaceSlug: string; projectId: string }>();
@@ -44,21 +34,6 @@ const SchedulerBindingsSettingsPage = observer(function SchedulerBindingsSetting
   // actions, which adds no value over the workspace catalog view.
   const canManage = allowPermissions([EUserPermissions.ADMIN], EUserPermissionsLevel.PROJECT, slug, project);
 
-  // Bindings: per-project. Workspace schedulers: needed to populate the
-  // install picker. Both keys include the workspace + project so a
-  // navigation between projects refetches.
-  const { data: bindings, mutate: mutateBindings } = useSWR<ISchedulerBinding[]>(
-    slug && project ? ["scheduler-bindings", slug, project] : null,
-    () => schedulerService.listBindings(slug, project)
-  );
-  const { data: schedulers } = useSWR<IScheduler[]>(slug ? ["schedulers", slug] : null, () =>
-    schedulerService.listSchedulers(slug)
-  );
-
-  const [installOpen, setInstallOpen] = useState(false);
-  const [editTarget, setEditTarget] = useState<ISchedulerBinding | null>(null);
-  const [uninstallTarget, setUninstallTarget] = useState<ISchedulerBinding | null>(null);
-
   const pageTitle = currentProjectDetails?.name
     ? `${currentProjectDetails.name} · ${t("scheduler_bindings.title")}`
     : t("scheduler_bindings.title");
@@ -67,202 +42,14 @@ const SchedulerBindingsSettingsPage = observer(function SchedulerBindingsSetting
     return <NotAuthorizedView section="settings" isProjectView className="h-auto" />;
   }
 
-  const rows = bindings ?? [];
-
   return (
     <SettingsContentWrapper header={<SchedulersProjectSettingsHeader />}>
       <PageHead title={pageTitle} />
-
-      <div className="flex flex-col gap-6 p-6">
-        <header className="flex items-start justify-between gap-4">
-          <div>
-            <h1 className="text-16 font-semibold text-primary">{t("scheduler_bindings.title")}</h1>
-            <p className="mt-1 text-13 text-secondary">{t("scheduler_bindings.subtitle")}</p>
-          </div>
-          <Button onClick={() => setInstallOpen(true)}>{t("scheduler_bindings.install")}</Button>
-        </header>
-
-        <section className="rounded-md border border-subtle">
-          <table className="w-full text-13">
-            <thead className="bg-layer-1 text-left text-secondary">
-              <tr>
-                <th className="px-3 py-2">{t("scheduler_bindings.columns.name")}</th>
-                <th className="px-3 py-2">{t("scheduler_bindings.columns.cron")}</th>
-                <th className="px-3 py-2">{t("scheduler_bindings.columns.next_run")}</th>
-                <th className="px-3 py-2">{t("scheduler_bindings.columns.last_run")}</th>
-                <th className="px-3 py-2">{t("scheduler_bindings.columns.status")}</th>
-                <th className="px-3 py-2">{t("scheduler_bindings.columns.updated")}</th>
-                <th className="px-3 py-2"></th>
-              </tr>
-            </thead>
-            <tbody>
-              {rows.map((b) => (
-                <BindingRow
-                  key={b.id}
-                  binding={b}
-                  onEdit={() => setEditTarget(b)}
-                  onUninstall={() => setUninstallTarget(b)}
-                  onToggle={async (next) => {
-                    // Optimistic toggle — flip the cached row immediately, run
-                    // the PATCH, swap in the canonical server response on
-                    // success, roll back on error. SWR's optimisticData /
-                    // rollbackOnError handle the cache surgery; we just
-                    // surface the toast.
-                    try {
-                      await mutateBindings(
-                        async (current) => {
-                          const updated = await schedulerService.updateBinding(slug, project, b.id, {
-                            enabled: next,
-                          });
-                          return (current ?? []).map((row) => (row.id === b.id ? updated : row));
-                        },
-                        {
-                          // SWR diffs optimisticData by reference, so we
-                          // need a fresh array AND a fresh object for the
-                          // changed row. The spread-in-map pattern oxlint
-                          // flags as "inefficient" is the standard idiom
-                          // for immutable updates here. Build the new
-                          // array imperatively to dodge the rule and avoid
-                          // a mid-iteration spread.
-                          optimisticData: (current) => {
-                            const arr = current ?? [];
-                            const idx = arr.findIndex((row) => row.id === b.id);
-                            if (idx === -1) return arr;
-                            const out = arr.slice();
-                            out[idx] = Object.assign({}, arr[idx], { enabled: next });
-                            return out;
-                          },
-                          rollbackOnError: true,
-                          revalidate: false,
-                        }
-                      );
-                      setToast({
-                        type: TOAST_TYPE.SUCCESS,
-                        title: t("scheduler_bindings.toast.updated_title"),
-                        message: next
-                          ? t("scheduler_bindings.toast.enabled_message")
-                          : t("scheduler_bindings.toast.disabled_message"),
-                      });
-                    } catch (e: unknown) {
-                      const err = e as { error?: string } | null;
-                      setToast({
-                        type: TOAST_TYPE.ERROR,
-                        title: t("scheduler_bindings.toast.error_title"),
-                        message: err?.error ?? t("scheduler_bindings.toast.update_failed"),
-                      });
-                    }
-                  }}
-                />
-              ))}
-              {rows.length === 0 && (
-                <tr>
-                  <td colSpan={7} className="px-3 py-8 text-center text-secondary">
-                    {t("scheduler_bindings.list.empty")}
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-        </section>
+      <div className="p-6">
+        <ProjectSchedulerBindingsList workspaceSlug={slug} projectId={project} />
       </div>
-
-      <InstallSchedulerBindingModal
-        isOpen={installOpen}
-        onClose={() => setInstallOpen(false)}
-        workspaceSlug={slug}
-        projectId={project}
-        availableSchedulers={schedulers ?? []}
-        existingBindings={rows}
-        onInstalled={() => mutateBindings()}
-      />
-      <EditSchedulerBindingModal
-        isOpen={!!editTarget}
-        onClose={() => setEditTarget(null)}
-        workspaceSlug={slug}
-        projectId={project}
-        binding={editTarget}
-        onUpdated={() => mutateBindings()}
-      />
-      <UninstallSchedulerBindingModal
-        isOpen={!!uninstallTarget}
-        onClose={() => setUninstallTarget(null)}
-        workspaceSlug={slug}
-        projectId={project}
-        binding={uninstallTarget}
-        onUninstalled={() => mutateBindings()}
-      />
     </SettingsContentWrapper>
   );
 });
-
-type RowProps = {
-  binding: ISchedulerBinding;
-  onEdit: () => void;
-  onUninstall: () => void;
-  onToggle: (next: boolean) => Promise<void>;
-};
-
-function BindingRow({ binding, onEdit, onUninstall, onToggle }: RowProps) {
-  const { t } = useTranslation();
-  const [toggling, setToggling] = useState(false);
-
-  const formatTs = (ts: string | null) => (ts ? new Date(ts).toLocaleString() : t("scheduler_bindings.list.none_yet"));
-
-  // Wraps the parent's onToggle so the switch can render a disabled
-  // state during the in-flight PATCH (prevents a double-click from
-  // racing two requests). The optimistic / rollback bookkeeping lives
-  // in the parent because the SWR cache key does too.
-  const handleToggle = async (next: boolean) => {
-    if (toggling) return;
-    setToggling(true);
-    try {
-      await onToggle(next);
-    } finally {
-      setToggling(false);
-    }
-  };
-
-  return (
-    <tr className="border-t border-subtle">
-      <td className="px-3 py-2 font-medium text-primary">
-        {binding.scheduler_name}
-        <div className="text-12 text-secondary">
-          <code>{binding.scheduler_slug}</code>
-        </div>
-      </td>
-      <td className="px-3 py-2 text-secondary">
-        <code className="text-12">{binding.cron}</code>
-      </td>
-      <td className="px-3 py-2 text-secondary">{formatTs(binding.next_run_at)}</td>
-      <td className="px-3 py-2 text-secondary">{formatTs(binding.last_run_ended_at)}</td>
-      <td className="px-3 py-2">
-        <div className="flex items-center gap-2">
-          <ToggleSwitch
-            value={binding.enabled}
-            onChange={handleToggle}
-            disabled={toggling}
-            aria-label={
-              binding.enabled ? t("scheduler_bindings.actions.disable") : t("scheduler_bindings.actions.enable")
-            }
-          />
-          <span className="text-12 text-secondary">
-            {binding.enabled ? t("scheduler_bindings.status.enabled") : t("scheduler_bindings.status.disabled")}
-          </span>
-        </div>
-      </td>
-      <td className="px-3 py-2 text-secondary">{new Date(binding.updated_at).toLocaleString()}</td>
-      <td className="px-3 py-2 text-right">
-        <div className="flex items-center justify-end gap-2">
-          <Button variant="link-neutral" size="sm" onClick={onEdit}>
-            {t("scheduler_bindings.actions.edit")}
-          </Button>
-          <Button variant="tertiary-danger" size="sm" onClick={onUninstall}>
-            {t("scheduler_bindings.actions.uninstall")}
-          </Button>
-        </div>
-      </td>
-    </tr>
-  );
-}
 
 export default SchedulerBindingsSettingsPage;

--- a/apps/web/app/routes/core.ts
+++ b/apps/web/app/routes/core.ts
@@ -234,6 +234,15 @@ export const coreRoutes: RouteConfigEntry[] = [
               "./(all)/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/intake/page.tsx"
             ),
           ]),
+          // Schedulers (per-project) — top-level project route that mirrors
+          // the same scheduler bindings UI as Settings → Schedulers.
+          // Surfaced in the sidebar when project.scheduler_view is on.
+          layout("./(all)/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/schedulers/layout.tsx", [
+            route(
+              ":workspaceSlug/projects/:projectId/schedulers",
+              "./(all)/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/schedulers/page.tsx"
+            ),
+          ]),
         ]),
 
         // Project Archives - Issues, Cycles, Modules

--- a/apps/web/ce/components/navigations/use-navigation-items.ts
+++ b/apps/web/ce/components/navigations/use-navigation-items.ts
@@ -7,7 +7,15 @@
 import { useMemo, useCallback } from "react";
 // pi dash imports
 import { EUserPermissions, EUserPermissionsLevel } from "@pi-dash/constants";
-import { CycleIcon, IntakeIcon, ModuleIcon, PageIcon, ViewsIcon, WorkItemsIcon } from "@pi-dash/propel/icons";
+import {
+  CalendarAfterIcon,
+  CycleIcon,
+  IntakeIcon,
+  ModuleIcon,
+  PageIcon,
+  ViewsIcon,
+  WorkItemsIcon,
+} from "@pi-dash/propel/icons";
 import type { EUserProjectRoles, IPartialProject } from "@pi-dash/types";
 import type { TNavigationItem } from "@/components/navigation/tab-navigation-root";
 
@@ -31,12 +39,12 @@ export const useNavigationItems = ({
 }: UseNavigationItemsProps): TNavigationItem[] => {
   // Base navigation items
   const baseNavigation = useCallback(
-    (workspaceSlug: string, projectId: string): TNavigationItem[] => [
+    (slug: string, id: string): TNavigationItem[] => [
       {
         i18n_key: "sidebar.work_items",
         key: "work_items",
         name: "Work items",
-        href: `/${workspaceSlug}/projects/${projectId}/issues`,
+        href: `/${slug}/projects/${id}/issues`,
         icon: WorkItemsIcon,
         access: [EUserPermissions.ADMIN, EUserPermissions.MEMBER, EUserPermissions.GUEST],
         shouldRender: true,
@@ -46,7 +54,7 @@ export const useNavigationItems = ({
         i18n_key: "sidebar.cycles",
         key: "cycles",
         name: "Cycles",
-        href: `/${workspaceSlug}/projects/${projectId}/cycles`,
+        href: `/${slug}/projects/${id}/cycles`,
         icon: CycleIcon,
         access: [EUserPermissions.ADMIN, EUserPermissions.MEMBER],
         shouldRender: !!project?.cycle_view,
@@ -56,7 +64,7 @@ export const useNavigationItems = ({
         i18n_key: "sidebar.modules",
         key: "modules",
         name: "Modules",
-        href: `/${workspaceSlug}/projects/${projectId}/modules`,
+        href: `/${slug}/projects/${id}/modules`,
         icon: ModuleIcon,
         access: [EUserPermissions.ADMIN, EUserPermissions.MEMBER],
         shouldRender: !!project?.module_view,
@@ -66,7 +74,7 @@ export const useNavigationItems = ({
         i18n_key: "sidebar.views",
         key: "views",
         name: "Views",
-        href: `/${workspaceSlug}/projects/${projectId}/views`,
+        href: `/${slug}/projects/${id}/views`,
         icon: ViewsIcon,
         access: [EUserPermissions.ADMIN, EUserPermissions.MEMBER, EUserPermissions.GUEST],
         shouldRender: !!project?.issue_views_view,
@@ -76,7 +84,7 @@ export const useNavigationItems = ({
         i18n_key: "sidebar.pages",
         key: "pages",
         name: "Pages",
-        href: `/${workspaceSlug}/projects/${projectId}/pages`,
+        href: `/${slug}/projects/${id}/pages`,
         icon: PageIcon,
         access: [EUserPermissions.ADMIN, EUserPermissions.MEMBER, EUserPermissions.GUEST],
         shouldRender: !!project?.page_view,
@@ -86,11 +94,21 @@ export const useNavigationItems = ({
         i18n_key: "sidebar.intake",
         key: "intake",
         name: "Intake",
-        href: `/${workspaceSlug}/projects/${projectId}/intake`,
+        href: `/${slug}/projects/${id}/intake`,
         icon: IntakeIcon,
         access: [EUserPermissions.ADMIN, EUserPermissions.MEMBER, EUserPermissions.GUEST],
         shouldRender: !!project?.inbox_view,
         sortOrder: 6,
+      },
+      {
+        i18n_key: "sidebar.schedulers",
+        key: "schedulers",
+        name: "Scheduler",
+        href: `/${slug}/projects/${id}/schedulers`,
+        icon: CalendarAfterIcon,
+        access: [EUserPermissions.ADMIN],
+        shouldRender: !!project?.scheduler_view,
+        sortOrder: 7,
       },
     ],
     [project]
@@ -108,7 +126,7 @@ export const useNavigationItems = ({
     });
 
     // Sort by sortOrder
-    return filteredItems.sort((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0));
+    return filteredItems.toSorted((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0));
   }, [workspaceSlug, projectId, baseNavigation, allowPermissions, project?.id]);
 
   return navigationItems;

--- a/apps/web/ce/components/projects/navigation/helper.tsx
+++ b/apps/web/ce/components/projects/navigation/helper.tsx
@@ -6,7 +6,15 @@
 
 // pi dash imports
 import { EUserPermissions, EProjectFeatureKey } from "@pi-dash/constants";
-import { CycleIcon, IntakeIcon, ModuleIcon, PageIcon, ViewsIcon, WorkItemsIcon } from "@pi-dash/propel/icons";
+import {
+  CalendarAfterIcon,
+  CycleIcon,
+  IntakeIcon,
+  ModuleIcon,
+  PageIcon,
+  ViewsIcon,
+  WorkItemsIcon,
+} from "@pi-dash/propel/icons";
 // components
 import type { TNavigationItem } from "@/components/workspace/sidebar/project-navigation";
 
@@ -19,6 +27,7 @@ export const getProjectFeatureNavigation = (
     issue_views_view: boolean;
     page_view: boolean;
     inbox_view: boolean;
+    scheduler_view: boolean;
   }
 ): TNavigationItem[] => [
   {
@@ -80,5 +89,15 @@ export const getProjectFeatureNavigation = (
     access: [EUserPermissions.ADMIN, EUserPermissions.MEMBER, EUserPermissions.GUEST],
     shouldRender: project.inbox_view,
     sortOrder: 6,
+  },
+  {
+    i18n_key: "sidebar.schedulers",
+    key: EProjectFeatureKey.SCHEDULERS,
+    name: "Scheduler",
+    href: `/${workspaceSlug}/projects/${projectId}/schedulers`,
+    icon: CalendarAfterIcon,
+    access: [EUserPermissions.ADMIN],
+    shouldRender: project.scheduler_view,
+    sortOrder: 7,
   },
 ];

--- a/apps/web/core/components/navigation/tab-navigation-utils.ts
+++ b/apps/web/core/components/navigation/tab-navigation-utils.ts
@@ -72,6 +72,7 @@ export const getTabUrl = (workspaceSlug: string, projectId: string, tabKey: stri
     views: `${baseUrl}/views`,
     pages: `${baseUrl}/pages`,
     intake: `${baseUrl}/intake`,
+    schedulers: `${baseUrl}/schedulers`,
     overview: `${baseUrl}/overview`,
     epics: `${baseUrl}/epics`,
   };

--- a/apps/web/core/components/project/scheduler-bindings/binding-list.tsx
+++ b/apps/web/core/components/project/scheduler-bindings/binding-list.tsx
@@ -1,0 +1,228 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useState } from "react";
+import { observer } from "mobx-react";
+import useSWR from "swr";
+// pi dash imports
+import { useTranslation } from "@pi-dash/i18n";
+import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
+import type { IScheduler, ISchedulerBinding } from "@pi-dash/services";
+import { SchedulerService } from "@pi-dash/services";
+import { Button, ToggleSwitch } from "@pi-dash/ui";
+// components
+import { EditSchedulerBindingModal } from "@/components/project/scheduler-bindings/edit-binding-modal";
+import { InstallSchedulerBindingModal } from "@/components/project/scheduler-bindings/install-binding-modal";
+import { UninstallSchedulerBindingModal } from "@/components/project/scheduler-bindings/uninstall-binding-modal";
+
+const schedulerService = new SchedulerService();
+
+type Props = {
+  workspaceSlug: string;
+  projectId: string;
+};
+
+export const ProjectSchedulerBindingsList = observer(function ProjectSchedulerBindingsList(props: Props) {
+  const { workspaceSlug, projectId } = props;
+  const { t } = useTranslation();
+
+  // Bindings: per-project. Workspace schedulers: needed to populate the
+  // install picker. Both keys include the workspace + project so a
+  // navigation between projects refetches.
+  const { data: bindings, mutate: mutateBindings } = useSWR<ISchedulerBinding[]>(
+    workspaceSlug && projectId ? ["scheduler-bindings", workspaceSlug, projectId] : null,
+    () => schedulerService.listBindings(workspaceSlug, projectId)
+  );
+  const { data: schedulers } = useSWR<IScheduler[]>(workspaceSlug ? ["schedulers", workspaceSlug] : null, () =>
+    schedulerService.listSchedulers(workspaceSlug)
+  );
+
+  const [installOpen, setInstallOpen] = useState(false);
+  const [editTarget, setEditTarget] = useState<ISchedulerBinding | null>(null);
+  const [uninstallTarget, setUninstallTarget] = useState<ISchedulerBinding | null>(null);
+
+  const rows = bindings ?? [];
+
+  return (
+    <>
+      <div className="flex flex-col gap-6">
+        <header className="flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-16 font-semibold text-primary">{t("scheduler_bindings.title")}</h1>
+            <p className="mt-1 text-13 text-secondary">{t("scheduler_bindings.subtitle")}</p>
+          </div>
+          <Button onClick={() => setInstallOpen(true)}>{t("scheduler_bindings.install")}</Button>
+        </header>
+
+        <section className="rounded-md border border-subtle">
+          <table className="w-full text-13">
+            <thead className="bg-layer-1 text-left text-secondary">
+              <tr>
+                <th className="px-3 py-2">{t("scheduler_bindings.columns.name")}</th>
+                <th className="px-3 py-2">{t("scheduler_bindings.columns.cron")}</th>
+                <th className="px-3 py-2">{t("scheduler_bindings.columns.next_run")}</th>
+                <th className="px-3 py-2">{t("scheduler_bindings.columns.last_run")}</th>
+                <th className="px-3 py-2">{t("scheduler_bindings.columns.status")}</th>
+                <th className="px-3 py-2">{t("scheduler_bindings.columns.updated")}</th>
+                <th className="px-3 py-2"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((b) => (
+                <BindingRow
+                  key={b.id}
+                  binding={b}
+                  onEdit={() => setEditTarget(b)}
+                  onUninstall={() => setUninstallTarget(b)}
+                  onToggle={async (next) => {
+                    // Optimistic toggle — flip the cached row immediately, run
+                    // the PATCH, swap in the canonical server response on
+                    // success, roll back on error.
+                    try {
+                      await mutateBindings(
+                        async (current) => {
+                          const updated = await schedulerService.updateBinding(workspaceSlug, projectId, b.id, {
+                            enabled: next,
+                          });
+                          return (current ?? []).map((row) => (row.id === b.id ? updated : row));
+                        },
+                        {
+                          optimisticData: (current) => {
+                            const arr = current ?? [];
+                            const idx = arr.findIndex((row) => row.id === b.id);
+                            if (idx === -1) return arr;
+                            const out = arr.slice();
+                            out[idx] = Object.assign({}, arr[idx], { enabled: next });
+                            return out;
+                          },
+                          rollbackOnError: true,
+                          revalidate: false,
+                        }
+                      );
+                      setToast({
+                        type: TOAST_TYPE.SUCCESS,
+                        title: t("scheduler_bindings.toast.updated_title"),
+                        message: next
+                          ? t("scheduler_bindings.toast.enabled_message")
+                          : t("scheduler_bindings.toast.disabled_message"),
+                      });
+                    } catch (e: unknown) {
+                      const err = e as { error?: string } | null;
+                      setToast({
+                        type: TOAST_TYPE.ERROR,
+                        title: t("scheduler_bindings.toast.error_title"),
+                        message: err?.error ?? t("scheduler_bindings.toast.update_failed"),
+                      });
+                    }
+                  }}
+                />
+              ))}
+              {rows.length === 0 && (
+                <tr>
+                  <td colSpan={7} className="px-3 py-8 text-center text-secondary">
+                    {t("scheduler_bindings.list.empty")}
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </section>
+      </div>
+
+      <InstallSchedulerBindingModal
+        isOpen={installOpen}
+        onClose={() => setInstallOpen(false)}
+        workspaceSlug={workspaceSlug}
+        projectId={projectId}
+        availableSchedulers={schedulers ?? []}
+        existingBindings={rows}
+        onInstalled={() => mutateBindings()}
+      />
+      <EditSchedulerBindingModal
+        isOpen={!!editTarget}
+        onClose={() => setEditTarget(null)}
+        workspaceSlug={workspaceSlug}
+        projectId={projectId}
+        binding={editTarget}
+        onUpdated={() => mutateBindings()}
+      />
+      <UninstallSchedulerBindingModal
+        isOpen={!!uninstallTarget}
+        onClose={() => setUninstallTarget(null)}
+        workspaceSlug={workspaceSlug}
+        projectId={projectId}
+        binding={uninstallTarget}
+        onUninstalled={() => mutateBindings()}
+      />
+    </>
+  );
+});
+
+type RowProps = {
+  binding: ISchedulerBinding;
+  onEdit: () => void;
+  onUninstall: () => void;
+  onToggle: (next: boolean) => Promise<void>;
+};
+
+function BindingRow({ binding, onEdit, onUninstall, onToggle }: RowProps) {
+  const { t } = useTranslation();
+  const [toggling, setToggling] = useState(false);
+
+  const formatTs = (ts: string | null) => (ts ? new Date(ts).toLocaleString() : t("scheduler_bindings.list.none_yet"));
+
+  const handleToggle = async (next: boolean) => {
+    if (toggling) return;
+    setToggling(true);
+    try {
+      await onToggle(next);
+    } finally {
+      setToggling(false);
+    }
+  };
+
+  return (
+    <tr className="border-t border-subtle">
+      <td className="px-3 py-2 font-medium text-primary">
+        {binding.scheduler_name}
+        <div className="text-12 text-secondary">
+          <code>{binding.scheduler_slug}</code>
+        </div>
+      </td>
+      <td className="px-3 py-2 text-secondary">
+        <code className="text-12">{binding.cron}</code>
+      </td>
+      <td className="px-3 py-2 text-secondary">{formatTs(binding.next_run_at)}</td>
+      <td className="px-3 py-2 text-secondary">{formatTs(binding.last_run_ended_at)}</td>
+      <td className="px-3 py-2">
+        <div className="flex items-center gap-2">
+          <ToggleSwitch
+            value={binding.enabled}
+            onChange={handleToggle}
+            disabled={toggling}
+            aria-label={
+              binding.enabled ? t("scheduler_bindings.actions.disable") : t("scheduler_bindings.actions.enable")
+            }
+          />
+          <span className="text-12 text-secondary">
+            {binding.enabled ? t("scheduler_bindings.status.enabled") : t("scheduler_bindings.status.disabled")}
+          </span>
+        </div>
+      </td>
+      <td className="px-3 py-2 text-secondary">{new Date(binding.updated_at).toLocaleString()}</td>
+      <td className="px-3 py-2 text-right">
+        <div className="flex items-center justify-end gap-2">
+          <Button variant="link-neutral" size="sm" onClick={onEdit}>
+            {t("scheduler_bindings.actions.edit")}
+          </Button>
+          <Button variant="tertiary-danger" size="sm" onClick={onUninstall}>
+            {t("scheduler_bindings.actions.uninstall")}
+          </Button>
+        </div>
+      </td>
+    </tr>
+  );
+}

--- a/apps/web/core/components/project/settings/features-list.tsx
+++ b/apps/web/core/components/project/settings/features-list.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from "@pi-dash/i18n";
 import { setPromiseToast } from "@pi-dash/propel/toast";
 import { Tooltip } from "@pi-dash/propel/tooltip";
 import type { IProject } from "@pi-dash/types";
-import { CycleIcon, IntakeIcon, ModuleIcon, PageIcon, ViewsIcon } from "@pi-dash/propel/icons";
+import { CalendarAfterIcon, CycleIcon, IntakeIcon, ModuleIcon, PageIcon, ViewsIcon } from "@pi-dash/propel/icons";
 // components
 import { SettingsBoxedControlItem } from "@/components/settings/boxed-control-item";
 import { SettingsHeading } from "@/components/settings/heading";
@@ -70,6 +70,15 @@ const PROJECT_FEATURES_LIST = {
     title: "Intake",
     description: "Consider and discuss work items before you add them to your project.",
     icon: <IntakeIcon className="h-5 w-5 flex-shrink-0 text-tertiary" />,
+    isPro: false,
+    isEnabled: true,
+  },
+  schedulers: {
+    key: "schedulers",
+    property: "scheduler_view",
+    title: "Scheduler",
+    description: "Surface this project's scheduler installs in the sidebar so admins can manage them in one click.",
+    icon: <CalendarAfterIcon className="h-5 w-5 flex-shrink-0 text-tertiary" />,
     isPro: false,
     isEnabled: true,
   },

--- a/apps/web/core/components/workspace/sidebar/project-navigation.tsx
+++ b/apps/web/core/components/workspace/sidebar/project-navigation.tsx
@@ -10,7 +10,15 @@ import Link from "next/link";
 import { useParams, usePathname } from "next/navigation";
 import { EUserPermissionsLevel, EUserPermissions } from "@pi-dash/constants";
 import { useTranslation } from "@pi-dash/i18n";
-import { CycleIcon, IntakeIcon, ModuleIcon, PageIcon, ViewsIcon, WorkItemsIcon } from "@pi-dash/propel/icons";
+import {
+  CalendarAfterIcon,
+  CycleIcon,
+  IntakeIcon,
+  ModuleIcon,
+  PageIcon,
+  ViewsIcon,
+  WorkItemsIcon,
+} from "@pi-dash/propel/icons";
 import type { EUserProjectRoles } from "@pi-dash/types";
 // pi dash ui
 // components
@@ -69,12 +77,12 @@ export const ProjectNavigation = observer(function ProjectNavigation(props: TPro
   };
 
   const baseNavigation = useCallback(
-    (workspaceSlug: string, projectId: string): TNavigationItem[] => [
+    (slug: string, id: string): TNavigationItem[] => [
       {
         i18n_key: "sidebar.work_items",
         key: "work_items",
         name: "Work items",
-        href: `/${workspaceSlug}/projects/${projectId}/issues`,
+        href: `/${slug}/projects/${id}/issues`,
         icon: WorkItemsIcon,
         access: [EUserPermissions.ADMIN, EUserPermissions.MEMBER, EUserPermissions.GUEST],
         shouldRender: true,
@@ -84,7 +92,7 @@ export const ProjectNavigation = observer(function ProjectNavigation(props: TPro
         i18n_key: "sidebar.cycles",
         key: "cycles",
         name: "Cycles",
-        href: `/${workspaceSlug}/projects/${projectId}/cycles`,
+        href: `/${slug}/projects/${id}/cycles`,
         icon: CycleIcon,
         access: [EUserPermissions.ADMIN, EUserPermissions.MEMBER],
         shouldRender: project?.cycle_view ?? false,
@@ -94,7 +102,7 @@ export const ProjectNavigation = observer(function ProjectNavigation(props: TPro
         i18n_key: "sidebar.modules",
         key: "modules",
         name: "Modules",
-        href: `/${workspaceSlug}/projects/${projectId}/modules`,
+        href: `/${slug}/projects/${id}/modules`,
         icon: ModuleIcon,
         access: [EUserPermissions.ADMIN, EUserPermissions.MEMBER],
         shouldRender: project?.module_view ?? false,
@@ -104,7 +112,7 @@ export const ProjectNavigation = observer(function ProjectNavigation(props: TPro
         i18n_key: "sidebar.views",
         key: "views",
         name: "Views",
-        href: `/${workspaceSlug}/projects/${projectId}/views`,
+        href: `/${slug}/projects/${id}/views`,
         icon: ViewsIcon,
         access: [EUserPermissions.ADMIN, EUserPermissions.MEMBER, EUserPermissions.GUEST],
         shouldRender: project?.issue_views_view ?? false,
@@ -114,7 +122,7 @@ export const ProjectNavigation = observer(function ProjectNavigation(props: TPro
         i18n_key: "sidebar.pages",
         key: "pages",
         name: "Pages",
-        href: `/${workspaceSlug}/projects/${projectId}/pages`,
+        href: `/${slug}/projects/${id}/pages`,
         icon: PageIcon,
         access: [EUserPermissions.ADMIN, EUserPermissions.MEMBER, EUserPermissions.GUEST],
         shouldRender: project?.page_view ?? false,
@@ -124,11 +132,21 @@ export const ProjectNavigation = observer(function ProjectNavigation(props: TPro
         i18n_key: "sidebar.intake",
         key: "intake",
         name: "Intake",
-        href: `/${workspaceSlug}/projects/${projectId}/intake`,
+        href: `/${slug}/projects/${id}/intake`,
         icon: IntakeIcon,
         access: [EUserPermissions.ADMIN, EUserPermissions.MEMBER, EUserPermissions.GUEST],
         shouldRender: project?.inbox_view ?? false,
         sortOrder: 6,
+      },
+      {
+        i18n_key: "sidebar.schedulers",
+        key: "schedulers",
+        name: "Scheduler",
+        href: `/${slug}/projects/${id}/schedulers`,
+        icon: CalendarAfterIcon,
+        access: [EUserPermissions.ADMIN],
+        shouldRender: project?.scheduler_view ?? false,
+        sortOrder: 7,
       },
     ],
     [project]
@@ -136,18 +154,18 @@ export const ProjectNavigation = observer(function ProjectNavigation(props: TPro
 
   // memoized navigation items and adding additional navigation items
   const navigationItemsMemo = useMemo(() => {
-    const navigationItems = (workspaceSlug: string, projectId: string): TNavigationItem[] => {
-      const navItems = baseNavigation(workspaceSlug, projectId);
+    const navigationItems = (slug: string, id: string): TNavigationItem[] => {
+      const navItems = baseNavigation(slug, id);
 
       if (additionalNavigationItems) {
-        navItems.push(...additionalNavigationItems(workspaceSlug, projectId));
+        navItems.push(...additionalNavigationItems(slug, id));
       }
 
       return navItems;
     };
 
     // sort navigation items by sortOrder
-    const sortedNavigationItems = navigationItems(workspaceSlug, projectId).sort(
+    const sortedNavigationItems = navigationItems(workspaceSlug, projectId).toSorted(
       (a, b) => (a.sortOrder || 0) - (b.sortOrder || 0)
     );
 

--- a/packages/constants/src/project.ts
+++ b/packages/constants/src/project.ts
@@ -128,4 +128,5 @@ export enum EProjectFeatureKey {
   VIEWS = "views",
   PAGES = "pages",
   INTAKE = "intake",
+  SCHEDULERS = "schedulers",
 }

--- a/packages/i18n/src/locales/en/translations.ts
+++ b/packages/i18n/src/locales/en/translations.ts
@@ -225,6 +225,7 @@ export default {
   modules: "Modules",
   pages: "Pages",
   intake: "Intake",
+  schedulers: "Scheduler",
   time_tracking: "Time Tracking",
   work_management: "Work management",
   projects_and_issues: "Projects and work items",
@@ -235,6 +236,8 @@ export default {
   views_description: "Save custom sorts, filters, and display options or share them with your team.",
   pages_description: "Create and edit free-form content; notes, docs, anything.",
   intake_description: "Let non-members share bugs, feedback, and suggestions; without disrupting your workflow.",
+  schedulers_description:
+    "Surface this project's scheduler installs in the sidebar so admins can manage them in one click.",
   time_tracking_description: "Log time spent on work items and projects.",
   work_management_description: "Manage your work and projects with ease.",
   documentation: "Documentation",

--- a/packages/types/src/project/projects.ts
+++ b/packages/types/src/project/projects.ts
@@ -30,6 +30,7 @@ export interface IPartialProject {
   module_view: boolean;
   page_view: boolean;
   inbox_view: boolean;
+  scheduler_view: boolean;
   guest_view_all_features?: boolean;
   members_can_edit_states?: boolean;
   project_lead?: IUserLite | string | null;


### PR DESCRIPTION
## Summary
- Adds a new `scheduler_view` project feature flag (mirrors `cycle_view`, `module_view`, etc.). When admins toggle it on from **Project settings → Features**, a **Scheduler** entry appears under the project in the left sidebar.
- The new sidebar entry routes to `/<workspace>/projects/<id>/schedulers`, a new top-level project page that reuses the existing scheduler bindings UI from Settings → Schedulers (install / edit / enable / uninstall — identical functionality, just surfaced one click away from the project).
- Implementation extracts the scheduler bindings table + modals into a shared `ProjectSchedulerBindingsList` component used by both the settings page and the new top-level page, so there is one source of truth for the UI.

## Changes
- **Backend (Django):** add `Project.scheduler_view` (default `False`), migration `0135_project_scheduler_view`, expose it in `ProjectCreateSerializer` and the project-list endpoint's `values(...)` projection.
- **Frontend types/constants:** add `scheduler_view` to `IPartialProject`; add `SCHEDULERS` to `EProjectFeatureKey`.
- **Frontend sidebar:** add Scheduler nav entry (admin-only, sortOrder 7, `CalendarAfterIcon`) gated by `project.scheduler_view` in the three project-navigation registries (`use-navigation-items.ts`, `project-navigation.tsx`, `navigation/helper.tsx`). Also drives `getTabUrl` so default-tab selection works.
- **Frontend features list:** add the Scheduler toggle to the project-settings features list, alongside Cycles/Modules/Views/Pages/Intake.
- **Frontend route:** register `(all)/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/schedulers/{page,layout,header}.tsx` and add it to `app/routes/core.ts`.
- **Shared UI:** extract `ProjectSchedulerBindingsList` from the existing settings page; both surfaces now render the same component.
- **i18n:** add `schedulers` / `schedulers_description` English keys (sidebar label `sidebar.schedulers` already existed in `core.ts`). Other locales fall back to English via the i18n fallback.

## Test plan
- [ ] Apply migration `0135_project_scheduler_view`.
- [ ] On a project with `scheduler_view=False`, confirm sidebar shows no Scheduler entry.
- [ ] Toggle Scheduler on under **Project settings → Features**; confirm a `Scheduler` entry appears under the project in the left sidebar (admin only).
- [ ] Click the entry; confirm it navigates to `/<workspace>/projects/<id>/schedulers` and renders the install / edit / uninstall + enable toggle UI for `SchedulerBinding` rows on that project.
- [ ] Confirm the existing `/<workspace>/settings/projects/<id>/schedulers` page still renders identically (same shared component, different chrome).
- [ ] Toggle Scheduler off; confirm the sidebar entry disappears and the top-level page bounces to settings.
- [ ] Non-admin members never see the sidebar entry and get the not-authorized view if they navigate directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
