### PR TITLE
feat(auth): give CLI-minted APIToken a human-readable label

### DIFF
--- a/apps/api/pi_dash/authentication/views/cli/device.py
+++ b/apps/api/pi_dash/authentication/views/cli/device.py
@@ -281,13 +281,9 @@ class DeviceCodeTokenEndpoint(APIView):
                     status=status.HTTP_400_BAD_REQUEST,
                 )
 
-            # Approved + not yet consumed: mint a fresh APIToken for the
-            # user and consume the row in the same transaction. The label
-            # is what surfaces in the settings UI's token list; the default
-            # `generate_label_token` would render as an opaque hex string
-            # next to user-created PATs, so set a human-readable one with
-            # the issue time so the user can spot which row a given
-            # `pidash auth login` produced.
+            # Override the default `generate_label_token` (opaque hex)
+            # so this row is distinguishable from user-created PATs in
+            # the settings UI token list.
             api_token = APIToken.objects.create(
                 user=row.user,
                 workspace=row.workspace,

--- a/apps/api/pi_dash/authentication/views/cli/device.py
+++ b/apps/api/pi_dash/authentication/views/cli/device.py
@@ -282,11 +282,17 @@ class DeviceCodeTokenEndpoint(APIView):
                 )
 
             # Approved + not yet consumed: mint a fresh APIToken for the
-            # user and consume the row in the same transaction.
+            # user and consume the row in the same transaction. The label
+            # is what surfaces in the settings UI's token list; the default
+            # `generate_label_token` would render as an opaque hex string
+            # next to user-created PATs, so set a human-readable one with
+            # the issue time so the user can spot which row a given
+            # `pidash auth login` produced.
             api_token = APIToken.objects.create(
                 user=row.user,
                 workspace=row.workspace,
                 user_type=0,  # Human
+                label=f"pidash CLI · {now.strftime('%Y-%m-%d %H:%M')} UTC",
                 description="Issued by pidash auth login (device-code flow).",
             )
             row.consumed = True

--- a/apps/api/pi_dash/tests/unit/runner/test_cli_auth_flow.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_cli_auth_flow.py
@@ -10,6 +10,7 @@ runner mint + token revoke endpoints. See
 
 from __future__ import annotations
 
+import re
 from datetime import timedelta
 
 import pytest
@@ -65,11 +66,8 @@ def test_token_poll_pending_then_approved_mints_apitoken(
     assert poll2.status_code == 200, poll2.data
     assert poll2.data["access_token"].startswith("pi_dash_api_")
     assert poll2.data["user_email"] == create_user.email
-    # APIToken row exists with a human-readable label (not the default
-    # opaque hex from `generate_label_token`) so users can recognize it
-    # alongside manually-created PATs in the settings UI.
     minted = APIToken.objects.get(token=poll2.data["access_token"], user=create_user)
-    assert minted.label.startswith("pidash CLI")
+    assert re.fullmatch(r"pidash CLI · \d{4}-\d{2}-\d{2} \d{2}:\d{2} UTC", minted.label), minted.label
     # Row marked consumed.
     row = CLIDeviceCode.objects.get(device_code=start["device_code"])
     assert row.consumed is True

--- a/apps/api/pi_dash/tests/unit/runner/test_cli_auth_flow.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_cli_auth_flow.py
@@ -65,8 +65,11 @@ def test_token_poll_pending_then_approved_mints_apitoken(
     assert poll2.status_code == 200, poll2.data
     assert poll2.data["access_token"].startswith("pi_dash_api_")
     assert poll2.data["user_email"] == create_user.email
-    # APIToken row exists.
-    assert APIToken.objects.filter(token=poll2.data["access_token"], user=create_user).exists()
+    # APIToken row exists with a human-readable label (not the default
+    # opaque hex from `generate_label_token`) so users can recognize it
+    # alongside manually-created PATs in the settings UI.
+    minted = APIToken.objects.get(token=poll2.data["access_token"], user=create_user)
+    assert minted.label.startswith("pidash CLI")
     # Row marked consumed.
     row = CLIDeviceCode.objects.get(device_code=start["device_code"])
     assert row.consumed is True


### PR DESCRIPTION
## Summary
- Pass an explicit `label=\"pidash CLI · YYYY-MM-DD HH:MM UTC\"` when `DeviceCodeTokenEndpoint` mints an `APIToken` for `pidash auth login`. Default label is `generate_label_token()` (a bare hex uuid), which renders next to user-created PATs in `/settings/profile/api-tokens` and is indistinguishable from them at a glance.
- Update the existing `test_token_poll_pending_then_approved_mints_apitoken` to assert the minted row's label starts with \"pidash CLI\".

The token format, auth class, and revocation behavior are unchanged — only the human-visible label.

## Test plan
- [x] `pytest pi_dash/tests/unit/runner/test_cli_auth_flow.py` — all 8 device-code tests pass against local stack
- [ ] Manual: run \`pidash auth login\`, then open Settings → API Tokens and confirm the new row reads \"pidash CLI · 2026-05-23 …\" rather than a hex string
- [ ] Manual: revoke that row from settings and confirm subsequent `pidash` calls 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)