### PR TITLE
[codex] Mirror async run events to cloud

### DIFF
--- a/runner/src/cloud/http.rs
+++ b/runner/src/cloud/http.rs
@@ -631,6 +631,10 @@ impl RunnerCloudClient {
                 let body = to_value(&msg)?;
                 self.post_run_event(run_id, body, &idempotency_key).await
             }
+            msg @ ClientMsg::RunEvents { run_id, .. } => {
+                let body = to_value(&msg)?;
+                self.post_run_event(run_id, body, &idempotency_key).await
+            }
             msg @ ClientMsg::ApprovalRequest { run_id, .. } => {
                 let body = to_value(&msg)?;
                 self.post_run_lifecycle(run_id, "approvals", body, &idempotency_key)

--- a/runner/src/cloud/protocol.rs
+++ b/runner/src/cloud/protocol.rs
@@ -72,7 +72,7 @@ impl<T> Envelope<T> {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RunEventRecord {
-    pub seq: u64,
+    pub seq: u32,
     pub kind: String,
     pub payload: serde_json::Value,
 }

--- a/runner/src/cloud/protocol.rs
+++ b/runner/src/cloud/protocol.rs
@@ -70,6 +70,13 @@ impl<T> Envelope<T> {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunEventRecord {
+    pub seq: u64,
+    pub kind: String,
+    pub payload: serde_json::Value,
+}
+
 /// Messages the runner sends to the cloud.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -110,6 +117,10 @@ pub enum ClientMsg {
         seq: u64,
         kind: String,
         payload: serde_json::Value,
+    },
+    RunEvents {
+        run_id: Uuid,
+        events: Vec<RunEventRecord>,
     },
     ApprovalRequest {
         run_id: Uuid,

--- a/runner/src/daemon/state.rs
+++ b/runner/src/daemon/state.rs
@@ -236,12 +236,12 @@ impl StateHandle {
 
     /// Bump `last_event_at` and stamp `kind` / `summary` atomically.
     /// Called from `pump_events` on every `BridgeEvent` regardless of variant.
-    pub async fn note_agent_event(&self, ts: DateTime<Utc>, kind: String, summary: Option<String>) {
+    pub async fn note_agent_event(&self, ts: DateTime<Utc>, kind: &str, summary: Option<&str>) {
         let mut snap = self.inner.run_snapshot.lock().await;
         snap.last_event_at = Some(ts);
-        snap.last_event_kind = Some(kind);
+        snap.last_event_kind = Some(kind.to_string());
         if let Some(s) = summary {
-            snap.last_event_summary = Some(s);
+            snap.last_event_summary = Some(s.to_string());
         }
         drop(snap);
         self.tick();
@@ -505,7 +505,7 @@ mod tests {
         state.set_agent_pid(Some(4242)).await;
         state.set_agent_alive(true).await;
         state
-            .note_agent_event(Utc::now(), "raw".into(), Some("test".into()))
+            .note_agent_event(Utc::now(), "raw", Some("test"))
             .await;
 
         // Same rid → must NOT call reset_run_snapshot.
@@ -535,7 +535,7 @@ mod tests {
             .await;
         state.incr_turn().await;
         state
-            .note_agent_event(Utc::now(), "raw".into(), Some("a".into()))
+            .note_agent_event(Utc::now(), "raw", Some("a"))
             .await;
 
         state.set_current_run(Some(summary(rid_b, "running"))).await;
@@ -597,7 +597,7 @@ mod tests {
         let state = empty_state();
         let now = Utc::now();
         state
-            .note_agent_event(now, "tool/exec".into(), Some("running".into()))
+            .note_agent_event(now, "tool/exec", Some("running"))
             .await;
         let snap = state.observability_snapshot().await;
         assert_eq!(snap.last_event_at, Some(now));

--- a/runner/src/daemon/supervisor.rs
+++ b/runner/src/daemon/supervisor.rs
@@ -13,7 +13,7 @@ use crate::cloud::http::{
     RunnerCloudClient, SharedHttpTransport,
 };
 use crate::cloud::protocol::{
-    ClientMsg, FailureReason, RunnerStatus, ServerMsg, WIRE_VERSION, WorkspaceState,
+    ClientMsg, FailureReason, RunEventRecord, RunnerStatus, ServerMsg, WIRE_VERSION, WorkspaceState,
 };
 use crate::config::schema::{AgentKind, Config, Credentials};
 use crate::daemon::runner_instance::RunnerInstance;
@@ -36,6 +36,10 @@ pub struct Supervisor {
 
 type HelloRunner = (RunnerOut, StateHandle, Option<String>);
 type HelloRunnerMap = HashMap<uuid::Uuid, HelloRunner>;
+
+const RUN_EVENT_BATCH_SIZE: usize = 32;
+const RUN_EVENT_FLUSH_INTERVAL: Duration = Duration::from_secs(1);
+const RUN_EVENT_SEND_TIMEOUT: Duration = Duration::from_secs(5);
 
 impl Supervisor {
     pub fn new(
@@ -2233,6 +2237,7 @@ impl AssignWorker {
         let shutdown = self.state.shutdown_notified();
         let cancel = self.cancel.clone();
         let mut cancelled = false;
+        let mut run_events = RunEventMirror::new(cursor.run_id());
         loop {
             // Re-evaluate at every loop entry: an approval that opened on
             // the previous iteration disarms the watchdog; one that just
@@ -2250,6 +2255,7 @@ impl AssignWorker {
                 }
                 _ = cancel.notified(), if !cancelled => {
                     bridge.interrupt().await.ok();
+                    run_events.flush(&self.out).await;
                     let _ = self.out.send(ClientMsg::RunCancelled {
                         run_id: cursor.run_id(),
                         cancelled_at: Utc::now(),
@@ -2273,6 +2279,7 @@ impl AssignWorker {
                         let detail = self
                             .build_failure_detail("agent stdout closed", bridge)
                             .await;
+                        run_events.flush(&self.out).await;
                         self.send(ClientMsg::RunFailed {
                             run_id: cursor.run_id(),
                             reason,
@@ -2289,12 +2296,16 @@ impl AssignWorker {
                     };
                     for ev in events {
                         if let Some(out) = self
-                            .handle_bridge_event(ev, bridge, hist, workspace_root)
+                            .handle_bridge_event(ev, bridge, hist, workspace_root, &mut run_events)
                             .await?
                         {
+                            run_events.flush(&self.out).await;
                             return Ok(out);
                         }
                     }
+                }
+                _ = tokio::time::sleep(RUN_EVENT_FLUSH_INTERVAL), if run_events.has_pending() => {
+                    run_events.flush(&self.out).await;
                 }
                 _ = async {
                     match stall_deadline {
@@ -2305,6 +2316,7 @@ impl AssignWorker {
                     let mins = stall_timeout.as_secs() / 60;
                     let base = format!("no agent frames for {mins} minutes");
                     let detail = self.build_failure_detail(&base, bridge).await;
+                    run_events.flush(&self.out).await;
                     self.send(ClientMsg::RunFailed {
                         run_id: cursor.run_id(),
                         reason: FailureReason::Timeout,
@@ -2407,6 +2419,7 @@ impl AssignWorker {
         bridge: &mut AgentBridge,
         hist: &mut HistoryWriter,
         workspace_root: &std::path::Path,
+        run_events: &mut RunEventMirror,
     ) -> Result<Option<Outcome>> {
         self.state.incr_current_run_events().await;
         // Observability: every bridge event bumps last_event_at + stamps
@@ -2417,8 +2430,11 @@ impl AssignWorker {
         let kind = crate::daemon::observability::kind_of(&ev);
         let summary = crate::daemon::observability::summary_of(&ev);
         self.state
-            .note_agent_event(Utc::now(), kind, Some(summary))
+            .note_agent_event(Utc::now(), kind.clone(), Some(summary.clone()))
             .await;
+        if run_events.push(kind, summary) {
+            run_events.flush(&self.out).await;
+        }
         if let BridgeEvent::Raw { method, params, .. } = &ev {
             match method.as_str() {
                 "codex/event/token_count" => {
@@ -2482,6 +2498,7 @@ impl AssignWorker {
                 payload,
                 reason,
             } => {
+                run_events.flush(&self.out).await;
                 let policy = Policy::new(&self.runner_config.approval_policy, workspace_root);
                 let decision = policy.evaluate(kind, &payload);
                 if let Some(auto) = decision.into_cloud() {
@@ -2569,6 +2586,7 @@ impl AssignWorker {
             }
             BridgeEvent::AwaitingReauth { run_id, detail } => {
                 self.state.set_status(RunnerStatus::AwaitingReauth).await;
+                run_events.flush(&self.out).await;
                 self.send(ClientMsg::RunAwaitingReauth {
                     run_id,
                     detail: detail.clone(),
@@ -2587,6 +2605,7 @@ impl AssignWorker {
                 run_id,
                 done_payload,
             } => {
+                run_events.flush(&self.out).await;
                 self.send(ClientMsg::RunCompleted {
                     run_id,
                     done_payload: done_payload.clone(),
@@ -2622,6 +2641,7 @@ impl AssignWorker {
                     .clone()
                     .unwrap_or_else(|| "agent reported failure".to_string());
                 let enriched = self.build_failure_detail(&base, bridge).await;
+                run_events.flush(&self.out).await;
                 self.send(ClientMsg::RunFailed {
                     run_id,
                     reason,
@@ -2651,6 +2671,70 @@ impl AssignWorker {
 
 struct Outcome {
     status_label: String,
+}
+
+struct RunEventMirror {
+    run_id: uuid::Uuid,
+    next_seq: u64,
+    pending: Vec<RunEventRecord>,
+}
+
+impl RunEventMirror {
+    fn new(run_id: uuid::Uuid) -> Self {
+        Self {
+            run_id,
+            next_seq: 0,
+            pending: Vec::with_capacity(RUN_EVENT_BATCH_SIZE),
+        }
+    }
+
+    fn has_pending(&self) -> bool {
+        !self.pending.is_empty()
+    }
+
+    fn push(&mut self, kind: String, summary: String) -> bool {
+        self.next_seq = self.next_seq.saturating_add(1);
+        self.pending.push(RunEventRecord {
+            seq: self.next_seq,
+            kind,
+            payload: serde_json::json!({
+                "schema": "runner_event_summary_v1",
+                "summary": summary,
+            }),
+        });
+        self.pending.len() >= RUN_EVENT_BATCH_SIZE
+    }
+
+    async fn flush(&mut self, out: &RunnerOut) {
+        if self.pending.is_empty() {
+            return;
+        }
+        let events = std::mem::take(&mut self.pending);
+        let count = events.len();
+        let msg = ClientMsg::RunEvents {
+            run_id: self.run_id,
+            events,
+        };
+        match tokio::time::timeout(RUN_EVENT_SEND_TIMEOUT, out.send(msg)).await {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => {
+                tracing::warn!(
+                    run_id = %self.run_id,
+                    count,
+                    error = %err,
+                    "failed to mirror agent run events"
+                );
+            }
+            Err(_) => {
+                tracing::warn!(
+                    run_id = %self.run_id,
+                    count,
+                    timeout_ms = RUN_EVENT_SEND_TIMEOUT.as_millis(),
+                    "timed out mirroring agent run events"
+                );
+            }
+        }
+    }
 }
 
 /// Best-effort: if codex hands us a non-UUID approval id (it shouldn't, per
@@ -2914,5 +2998,49 @@ mod tests {
             stray.is_err(),
             "idle drain produced a stray frame: {stray:?}"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn run_event_mirror_flushes_sanitized_batch() {
+        let runner_id = uuid::Uuid::new_v4();
+        let run_id = uuid::Uuid::new_v4();
+        let (out_tx, mut out_rx) = mpsc::channel::<Envelope<ClientMsg>>(8);
+        let out = RunnerOut::new(runner_id, out_tx);
+        let mut mirror = RunEventMirror::new(run_id);
+
+        assert!(!mirror.push(
+            "assistant/message".into(),
+            "raw method=assistant/message".into()
+        ));
+        assert!(!mirror.push("run/completed".into(), "run completed".into()));
+        mirror.flush(&out).await;
+
+        let env = tokio::time::timeout(std::time::Duration::from_secs(2), out_rx.recv())
+            .await
+            .expect("timed out waiting for RunEvents")
+            .expect("channel closed before RunEvents arrived");
+        assert_eq!(env.runner_id, Some(runner_id));
+        match env.body {
+            ClientMsg::RunEvents {
+                run_id: seen_run_id,
+                events,
+            } => {
+                assert_eq!(seen_run_id, run_id);
+                assert_eq!(events.len(), 2);
+                assert_eq!(events[0].seq, 1);
+                assert_eq!(events[0].kind, "assistant/message");
+                assert_eq!(
+                    events[0].payload,
+                    serde_json::json!({
+                        "schema": "runner_event_summary_v1",
+                        "summary": "raw method=assistant/message",
+                    })
+                );
+                assert_eq!(events[1].seq, 2);
+                assert_eq!(events[1].kind, "run/completed");
+                assert!(events[0].payload.get("params").is_none());
+            }
+            other => panic!("expected RunEvents, got {other:?}"),
+        }
     }
 }

--- a/runner/src/daemon/supervisor.rs
+++ b/runner/src/daemon/supervisor.rs
@@ -40,6 +40,9 @@ type HelloRunnerMap = HashMap<uuid::Uuid, HelloRunner>;
 const RUN_EVENT_BATCH_SIZE: usize = 32;
 const RUN_EVENT_FLUSH_INTERVAL: Duration = Duration::from_secs(1);
 const RUN_EVENT_SEND_TIMEOUT: Duration = Duration::from_secs(5);
+const RUN_EVENT_LIFECYCLE_FLUSH_ATTEMPTS: usize = 3;
+const RUN_EVENT_LIFECYCLE_RETRY_DELAY: Duration = Duration::from_millis(250);
+const RUN_EVENT_MAX_SEQ: u32 = i32::MAX as u32;
 
 impl Supervisor {
     pub fn new(
@@ -2247,15 +2250,17 @@ impl AssignWorker {
             } else {
                 None
             };
+            let run_event_flush_deadline = run_events.flush_deadline();
             tokio::select! {
                 biased;
                 _ = shutdown.notified(), if !cancelled => {
                     cancelled = true;
+                    run_events.flush_before_lifecycle(&self.out).await;
                     bridge.interrupt().await.ok();
                 }
                 _ = cancel.notified(), if !cancelled => {
+                    run_events.flush_before_lifecycle(&self.out).await;
                     bridge.interrupt().await.ok();
-                    run_events.flush(&self.out).await;
                     let _ = self.out.send(ClientMsg::RunCancelled {
                         run_id: cursor.run_id(),
                         cancelled_at: Utc::now(),
@@ -2273,13 +2278,21 @@ impl AssignWorker {
                     ).await;
                     return Ok(Outcome { status_label: "cancelled".into() });
                 }
+                _ = async {
+                    match run_event_flush_deadline {
+                        Some(d) => tokio::time::sleep_until(d).await,
+                        None => std::future::pending::<()>().await,
+                    }
+                } => {
+                    run_events.flush(&self.out).await;
+                }
                 events = bridge.next_events(cursor) => {
                     let Some(events) = events else {
                         let reason = self.crash_reason();
                         let detail = self
                             .build_failure_detail("agent stdout closed", bridge)
                             .await;
-                        run_events.flush(&self.out).await;
+                        run_events.flush_before_lifecycle(&self.out).await;
                         self.send(ClientMsg::RunFailed {
                             run_id: cursor.run_id(),
                             reason,
@@ -2299,13 +2312,9 @@ impl AssignWorker {
                             .handle_bridge_event(ev, bridge, hist, workspace_root, &mut run_events)
                             .await?
                         {
-                            run_events.flush(&self.out).await;
                             return Ok(out);
                         }
                     }
-                }
-                _ = tokio::time::sleep(RUN_EVENT_FLUSH_INTERVAL), if run_events.has_pending() => {
-                    run_events.flush(&self.out).await;
                 }
                 _ = async {
                     match stall_deadline {
@@ -2316,7 +2325,7 @@ impl AssignWorker {
                     let mins = stall_timeout.as_secs() / 60;
                     let base = format!("no agent frames for {mins} minutes");
                     let detail = self.build_failure_detail(&base, bridge).await;
-                    run_events.flush(&self.out).await;
+                    run_events.flush_before_lifecycle(&self.out).await;
                     self.send(ClientMsg::RunFailed {
                         run_id: cursor.run_id(),
                         reason: FailureReason::Timeout,
@@ -2498,7 +2507,7 @@ impl AssignWorker {
                 payload,
                 reason,
             } => {
-                run_events.flush(&self.out).await;
+                run_events.flush_before_lifecycle(&self.out).await;
                 let policy = Policy::new(&self.runner_config.approval_policy, workspace_root);
                 let decision = policy.evaluate(kind, &payload);
                 if let Some(auto) = decision.into_cloud() {
@@ -2586,7 +2595,7 @@ impl AssignWorker {
             }
             BridgeEvent::AwaitingReauth { run_id, detail } => {
                 self.state.set_status(RunnerStatus::AwaitingReauth).await;
-                run_events.flush(&self.out).await;
+                run_events.flush_before_lifecycle(&self.out).await;
                 self.send(ClientMsg::RunAwaitingReauth {
                     run_id,
                     detail: detail.clone(),
@@ -2605,7 +2614,7 @@ impl AssignWorker {
                 run_id,
                 done_payload,
             } => {
-                run_events.flush(&self.out).await;
+                run_events.flush_before_lifecycle(&self.out).await;
                 self.send(ClientMsg::RunCompleted {
                     run_id,
                     done_payload: done_payload.clone(),
@@ -2641,7 +2650,7 @@ impl AssignWorker {
                     .clone()
                     .unwrap_or_else(|| "agent reported failure".to_string());
                 let enriched = self.build_failure_detail(&base, bridge).await;
-                run_events.flush(&self.out).await;
+                run_events.flush_before_lifecycle(&self.out).await;
                 self.send(ClientMsg::RunFailed {
                     run_id,
                     reason,
@@ -2675,8 +2684,10 @@ struct Outcome {
 
 struct RunEventMirror {
     run_id: uuid::Uuid,
-    next_seq: u64,
+    next_seq: u32,
     pending: Vec<RunEventRecord>,
+    flush_deadline: Option<tokio::time::Instant>,
+    seq_exhausted_warned: bool,
 }
 
 impl RunEventMirror {
@@ -2685,15 +2696,31 @@ impl RunEventMirror {
             run_id,
             next_seq: 0,
             pending: Vec::with_capacity(RUN_EVENT_BATCH_SIZE),
+            flush_deadline: None,
+            seq_exhausted_warned: false,
         }
     }
 
-    fn has_pending(&self) -> bool {
-        !self.pending.is_empty()
+    fn flush_deadline(&self) -> Option<tokio::time::Instant> {
+        self.flush_deadline
     }
 
     fn push(&mut self, kind: String, summary: String) -> bool {
-        self.next_seq = self.next_seq.saturating_add(1);
+        if self.next_seq >= RUN_EVENT_MAX_SEQ {
+            if !self.seq_exhausted_warned {
+                self.seq_exhausted_warned = true;
+                tracing::warn!(
+                    run_id = %self.run_id,
+                    max_seq = RUN_EVENT_MAX_SEQ,
+                    "agent run event sequence exhausted; dropping further mirrored events"
+                );
+            }
+            return false;
+        }
+        if self.pending.is_empty() {
+            self.flush_deadline = Some(tokio::time::Instant::now() + RUN_EVENT_FLUSH_INTERVAL);
+        }
+        self.next_seq += 1;
         self.pending.push(RunEventRecord {
             seq: self.next_seq,
             kind,
@@ -2705,35 +2732,58 @@ impl RunEventMirror {
         self.pending.len() >= RUN_EVENT_BATCH_SIZE
     }
 
-    async fn flush(&mut self, out: &RunnerOut) {
+    async fn flush(&mut self, out: &RunnerOut) -> bool {
         if self.pending.is_empty() {
-            return;
+            self.flush_deadline = None;
+            return true;
         }
-        let events = std::mem::take(&mut self.pending);
+        let mut events = Vec::with_capacity(RUN_EVENT_BATCH_SIZE);
+        std::mem::swap(&mut events, &mut self.pending);
         let count = events.len();
         let msg = ClientMsg::RunEvents {
             run_id: self.run_id,
-            events,
+            events: events.clone(),
         };
         match tokio::time::timeout(RUN_EVENT_SEND_TIMEOUT, out.send(msg)).await {
-            Ok(Ok(())) => {}
+            Ok(Ok(())) => {
+                self.flush_deadline = None;
+                true
+            }
             Ok(Err(err)) => {
+                self.pending = events;
+                self.flush_deadline = Some(tokio::time::Instant::now() + RUN_EVENT_FLUSH_INTERVAL);
                 tracing::warn!(
                     run_id = %self.run_id,
                     count,
                     error = %err,
                     "failed to mirror agent run events"
                 );
+                false
             }
             Err(_) => {
+                self.pending = events;
+                self.flush_deadline = Some(tokio::time::Instant::now() + RUN_EVENT_FLUSH_INTERVAL);
                 tracing::warn!(
                     run_id = %self.run_id,
                     count,
                     timeout_ms = RUN_EVENT_SEND_TIMEOUT.as_millis(),
                     "timed out mirroring agent run events"
                 );
+                false
             }
         }
+    }
+
+    async fn flush_before_lifecycle(&mut self, out: &RunnerOut) -> bool {
+        for attempt in 0..RUN_EVENT_LIFECYCLE_FLUSH_ATTEMPTS {
+            if self.flush(out).await {
+                return true;
+            }
+            if attempt + 1 < RUN_EVENT_LIFECYCLE_FLUSH_ATTEMPTS {
+                tokio::time::sleep(RUN_EVENT_LIFECYCLE_RETRY_DELAY).await;
+            }
+        }
+        false
     }
 }
 
@@ -3013,7 +3063,7 @@ mod tests {
             "raw method=assistant/message".into()
         ));
         assert!(!mirror.push("run/completed".into(), "run completed".into()));
-        mirror.flush(&out).await;
+        assert!(mirror.flush(&out).await);
 
         let env = tokio::time::timeout(std::time::Duration::from_secs(2), out_rx.recv())
             .await
@@ -3038,9 +3088,91 @@ mod tests {
                 );
                 assert_eq!(events[1].seq, 2);
                 assert_eq!(events[1].kind, "run/completed");
-                assert!(events[0].payload.get("params").is_none());
+                assert_eq!(
+                    events[1].payload,
+                    serde_json::json!({
+                        "schema": "runner_event_summary_v1",
+                        "summary": "run completed",
+                    })
+                );
+                for event in events {
+                    let obj = event.payload.as_object().expect("payload object");
+                    assert_eq!(obj.len(), 2);
+                    assert!(obj.contains_key("schema"));
+                    assert!(obj.contains_key("summary"));
+                }
             }
             other => panic!("expected RunEvents, got {other:?}"),
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn run_event_mirror_retains_batch_after_send_failure() {
+        let runner_id = uuid::Uuid::new_v4();
+        let run_id = uuid::Uuid::new_v4();
+        let (failed_tx, failed_rx) = mpsc::channel::<Envelope<ClientMsg>>(1);
+        drop(failed_rx);
+        let failed_out = RunnerOut::new(runner_id, failed_tx);
+        let mut mirror = RunEventMirror::new(run_id);
+
+        mirror.push("assistant/message".into(), "raw method=assistant/message".into());
+        assert!(!mirror.flush(&failed_out).await);
+        assert_eq!(mirror.pending.len(), 1);
+        assert!(mirror.flush_deadline().is_some());
+
+        let (ok_tx, mut ok_rx) = mpsc::channel::<Envelope<ClientMsg>>(1);
+        let ok_out = RunnerOut::new(runner_id, ok_tx);
+        assert!(mirror.flush(&ok_out).await);
+        assert!(mirror.pending.is_empty());
+        assert!(mirror.flush_deadline().is_none());
+
+        let env = tokio::time::timeout(std::time::Duration::from_secs(2), ok_rx.recv())
+            .await
+            .expect("timed out waiting for retry")
+            .expect("channel closed before retry arrived");
+        match env.body {
+            ClientMsg::RunEvents { events, .. } => {
+                assert_eq!(events.len(), 1);
+                assert_eq!(events[0].seq, 1);
+            }
+            other => panic!("expected RunEvents, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn run_event_mirror_keeps_flush_deadline_until_flush() {
+        let run_id = uuid::Uuid::new_v4();
+        let mut mirror = RunEventMirror::new(run_id);
+
+        assert!(mirror.flush_deadline().is_none());
+        assert!(!mirror.push("raw".into(), "raw method=a".into()));
+        let first_deadline = mirror.flush_deadline().expect("deadline after first event");
+        assert!(!mirror.push("raw".into(), "raw method=b".into()));
+        assert_eq!(mirror.flush_deadline(), Some(first_deadline));
+    }
+
+    #[test]
+    fn run_event_mirror_auto_flushes_at_batch_size() {
+        let run_id = uuid::Uuid::new_v4();
+        let mut mirror = RunEventMirror::new(run_id);
+
+        for i in 0..RUN_EVENT_BATCH_SIZE {
+            let should_flush = mirror.push("raw".into(), format!("raw method={i}"));
+            assert_eq!(should_flush, i + 1 == RUN_EVENT_BATCH_SIZE);
+        }
+        assert_eq!(mirror.pending.len(), RUN_EVENT_BATCH_SIZE);
+    }
+
+    #[test]
+    fn run_event_mirror_caps_seq_at_cloud_column_limit() {
+        let run_id = uuid::Uuid::new_v4();
+        let mut mirror = RunEventMirror::new(run_id);
+        mirror.next_seq = RUN_EVENT_MAX_SEQ - 1;
+
+        assert!(!mirror.push("raw".into(), "raw method=last".into()));
+        assert_eq!(mirror.pending.last().map(|event| event.seq), Some(RUN_EVENT_MAX_SEQ));
+        assert!(!mirror.push("raw".into(), "raw method=dropped".into()));
+        assert_eq!(mirror.pending.len(), 1);
+        assert_eq!(mirror.next_seq, RUN_EVENT_MAX_SEQ);
     }
 }

--- a/runner/src/daemon/supervisor.rs
+++ b/runner/src/daemon/supervisor.rs
@@ -2439,7 +2439,7 @@ impl AssignWorker {
         let kind = crate::daemon::observability::kind_of(&ev);
         let summary = crate::daemon::observability::summary_of(&ev);
         self.state
-            .note_agent_event(Utc::now(), kind.clone(), Some(summary.clone()))
+            .note_agent_event(Utc::now(), &kind, Some(&summary))
             .await;
         if run_events.push(kind, summary) {
             run_events.flush(&self.out).await;

--- a/runner/tests/cloud_http_run_events.rs
+++ b/runner/tests/cloud_http_run_events.rs
@@ -1,0 +1,205 @@
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+
+use chrono::{Duration as ChronoDuration, Utc};
+use pidash::cloud::http::{
+    CredentialsHandle, RunnerCloudClient, RunnerCredentials, SharedHttpTransport,
+};
+use pidash::cloud::protocol::{ClientMsg, Envelope, RunEventRecord};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use uuid::Uuid;
+
+#[derive(Debug, Clone)]
+struct RecordedRequest {
+    method: String,
+    path: String,
+    authorization: Option<String>,
+    idempotency_key: Option<String>,
+    body: String,
+}
+
+async fn start_fake_cloud(
+    runner_id: Uuid,
+    run_id: Uuid,
+) -> (
+    SocketAddr,
+    Arc<Mutex<Vec<RecordedRequest>>>,
+    tokio::task::JoinHandle<()>,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let recorded = Arc::new(Mutex::new(Vec::new()));
+    let recorded_srv = recorded.clone();
+    let handle = tokio::spawn(async move {
+        loop {
+            let (socket, _) = match listener.accept().await {
+                Ok(v) => v,
+                Err(_) => return,
+            };
+            let recorded = recorded_srv.clone();
+            tokio::spawn(async move {
+                handle_conn(socket, recorded, runner_id, run_id).await;
+            });
+        }
+    });
+    (addr, recorded, handle)
+}
+
+async fn handle_conn(
+    mut socket: TcpStream,
+    recorded: Arc<Mutex<Vec<RecordedRequest>>>,
+    runner_id: Uuid,
+    run_id: Uuid,
+) {
+    let mut buf = Vec::with_capacity(4096);
+    let mut chunk = [0u8; 2048];
+    let mut headers_end = None;
+    loop {
+        let n = match socket.read(&mut chunk).await {
+            Ok(0) => break,
+            Ok(n) => n,
+            Err(_) => return,
+        };
+        buf.extend_from_slice(&chunk[..n]);
+        if let Some(idx) = find_header_end(&buf) {
+            headers_end = Some(idx);
+            let content_length = content_length(&buf[..idx]).unwrap_or(0);
+            if buf.len() >= idx + 4 + content_length {
+                break;
+            }
+        }
+    }
+    let Some(idx) = headers_end else { return };
+    let head = String::from_utf8_lossy(&buf[..idx]).to_string();
+    let body = String::from_utf8_lossy(&buf[idx + 4..]).to_string();
+
+    let mut lines = head.lines();
+    let request_line = lines.next().unwrap_or("");
+    let mut parts = request_line.split_whitespace();
+    let method = parts.next().unwrap_or("").to_string();
+    let path = parts.next().unwrap_or("").to_string();
+    let mut authorization = None;
+    let mut idempotency_key = None;
+    for line in lines {
+        if let Some(rest) = line
+            .strip_prefix("Authorization: ")
+            .or_else(|| line.strip_prefix("authorization: "))
+        {
+            authorization = Some(rest.to_string());
+        } else if let Some(rest) = line
+            .strip_prefix("Idempotency-Key: ")
+            .or_else(|| line.strip_prefix("idempotency-key: "))
+        {
+            idempotency_key = Some(rest.to_string());
+        }
+    }
+    recorded.lock().unwrap().push(RecordedRequest {
+        method: method.clone(),
+        path: path.clone(),
+        authorization,
+        idempotency_key,
+        body,
+    });
+
+    let refresh_path = format!("/api/v1/runner/runners/{runner_id}/refresh/");
+    let events_path = format!("/api/v1/runner/runs/{run_id}/events/");
+    let response = if method == "POST" && path == refresh_path {
+        let exp = (Utc::now() + ChronoDuration::hours(1)).to_rfc3339();
+        format!(
+            r#"{{"refresh_token":"refresh-2","access_token":"access-1","access_token_expires_at":"{exp}","refresh_token_generation":2}}"#
+        )
+    } else if method == "POST" && path == events_path {
+        r#"{"ok":true,"accepted":1}"#.to_string()
+    } else {
+        r#"{"error":"not found"}"#.to_string()
+    };
+    let status = if response.contains("not found") {
+        "404 Not Found"
+    } else {
+        "200 OK"
+    };
+    let payload = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        response.len(),
+        response
+    );
+    let _ = socket.write_all(payload.as_bytes()).await;
+}
+
+fn find_header_end(buf: &[u8]) -> Option<usize> {
+    buf.windows(4).position(|w| w == b"\r\n\r\n")
+}
+
+fn content_length(head: &[u8]) -> Option<usize> {
+    let head = std::str::from_utf8(head).ok()?;
+    for line in head.lines() {
+        if let Some(rest) = line
+            .strip_prefix("Content-Length: ")
+            .or_else(|| line.strip_prefix("content-length: "))
+        {
+            return rest.trim().parse().ok();
+        }
+    }
+    None
+}
+
+#[tokio::test]
+async fn http_transport_posts_run_events_batch_to_events_endpoint() {
+    let runner_id = Uuid::new_v4();
+    let run_id = Uuid::new_v4();
+    let (addr, recorded, _server) = start_fake_cloud(runner_id, run_id).await;
+    let temp = tempfile::tempdir().unwrap();
+    let creds = CredentialsHandle::new(
+        temp.path().join("credentials.toml"),
+        RunnerCredentials {
+            runner_id,
+            name: "runner".into(),
+            refresh_token: "refresh-1".into(),
+            refresh_token_generation: 1,
+        },
+    );
+    let transport = SharedHttpTransport::new(format!("http://{addr}")).unwrap();
+    let client = RunnerCloudClient::new(runner_id, creds, transport);
+
+    let env = Envelope::for_runner(
+        runner_id,
+        ClientMsg::RunEvents {
+            run_id,
+            events: vec![RunEventRecord {
+                seq: 1,
+                kind: "assistant/message".into(),
+                payload: serde_json::json!({
+                    "schema": "runner_event_summary_v1",
+                    "summary": "raw method=assistant/message",
+                }),
+            }],
+        },
+    );
+    client.dispatch_client_msg(env).await.unwrap();
+
+    let recorded = recorded.lock().unwrap();
+    assert_eq!(recorded.len(), 2);
+    assert_eq!(
+        recorded[0].path,
+        format!("/api/v1/runner/runners/{runner_id}/refresh/")
+    );
+    assert_eq!(
+        recorded[1].path,
+        format!("/api/v1/runner/runs/{run_id}/events/")
+    );
+    assert_eq!(recorded[1].method, "POST");
+    assert_eq!(
+        recorded[1].authorization.as_deref(),
+        Some("Bearer access-1")
+    );
+    assert!(recorded[1].idempotency_key.is_some());
+    let body: serde_json::Value = serde_json::from_str(&recorded[1].body).unwrap();
+    assert_eq!(body["type"], "run_events");
+    assert_eq!(body["run_id"], run_id.to_string());
+    assert_eq!(body["events"][0]["seq"], 1);
+    assert_eq!(
+        body["events"][0]["payload"]["summary"],
+        "raw method=assistant/message"
+    );
+}

--- a/runner/tests/protocol_roundtrip.rs
+++ b/runner/tests/protocol_roundtrip.rs
@@ -6,7 +6,8 @@ use pidash::approval::{
     router::{ApprovalRecord, ApprovalRouter, ApprovalStatus, DecisionSource},
 };
 use pidash::cloud::protocol::{
-    ApprovalDecision, ApprovalKind, ClientMsg, Envelope, RunnerStatus, ServerMsg, WIRE_VERSION,
+    ApprovalDecision, ApprovalKind, ClientMsg, Envelope, RunEventRecord, RunnerStatus, ServerMsg,
+    WIRE_VERSION,
 };
 use pidash::config::schema::ApprovalPolicySection;
 use std::path::Path;
@@ -34,6 +35,17 @@ fn envelope_roundtrips_all_client_variants() {
             run_id: Uuid::new_v4(),
             done_payload: serde_json::json!({"conclusion": "success"}),
             ended_at: chrono::Utc::now(),
+        },
+        ClientMsg::RunEvents {
+            run_id: Uuid::new_v4(),
+            events: vec![RunEventRecord {
+                seq: 1,
+                kind: "assistant/message".into(),
+                payload: serde_json::json!({
+                    "schema": "runner_event_summary_v1",
+                    "summary": "raw method=assistant/message",
+                }),
+            }],
         },
     ];
     for v in variants {


### PR DESCRIPTION
## Summary

- Add a batched `RunEvents` runner protocol message and route it through the existing run-events HTTP endpoint.
- Mirror async agent bridge events from the runner supervisor into cloud `AgentRunEvent` rows.
- Store sanitized event summaries only, avoiding raw model/tool payloads while still making the Runs page show progress.

## Root Cause

Async issue-assignment runs counted bridge events locally and wrote local history, but never sent `ClientMsg::RunEvent` to the cloud. As a result, runs could complete successfully while `GET /api/runners/runs/<id>/?include_events=1` returned zero events.

## Validation

- `cargo check -p pidash`
- `cargo test -p pidash run_event_mirror_flushes_sanitized_batch`
