### PR TITLE
[codex] Add CLI install onboarding step

### DIFF
--- a/apps/web/core/components/onboarding/header.tsx
+++ b/apps/web/core/components/onboarding/header.tsx
@@ -33,6 +33,9 @@ export const OnboardingHeader = observer(function OnboardingHeader(props: Onboar
   // handle step back
   const handleStepBack = () => {
     switch (currentStep) {
+      case EOnboardingSteps.PROFILE_SETUP:
+        updateCurrentStep(EOnboardingSteps.CLI_INSTALL);
+        break;
       case EOnboardingSteps.ROLE_SETUP:
         updateCurrentStep(EOnboardingSteps.PROFILE_SETUP);
         break;
@@ -46,11 +49,12 @@ export const OnboardingHeader = observer(function OnboardingHeader(props: Onboar
   };
 
   // can go back
-  const canGoBack = ![EOnboardingSteps.PROFILE_SETUP, EOnboardingSteps.INVITE_MEMBERS].includes(currentStep);
+  const canGoBack = ![EOnboardingSteps.CLI_INSTALL, EOnboardingSteps.INVITE_MEMBERS].includes(currentStep);
 
   // step order for progress tracking — include INVITE_MEMBERS if user is currently on it
   const showInviteStep = !hasInvitations || currentStep === EOnboardingSteps.INVITE_MEMBERS;
   const stepOrder: TOnboardingStep[] = [
+    EOnboardingSteps.CLI_INSTALL,
     EOnboardingSteps.PROFILE_SETUP,
     ...(isSelfManaged ? [] : [EOnboardingSteps.ROLE_SETUP, EOnboardingSteps.USE_CASE_SETUP]),
     EOnboardingSteps.WORKSPACE_CREATE_OR_JOIN,

--- a/apps/web/core/components/onboarding/root.tsx
+++ b/apps/web/core/components/onboarding/root.tsx
@@ -23,7 +23,7 @@ type Props = {
 };
 
 export const OnboardingRoot = observer(function OnboardingRoot({ invitations = [] }: Props) {
-  const [currentStep, setCurrentStep] = useState<TOnboardingStep>(EOnboardingSteps.PROFILE_SETUP);
+  const [currentStep, setCurrentStep] = useState<TOnboardingStep>(EOnboardingSteps.CLI_INSTALL);
   // store hooks
   const { data: user } = useUser();
   const { data: userProfile, updateUserProfile, finishUserOnboarding } = useUserProfile();
@@ -70,6 +70,9 @@ export const OnboardingRoot = observer(function OnboardingRoot({ invitations = [
   const handleStepChange = useCallback(
     (step: EOnboardingSteps, skipInvites?: boolean) => {
       switch (step) {
+        case EOnboardingSteps.CLI_INSTALL:
+          setCurrentStep(EOnboardingSteps.PROFILE_SETUP);
+          break;
         case EOnboardingSteps.PROFILE_SETUP:
           if (isSelfManaged) {
             // Skip role & use case steps for self-hosted

--- a/apps/web/core/components/onboarding/steps/cli-install/index.ts
+++ b/apps/web/core/components/onboarding/steps/cli-install/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+export * from "./root";

--- a/apps/web/core/components/onboarding/steps/cli-install/root.tsx
+++ b/apps/web/core/components/onboarding/steps/cli-install/root.tsx
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useState } from "react";
+import { AlertTriangle, Check, Copy, Terminal } from "lucide-react";
+// pi dash imports
+import { Button } from "@pi-dash/propel/button";
+import { EOnboardingSteps } from "@pi-dash/types";
+// local components
+import { CommonOnboardingHeader } from "../common";
+
+type Props = {
+  handleStepChange: (step: EOnboardingSteps, skipInvites?: boolean) => void;
+};
+
+const INSTALL_SCRIPT = `curl -fsSL https://github.com/The-AI-Republic/pi-dash/releases/latest/download/pidash-installer.sh | sh`;
+
+export function CliInstallStep({ handleStepChange }: Props) {
+  const [hasCopied, setHasCopied] = useState(false);
+
+  const continueToProfile = () => handleStepChange(EOnboardingSteps.CLI_INSTALL);
+  const copyCommand = async () => {
+    await navigator.clipboard.writeText(INSTALL_SCRIPT);
+    setHasCopied(true);
+    window.setTimeout(() => setHasCopied(false), 2000);
+  };
+
+  return (
+    <div className="flex flex-col gap-10">
+      <CommonOnboardingHeader
+        title="Install the Pi Dash CLI."
+        description="Run this on the machine where your coding agent will execute work."
+      />
+
+      <div className="flex gap-2 text-warning-primary">
+        <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+        <p className="text-body-sm-medium">
+          Important: Pi Dash CLI has to be installed on the dev machine together with AI agents like Claude and Codex to
+          make Pi Dash work end to end.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2 text-body-sm-semibold text-placeholder">
+            <Terminal className="size-4" />
+            <span>Terminal</span>
+          </div>
+          <Button
+            variant="secondary"
+            size="lg"
+            className="shrink-0"
+            onClick={copyCommand}
+            prependIcon={hasCopied ? <Check /> : <Copy />}
+          >
+            {hasCopied ? "Copied" : "Copy command"}
+          </Button>
+        </div>
+        <pre className="max-w-full overflow-x-auto rounded-lg border border-subtle bg-surface-2 p-4 text-left">
+          <code className="font-mono text-13 leading-5 break-words whitespace-pre-wrap text-secondary">
+            {INSTALL_SCRIPT}
+          </code>
+        </pre>
+      </div>
+
+      <div className="space-y-3">
+        <Button variant="ghost" size="xl" className="w-full text-tertiary" onClick={continueToProfile}>
+          Skip for now
+        </Button>
+        <Button variant="primary" size="xl" className="w-full" onClick={continueToProfile}>
+          Done, Continue
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/core/components/onboarding/steps/root.tsx
+++ b/apps/web/core/components/onboarding/steps/root.tsx
@@ -9,6 +9,7 @@ import { useEffect, useRef } from "react";
 import type { IWorkspaceMemberInvitation } from "@pi-dash/types";
 import { EOnboardingSteps } from "@pi-dash/types";
 // local components
+import { CliInstallStep } from "./cli-install";
 import { ProfileSetupStep } from "./profile";
 import { RoleSetupStep } from "./role";
 import { InviteTeamStep } from "./team";
@@ -23,6 +24,8 @@ type Props = {
 
 function OnboardingStepContent({ currentStep, invitations, handleStepChange }: Props) {
   switch (currentStep) {
+    case EOnboardingSteps.CLI_INSTALL:
+      return <CliInstallStep handleStepChange={handleStepChange} />;
     case EOnboardingSteps.PROFILE_SETUP:
       return <ProfileSetupStep handleStepChange={handleStepChange} />;
     case EOnboardingSteps.ROLE_SETUP:

--- a/packages/types/src/workspace.ts
+++ b/packages/types/src/workspace.ts
@@ -253,6 +253,7 @@ export interface IWorkspaceSidebarNavigation {
 }
 
 export enum EOnboardingSteps {
+  CLI_INSTALL = "CLI_INSTALL",
   PROFILE_SETUP = "PROFILE_SETUP",
   ROLE_SETUP = "ROLE_SETUP",
   USE_CASE_SETUP = "USE_CASE_SETUP",


### PR DESCRIPTION
## Summary

Adds a new first onboarding step that prompts users to install the Pi Dash CLI before creating their profile.

## Changes

- Adds a `CLI_INSTALL` onboarding step before `PROFILE_SETUP`.
- Shows the current `pidash-installer.sh` command with a copy button.
- Adds an important yellow warning that the CLI must be installed on the dev machine alongside AI agents such as Claude and Codex for end-to-end Pi Dash usage.
- Wires skip/continue actions to advance to the existing profile setup flow.
- Updates onboarding progress/back behavior to include the new first step.

## Validation

- `pnpm exec oxfmt --check apps/web/core/components/onboarding/root.tsx apps/web/core/components/onboarding/header.tsx apps/web/core/components/onboarding/steps/root.tsx apps/web/core/components/onboarding/steps/cli-install/root.tsx apps/web/core/components/onboarding/steps/cli-install/index.ts packages/types/src/workspace.ts`
- `pnpm --filter @pi-dash/types check:types`
- Local private cloud rebuilt; `/onboarding` returned `200` at `http://localhost:3030/onboarding`.

## Notes

Full web type-check was not used as a gating check because the current app has unrelated existing TypeScript failures in GitHub integration/scheduler/test config areas.
