### PR TITLE
[codex] Limit runner remove revoke timeout

### DIFF
--- a/runner/src/cli/connect.rs
+++ b/runner/src/cli/connect.rs
@@ -16,6 +16,7 @@ use chrono::Utc;
 use clap::Args as ClapArgs;
 use std::io::{BufRead, IsTerminal, Write};
 use std::path::PathBuf;
+use std::time::Duration;
 
 use crate::cloud::http::{
     RunnerCredentials, SharedHttpTransport, TransportError, enroll_runner, write_runner_credentials,
@@ -25,6 +26,8 @@ use crate::config::schema::{
     AgentKind, AgentSection, Config, Credentials, DaemonConfig, RunnerConfig, WorkspaceSection,
 };
 use crate::util::paths::Paths;
+
+const REVOKE_TRANSPORT_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(Debug, ClapArgs)]
 pub struct Args {
@@ -566,8 +569,11 @@ pub async fn revoke_additional_runner(
         )
         .await
         .map_err(|e| RemoveAdditionalError::LoadCredentials(format!("{e:#}")))?;
-        let transport = SharedHttpTransport::new(cfg.daemon.cloud_url.clone())
-            .map_err(|e| RemoveAdditionalError::Network(format!("transport: {e:#}")))?;
+        let transport = SharedHttpTransport::new_with_timeout(
+            cfg.daemon.cloud_url.clone(),
+            REVOKE_TRANSPORT_TIMEOUT,
+        )
+        .map_err(|e| RemoveAdditionalError::Network(format!("transport: {e:#}")))?;
         let client = crate::cloud::http::RunnerCloudClient::new(runner_id, creds, transport);
         crate::cloud::http::revoke_runner_self(&client)
             .await

--- a/runner/src/cloud/http.rs
+++ b/runner/src/cloud/http.rs
@@ -108,9 +108,13 @@ pub struct SharedHttpTransport {
 
 impl SharedHttpTransport {
     pub fn new(cloud_url: String) -> Result<Self> {
+        Self::new_with_timeout(cloud_url, Duration::from_secs(60))
+    }
+
+    pub fn new_with_timeout(cloud_url: String, timeout: Duration) -> Result<Self> {
         let http = Client::builder()
             .pool_idle_timeout(Duration::from_secs(60))
-            .timeout(Duration::from_secs(60))
+            .timeout(timeout)
             .user_agent(format!("pidash/{}", crate::RUNNER_VERSION))
             .build()
             .context("building shared reqwest::Client")?;


### PR DESCRIPTION
## Summary
- add a configurable timeout constructor for the shared runner HTTP transport
- use a 10 second transport timeout for runner self-revoke during `pidash remove --all`
- keep the daemon's normal 60 second transport timeout unchanged

## Why
`pidash remove --all` revokes each runner sequentially. When the configured cloud URL is unreachable, each revoke currently waits for the daemon transport's 60 second timeout during `/refresh/`, making teardown feel stuck. A 10 second revoke timeout keeps best-effort cloud cleanup bounded while still allowing local state removal to proceed.

## Validation
- `cargo check -p pidash`
- rebuilt and installed local `pidash` binary
