### PR TITLE
Add Windows and Intel Mac CLI release support

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,15 +108,21 @@ For real self-hosted deployments (not local development), pick the path that mat
 Install the CLI on any machine where you want agents to pick up and execute tasks. Currently supported platforms:
 
 - **macOS** — Apple Silicon (arm64)
+- **macOS** — Intel (x86_64)
 - **Linux** — arm64 and x86_64
+- **Windows** — x86_64
 
-> Intel Macs are not in the prebuilt matrix — GitHub retired the `macos-13` runner image. You can still build from source on Intel macOS with Rust 1.93+.
-
-Run the following command in your dev machine terminal:
+On macOS and Linux, run the following command in your dev machine terminal:
 
 ```bash
 curl --proto '=https' --tlsv1.2 -LsSf \
   https://github.com/The-AI-Republic/pi-dash/releases/latest/download/pidash-installer.sh | sh
+```
+
+On Windows, run this in PowerShell:
+
+```powershell
+powershell -ExecutionPolicy Bypass -c "irm https://github.com/The-AI-Republic/pi-dash/releases/latest/download/pidash-installer.ps1 | iex"
 ```
 
 Then authenticate the machine and register a runner. The standard flow is two commands:
@@ -128,8 +134,8 @@ pidash auth login --url https://your-pidash-instance.com
 
 # 2. Register this host as a runner. Uses the token from step 1 — no
 #    enrollment-token paste needed. On the first runner, installs the OS
-#    service (systemd user unit on Linux, launchd agent on macOS) and
-#    starts the daemon.
+#    service (systemd user unit on Linux, launchd agent on macOS, or a
+#    per-user scheduled task on Windows) and starts the daemon.
 pidash runner add --project <project-id>
 ```
 

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -8,7 +8,7 @@ members = ["cargo:runner"]
 [dist]
 cargo-dist-version = "0.22.1"
 ci = "github"
-installers = ["shell"]
+installers = ["shell", "powershell"]
 # cargo-dist 0.22.1 defaults to the retired ubuntu-20.04 runner image.
 # The workflow is hand-patched to ubuntu-22.04; tell cargo-dist to stop
 # policing it so `cargo dist plan` does not abort on the diff.
@@ -16,17 +16,18 @@ allow-dirty = ["ci"]
 targets = [
     "aarch64-apple-darwin",
     "aarch64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "x86_64-pc-windows-msvc",
     "x86_64-unknown-linux-gnu",
 ]
 pr-run-mode = "plan"
 install-path = "$HOME/.local/bin"
 
-# x86_64-apple-darwin (Intel Mac) intentionally omitted: GitHub's
-# macos-13 runner pool is effectively unavailable in 2026, so the build
-# job sits queued for hours. Apple stopped selling Intel Macs in 2023;
-# Apple Silicon (aarch64-apple-darwin) covers the modern user base.
-# Revisit via cross-compile from macos-14 if Intel Mac demand appears.
+# Intel macOS uses GitHub's current x64 image. Windows builds run on the
+# MSVC image so cargo-dist can produce archives plus the PowerShell installer.
 [dist.github-custom-runners]
 aarch64-apple-darwin = "macos-14"
 aarch64-unknown-linux-gnu = "ubuntu-22.04-arm"
+x86_64-apple-darwin = "macos-15-intel"
+x86_64-pc-windows-msvc = "windows-2022"
 x86_64-unknown-linux-gnu = "ubuntu-22.04"

--- a/runner/Cargo.lock
+++ b/runner/Cargo.lock
@@ -590,6 +590,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1381,6 +1391,7 @@ dependencies = [
  "clap",
  "crossterm",
  "directories",
+ "fs2",
  "futures-util",
  "http",
  "nix 0.29.0",

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -6,6 +6,7 @@ rust-version = "1.93"
 description = "Pi Dash local runner: connects a dev machine to the Pi Dash cloud and drives Codex for assigned tasks."
 license = "AGPL-3.0-only"
 repository = "https://github.com/The-AI-Republic/pi-dash"
+authors = ["AI Republic <privacy_security@airepublic.com>"]
 default-run = "pidash"
 
 [[bin]]
@@ -63,6 +64,7 @@ axoupdater = { version = "0.10", default-features = false, features = [
     "github_releases",
     "tokio",
 ] }
+fs2 = "0.4"
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.29", features = ["fs", "signal", "user", "hostname"] }

--- a/runner/README.md
+++ b/runner/README.md
@@ -4,7 +4,7 @@ Local daemon + TUI (`pidash` binary) that connects a developer machine to the Pi
 
 ## Install
 
-Prebuilt binaries for macOS (arm64) and Linux (arm64, x86_64) are published to GitHub Releases. The one-liner below downloads the installer, verifies checksums, and drops `pidash` into `$HOME/.local/bin`:
+Prebuilt binaries for macOS (arm64, x86_64), Linux (arm64, x86_64), and Windows (x86_64) are published to GitHub Releases. On macOS and Linux, the one-liner below downloads the installer, verifies checksums, and drops `pidash` into `$HOME/.local/bin`:
 
 ```bash
 curl --proto '=https' --tlsv1.2 -LsSf \
@@ -12,6 +12,14 @@ curl --proto '=https' --tlsv1.2 -LsSf \
 ```
 
 Pin to a specific version instead of `latest` by swapping in the tag, e.g. `.../releases/download/v0.1.0/pidash-installer.sh`.
+
+On Windows, use the PowerShell installer:
+
+```powershell
+powershell -ExecutionPolicy Bypass -c "irm https://github.com/The-AI-Republic/pi-dash/releases/latest/download/pidash-installer.ps1 | iex"
+```
+
+Windows release assets also include a `pidash-x86_64-pc-windows-msvc.zip` archive with `pidash.exe`.
 
 **Prerequisite:** the runner shells out to [Codex](https://github.com/openai/codex) — install it and make sure `codex --version` works before running `pidash configure`. `pidash doctor` checks this.
 
@@ -25,8 +33,8 @@ pidash auth login --url https://pidash.example.com
 
 # 2. Register this host as a runner. Uses the token from step 1 to mint
 #    runner credentials cloud-side; no enrollment-token paste needed. On
-#    the first runner, installs the systemd user unit / launchd agent and
-#    starts the daemon.
+#    the first runner, installs the systemd user unit, launchd agent, or
+#    Windows per-user scheduled task and starts the daemon.
 pidash runner add --project WEB
 
 # 3. Optional: open the interactive UI.
@@ -115,9 +123,9 @@ runner/
 │   ├── codex/                # app-server subprocess + JSON-RPC bridge
 │   ├── workspace/            # working_dir resolution + `git clone` on first task
 │   ├── approval/             # policy engine + first-writer-wins router
-│   ├── ipc/                  # Unix-socket IPC between daemon and TUI/CLI
+│   ├── ipc/                  # local IPC between daemon and TUI/CLI
 │   ├── history/              # JSONL per-run transcripts + recent-runs index
-│   ├── service/              # systemd / launchd unit generators
+│   ├── service/              # systemd / launchd / Windows scheduled-task setup
 │   ├── tui/                  # Ratatui app + views (Status / Runs / Config / Approvals)
 │   ├── config/               # TOML config + credential files (0600)
 │   └── util/                 # paths, logging, backoff, signal handling
@@ -135,13 +143,13 @@ cargo clippy -- -D warnings                  # lint
 
 From a debug build, substitute `./target/debug/pidash` for `pidash` in any of the commands above.
 
-## Runtime paths (XDG)
+## Runtime paths
 
-- Config: `~/.config/pidash/`
-- Data / logs: `~/.local/share/pidash/`
-- Runtime dir: `$XDG_RUNTIME_DIR/pidash/` (Unix socket, PID file)
+- Config: platform config directory for `pidash`
+- Data / logs: platform data directory for `pidash`
+- Runtime dir: platform runtime directory for local IPC and the PID file
 
-All secrets on disk are written with `0600`. The Unix IPC socket is also `0600`.
+On Unix-like systems, secrets on disk are written with `0600` and the IPC socket is also `0600`. On Windows, files are stored under the user's profile directories and daemon IPC uses a local named pipe.
 
 ## Protocol
 
@@ -151,11 +159,11 @@ Wire version is `4` — bumped on incompatible shape changes. See `src/cloud/pro
 
 - **Unit:** `cargo test` — deterministic table-driven tests for protocol serde, approval policy, reconnect backoff, workspace resolve, config roundtrip.
 - **Integration:** `tests/protocol_roundtrip.rs` — every client/server variant round-trips; router state machine invariants.
-- **Manual QA** (per release): macOS arm64 + Linux x64 → first-run `configure` → `install` → `start` → TUI shows connected → synthetic run via `/api/runners/runs/` → approval prompt → decision.
+- **Manual QA** (per release): macOS arm64/x64 + Linux x64 + Windows x64 -> first-run `configure` -> `install` -> `start` -> TUI shows connected -> synthetic run via `/api/runners/runs/` -> approval prompt -> decision.
 
 ## Release
 
-Managed by `cargo-dist` (see `dist-workspace.toml` + `.github/workflows/release.yml`). Pushing a SemVer tag (e.g. `v0.1.0`) triggers the workflow, which builds binaries for macOS arm64 and Linux arm64/x64, generates the shell installer, and publishes everything to a GitHub Release.
+Managed by `cargo-dist` (see `dist-workspace.toml` + `.github/workflows/release.yml`). Pushing a SemVer tag (e.g. `v0.1.0`) triggers the workflow, which builds binaries for macOS arm64/x64, Linux arm64/x64, and Windows x64, generates shell and PowerShell installers, and publishes everything to a GitHub Release.
 
 To cut a release:
 

--- a/runner/src/config/file.rs
+++ b/runner/src/config/file.rs
@@ -1,9 +1,7 @@
 use anyhow::{Context, Result};
+use fs2::FileExt;
 use std::fs;
-use std::os::unix::fs::OpenOptionsExt;
 use std::path::Path;
-
-use nix::fcntl::{Flock, FlockArg};
 
 use super::schema::{Config, Credentials};
 use crate::util::paths::Paths;
@@ -107,7 +105,8 @@ where
 {
     paths.ensure()?;
     let lock_path = config_lock_path(paths);
-    let lock_file = fs::OpenOptions::new()
+    let mut lock_options = fs::OpenOptions::new();
+    lock_options
         .create(true)
         .read(true)
         .write(true)
@@ -115,12 +114,16 @@ where
         // never read or write its contents, so explicitly opt out of
         // truncation. Without this, a concurrent `mutate_config` could
         // see a 0-byte stat between the open and the flock acquisition.
-        .truncate(false)
-        .mode(0o600)
+        .truncate(false);
+    set_private_open_mode(&mut lock_options);
+    let lock_file = lock_options
         .open(&lock_path)
         .with_context(|| format!("opening config lock {lock_path:?}"))?;
-    let _guard = Flock::lock(lock_file, FlockArg::LockExclusive)
-        .map_err(|(_, errno)| anyhow::anyhow!("flock({lock_path:?}) failed: {errno}"))?;
+    set_private_permissions(&lock_path)?;
+    lock_file
+        .lock_exclusive()
+        .with_context(|| format!("locking config lock {lock_path:?}"))?;
+    let _guard = ConfigLockGuard(lock_file);
     let mut cfg = match load_config(paths) {
         Ok(c) => c,
         Err(e) => {
@@ -169,23 +172,47 @@ fn write_private(path: &Path, bytes: &[u8]) -> Result<()> {
     }
     let tmp = path.with_extension("tmp");
     {
-        let mut f = fs::OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .mode(0o600)
-            .open(&tmp)?;
+        let mut options = fs::OpenOptions::new();
+        options.create(true).write(true).truncate(true);
+        set_private_open_mode(&mut options);
+        let mut f = options.open(&tmp)?;
         use std::io::Write;
         f.write_all(bytes)?;
         f.sync_all()?;
     }
     fs::rename(&tmp, path)?;
-    // `rename` preserves the destination's mode on some filesystems; enforce 0600 again.
-    let mut perm = fs::metadata(path)?.permissions();
-    use std::os::unix::fs::PermissionsExt;
-    perm.set_mode(0o600);
-    fs::set_permissions(path, perm)?;
+    // `rename` preserves the destination's mode on some filesystems; enforce privacy again.
+    set_private_permissions(path)?;
     Ok(())
+}
+
+struct ConfigLockGuard(std::fs::File);
+
+impl Drop for ConfigLockGuard {
+    fn drop(&mut self) {
+        let _ = self.0.unlock();
+    }
+}
+
+fn set_private_permissions(path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        // 0600 on Unix. Windows has no portable std equivalent for ACL
+        // tightening; the file still lands in the user's profile config dir.
+        let mut perm = fs::metadata(path)?.permissions();
+        use std::os::unix::fs::PermissionsExt;
+        perm.set_mode(0o600);
+        fs::set_permissions(path, perm)?;
+    }
+    Ok(())
+}
+
+fn set_private_open_mode(options: &mut fs::OpenOptions) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
 }
 
 #[cfg(test)]
@@ -217,6 +244,7 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
     #[test]
     fn writes_and_reads_config_with_0600() {
         let tmp = tempdir().unwrap();

--- a/runner/src/ipc/client.rs
+++ b/runner/src/ipc/client.rs
@@ -1,21 +1,24 @@
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufStream};
-use tokio::net::UnixStream;
+#[cfg(unix)]
+use tokio::net::UnixStream as IpcStream;
+#[cfg(windows)]
+use tokio::net::windows::named_pipe::{ClientOptions, NamedPipeClient as IpcStream};
 
 use super::protocol::{Request, Response};
 
 pub struct Client {
-    stream: BufStream<UnixStream>,
+    stream: BufStream<IpcStream>,
     path: PathBuf,
 }
 
 impl Client {
     pub async fn connect(path: impl AsRef<Path>) -> Result<Self> {
         let path = path.as_ref().to_path_buf();
-        let stream = UnixStream::connect(&path)
+        let stream = connect_stream(&path)
             .await
-            .with_context(|| format!("connecting to runner IPC at {path:?}"))?;
+            .with_context(|| format!("connecting to runner IPC at {}", endpoint_display(&path)))?;
         Ok(Self {
             stream: BufStream::new(stream),
             path,
@@ -49,6 +52,26 @@ impl Client {
 }
 
 /// Convenience that returns a reader half bound to the same stream.
-pub fn reader_from(stream: UnixStream) -> BufReader<UnixStream> {
+pub fn reader_from(stream: IpcStream) -> BufReader<IpcStream> {
     BufReader::new(stream)
+}
+
+#[cfg(unix)]
+async fn connect_stream(path: &Path) -> std::io::Result<IpcStream> {
+    IpcStream::connect(path).await
+}
+
+#[cfg(windows)]
+async fn connect_stream(path: &Path) -> std::io::Result<IpcStream> {
+    ClientOptions::new().open(crate::ipc::windows_pipe_name(path))
+}
+
+#[cfg(unix)]
+fn endpoint_display(path: &Path) -> String {
+    format!("{path:?}")
+}
+
+#[cfg(windows)]
+fn endpoint_display(path: &Path) -> String {
+    crate::ipc::windows_pipe_name(path)
 }

--- a/runner/src/ipc/mod.rs
+++ b/runner/src/ipc/mod.rs
@@ -1,3 +1,12 @@
 pub mod client;
 pub mod protocol;
 pub mod server;
+
+#[cfg(windows)]
+pub(crate) fn windows_pipe_name(path: &std::path::Path) -> String {
+    let id = uuid::Uuid::new_v5(
+        &uuid::Uuid::NAMESPACE_OID,
+        path.to_string_lossy().as_bytes(),
+    );
+    format!(r"\\.\pipe\pidash-{id}")
+}

--- a/runner/src/ipc/server.rs
+++ b/runner/src/ipc/server.rs
@@ -1,10 +1,14 @@
 use anyhow::{Context, Result};
 use std::collections::HashMap;
+#[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufStream};
-use tokio::net::{UnixListener, UnixStream};
+#[cfg(windows)]
+use tokio::net::windows::named_pipe::{NamedPipeServer as IpcStream, ServerOptions};
+#[cfg(unix)]
+use tokio::net::{UnixListener, UnixStream as IpcStream};
 use uuid::Uuid;
 
 use super::protocol::{Request, Response, RpcError, StatusSnapshot};
@@ -31,6 +35,7 @@ pub struct IpcServer {
 }
 
 impl IpcServer {
+    #[cfg(unix)]
     pub async fn run(self) -> Result<()> {
         // Clean up stale socket.
         let _ = tokio::fs::remove_file(&self.path).await;
@@ -69,7 +74,34 @@ impl IpcServer {
         }
     }
 
-    async fn handle_conn(&self, stream: UnixStream) -> Result<()> {
+    #[cfg(windows)]
+    pub async fn run(self) -> Result<()> {
+        let pipe_name = crate::ipc::windows_pipe_name(&self.path);
+        let mut server = ServerOptions::new()
+            .first_pipe_instance(true)
+            .create(&pipe_name)
+            .with_context(|| format!("creating named pipe {pipe_name}"))?;
+
+        let me = Arc::new(self);
+        loop {
+            server
+                .connect()
+                .await
+                .with_context(|| format!("accepting named-pipe client at {pipe_name}"))?;
+            let connected = server;
+            server = ServerOptions::new()
+                .create(&pipe_name)
+                .with_context(|| format!("creating next named pipe {pipe_name}"))?;
+            let server = me.clone();
+            tokio::spawn(async move {
+                if let Err(e) = server.handle_conn(connected).await {
+                    tracing::warn!("ipc conn error: {e:#}");
+                }
+            });
+        }
+    }
+
+    async fn handle_conn(&self, stream: IpcStream) -> Result<()> {
         let mut buf = BufStream::new(stream);
         let mut line = String::new();
         loop {
@@ -110,7 +142,7 @@ impl IpcServer {
         Ok(())
     }
 
-    async fn dispatch(&self, req: Request, buf: &mut BufStream<UnixStream>) -> Result<Response> {
+    async fn dispatch(&self, req: Request, buf: &mut BufStream<IpcStream>) -> Result<Response> {
         match req {
             Request::StatusGet => Ok(Response::Status(self.status_snapshot().await)),
             Request::StatusSubscribe => {
@@ -320,7 +352,7 @@ impl IpcServer {
     }
 }
 
-async fn write_line(buf: &mut BufStream<UnixStream>, resp: &Response) -> Result<()> {
+async fn write_line(buf: &mut BufStream<IpcStream>, resp: &Response) -> Result<()> {
     let mut line = serde_json::to_vec(resp)?;
     line.push(b'\n');
     buf.write_all(&line).await?;

--- a/runner/src/service/mod.rs
+++ b/runner/src/service/mod.rs
@@ -3,9 +3,13 @@ use std::path::Path;
 
 use crate::util::paths::Paths;
 
+#[cfg(target_os = "macos")]
 pub mod launchd;
 pub mod reload;
+#[cfg(target_os = "linux")]
 pub mod systemd;
+#[cfg(windows)]
+pub mod windows;
 
 /// Reject paths containing characters that would break the systemd unit /
 /// launchd plist we generate. Newlines could inject extra directives; control
@@ -72,8 +76,12 @@ pub(crate) fn capture_install_time_path() -> Option<String> {
 }
 
 pub enum Service {
+    #[cfg(target_os = "linux")]
     Systemd,
+    #[cfg(target_os = "macos")]
     Launchd,
+    #[cfg(windows)]
+    WindowsTask,
 }
 
 /// Outcome of `Service::ensure_boot_start`. Only two variants represent a
@@ -97,12 +105,19 @@ pub enum BootStartOutcome {
     EnableFailed(String),
 }
 
+#[cfg(target_os = "linux")]
 pub fn detect() -> Service {
-    if cfg!(target_os = "macos") {
-        Service::Launchd
-    } else {
-        Service::Systemd
-    }
+    Service::Systemd
+}
+
+#[cfg(target_os = "macos")]
+pub fn detect() -> Service {
+    Service::Launchd
+}
+
+#[cfg(windows)]
+pub fn detect() -> Service {
+    Service::WindowsTask
 }
 
 impl Service {
@@ -110,16 +125,24 @@ impl Service {
     /// start. Allows `pidash install` to gate activation on configuration.
     pub async fn write_unit(&self, paths: &Paths) -> Result<()> {
         match self {
+            #[cfg(target_os = "linux")]
             Service::Systemd => systemd::write_unit(paths).await,
+            #[cfg(target_os = "macos")]
             Service::Launchd => launchd::write_unit(paths).await,
+            #[cfg(windows)]
+            Service::WindowsTask => windows::write_unit(paths).await,
         }
     }
 
     /// Enable at boot/login and start now. Must run after `write_unit`.
     pub async fn enable_and_start(&self) -> Result<()> {
         match self {
+            #[cfg(target_os = "linux")]
             Service::Systemd => systemd::enable_and_start().await,
+            #[cfg(target_os = "macos")]
             Service::Launchd => launchd::enable_and_start().await,
+            #[cfg(windows)]
+            Service::WindowsTask => windows::enable_and_start().await,
         }
     }
 
@@ -129,36 +152,56 @@ impl Service {
     /// — the returned outcome drives post-install messaging.
     pub async fn ensure_boot_start(&self) -> BootStartOutcome {
         match self {
+            #[cfg(target_os = "linux")]
             Service::Systemd => systemd::ensure_linger().await,
+            #[cfg(target_os = "macos")]
             Service::Launchd => BootStartOutcome::NotApplicable,
+            #[cfg(windows)]
+            Service::WindowsTask => BootStartOutcome::NotApplicable,
         }
     }
 
     pub async fn uninstall(&self, paths: &Paths) -> Result<()> {
         match self {
+            #[cfg(target_os = "linux")]
             Service::Systemd => systemd::uninstall(paths).await,
+            #[cfg(target_os = "macos")]
             Service::Launchd => launchd::uninstall(paths).await,
+            #[cfg(windows)]
+            Service::WindowsTask => windows::uninstall(paths).await,
         }
     }
 
     pub async fn start(&self) -> Result<()> {
         match self {
+            #[cfg(target_os = "linux")]
             Service::Systemd => systemd::start().await,
+            #[cfg(target_os = "macos")]
             Service::Launchd => launchd::start().await,
+            #[cfg(windows)]
+            Service::WindowsTask => windows::start().await,
         }
     }
 
     pub async fn stop(&self) -> Result<()> {
         match self {
+            #[cfg(target_os = "linux")]
             Service::Systemd => systemd::stop().await,
+            #[cfg(target_os = "macos")]
             Service::Launchd => launchd::stop().await,
+            #[cfg(windows)]
+            Service::WindowsTask => windows::stop().await,
         }
     }
 
     pub async fn status(&self) -> Result<String> {
         match self {
+            #[cfg(target_os = "linux")]
             Service::Systemd => systemd::status().await,
+            #[cfg(target_os = "macos")]
             Service::Launchd => launchd::status().await,
+            #[cfg(windows)]
+            Service::WindowsTask => windows::status().await,
         }
     }
 }

--- a/runner/src/service/windows.rs
+++ b/runner/src/service/windows.rs
@@ -1,0 +1,92 @@
+use anyhow::{Context, Result};
+use std::path::Path;
+use tokio::process::Command;
+
+use crate::util::paths::Paths;
+
+const TASK_NAME: &str = "PiDash";
+
+/// Register a per-user scheduled task that starts the daemon at logon.
+///
+/// This mirrors the user-level systemd/launchd setup used on Unix-like hosts:
+/// it does not require administrator privileges and keeps the daemon scoped to
+/// the interactive user who installed Pi Dash.
+pub async fn write_unit(paths: &Paths) -> Result<()> {
+    paths.ensure()?;
+    let exe = std::env::current_exe().context("resolving current pidash.exe path")?;
+    let exe = validate_exe_path(&exe)?;
+    let task_run = format!("\"{exe}\" __run");
+    run_schtasks(&[
+        "/Create", "/TN", TASK_NAME, "/SC", "ONLOGON", "/TR", &task_run, "/F",
+    ])
+    .await?;
+    println!("installed Windows scheduled task {TASK_NAME}");
+    Ok(())
+}
+
+pub async fn enable_and_start() -> Result<()> {
+    start().await
+}
+
+pub async fn uninstall(_paths: &Paths) -> Result<()> {
+    match run_schtasks(&["/Delete", "/TN", TASK_NAME, "/F"]).await {
+        Ok(_) => {
+            println!("uninstalled Windows scheduled task {TASK_NAME}");
+            Ok(())
+        }
+        Err(e) if looks_task_missing(&e) => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+pub async fn start() -> Result<()> {
+    run_schtasks(&["/Run", "/TN", TASK_NAME]).await?;
+    Ok(())
+}
+
+pub async fn stop() -> Result<()> {
+    match run_schtasks(&["/End", "/TN", TASK_NAME]).await {
+        Ok(_) => Ok(()),
+        Err(e) if looks_not_running(&e) => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+pub async fn status() -> Result<String> {
+    run_schtasks(&["/Query", "/TN", TASK_NAME, "/FO", "LIST", "/V"]).await
+}
+
+fn validate_exe_path(path: &Path) -> Result<&str> {
+    let s = path
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("path is not valid UTF-8: {path:?}"))?;
+    if s.contains(['\n', '\r', '\0']) || s.chars().any(|c| c.is_control()) {
+        anyhow::bail!("path contains a control character; refusing to write task: {s:?}");
+    }
+    Ok(s)
+}
+
+async fn run_schtasks(args: &[&str]) -> Result<String> {
+    let out = Command::new("schtasks")
+        .args(args)
+        .output()
+        .await
+        .context("running schtasks.exe")?;
+    let stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
+    if out.status.success() {
+        return Ok(if stdout.is_empty() { stderr } else { stdout });
+    }
+    let detail = if stderr.is_empty() { stdout } else { stderr };
+    anyhow::bail!("schtasks.exe failed: {detail}");
+}
+
+fn looks_task_missing(e: &anyhow::Error) -> bool {
+    let s = e.to_string();
+    s.contains("cannot find") || s.contains("The system cannot find")
+}
+
+fn looks_not_running(e: &anyhow::Error) -> bool {
+    let s = e.to_string();
+    s.contains("not currently running") || s.contains("cannot find")
+}

--- a/runner/src/tui/views/general.rs
+++ b/runner/src/tui/views/general.rs
@@ -846,15 +846,7 @@ fn mask_token(raw: &str) -> String {
 }
 
 fn default_hostname() -> String {
-    if let Ok(h) = std::env::var("HOSTNAME")
-        && !h.is_empty()
-    {
-        return h;
-    }
-    nix::unistd::gethostname()
-        .ok()
-        .and_then(|os| os.into_string().ok())
-        .unwrap_or_else(|| "runner".to_string())
+    crate::util::hostname::default_hostname()
 }
 
 /// Submit the register form. Spawned by `App::spawn_register_submit`.

--- a/runner/src/tui/views/modals/add_runner.rs
+++ b/runner/src/tui/views/modals/add_runner.rs
@@ -306,15 +306,7 @@ fn default_working_dir(data: &AppData) -> String {
 }
 
 fn default_host_label() -> String {
-    if let Ok(h) = std::env::var("HOSTNAME")
-        && !h.is_empty()
-    {
-        return h;
-    }
-    nix::unistd::gethostname()
-        .ok()
-        .and_then(|os| os.into_string().ok())
-        .unwrap_or_else(|| "runner".to_string())
+    crate::util::hostname::default_hostname()
 }
 
 fn mask_token(raw: &str) -> String {

--- a/runner/src/util/hostname.rs
+++ b/runner/src/util/hostname.rs
@@ -1,0 +1,25 @@
+pub fn default_hostname() -> String {
+    if let Ok(h) = std::env::var("HOSTNAME")
+        && !h.is_empty()
+    {
+        return h;
+    }
+    if let Ok(h) = std::env::var("COMPUTERNAME")
+        && !h.is_empty()
+    {
+        return h;
+    }
+    platform_hostname().unwrap_or_else(|| "runner".to_string())
+}
+
+#[cfg(unix)]
+fn platform_hostname() -> Option<String> {
+    nix::unistd::gethostname()
+        .ok()
+        .and_then(|os| os.into_string().ok())
+}
+
+#[cfg(not(unix))]
+fn platform_hostname() -> Option<String> {
+    None
+}

--- a/runner/src/util/mod.rs
+++ b/runner/src/util/mod.rs
@@ -1,5 +1,6 @@
 pub mod backoff;
 pub mod confirm;
+pub mod hostname;
 pub mod logging;
 pub mod paths;
 pub mod runner_id;

--- a/runner/src/util/signal.rs
+++ b/runner/src/util/signal.rs
@@ -1,7 +1,10 @@
 use anyhow::Result;
+
+#[cfg(unix)]
 use tokio::signal::unix::{SignalKind, signal};
 
 /// Resolves when SIGTERM or SIGINT fires.
+#[cfg(unix)]
 pub async fn shutdown() -> Result<()> {
     let mut term = signal(SignalKind::terminate())?;
     let mut intr = signal(SignalKind::interrupt())?;
@@ -9,5 +12,13 @@ pub async fn shutdown() -> Result<()> {
         _ = term.recv() => tracing::info!("SIGTERM received"),
         _ = intr.recv() => tracing::info!("SIGINT received"),
     }
+    Ok(())
+}
+
+/// Resolves when Ctrl+C fires.
+#[cfg(not(unix))]
+pub async fn shutdown() -> Result<()> {
+    tokio::signal::ctrl_c().await?;
+    tracing::info!("Ctrl+C received");
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add Intel macOS and Windows x64 targets to cargo-dist, including the PowerShell installer
- add Windows named-pipe IPC, Ctrl+C shutdown, and per-user scheduled-task service management
- replace Unix-only config locking with cross-platform file locking and centralize hostname fallback
- update CLI installation docs for Intel Mac and Windows

## Verification
- `cargo check --locked --all-targets`
- `cargo test --locked`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo dist plan`

## Notes
- A local Linux `cargo check --target x86_64-pc-windows-msvc` cannot complete because this host does not have MSVC `lib.exe`; the release matrix runs that build on `windows-2022`.
- Windows MSI packaging is handled separately in the stacked PR.
