### PR TITLE
chore: refresh root pi-symbol SVGs (dot-dash mark, trim left padding)

### DIFF
--- a/pi-symbol-dark.svg
+++ b/pi-symbol-dark.svg
@@ -1,5 +1,16 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 588.42 568.88">
-<path style="fill:#ffffff; stroke:none"
-      d="M 10.499686,177.03840 L 31.174931,178.56990 C 52.615925,154.32116 61.039171,82.595924 187.38789,96.634671 C 182.79339,403.95560 48.021426,436.37234 56.444675,499.41907 C 59.507674,535.15406 87.840417,557.10556 118.47041,558.38181 C 215.21014,555.06356 210.87089,424.63084 240.99038,95.868921 L 365.80760,95.868921 C 359.17110,211.75239 341.04836,327.63586 339.00636,441.22208 C 340.53786,516.77606 386.48285,557.10556 446.97708,557.61606 C 546.52456,560.93431 577.92030,444.79558 577.92030,395.27709 L 556.47931,395.27710 C 554.43731,436.11709 534.78306,465.47083 492.92207,467.25758 C 378.82535,468.78908 441.61683,266.63113 442.38258,97.400421 L 577.92030,98.166171 L 577.15455,11.636437 C 13.807491,8.9075799 85.312284,-2.1366151 10.499686,177.03840 z" />
+<svg width="258" height="140" viewBox="30 0 258 140" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="dot dash dash dot icon, shorter dashes, evenly spaced">
+  <title>Dot dash dash dot - shorter dashes, evenly spaced</title>
+  <g fill="#ffffff">
+    <!-- dot -->
+    <circle cx="54" cy="70" r="24"/>
+
+    <!-- dash: rounded on both sides, a little longer than dot -->
+    <rect x="84" y="46" width="72" height="48" rx="24" ry="24"/>
+
+    <!-- dash: rounded on both sides, a little longer than dot -->
+    <rect x="162" y="46" width="72" height="48" rx="24" ry="24"/>
+
+    <!-- dot -->
+    <circle cx="264" cy="70" r="24"/>
+  </g>
 </svg>

--- a/pi-symbol-light.svg
+++ b/pi-symbol-light.svg
@@ -1,5 +1,16 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 588.42 568.88">
-<path style="fill:#000000; stroke:none"
-      d="M 10.499686,177.03840 L 31.174931,178.56990 C 52.615925,154.32116 61.039171,82.595924 187.38789,96.634671 C 182.79339,403.95560 48.021426,436.37234 56.444675,499.41907 C 59.507674,535.15406 87.840417,557.10556 118.47041,558.38181 C 215.21014,555.06356 210.87089,424.63084 240.99038,95.868921 L 365.80760,95.868921 C 359.17110,211.75239 341.04836,327.63586 339.00636,441.22208 C 340.53786,516.77606 386.48285,557.10556 446.97708,557.61606 C 546.52456,560.93431 577.92030,444.79558 577.92030,395.27709 L 556.47931,395.27710 C 554.43731,436.11709 534.78306,465.47083 492.92207,467.25758 C 378.82535,468.78908 441.61683,266.63113 442.38258,97.400421 L 577.92030,98.166171 L 577.15455,11.636437 C 13.807491,8.9075799 85.312284,-2.1366151 10.499686,177.03840 z" />
+<svg width="258" height="140" viewBox="30 0 258 140" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="dot dash dash dot icon, shorter dashes, evenly spaced">
+  <title>Dot dash dash dot - shorter dashes, evenly spaced</title>
+  <g fill="currentColor">
+    <!-- dot -->
+    <circle cx="54" cy="70" r="24"/>
+
+    <!-- dash: rounded on both sides, a little longer than dot -->
+    <rect x="84" y="46" width="72" height="48" rx="24" ry="24"/>
+
+    <!-- dash: rounded on both sides, a little longer than dot -->
+    <rect x="162" y="46" width="72" height="48" rx="24" ry="24"/>
+
+    <!-- dot -->
+    <circle cx="264" cy="70" r="24"/>
+  </g>
 </svg>


### PR DESCRIPTION
## Summary
- Replace the legacy π-letter root logos (`pi-symbol-light.svg`, `pi-symbol-dark.svg`) with the dot-dash-dash-dot mark used elsewhere in the brand.
- Light variant uses `fill="currentColor"`; dark variant is hard-coded `#ffffff`.
- Trim viewBox to `30 0 258 140` (width `258`) to remove 30 units of empty space on the left. Shape coordinates are unchanged.

## Test plan
- [ ] Open both SVGs in a browser / preview tool and confirm the dot-dash-dash-dot mark renders without left padding.
- [ ] Verify the light variant inherits its color from the surrounding CSS context (`currentColor`).
- [ ] Verify the dark variant renders white on a dark background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)