### PR TITLE
[codex] fix Codex runner working-dir command

### DIFF
--- a/apps/web/core/components/runners/add-runner-modal.tsx
+++ b/apps/web/core/components/runners/add-runner-modal.tsx
@@ -44,10 +44,18 @@ interface FormValues {
   agent: TAgent;
 }
 
+type CommandOptions = Pick<FormValues, "hostLabel" | "workingDir" | "agent">;
+
 const DEFAULT_VALUES: FormValues = {
   projectIdentifier: "",
   podName: "",
   name: "",
+  hostLabel: "",
+  workingDir: "",
+  agent: DEFAULT_AGENT,
+};
+
+const DEFAULT_COMMAND_OPTIONS: CommandOptions = {
   hostLabel: "",
   workingDir: "",
   agent: DEFAULT_AGENT,
@@ -71,6 +79,7 @@ export const AddRunnerModal = observer(function AddRunnerModal(props: Props) {
   } = useForm<FormValues>({ defaultValues: DEFAULT_VALUES });
 
   const [invite, setInvite] = useState<IRunnerInvite | null>(null);
+  const [commandOptions, setCommandOptions] = useState<CommandOptions>(DEFAULT_COMMAND_OPTIONS);
 
   // Reset everything on close→open. State persists between consecutive
   // opens otherwise (RHF + local invite state would carry the stale
@@ -78,6 +87,7 @@ export const AddRunnerModal = observer(function AddRunnerModal(props: Props) {
   useEffect(() => {
     if (!isOpen) return;
     setInvite(null);
+    setCommandOptions(DEFAULT_COMMAND_OPTIONS);
     reset(DEFAULT_VALUES);
   }, [isOpen, reset]);
 
@@ -130,10 +140,6 @@ export const AddRunnerModal = observer(function AddRunnerModal(props: Props) {
     if (!stillFits) setValue("podName", "");
   }, [selectedProject, selectedPodName, podsForPicker, setValue]);
 
-  const hostLabelInput = watch("hostLabel");
-  const workingDirInput = watch("workingDir");
-  const agentInput = watch("agent");
-
   const agentOptionLabel = (value: TAgent): string =>
     value === "claude-code"
       ? t("runners.add_modal.agent_options.claude_code")
@@ -146,6 +152,11 @@ export const AddRunnerModal = observer(function AddRunnerModal(props: Props) {
         projectIdentifier: values.projectIdentifier,
         podName: values.podName || undefined,
         name: values.name.trim() || undefined,
+      });
+      setCommandOptions({
+        hostLabel: values.hostLabel,
+        workingDir: values.workingDir,
+        agent: values.agent,
       });
       setInvite(result);
       onCreated();
@@ -348,9 +359,9 @@ export const AddRunnerModal = observer(function AddRunnerModal(props: Props) {
 
           <RunnerEnrollmentCommand
             invite={invite}
-            hostLabel={hostLabelInput}
-            workingDir={workingDirInput}
-            agent={agentInput}
+            hostLabel={commandOptions.hostLabel}
+            workingDir={commandOptions.workingDir}
+            agent={commandOptions.agent}
           />
 
           <div className="flex justify-end">

--- a/apps/web/tests/runners/add-runner-modal.test.tsx
+++ b/apps/web/tests/runners/add-runner-modal.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createRunnerInvite, listPods, listProjects, setToast } = vi.hoisted(() => ({
+  createRunnerInvite: vi.fn(),
+  listPods: vi.fn(),
+  listProjects: vi.fn(),
+  setToast: vi.fn(),
+}));
+
+vi.mock("@pi-dash/constants", () => ({
+  API_BASE_URL: "http://localhost:8000",
+}));
+
+vi.mock("@pi-dash/services", () => ({
+  PodService: class {
+    list = listPods;
+  },
+  RunnerService: class {
+    createRunnerInvite = createRunnerInvite;
+  },
+}));
+
+vi.mock("@/services/project", () => ({
+  ProjectService: class {
+    getProjectsLite = listProjects;
+  },
+}));
+
+vi.mock("@pi-dash/i18n", () => ({
+  useTranslation: () => ({
+    t: (key: string, vars?: Record<string, unknown>) => (vars ? `${key}:${JSON.stringify(vars)}` : key),
+  }),
+}));
+
+vi.mock("@pi-dash/propel/toast", () => ({
+  TOAST_TYPE: { ERROR: "ERROR", SUCCESS: "SUCCESS" },
+  setToast,
+}));
+
+vi.mock("@pi-dash/propel/button", () => ({
+  Button: ({
+    children,
+    loading: _loading,
+    variant: _variant,
+    size: _size,
+    ...props
+  }: {
+    children: React.ReactNode;
+    loading?: boolean;
+    variant?: string;
+    size?: string;
+  } & React.ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+}));
+
+vi.mock("@pi-dash/ui", async () => {
+  const { forwardRef: fwd } = await import("react");
+  type SelectProps = {
+    value: string;
+    onChange: (v: string) => void;
+    children: React.ReactNode;
+    disabled?: boolean;
+  };
+  // eslint-disable-next-line unicorn/consistent-function-scoping -- inside vi.mock factory; cannot hoist out
+  const Sel = ({ value, onChange, children, disabled }: SelectProps) => (
+    <select data-testid="select" value={value} disabled={disabled} onChange={(e) => onChange(e.target.value)}>
+      <option value="" disabled>
+        placeholder
+      </option>
+      {children}
+    </select>
+  );
+  Sel.Option = ({ value, children }: { value: string; children: React.ReactNode }) => (
+    <option value={value}>{children}</option>
+  );
+  return {
+    ModalCore: ({ isOpen, children }: { isOpen: boolean; children: React.ReactNode }) =>
+      isOpen ? <div role="dialog">{children}</div> : null,
+    EModalPosition: { CENTER: "CENTER" },
+    EModalWidth: { XXL: "XXL" },
+    Input: fwd<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(function Input(props, ref) {
+      return <input ref={ref} {...props} />;
+    }),
+    CustomSelect: Sel,
+  };
+});
+
+import { AddRunnerModal } from "@/components/runners/add-runner-modal";
+
+const PROJECTS = [{ id: "project-1", identifier: "BROWSERX", name: "BrowserX" }];
+
+const PODS = [
+  {
+    id: "pod-1",
+    name: "pod-a",
+    description: "",
+    is_default: false,
+    workspace: "workspace-1",
+    project: "project-1",
+    project_identifier: "BROWSERX",
+    created_by: null,
+    runner_count: 0,
+    created_at: "2026-05-23T00:00:00Z",
+    updated_at: "2026-05-23T00:00:00Z",
+  },
+];
+
+const INVITE = {
+  runner_id: "runner-1",
+  name: "runner-1",
+  workspace_slug: "acme",
+  project_identifier: "BROWSERX",
+  pod_id: "pod-1",
+  enrollment_token: "apd_test_token",
+  enrollment_expires_at: "2026-05-23T00:30:00Z",
+};
+
+describe("AddRunnerModal", () => {
+  beforeEach(() => {
+    createRunnerInvite.mockReset().mockResolvedValue(INVITE);
+    listPods.mockReset().mockResolvedValue(PODS);
+    listProjects.mockReset().mockResolvedValue(PROJECTS);
+    setToast.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function renderModal() {
+    const onClose = vi.fn();
+    const onCreated = vi.fn();
+    const utils = render(
+      <AddRunnerModal isOpen onClose={onClose} workspaceId="workspace-1" workspaceSlug="acme" onCreated={onCreated} />
+    );
+    return { ...utils, onClose, onCreated };
+  }
+
+  it("includes working-dir when the submitted agent is codex", async () => {
+    const user = userEvent.setup();
+    const workingDir = "/home/rich/dev/airepublic/open_source/s6/browserx";
+    const { onCreated } = renderModal();
+
+    await screen.findByRole("option", { name: "BrowserX" });
+
+    const selects = screen.getAllByTestId("select");
+    await user.selectOptions(selects[0], "BROWSERX");
+    await user.type(screen.getByPlaceholderText("runners.add_modal.working_dir_placeholder"), workingDir);
+    await user.selectOptions(selects[2], "codex");
+    await user.click(screen.getByRole("button", { name: "runners.add_modal.submit" }));
+
+    await waitFor(() => {
+      expect(createRunnerInvite).toHaveBeenCalledWith({
+        workspaceId: "workspace-1",
+        projectIdentifier: "BROWSERX",
+        podName: undefined,
+        name: undefined,
+      });
+    });
+    expect(onCreated).toHaveBeenCalled();
+
+    const command = await screen.findByText(
+      (_content: string, node: Element | null) => node?.tagName.toLowerCase() === "pre"
+    );
+    expect(command.textContent).toContain(`--working-dir ${workingDir}`);
+    expect(command.textContent).toContain("--agent codex");
+  });
+});


### PR DESCRIPTION
## What changed

- Snapshot the Add Runner modal's CLI-only command options (`hostLabel`, `workingDir`, `agent`) from the submitted form values before rendering the enrollment command.
- Add a web regression test that submits the Add Runner flow with `agent=codex` and verifies the generated `pidash connect` command includes both `--working-dir` and `--agent codex`.

## Why

`workingDir` is not sent to the create-invite API; it only belongs in the displayed `pidash connect` command. The previous result screen read it via React Hook Form `watch()` after the form inputs had been unmounted, so the Codex path could render an empty working directory and omit `--working-dir`, causing the runner to fall back to its per-runner temporary workspace.

## Impact

Users adding a Codex runner now get a ready-to-copy command that preserves the working directory they submitted, matching the Claude Code behavior.

## Validation

- Rebased onto latest `main` (`425eefef`).
- GitHub Actions passed on the rebased head: `plan`, `test`.
- `pnpm --filter web test -- tests/runners/add-runner-modal.test.tsx` passed (`16` runner tests).
- `pnpm exec oxfmt --check apps/web/core/components/runners/add-runner-modal.tsx apps/web/tests/runners/add-runner-modal.test.tsx` passed.
- `pnpm exec oxlint apps/web/core/components/runners/add-runner-modal.tsx apps/web/tests/runners/add-runner-modal.test.tsx` passed.
- `pnpm --filter web exec tsc --noEmit` was attempted separately and still fails on existing unrelated GitHub/scheduler type errors in the web app.