### PR TITLE
feat(runner): auto-launch auth login after install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,8 +276,15 @@ jobs:
       # documented one-liner (…/releases/latest/download/install.sh)
       # resolves. The wrapper drops the binary via pidash-installer.sh
       # and immediately launches `pidash auth login`.
+      #
+      # The wrapper ships with `latest` baked into its download URL so a
+      # plain `gh release upload runner/install.sh` would mean that even
+      # a tag-pinned wrapper (…/releases/download/pidash-v0.1.0/install.sh)
+      # would silently fetch the latest binary. sed the actual tag in
+      # before upload so pinning works as documented.
       - name: Upload install.sh wrapper
         run: |
+          sed -i "s|/releases/latest/download/pidash-installer.sh|/releases/download/${{ needs.plan.outputs.tag }}/pidash-installer.sh|" runner/install.sh
           gh release upload "${{ needs.plan.outputs.tag }}" runner/install.sh --clobber
 
   announce:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,6 +271,15 @@ jobs:
 
           gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
 
+      # Hand-added (cargo-dist doesn't know about this): publish the
+      # install.sh wrapper alongside the cargo-dist artifacts so the
+      # documented one-liner (…/releases/latest/download/install.sh)
+      # resolves. The wrapper drops the binary via pidash-installer.sh
+      # and immediately launches `pidash auth login`.
+      - name: Upload install.sh wrapper
+        run: |
+          gh release upload "${{ needs.plan.outputs.tag }}" runner/install.sh --clobber
+
   announce:
     needs:
       - plan

--- a/runner/README.md
+++ b/runner/README.md
@@ -44,6 +44,15 @@ Or on Windows, download and run the MSI installer:
 
 <https://github.com/The-AI-Republic/pi-dash/releases/latest/download/pidash-x86_64-pc-windows-msvc.msi>
 
+The MSI is a standard double-click Windows Installer — it drops `pidash.exe` and exits. It does **not** automatically launch the auth flow (MSI typically runs elevated as the Windows Installer service, and many MSI invocations are silent for IT/Group Policy deploys, so spawning a terminal from it would be wrong). To finish setup after the MSI closes:
+
+```powershell
+# Open PowerShell and run:
+pidash
+```
+
+With no config yet, bare `pidash` drops into `auth login` and walks you through the same device-code flow as the `install.ps1` one-liner. (A discoverable Start Menu shortcut for this step is tracked as a follow-up.)
+
 Windows release assets also include a `pidash-x86_64-pc-windows-msvc.zip` archive with `pidash.exe` for advanced/manual installs.
 
 Then run the setup steps manually:

--- a/runner/README.md
+++ b/runner/README.md
@@ -4,18 +4,27 @@ Local daemon + TUI (`pidash` binary) that connects a developer machine to the Pi
 
 ## Install
 
-Prebuilt binaries for macOS (arm64) and Linux (arm64, x86_64) are published to GitHub Releases. The one-liner below downloads the installer, verifies checksums, and drops `pidash` into `$HOME/.local/bin`:
+Prebuilt binaries for macOS (arm64) and Linux (arm64, x86_64) are published to GitHub Releases. The one-liner below downloads the installer, verifies checksums, drops `pidash` into `$HOME/.local/bin`, and immediately starts the device-code login so the host is registered with your Pi Dash cloud before you leave the terminal:
+
+```bash
+curl --proto '=https' --tlsv1.2 -LsSf \
+  https://github.com/The-AI-Republic/pi-dash/releases/latest/download/install.sh | sh
+```
+
+The installer will prompt for your Pi Dash cloud URL, walk you through device-code approval in the browser, and offer to register this host as a runner — for the typical dev-laptop case, that's the entire setup.
+
+Pin to a specific version by swapping `latest` for a tag, e.g. `.../releases/download/pidash-v0.1.0/install.sh`.
+
+**Prerequisite:** the runner shells out to [Codex](https://github.com/openai/codex) — install it and make sure `codex --version` works before running `pidash configure`. `pidash doctor` checks this.
+
+If you'd rather install the binary without the auto-auth (e.g. for a base image where auth happens later), use the underlying cargo-dist installer directly:
 
 ```bash
 curl --proto '=https' --tlsv1.2 -LsSf \
   https://github.com/The-AI-Republic/pi-dash/releases/latest/download/pidash-installer.sh | sh
 ```
 
-Pin to a specific version instead of `latest` by swapping in the tag, e.g. `.../releases/download/v0.1.0/pidash-installer.sh`.
-
-**Prerequisite:** the runner shells out to [Codex](https://github.com/openai/codex) — install it and make sure `codex --version` works before running `pidash configure`. `pidash doctor` checks this.
-
-After install:
+Then run the setup steps manually:
 
 ```bash
 # 1. Log in as your user. Opens a browser to approve a short code shown in
@@ -33,7 +42,7 @@ pidash runner add --project WEB
 pidash tui
 ```
 
-`pidash auth login` prompts to add a runner inline when no runner exists yet on the host — for the dev-laptop case, that single command is enough.
+`pidash auth login` prompts to add a runner inline when no runner exists yet on the host — for the dev-laptop case, that single command is enough. Bare `pidash` with no subcommand also drops into the login flow when no config exists, so if you skipped auto-auth at install time you can re-trigger it just by typing `pidash`.
 
 Useful follow-ups:
 

--- a/runner/install.sh
+++ b/runner/install.sh
@@ -38,7 +38,13 @@ echo ""
 # pipe and an interactive prompt would see EOF. Reattach /dev/tty so
 # the device-code flow can read keystrokes for the workspace and
 # runner-add prompts.
-if [ -e /dev/tty ]; then
+#
+# `[ -e /dev/tty ]` is not enough: the device node exists on disk even
+# in headless contexts (Docker without -t, cron, systemd, SSH without
+# -t), so the check would pass and then `< /dev/tty` would crash with
+# "No such device or address". Probe openability by actually trying to
+# read from /dev/tty in a subshell.
+if (: </dev/tty) 2>/dev/null; then
   exec "$PIDASH_BIN" auth login < /dev/tty
 fi
 

--- a/runner/install.sh
+++ b/runner/install.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env sh
+# Pi Dash runner installer.
+#
+# Wraps the cargo-dist-generated `pidash-installer.sh` and then
+# launches `pidash auth login` so the user lands in the device-code
+# flow on the same install one-liner. The runner is a "set up once,
+# forget" daemon driven by Pi Dash cloud, so the natural moment to
+# authenticate is right now while the user is at the terminal — not
+# the first time they happen to type `pidash` themselves (which may
+# be never).
+#
+# Usage:
+#   curl --proto '=https' --tlsv1.2 -LsSf \
+#     https://github.com/The-AI-Republic/pi-dash/releases/latest/download/install.sh | sh
+set -eu
+
+INSTALLER_URL="https://github.com/The-AI-Republic/pi-dash/releases/latest/download/pidash-installer.sh"
+
+echo "==> Downloading pidash..."
+curl --proto '=https' --tlsv1.2 -LsSf "$INSTALLER_URL" | sh
+
+# cargo-dist drops the binary into $HOME/.local/bin (install-path in
+# dist-workspace.toml). If a future release moves it, surface a clear
+# error instead of silently continuing.
+PIDASH_BIN="$HOME/.local/bin/pidash"
+if [ ! -x "$PIDASH_BIN" ]; then
+  echo ""
+  echo "pidash binary not found at $PIDASH_BIN after install."
+  echo "Run \`$INSTALLER_URL\` manually, then \`pidash auth login\`."
+  exit 1
+fi
+
+echo ""
+echo "==> Starting authentication..."
+echo ""
+
+# When this script is invoked as `curl … | sh`, sh's stdin is the curl
+# pipe and an interactive prompt would see EOF. Reattach /dev/tty so
+# the device-code flow can read keystrokes for the workspace and
+# runner-add prompts.
+if [ -e /dev/tty ]; then
+  exec "$PIDASH_BIN" auth login < /dev/tty
+fi
+
+# No TTY (CI, Dockerfile, piped without a terminal): don't try to
+# auth — there's no one to approve the device code. Point at the
+# headless path instead.
+echo "No terminal detected — skipping auto-auth."
+echo "Run \`pidash auth login\` from a terminal, or use the headless"
+echo "enrollment path: \`pidash connect --url <URL> --token <TOKEN>\`."

--- a/runner/src/cli/auth/login.rs
+++ b/runner/src/cli/auth/login.rs
@@ -101,7 +101,8 @@ pub async fn run(args: Args, paths: &Paths) -> Result<()> {
     // v1: a CLI install is bound to one workspace. Resolve which one
     // (auto-pick if there's only one membership; prompt otherwise),
     // persist the choice, and use it for any subsequent runner-add.
-    let workspace_slug = resolve_workspace_binding(paths, &cloud_url, &token.access_token).await?;
+    let workspace_slug =
+        resolve_workspace_binding(paths, &cloud_url, &token.access_token).await?;
     println!("  Workspace: {workspace_slug}");
 
     if args.no_runner_prompt {
@@ -127,7 +128,9 @@ fn resolve_cloud_url(args: &Args, paths: &Paths) -> Result<String> {
     if std::io::stdin().is_terminal() {
         return prompt_for_cloud_url();
     }
-    anyhow::bail!("no cloud URL configured — pass --url https://your-pi-dash-instance.example.com");
+    anyhow::bail!(
+        "no cloud URL configured — pass --url https://your-pi-dash-instance.example.com"
+    );
 }
 
 fn prompt_for_cloud_url() -> Result<String> {
@@ -306,7 +309,9 @@ async fn resolve_workspace_binding(
     } else {
         if stored.is_some() {
             println!();
-            println!("(Previous workspace binding is no longer valid — pick a new one.)");
+            println!(
+                "(Previous workspace binding is no longer valid — pick a new one.)"
+            );
         }
         let picked = pick_workspace(&workspaces)?;
         picked.slug.clone()
@@ -345,7 +350,8 @@ async fn fetch_workspaces(
         let body = resp.text().await.unwrap_or_default();
         anyhow::bail!("workspace list failed: HTTP {status}: {body}");
     }
-    let parsed: WorkspaceListResponse = resp.json().await.context("parsing workspace list")?;
+    let parsed: WorkspaceListResponse =
+        resp.json().await.context("parsing workspace list")?;
     Ok(parsed.workspaces)
 }
 
@@ -387,9 +393,7 @@ async fn maybe_offer_runner_add(
     if existing_runners > 0 {
         println!();
         println!("This host already has {existing_runners} runner(s) registered.");
-        println!(
-            "Use `pidash runner add` to register another, or `pidash runner list` to see them."
-        );
+        println!("Use `pidash runner add` to register another, or `pidash runner list` to see them.");
         return Ok(());
     }
 
@@ -397,17 +401,16 @@ async fn maybe_offer_runner_add(
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(15))
         .build()?;
-    let projects = match fetch_projects(&client, cloud_url, api_token).await {
-        Ok(p) => p,
-        Err(e) => {
-            // Non-fatal: we logged in fine, the picker just can't run.
-            println!();
-            println!(
-                "(Couldn't list projects: {e}. You can run `pidash runner add --project <SLUG>` later.)"
-            );
-            return Ok(());
-        }
-    };
+    let projects =
+        match fetch_projects(&client, cloud_url, api_token).await {
+            Ok(p) => p,
+            Err(e) => {
+                // Non-fatal: we logged in fine, the picker just can't run.
+                println!();
+                println!("(Couldn't list projects: {e}. You can run `pidash runner add --project <SLUG>` later.)");
+                return Ok(());
+            }
+        };
 
     if projects.is_empty() {
         println!();
@@ -471,10 +474,7 @@ async fn fetch_projects(
 fn pick_project(projects: &[ProjectRow]) -> Result<Option<&ProjectRow>> {
     use std::io::BufRead;
     if projects.len() == 1 {
-        print!(
-            "Register this host for project '{}'? [Y/n] ",
-            projects[0].identifier
-        );
+        print!("Register this host for project '{}'? [Y/n] ", projects[0].identifier);
         std::io::stdout().flush().ok();
         let stdin = std::io::stdin();
         let mut line = String::new();
@@ -505,3 +505,4 @@ fn pick_project(projects: &[ProjectRow]) -> Result<Option<&ProjectRow>> {
     }
     Ok(Some(&projects[idx - 1]))
 }
+

--- a/runner/src/cli/auth/login.rs
+++ b/runner/src/cli/auth/login.rs
@@ -101,8 +101,7 @@ pub async fn run(args: Args, paths: &Paths) -> Result<()> {
     // v1: a CLI install is bound to one workspace. Resolve which one
     // (auto-pick if there's only one membership; prompt otherwise),
     // persist the choice, and use it for any subsequent runner-add.
-    let workspace_slug =
-        resolve_workspace_binding(paths, &cloud_url, &token.access_token).await?;
+    let workspace_slug = resolve_workspace_binding(paths, &cloud_url, &token.access_token).await?;
     println!("  Workspace: {workspace_slug}");
 
     if args.no_runner_prompt {
@@ -125,9 +124,31 @@ fn resolve_cloud_url(args: &Args, paths: &Paths) -> Result<String> {
             return Ok(cfg.daemon.cloud_url.trim_end_matches('/').to_string());
         }
     }
-    anyhow::bail!(
-        "no cloud URL configured — pass --url https://your-pi-dash-instance.example.com"
-    );
+    if std::io::stdin().is_terminal() {
+        return prompt_for_cloud_url();
+    }
+    anyhow::bail!("no cloud URL configured — pass --url https://your-pi-dash-instance.example.com");
+}
+
+fn prompt_for_cloud_url() -> Result<String> {
+    use std::io::BufRead;
+    println!();
+    println!("Enter your Pi Dash cloud URL.");
+    println!("(For AI Republic-hosted Pi Dash this is https://pidash.airepublic.com;");
+    println!(" for a self-hosted instance use your own URL.)");
+    println!();
+    print!("Cloud URL: ");
+    std::io::stdout().flush().ok();
+    let mut line = String::new();
+    std::io::stdin()
+        .lock()
+        .read_line(&mut line)
+        .context("reading cloud URL from stdin")?;
+    let url = line.trim();
+    if url.is_empty() {
+        anyhow::bail!("no cloud URL entered — re-run `pidash auth login --url <URL>`");
+    }
+    Ok(url.trim_end_matches('/').to_string())
 }
 
 async fn start_device_code(client: &reqwest::Client, cloud_url: &str) -> Result<StartResponse> {
@@ -285,9 +306,7 @@ async fn resolve_workspace_binding(
     } else {
         if stored.is_some() {
             println!();
-            println!(
-                "(Previous workspace binding is no longer valid — pick a new one.)"
-            );
+            println!("(Previous workspace binding is no longer valid — pick a new one.)");
         }
         let picked = pick_workspace(&workspaces)?;
         picked.slug.clone()
@@ -326,8 +345,7 @@ async fn fetch_workspaces(
         let body = resp.text().await.unwrap_or_default();
         anyhow::bail!("workspace list failed: HTTP {status}: {body}");
     }
-    let parsed: WorkspaceListResponse =
-        resp.json().await.context("parsing workspace list")?;
+    let parsed: WorkspaceListResponse = resp.json().await.context("parsing workspace list")?;
     Ok(parsed.workspaces)
 }
 
@@ -369,7 +387,9 @@ async fn maybe_offer_runner_add(
     if existing_runners > 0 {
         println!();
         println!("This host already has {existing_runners} runner(s) registered.");
-        println!("Use `pidash runner add` to register another, or `pidash runner list` to see them.");
+        println!(
+            "Use `pidash runner add` to register another, or `pidash runner list` to see them."
+        );
         return Ok(());
     }
 
@@ -377,16 +397,17 @@ async fn maybe_offer_runner_add(
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(15))
         .build()?;
-    let projects =
-        match fetch_projects(&client, cloud_url, api_token).await {
-            Ok(p) => p,
-            Err(e) => {
-                // Non-fatal: we logged in fine, the picker just can't run.
-                println!();
-                println!("(Couldn't list projects: {e}. You can run `pidash runner add --project <SLUG>` later.)");
-                return Ok(());
-            }
-        };
+    let projects = match fetch_projects(&client, cloud_url, api_token).await {
+        Ok(p) => p,
+        Err(e) => {
+            // Non-fatal: we logged in fine, the picker just can't run.
+            println!();
+            println!(
+                "(Couldn't list projects: {e}. You can run `pidash runner add --project <SLUG>` later.)"
+            );
+            return Ok(());
+        }
+    };
 
     if projects.is_empty() {
         println!();
@@ -450,7 +471,10 @@ async fn fetch_projects(
 fn pick_project(projects: &[ProjectRow]) -> Result<Option<&ProjectRow>> {
     use std::io::BufRead;
     if projects.len() == 1 {
-        print!("Register this host for project '{}'? [Y/n] ", projects[0].identifier);
+        print!(
+            "Register this host for project '{}'? [Y/n] ",
+            projects[0].identifier
+        );
         std::io::stdout().flush().ok();
         let stdin = std::io::stdin();
         let mut line = String::new();
@@ -481,4 +505,3 @@ fn pick_project(projects: &[ProjectRow]) -> Result<Option<&ProjectRow>> {
     }
     Ok(Some(&projects[idx - 1]))
 }
-

--- a/runner/src/cli/mod.rs
+++ b/runner/src/cli/mod.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
 
 pub mod auth;
 mod comment;
@@ -40,7 +40,7 @@ pub async fn run_for_tests(args: RunArgs, paths: &crate::util::paths::Paths) -> 
 #[command(name = "pidash", version, about, long_about = None)]
 pub struct Cli {
     #[command(subcommand)]
-    pub command: Command,
+    pub command: Option<Command>,
 
     /// Override config directory (XDG config by default).
     #[arg(long, global = true, env = "PIDASH_CONFIG_DIR")]
@@ -132,7 +132,11 @@ pub async fn run(cli: Cli) -> Result<()> {
     let paths = crate::util::paths::Paths::resolve(cli.config_dir.clone(), cli.data_dir.clone())?;
     tracing::debug!(?paths, "resolved runner paths");
 
-    match cli.command {
+    let Some(command) = cli.command else {
+        return run_default(&paths).await;
+    };
+
+    match command {
         Command::Auth(args) => auth::run(args, &paths).await,
         Command::Connect(args) => connect::run(args, &paths).await,
         Command::Config(args) => config_cmd::run(args, &paths).await,
@@ -155,6 +159,27 @@ pub async fn run(cli: Cli) -> Result<()> {
         Command::Workspace(args) => run_crud(workspace::run(args, &paths).await),
         Command::Run(args) => run::run(args, &paths).await,
     }
+}
+
+/// No-subcommand entrypoint. Acts as a first-run launcher: if this
+/// host has no config yet, drop straight into `pidash auth login` so
+/// the user lands in the device-code flow immediately after the
+/// install one-liner. If config already exists, fall through to
+/// clap's help so the bare command behaves like every other CLI.
+async fn run_default(paths: &crate::util::paths::Paths) -> Result<()> {
+    if !paths.config_path().exists() {
+        let args = auth::AuthArgs {
+            command: auth::AuthCommand::Login(auth::login::Args {
+                url: None,
+                no_browser: false,
+                no_runner_prompt: false,
+            }),
+        };
+        return auth::run(args, paths).await;
+    }
+    Cli::command().print_help()?;
+    println!();
+    Ok(())
 }
 
 fn run_crud(code: i32) -> Result<()> {


### PR DESCRIPTION
## Summary
- Pulls runner authentication from "the user remembers to run `pidash` someday" to "happens at install time, while the user is at the terminal." The runner is a set-up-once daemon driven by Pi Dash cloud, so silent unauth was a real failure mode.
- New `runner/install.sh` wrapper runs the existing `pidash-installer.sh` to drop the binary, then `exec`s `pidash auth login < /dev/tty` so the device-code flow opens in the same one-liner.
- `pidash auth login` now prompts for the cloud URL when `--url` is missing on a TTY (so the wrapper's `exec` actually completes); bails as before in non-TTY contexts.
- Bare `pidash` becomes a first-run launcher: routes into `auth login` when no `config.toml` exists, prints clap help otherwise. Backstop for users who installed via the cargo-dist installer directly or before this wrapper shipped.
- `release.yml` uploads `runner/install.sh` to each release so `…/releases/latest/download/install.sh` resolves.
- `runner/README.md` points the one-liner at `install.sh` and documents the new flow; the bare `pidash-installer.sh` URL stays valid as the no-auth escape hatch (CI base images, Dockerfiles).

## Test plan
- [x] `cargo test --all-targets` — 275 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] Manual smoke: bare `pidash` with empty config dir + non-TTY stdin → bails with the existing "no cloud URL" message (correct; nothing to prompt against)
- [x] Manual smoke: bare `pidash` with a populated config → prints clap help
- [ ] End-to-end install: tag a release, run the published `install.sh` from a fresh box, confirm device-code flow opens and runner registers
- [ ] Headless path: pipe `install.sh` to a Dockerfile `RUN`, confirm hint prints and exits 0 instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)