### PR TITLE
release(runner): bump pidash to 0.1.4-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1382,7 +1382,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pidash"
-version = "0.1.3"
+version = "0.1.4-rc.1"
 dependencies = [
  "anyhow",
  "axoupdater",

--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ On Windows, download and run the MSI installer:
 
 <https://github.com/The-AI-Republic/pi-dash/releases/latest/download/pidash-x86_64-pc-windows-msvc.msi>
 
+To pin to a specific version (or install a prerelease), swap `latest` for the tag, e.g. `.../releases/download/pidash-v0.1.4-rc.1/pidash-installer.sh`. Prereleases are excluded from `/latest/`, so the one-liners above always serve the last stable release. Full pinning recipes — wrapper, bare installer, Windows variants — are in [`runner/README.md`](./runner/README.md#installing-a-specific-version-pinning--prereleases).
+
 Then authenticate the machine and register a runner. The standard flow is two commands:
 
 ```bash

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pidash"
-version = "0.1.3"
+version = "0.1.4-rc.1"
 edition = "2024"
 rust-version = "1.93"
 description = "Pi Dash local runner: connects a dev machine to the Pi Dash cloud and drives Codex for assigned tasks."

--- a/runner/README.md
+++ b/runner/README.md
@@ -21,7 +21,34 @@ irm https://github.com/The-AI-Republic/pi-dash/releases/latest/download/install.
 
 The installer will prompt for your Pi Dash cloud URL, walk you through device-code approval in the browser, and offer to register this host as a runner — for the typical dev-laptop case, that's the entire setup.
 
-Pin to a specific version by swapping `latest` for a tag, e.g. `.../releases/download/pidash-v0.1.0/install.sh` (or `install.ps1`).
+### Installing a specific version (pinning / prereleases)
+
+Both the wrapper (`install.sh` / `install.ps1`) and the underlying cargo-dist installer (`pidash-installer.sh` / `pidash-installer.ps1`) select a release purely by URL path — swap `latest` for the tag you want:
+
+```bash
+# macOS / Linux — wrapper (with auto-auth)
+curl --proto '=https' --tlsv1.2 -LsSf \
+  https://github.com/The-AI-Republic/pi-dash/releases/download/pidash-v0.1.0/install.sh | sh
+
+# macOS / Linux — bare installer (no auto-auth)
+curl --proto '=https' --tlsv1.2 -LsSf \
+  https://github.com/The-AI-Republic/pi-dash/releases/download/pidash-v0.1.0/pidash-installer.sh | sh
+```
+
+```powershell
+# Windows — wrapper
+irm https://github.com/The-AI-Republic/pi-dash/releases/download/pidash-v0.1.0/install.ps1 | iex
+
+# Windows — bare installer
+irm https://github.com/The-AI-Republic/pi-dash/releases/download/pidash-v0.1.0/pidash-installer.ps1 | iex
+```
+
+**Prereleases** (tags with a SemVer suffix like `-rc.1`, `-alpha.1`, `-beta.1`) are deliberately excluded from `/releases/latest/`, so the public one-liners above keep serving the last stable release. To install a prerelease for testing, use the tag-pinned URL above with the rc tag, e.g.:
+
+```bash
+curl --proto '=https' --tlsv1.2 -LsSf \
+  https://github.com/The-AI-Republic/pi-dash/releases/download/pidash-v0.1.4-rc.1/install.sh | sh
+```
 
 **Prerequisite:** the runner shells out to [Codex](https://github.com/openai/codex) — install it and make sure `codex --version` works before running `pidash configure`. `pidash doctor` checks this.
 


### PR DESCRIPTION
## Summary

- Bumps `runner/Cargo.toml` (and `Cargo.lock`) from `0.1.3` → `0.1.4-rc.1`.
- After merge, tag the merge commit `pidash-v0.1.4-rc.1` to fire `release.yml`. cargo-dist parses the `-rc.1` SemVer suffix and creates the GitHub Release with `--prerelease`, which **excludes it from `/releases/latest/`** — the public install one-liner keeps serving `pidash-v0.1.3`.
- Testers install via the pinned URL:
  ```
  curl --proto '=https' --tlsv1.2 -LsSf \
    https://github.com/The-AI-Republic/pi-dash/releases/download/pidash-v0.1.4-rc.1/install.sh | sh
  ```
- The publish job's `sed` step rewrites the cargo-dist installer path inside the uploaded `install.sh` to the same tag, so the wrapper pulls rc binaries (not `latest`).

## What's in 0.1.4-rc.1 (vs 0.1.3)

- Runner direct-chat (#136) + warm-runtime optimization
- Chat latency timing events
- Auto-launch `auth login` after install (#141)
- Windows MSI installer packaging (#142)
- Windows + Intel Mac CLI release targets (#140)
- Agent project context support (#139)

## Test plan

- [ ] PR merges cleanly; runner CI green
- [ ] After merge, push tag `pidash-v0.1.4-rc.1` → `release.yml` succeeds and creates a GitHub Release marked **Pre-release**
- [ ] `/releases/latest/download/install.sh` still resolves to `pidash-v0.1.3` artifacts
- [ ] Tag-pinned `…/releases/download/pidash-v0.1.4-rc.1/install.sh` resolves and installs the rc binary on macOS / Linux / Windows
- [ ] `pidash --version` reports `0.1.4-rc.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)