### PR TITLE
fix(migrations): merge default-project and github-sync 0137 leaves

### DIFF
--- a/apps/api/pi_dash/db/migrations/0138_merge_default_project_and_github_sync.py
+++ b/apps/api/pi_dash/db/migrations/0138_merge_default_project_and_github_sync.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Merge the two 0137 leaves: github-sync unique drop + default-project constraint."""
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("db", "0137_drop_github_repository_sync_repository_unique"),
+        ("db", "0137_project_unique_default_per_workspace"),
+    ]
+
+    operations = []


### PR DESCRIPTION
## Summary

- Two parallel migrations landed on `main` both numbered `0137`:
  - `0137_drop_github_repository_sync_repository_unique` (PR #139 ancestor branch)
  - `0137_project_unique_default_per_workspace` (default-project work)
- Django refuses to migrate with multiple leaves in the graph (the migrator dies with `CommandError: Conflicting migrations detected; multiple leaf nodes …`).
- Adds an empty `0138_merge_default_project_and_github_sync.py` depending on both leaves — same pattern as the existing `0136_merge_cli_device_code_and_review_state.py`.

## Why now

The cloud test deploy (`private-pi-dash` release `v2026.5.24`) failed in the migrator with this exact error. The cloud build resolves OSS `main` HEAD at build time, so this lands here, not in the cloud overlay.

## Test plan

- [ ] `cd apps/api && python manage.py showmigrations db | tail -5` — single leaf at `0138_merge_default_project_and_github_sync`
- [ ] `python manage.py migrate --plan` — no conflict, plan completes
- [ ] CI passes
- [ ] After merge, re-run private-pi-dash `build-and-deploy.yml` (workflow_dispatch, target=test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)