### PR TITLE
feat(web): restructure left sidebar around AI orchestration

### DIFF
--- a/apps/web/app/(all)/[workspaceSlug]/prompts/layout.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/prompts/layout.tsx
@@ -8,13 +8,16 @@ import { observer } from "mobx-react";
 import { Outlet } from "react-router";
 import { EUserPermissions, EUserPermissionsLevel } from "@pi-dash/constants";
 import { NotAuthorizedView } from "@/components/auth-screens/not-authorized-view";
-import { WorkspaceShell } from "@/components/workspace/workspace-shell";
 import { useUserPermissions } from "@/hooks/store/user";
 
 /**
  * Wrapper for the ``/:workspaceSlug/prompts/*`` routes. Any active workspace
  * member (Admin / Member / Guest) can *view* prompt templates; create and
  * edit operations are gated per-action on the page, not here.
+ *
+ * The parent (projects) layout already provides the WorkspaceShell (sidebar +
+ * main); this layout must NOT wrap in a second one or the workspace sidebar
+ * mirrors into the content area.
  */
 const PromptsLayout = observer(function PromptsLayout() {
   const { workspaceUserInfo, allowPermissions } = useUserPermissions();
@@ -25,19 +28,13 @@ const PromptsLayout = observer(function PromptsLayout() {
   );
 
   if (workspaceUserInfo && !canView) {
-    return (
-      <WorkspaceShell>
-        <NotAuthorizedView section="general" className="h-auto" />
-      </WorkspaceShell>
-    );
+    return <NotAuthorizedView section="general" className="h-auto" />;
   }
 
   return (
-    <WorkspaceShell>
-      <div className="flex-1 overflow-auto">
-        <Outlet />
-      </div>
-    </WorkspaceShell>
+    <div className="flex-1 overflow-auto">
+      <Outlet />
+    </div>
   );
 });
 

--- a/apps/web/app/(all)/[workspaceSlug]/prompts/layout.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/prompts/layout.tsx
@@ -28,7 +28,11 @@ const PromptsLayout = observer(function PromptsLayout() {
   );
 
   if (workspaceUserInfo && !canView) {
-    return <NotAuthorizedView section="general" className="h-auto" />;
+    return (
+      <div className="flex-1 overflow-auto">
+        <NotAuthorizedView section="general" className="h-auto" />
+      </div>
+    );
   }
 
   return (

--- a/apps/web/app/(all)/[workspaceSlug]/schedulers/layout.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/schedulers/layout.tsx
@@ -8,7 +8,6 @@ import { observer } from "mobx-react";
 import { Outlet } from "react-router";
 import { EUserPermissions, EUserPermissionsLevel } from "@pi-dash/constants";
 import { NotAuthorizedView } from "@/components/auth-screens/not-authorized-view";
-import { WorkspaceShell } from "@/components/workspace/workspace-shell";
 import { useUserPermissions } from "@/hooks/store/user";
 
 /**
@@ -16,6 +15,10 @@ import { useUserPermissions } from "@/hooks/store/user";
  * workspace member can *view* scheduler definitions (so the project-side
  * install picker has something to populate); workspace-admin checks gate
  * mutations on the page itself.
+ *
+ * The parent (projects) layout already provides the WorkspaceShell (sidebar +
+ * main); this layout must NOT wrap in a second one or the workspace sidebar
+ * mirrors into the content area.
  */
 const SchedulersLayout = observer(function SchedulersLayout() {
   const { workspaceUserInfo, allowPermissions } = useUserPermissions();
@@ -26,19 +29,13 @@ const SchedulersLayout = observer(function SchedulersLayout() {
   );
 
   if (workspaceUserInfo && !canView) {
-    return (
-      <WorkspaceShell>
-        <NotAuthorizedView section="general" className="h-auto" />
-      </WorkspaceShell>
-    );
+    return <NotAuthorizedView section="general" className="h-auto" />;
   }
 
   return (
-    <WorkspaceShell>
-      <div className="flex-1 overflow-auto">
-        <Outlet />
-      </div>
-    </WorkspaceShell>
+    <div className="flex-1 overflow-auto">
+      <Outlet />
+    </div>
   );
 });
 

--- a/apps/web/app/(all)/[workspaceSlug]/schedulers/layout.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/schedulers/layout.tsx
@@ -29,7 +29,11 @@ const SchedulersLayout = observer(function SchedulersLayout() {
   );
 
   if (workspaceUserInfo && !canView) {
-    return <NotAuthorizedView section="general" className="h-auto" />;
+    return (
+      <div className="flex-1 overflow-auto">
+        <NotAuthorizedView section="general" className="h-auto" />
+      </div>
+    );
   }
 
   return (

--- a/apps/web/ce/components/navigations/top-navigation-root.tsx
+++ b/apps/web/ce/components/navigations/top-navigation-root.tsx
@@ -12,7 +12,6 @@ import { cn } from "@pi-dash/utils";
 import { TopNavPowerK } from "@/components/navigation";
 import { AppSidebarToggleButton } from "@/components/sidebar/sidebar-toggle-button";
 import { HelpMenuRoot } from "@/components/workspace/sidebar/help-section/root";
-import { UserMenuRoot } from "@/components/workspace/sidebar/user-menu-root";
 import { WorkspaceMenuRoot } from "@/components/workspace/sidebar/workspace-menu-root";
 import { useAppTheme } from "@/hooks/store/use-app-theme";
 import { useAppRailPreferences } from "@/hooks/use-navigation-preferences";
@@ -97,9 +96,6 @@ export const TopNavigationRoot = observer(function TopNavigationRoot() {
         </Tooltip>
         <HelpMenuRoot />
         <StarUsOnGitHubLink />
-        <div className="flex size-8 items-center justify-center rounded-md hover:bg-layer-1-hover">
-          <UserMenuRoot />
-        </div>
       </div>
     </div>
   );

--- a/apps/web/ce/components/navigations/top-navigation-root.tsx
+++ b/apps/web/ce/components/navigations/top-navigation-root.tsx
@@ -12,6 +12,7 @@ import { cn } from "@pi-dash/utils";
 import { TopNavPowerK } from "@/components/navigation";
 import { AppSidebarToggleButton } from "@/components/sidebar/sidebar-toggle-button";
 import { HelpMenuRoot } from "@/components/workspace/sidebar/help-section/root";
+import { UserMenuRoot } from "@/components/workspace/sidebar/user-menu-root";
 import { WorkspaceMenuRoot } from "@/components/workspace/sidebar/workspace-menu-root";
 import { useAppTheme } from "@/hooks/store/use-app-theme";
 import { useAppRailPreferences } from "@/hooks/use-navigation-preferences";
@@ -96,6 +97,14 @@ export const TopNavigationRoot = observer(function TopNavigationRoot() {
         </Tooltip>
         <HelpMenuRoot />
         <StarUsOnGitHubLink />
+        {/* Fallback user menu — only when the sidebar (which hosts the canonical bottom user menu)
+            is not mounted or is collapsed. Keeps Settings/Sign-out reachable on /notifications,
+            /settings, and when the sidebar is collapsed. */}
+        {(!sidebarMounted || sidebarCollapsed) && (
+          <div className="flex size-8 items-center justify-center rounded-md hover:bg-layer-1-hover">
+            <UserMenuRoot />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/web/ce/components/workspace/sidebar/sidebar-item.tsx
+++ b/apps/web/ce/components/workspace/sidebar/sidebar-item.tsx
@@ -9,8 +9,9 @@ import { SidebarItemBase } from "@/components/workspace/sidebar/sidebar-item";
 
 type Props = {
   item: IWorkspaceSidebarNavigationItem;
+  additionalStaticItems?: string[];
 };
 
-export function SidebarItem({ item }: Props) {
-  return <SidebarItemBase item={item} />;
+export function SidebarItem({ item, additionalStaticItems }: Props) {
+  return <SidebarItemBase item={item} additionalStaticItems={additionalStaticItems} />;
 }

--- a/apps/web/core/components/navigation/customize-navigation-dialog.tsx
+++ b/apps/web/core/components/navigation/customize-navigation-dialog.tsx
@@ -5,21 +5,15 @@
  */
 
 import { useCallback, useMemo, useState } from "react";
+import { orderBy } from "lodash-es";
 import { observer } from "mobx-react";
-import { useParams } from "next/navigation";
 import { GripVertical, X } from "lucide-react";
 // pi dash imports
-import { WORKSPACE_SIDEBAR_DYNAMIC_NAVIGATION_ITEMS_LINKS, EUserPermissionsLevel } from "@pi-dash/constants";
 import { useTranslation } from "@pi-dash/i18n";
 import { Checkbox, EModalPosition, EModalWidth, ModalCore, Sortable } from "@pi-dash/ui";
 import { cn } from "@pi-dash/utils";
 // hooks
-import { useUserPermissions } from "@/hooks/store/user";
-import {
-  usePersonalNavigationPreferences,
-  useProjectNavigationPreferences,
-  useWorkspaceNavigationPreferences,
-} from "@/hooks/use-navigation-preferences";
+import { usePersonalNavigationPreferences, useProjectNavigationPreferences } from "@/hooks/use-navigation-preferences";
 // helpers
 import { getSidebarNavigationItemIcon } from "@/pi-dash-web/components/workspace/sidebar/helper";
 // types
@@ -30,18 +24,18 @@ type TCustomizeNavigationDialogProps = {
   onClose: () => void;
 };
 
-type TWorkspaceNavigationItem = {
-  key: string;
-  labelTranslationKey: string;
-  isPinned: boolean;
-  sortOrder: number;
-};
-
 const PERSONAL_ITEMS: Array<{ key: TPersonalNavigationItemKey; labelTranslationKey: string }> = [
   { key: "stickies", labelTranslationKey: "sidebar.stickies" },
   { key: "your_work", labelTranslationKey: "sidebar.your_work" },
   { key: "drafts", labelTranslationKey: "drafts" },
 ];
+
+// Block: e, E, +, -, . — extracted to module scope so the handler isn't recreated on every render.
+const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  if (["e", "E", "+", "-", "."].includes(e.key)) {
+    e.preventDefault();
+  }
+};
 
 export const CustomizeNavigationDialog = observer(function CustomizeNavigationDialog(
   props: TCustomizeNavigationDialogProps
@@ -49,11 +43,7 @@ export const CustomizeNavigationDialog = observer(function CustomizeNavigationDi
   const { isOpen, onClose } = props;
   const { t } = useTranslation();
 
-  // router
-  const { workspaceSlug } = useParams();
-
   // store hooks
-  const { allowPermissions } = useUserPermissions();
   const {
     preferences: personalPreferences,
     togglePersonalItem,
@@ -65,64 +55,12 @@ export const CustomizeNavigationDialog = observer(function CustomizeNavigationDi
     updateShowLimitedProjects,
     updateLimitedProjectsCount,
   } = useProjectNavigationPreferences();
-  const {
-    preferences: workspacePreferences,
-    toggleWorkspaceItem,
-    updateWorkspaceItemOrder,
-  } = useWorkspaceNavigationPreferences();
 
   // local state for limited projects count input
   const [projectCountInput, setProjectCountInput] = useState(projectPreferences.limitedProjectsCount.toString());
 
   // Filter personal items by feature flags
   const filteredPersonalItems = PERSONAL_ITEMS;
-
-  // Filter workspace items by permissions and feature flags, then get pinned/unpinned items
-  const workspaceItems = useMemo(() => {
-    const items = WORKSPACE_SIDEBAR_DYNAMIC_NAVIGATION_ITEMS_LINKS.filter((item) => {
-      // Permission check
-      const hasPermission = allowPermissions(
-        item.access,
-        EUserPermissionsLevel.WORKSPACE,
-        workspaceSlug?.toString() || ""
-      );
-      return hasPermission;
-    }).map((item) => {
-      // Get pinned status and sort order from localStorage
-      const preference = workspacePreferences.items[item.key];
-      const isPinned = preference?.is_pinned ?? false;
-      const sortOrder = preference?.sort_order ?? 0;
-
-      return {
-        key: item.key,
-        labelTranslationKey: item.labelTranslationKey,
-        isPinned,
-        sortOrder,
-      };
-    });
-
-    return items.sort((a, b) => a.sortOrder - b.sortOrder);
-  }, [workspaceSlug, allowPermissions, workspacePreferences]);
-
-  // Handle checkbox toggle
-  const handleWorkspaceItemToggle = useCallback(
-    (itemKey: string, checked: boolean) => {
-      toggleWorkspaceItem(itemKey, checked);
-    },
-    [toggleWorkspaceItem]
-  );
-
-  // Handle reorder of pinned workspace items
-  const handleReorder = useCallback(
-    (newData: TWorkspaceNavigationItem[]) => {
-      const itemsWithOrder = newData.map((item, index) => ({
-        key: item.key,
-        sortOrder: index,
-      }));
-      updateWorkspaceItemOrder(itemsWithOrder);
-    },
-    [updateWorkspaceItemOrder]
-  );
 
   // Handle reorder of enabled personal items
   const handlePersonalReorder = useCallback(
@@ -150,16 +88,8 @@ export const CustomizeNavigationDialog = observer(function CustomizeNavigationDi
       };
     });
 
-    return items.sort((a, b) => a.sortOrder - b.sortOrder);
+    return orderBy(items, ["sortOrder"], ["asc"]);
   }, [personalPreferences, filteredPersonalItems]);
-
-  // Prevent typing invalid characters in number input
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    // Block: e, E, +, -, .
-    if (["e", "E", "+", "-", "."].includes(e.key)) {
-      e.preventDefault();
-    }
-  };
 
   // Handle project count input change
   const handleProjectCountChange = (value: string) => {
@@ -185,8 +115,8 @@ export const CustomizeNavigationDialog = observer(function CustomizeNavigationDi
           <div>
             <h2 className="text-18 font-semibold text-primary">{t("customize_navigation")}</h2>
             <p className="mt-1 text-13 text-tertiary">
-              Selected items will always stay visible in your sidebar. You can still find the others anytime from the
-              More menu. These changes are personal to you and won&apos;t affect anyone else on your workspace.
+              Toggle which personal items appear in the sidebar and configure how projects are listed. These changes are
+              personal to you and won&apos;t affect anyone else on your workspace.
             </p>
           </div>
           <button
@@ -228,36 +158,6 @@ export const CustomizeNavigationDialog = observer(function CustomizeNavigationDi
             </div>
           </div>
 
-          {/* Workspace Section */}
-          <div className="flex flex-col gap-2">
-            <h3 className="text-13 font-semibold text-placeholder">{t("workspace")}</h3>
-            <div className="rounded-md border border-subtle bg-surface-2 py-2">
-              {/* Pinned Items - Draggable */}
-              <Sortable
-                data={workspaceItems}
-                onChange={handleReorder}
-                keyExtractor={(item) => item.key}
-                id="workspace-pinned-items"
-                render={(item) => {
-                  const icon = getSidebarNavigationItemIcon(item.key);
-                  return (
-                    <div className="group flex items-center gap-2 rounded-md px-2 py-1.5 transition-all duration-200 hover:bg-surface-2">
-                      <GripVertical className="size-4 cursor-grab text-placeholder transition-colors active:cursor-grabbing" />
-                      <Checkbox
-                        checked={!!workspacePreferences.items[item.key]?.is_pinned}
-                        onChange={(e) => handleWorkspaceItemToggle(item.key, e.target.checked)}
-                      />
-                      <div className="flex flex-1 items-center gap-2">
-                        {icon}
-                        <span className="text-13 text-primary">{t(item.labelTranslationKey)}</span>
-                      </div>
-                    </div>
-                  );
-                }}
-              />
-            </div>
-          </div>
-
           {/* Projects Section */}
           <div className="flex flex-col gap-2">
             <h3 className="text-13 font-semibold text-placeholder">{t("projects")}</h3>
@@ -266,7 +166,10 @@ export const CustomizeNavigationDialog = observer(function CustomizeNavigationDi
               <div className="space-y-3">
                 {/* Navigation Mode Radio Buttons */}
                 <div className="space-y-2">
-                  <label className="flex cursor-pointer gap-2 rounded-md px-2 py-1.5 hover:bg-surface-2">
+                  <label
+                    aria-label={t("accordion_navigation_control")}
+                    className="flex cursor-pointer gap-2 rounded-md px-2 py-1.5 hover:bg-surface-2"
+                  >
                     <input
                       type="radio"
                       name="navigation-mode"
@@ -283,7 +186,10 @@ export const CustomizeNavigationDialog = observer(function CustomizeNavigationDi
                     </div>
                   </label>
 
-                  <label className="flex cursor-pointer gap-2 rounded-md px-2 py-1.5 hover:bg-surface-2">
+                  <label
+                    aria-label={t("horizontal_navigation_bar")}
+                    className="flex cursor-pointer gap-2 rounded-md px-2 py-1.5 hover:bg-surface-2"
+                  >
                     <input
                       type="radio"
                       name="navigation-mode"

--- a/apps/web/core/components/sidebar/sidebar-wrapper.tsx
+++ b/apps/web/core/components/sidebar/sidebar-wrapper.tsx
@@ -79,10 +79,15 @@ export const SidebarWrapper = observer(function SidebarWrapper(props: TSidebarWr
         >
           {children}
         </ScrollArea>
-        {/* User menu (folds Community in as a sub-item) */}
-        <div className="flex items-center border-t border-subtle bg-surface-1 px-2 py-2">
-          <UserMenuRoot variant="sidebar" />
-        </div>
+        {/* User menu (folds Community in as a sub-item). Only mounted when the
+            sidebar is fully visible — when collapsed, TopNavigationRoot renders
+            the compact fallback instead, so there is exactly one UserMenuRoot
+            on screen at any time. */}
+        {!sidebarCollapsed && (
+          <div className="flex items-center border-t border-subtle bg-surface-1 px-2 py-2">
+            <UserMenuRoot variant="sidebar" />
+          </div>
+        )}
       </div>
     </>
   );

--- a/apps/web/core/components/sidebar/sidebar-wrapper.tsx
+++ b/apps/web/core/components/sidebar/sidebar-wrapper.tsx
@@ -16,8 +16,7 @@ import { CustomizeNavigationDialog } from "@/components/navigation/customize-nav
 import { useAppTheme } from "@/hooks/store/use-app-theme";
 import useSize from "@/hooks/use-window-size";
 // pi dash web components
-import { WorkspaceEditionBadge } from "@/pi-dash-web/components/workspace/edition-badge";
-import { AppSidebarToggleButton } from "./sidebar-toggle-button";
+import { UserMenuRoot } from "@/components/workspace/sidebar/user-menu-root";
 import { IconButton } from "@pi-dash/propel/icon-button";
 
 type TSidebarWrapperProps = {
@@ -57,7 +56,7 @@ export const SidebarWrapper = observer(function SidebarWrapper(props: TSidebarWr
           <div className="flex items-center justify-between gap-2 px-2">
             <span className="pt-1 text-16 font-medium text-primary">{title}</span>
             <div className="flex items-center gap-2">
-              {title === "Projects" && (
+              {title === "Pi Dash" && (
                 <IconButton
                   size="base"
                   variant="ghost"
@@ -65,7 +64,6 @@ export const SidebarWrapper = observer(function SidebarWrapper(props: TSidebarWr
                   onClick={() => setIsCustomizeNavDialogOpen(true)}
                 />
               )}
-              <AppSidebarToggleButton />
             </div>
           </div>
           {/* Quick actions */}
@@ -81,14 +79,9 @@ export const SidebarWrapper = observer(function SidebarWrapper(props: TSidebarWr
         >
           {children}
         </ScrollArea>
-        {/* Help Section */}
-        <div className="flex h-12 items-center justify-between border-t border-subtle bg-surface-1 p-3">
-          <WorkspaceEditionBadge />
-          {/* TODO: To be checked if we need this */}
-          {/* <div className="flex items-center gap-2">
-          {!shouldRenderAppRail && <HelpMenu />}
-          {!isAppRailEnabled && <AppSidebarToggleButton />}
-        </div> */}
+        {/* User menu (folds Community in as a sub-item) */}
+        <div className="flex items-center border-t border-subtle bg-surface-1 px-2 py-2">
+          <UserMenuRoot variant="sidebar" />
         </div>
       </div>
     </>

--- a/apps/web/core/components/workspace/sidebar/app/workspace-app-sidebar.tsx
+++ b/apps/web/core/components/workspace/sidebar/app/workspace-app-sidebar.tsx
@@ -15,27 +15,17 @@ import { ResizableSidebar } from "@/components/sidebar/resizable-sidebar";
 // hooks
 import { useAppTheme } from "@/hooks/store/use-app-theme";
 // local imports
-import { ExtendedWorkspaceSidebar } from "./extended-workspace-sidebar";
 import { WorkspaceSidebar } from "./workspace-sidebar";
 
 export const WorkspaceAppSidebar = observer(function WorkspaceAppSidebar() {
   // store hooks
-  const {
-    sidebarCollapsed,
-    toggleSidebar,
-    sidebarPeek,
-    toggleSidebarPeek,
-    isExtendedSidebarOpened,
-    isAnySidebarDropdownOpen,
-  } = useAppTheme();
+  const { sidebarCollapsed, toggleSidebar, sidebarPeek, toggleSidebarPeek, isAnySidebarDropdownOpen } = useAppTheme();
   const { storedValue, setValue } = useLocalStorage("sidebarWidth", SIDEBAR_WIDTH);
   // states
   const [sidebarWidth, setSidebarWidth] = useState<number>(storedValue ?? SIDEBAR_WIDTH);
   // routes
   const { workspaceSlug } = useParams();
   const pathname = usePathname();
-  // derived values
-  const isAnyExtendedSidebarOpen = isExtendedSidebarOpened;
 
   const isNotificationsPath = pathname.includes(`/${workspaceSlug}/notifications`);
 
@@ -45,29 +35,22 @@ export const WorkspaceAppSidebar = observer(function WorkspaceAppSidebar() {
   if (isNotificationsPath) return null;
 
   return (
-    <>
-      <ResizableSidebar
-        showPeek={sidebarPeek}
-        defaultWidth={storedValue ?? 250}
-        width={sidebarWidth}
-        setWidth={setSidebarWidth}
-        defaultCollapsed={sidebarCollapsed}
-        peekDuration={1500}
-        onWidthChange={handleWidthChange}
-        onCollapsedChange={toggleSidebar}
-        isCollapsed={sidebarCollapsed}
-        toggleCollapsed={toggleSidebar}
-        togglePeek={toggleSidebarPeek}
-        extendedSidebar={
-          <>
-            <ExtendedWorkspaceSidebar />
-          </>
-        }
-        isAnyExtendedSidebarExpanded={isAnyExtendedSidebarOpen}
-        isAnySidebarDropdownOpen={isAnySidebarDropdownOpen}
-      >
-        <WorkspaceSidebar />
-      </ResizableSidebar>
-    </>
+    <ResizableSidebar
+      showPeek={sidebarPeek}
+      defaultWidth={storedValue ?? 250}
+      width={sidebarWidth}
+      setWidth={setSidebarWidth}
+      defaultCollapsed={sidebarCollapsed}
+      peekDuration={1500}
+      onWidthChange={handleWidthChange}
+      onCollapsedChange={toggleSidebar}
+      isCollapsed={sidebarCollapsed}
+      toggleCollapsed={toggleSidebar}
+      togglePeek={toggleSidebarPeek}
+      isAnyExtendedSidebarExpanded={false}
+      isAnySidebarDropdownOpen={isAnySidebarDropdownOpen}
+    >
+      <WorkspaceSidebar />
+    </ResizableSidebar>
   );
 });

--- a/apps/web/core/components/workspace/sidebar/app/workspace-sidebar.tsx
+++ b/apps/web/core/components/workspace/sidebar/app/workspace-sidebar.tsx
@@ -11,6 +11,7 @@ import { EUserPermissions, EUserPermissionsLevel } from "@pi-dash/constants";
 // components
 import { SidebarWrapper } from "@/components/sidebar/sidebar-wrapper";
 import { SidebarFavoritesMenu } from "@/components/workspace/sidebar/favorites/favorites-menu";
+import { SidebarMoreSection } from "@/components/workspace/sidebar/more-section";
 import { SidebarProjectsList } from "@/components/workspace/sidebar/projects-list";
 import { SidebarQuickActions } from "@/components/workspace/sidebar/quick-actions";
 import { SidebarMenuItems } from "@/components/workspace/sidebar/sidebar-menu-items";
@@ -34,14 +35,16 @@ export const WorkspaceSidebar = observer(function WorkspaceSidebar() {
   const isFavoriteEmpty = isEmpty(groupedFavorites);
 
   return (
-    <SidebarWrapper title="Projects" quickActions={<SidebarQuickActions />}>
+    <SidebarWrapper title="Pi Dash" quickActions={<SidebarQuickActions />}>
       <SidebarMenuItems />
       {/* Favorites Menu */}
       {canPerformWorkspaceMemberActions && !isFavoriteEmpty && <SidebarFavoritesMenu />}
       {/* Teams List */}
       <SidebarTeamsList />
-      {/* Projects List */}
+      {/* Projects List (renders Drafts + Work Items as the first two items) */}
       <SidebarProjectsList />
+      {/* More — Prompts, Schedulers, Analytics */}
+      <SidebarMoreSection />
     </SidebarWrapper>
   );
 });

--- a/apps/web/core/components/workspace/sidebar/more-section.tsx
+++ b/apps/web/core/components/workspace/sidebar/more-section.tsx
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { observer } from "mobx-react";
+import { Disclosure, Transition } from "@headlessui/react";
+// pi dash imports
+import {
+  WORKSPACE_SIDEBAR_DYNAMIC_NAVIGATION_ITEMS,
+  WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS,
+} from "@pi-dash/constants";
+import { ChevronRightIcon } from "@pi-dash/propel/icons";
+import { cn } from "@pi-dash/utils";
+// hooks
+import useLocalStorage from "@/hooks/use-local-storage";
+// components
+import { SidebarItemBase } from "@/components/workspace/sidebar/sidebar-item";
+
+const MORE_ITEM_KEYS = ["prompts", "schedulers", "analytics", "archives"];
+
+const MORE_STATIC_KEYS = ["analytics", "archives"];
+
+export const SidebarMoreSection = observer(function SidebarMoreSection() {
+  const { setValue: toggleMoreMenu, storedValue: isMoreMenuOpen } = useLocalStorage<boolean>(
+    "is_sidebar_more_menu_open",
+    true
+  );
+
+  const items = MORE_ITEM_KEYS.map(
+    (key) => WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS[key] ?? WORKSPACE_SIDEBAR_DYNAMIC_NAVIGATION_ITEMS[key]
+  ).filter((item): item is NonNullable<typeof item> => Boolean(item));
+
+  const toggleListDisclosure = (isOpen: boolean) => {
+    toggleMoreMenu(isOpen);
+  };
+
+  return (
+    <Disclosure as="div" className="flex flex-col" defaultOpen={!!isMoreMenuOpen}>
+      <div className="group flex w-full items-center justify-between rounded-sm px-2 py-1.5 text-placeholder hover:bg-layer-transparent-hover">
+        <Disclosure.Button
+          as="button"
+          type="button"
+          className="flex w-full items-center gap-1 text-left text-13 font-semibold whitespace-nowrap text-placeholder"
+          onClick={() => toggleListDisclosure(!isMoreMenuOpen)}
+        >
+          <span className="text-13 font-semibold">More</span>
+        </Disclosure.Button>
+        <div className="pointer-events-none flex items-center opacity-0 group-hover:pointer-events-auto group-hover:opacity-100">
+          <Disclosure.Button
+            as="button"
+            type="button"
+            className="flex-shrink-0 rounded-sm p-0.5 hover:bg-layer-1"
+            onClick={() => toggleListDisclosure(!isMoreMenuOpen)}
+          >
+            <ChevronRightIcon
+              className={cn("size-3 flex-shrink-0 transition-all", {
+                "rotate-90": isMoreMenuOpen,
+              })}
+            />
+          </Disclosure.Button>
+        </div>
+      </div>
+      <Transition
+        show={!!isMoreMenuOpen}
+        enter="transition duration-100 ease-out"
+        enterFrom="transform scale-95 opacity-0"
+        enterTo="transform scale-100 opacity-100"
+        leave="transition duration-75 ease-out"
+        leaveFrom="transform scale-100 opacity-100"
+        leaveTo="transform scale-95 opacity-0"
+      >
+        {isMoreMenuOpen && (
+          <Disclosure.Panel as="div" className="flex flex-col gap-0.5" static>
+            {items.map((item) => (
+              <SidebarItemBase key={item.key} item={item} additionalStaticItems={MORE_STATIC_KEYS} />
+            ))}
+          </Disclosure.Panel>
+        )}
+      </Transition>
+    </Disclosure>
+  );
+});

--- a/apps/web/core/components/workspace/sidebar/more-section.tsx
+++ b/apps/web/core/components/workspace/sidebar/more-section.tsx
@@ -15,8 +15,8 @@ import { ChevronRightIcon } from "@pi-dash/propel/icons";
 import { cn } from "@pi-dash/utils";
 // hooks
 import useLocalStorage from "@/hooks/use-local-storage";
-// components
-import { SidebarItemBase } from "@/components/workspace/sidebar/sidebar-item";
+// pi-dash-web imports
+import { SidebarItem } from "@/pi-dash-web/components/workspace/sidebar/sidebar-item";
 
 const MORE_ITEM_KEYS = ["projects", "prompts", "schedulers", "analytics", "archives"];
 
@@ -74,7 +74,7 @@ export const SidebarMoreSection = observer(function SidebarMoreSection() {
         {isMoreMenuOpen && (
           <Disclosure.Panel as="div" className="flex flex-col gap-0.5" static>
             {items.map((item) => (
-              <SidebarItemBase key={item.key} item={item} additionalStaticItems={MORE_STATIC_KEYS} />
+              <SidebarItem key={item.key} item={item} additionalStaticItems={MORE_STATIC_KEYS} />
             ))}
           </Disclosure.Panel>
         )}

--- a/apps/web/core/components/workspace/sidebar/more-section.tsx
+++ b/apps/web/core/components/workspace/sidebar/more-section.tsx
@@ -4,13 +4,16 @@
  * See the LICENSE file for details.
  */
 
+import { useEffect } from "react";
 import { observer } from "mobx-react";
+import { usePathname } from "next/navigation";
 import { Disclosure, Transition } from "@headlessui/react";
 // pi dash imports
 import {
   WORKSPACE_SIDEBAR_DYNAMIC_NAVIGATION_ITEMS,
   WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS,
 } from "@pi-dash/constants";
+import { useTranslation } from "@pi-dash/i18n";
 import { ChevronRightIcon } from "@pi-dash/propel/icons";
 import { cn } from "@pi-dash/utils";
 // hooks
@@ -22,7 +25,13 @@ const MORE_ITEM_KEYS = ["projects", "prompts", "schedulers", "analytics", "archi
 
 const MORE_STATIC_KEYS = ["analytics", "archives"];
 
+// Path segments that, when visited, should auto-open the More disclosure so
+// the active row is visible.
+const MORE_PATH_SEGMENTS = ["/prompts", "/schedulers", "/analytics", "/archives"];
+
 export const SidebarMoreSection = observer(function SidebarMoreSection() {
+  const { t } = useTranslation();
+  const pathname = usePathname();
   const { setValue: toggleMoreMenu, storedValue: isMoreMenuOpen } = useLocalStorage<boolean>(
     "is_sidebar_more_menu_open",
     true
@@ -36,6 +45,17 @@ export const SidebarMoreSection = observer(function SidebarMoreSection() {
     toggleMoreMenu(isOpen);
   };
 
+  // Auto-open when the user navigates to a route hosted under More, so the
+  // active row is not hidden behind a collapsed disclosure.
+  useEffect(() => {
+    if (!pathname) return;
+    if (MORE_PATH_SEGMENTS.some((segment) => pathname.includes(segment))) {
+      toggleMoreMenu(true);
+    }
+    // toggleMoreMenu identity is stable per render; depending on pathname is enough.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathname]);
+
   return (
     <Disclosure as="div" className="flex flex-col" defaultOpen={!!isMoreMenuOpen}>
       <div className="group flex w-full items-center justify-between rounded-sm px-2 py-1.5 text-placeholder hover:bg-layer-transparent-hover">
@@ -45,7 +65,7 @@ export const SidebarMoreSection = observer(function SidebarMoreSection() {
           className="flex w-full items-center gap-1 text-left text-13 font-semibold whitespace-nowrap text-placeholder"
           onClick={() => toggleListDisclosure(!isMoreMenuOpen)}
         >
-          <span className="text-13 font-semibold">More</span>
+          <span className="text-13 font-semibold">{t("sidebar.more")}</span>
         </Disclosure.Button>
         <div className="pointer-events-none flex items-center opacity-0 group-hover:pointer-events-auto group-hover:opacity-100">
           <Disclosure.Button

--- a/apps/web/core/components/workspace/sidebar/more-section.tsx
+++ b/apps/web/core/components/workspace/sidebar/more-section.tsx
@@ -18,7 +18,7 @@ import useLocalStorage from "@/hooks/use-local-storage";
 // components
 import { SidebarItemBase } from "@/components/workspace/sidebar/sidebar-item";
 
-const MORE_ITEM_KEYS = ["prompts", "schedulers", "analytics", "archives"];
+const MORE_ITEM_KEYS = ["projects", "prompts", "schedulers", "analytics", "archives"];
 
 const MORE_STATIC_KEYS = ["analytics", "archives"];
 

--- a/apps/web/core/components/workspace/sidebar/projects-list.tsx
+++ b/apps/web/core/components/workspace/sidebar/projects-list.tsx
@@ -34,12 +34,11 @@ import { useAppTheme } from "@/hooks/store/use-app-theme";
 import { useCommandPalette } from "@/hooks/store/use-command-palette";
 import { useProject } from "@/hooks/store/use-project";
 import { useUserPermissions } from "@/hooks/store/user";
-import { useProjectNavigationPreferences } from "@/hooks/use-navigation-preferences";
+import { usePersonalNavigationPreferences, useProjectNavigationPreferences } from "@/hooks/use-navigation-preferences";
 // pi dash web imports
 import { SidebarItem } from "@/pi-dash-web/components/workspace/sidebar/sidebar-item";
 import type { TProject } from "@/pi-dash-web/types";
 // local imports
-import { SidebarItemBase } from "./sidebar-item";
 import { SidebarProjectsListItem } from "./projects-list-item";
 
 export const SidebarProjectsList = observer(function SidebarProjectsList() {
@@ -54,6 +53,8 @@ export const SidebarProjectsList = observer(function SidebarProjectsList() {
   const { toggleCreateProjectModal } = useCommandPalette();
   const { allowPermissions } = useUserPermissions();
   const { preferences: projectPreferences } = useProjectNavigationPreferences();
+  const { preferences: personalPreferences } = usePersonalNavigationPreferences();
+  const isDraftsEnabled = personalPreferences.items.drafts?.enabled ?? true;
   const { isExtendedProjectSidebarOpened, toggleExtendedProjectSidebar } = useAppTheme();
 
   const { loader, getPartialProjectById, joinedProjectIds: joinedProjects, updateProjectView } = useProject();
@@ -77,12 +78,20 @@ export const SidebarProjectsList = observer(function SidebarProjectsList() {
     projectPreferences.showLimitedProjects && joinedProjects.length > projectPreferences.limitedProjectsCount;
 
   const handleCopyText = async (projectId: string) => {
-    await copyUrlToClipboard(`${workspaceSlug}/projects/${projectId}/issues`);
-    setToast({
-      type: TOAST_TYPE.SUCCESS,
-      title: t("link_copied"),
-      message: t("project_link_copied_to_clipboard"),
-    });
+    try {
+      await copyUrlToClipboard(`${workspaceSlug}/projects/${projectId}/issues`);
+      setToast({
+        type: TOAST_TYPE.SUCCESS,
+        title: t("link_copied"),
+        message: t("project_link_copied_to_clipboard"),
+      });
+    } catch {
+      setToast({
+        type: TOAST_TYPE.ERROR,
+        title: t("error"),
+        message: t("something_went_wrong"),
+      });
+    }
   };
 
   const handleOnProjectDrop = (
@@ -244,11 +253,11 @@ export const SidebarProjectsList = observer(function SidebarProjectsList() {
               {isAllProjectsListOpen && (
                 <Disclosure.Panel as="div" className="flex flex-col gap-0.5" static>
                   <>
-                    {WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS["drafts"] && (
+                    {isDraftsEnabled && WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS["drafts"] && (
                       <SidebarItem item={WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS["drafts"]} />
                     )}
                     {WORKSPACE_SIDEBAR_DYNAMIC_NAVIGATION_ITEMS["views"] && (
-                      <SidebarItemBase
+                      <SidebarItem
                         item={{
                           ...WORKSPACE_SIDEBAR_DYNAMIC_NAVIGATION_ITEMS["views"],
                           labelTranslationKey: "sidebar.work_items",

--- a/apps/web/core/components/workspace/sidebar/projects-list.tsx
+++ b/apps/web/core/components/workspace/sidebar/projects-list.tsx
@@ -12,7 +12,13 @@ import { useParams, usePathname } from "next/navigation";
 import { Ellipsis } from "lucide-react";
 import { Disclosure, Transition } from "@headlessui/react";
 // pi dash imports
-import { EUserPermissions, EUserPermissionsLevel, PROJECT_TRACKER_ELEMENTS } from "@pi-dash/constants";
+import {
+  EUserPermissions,
+  EUserPermissionsLevel,
+  PROJECT_TRACKER_ELEMENTS,
+  WORKSPACE_SIDEBAR_DYNAMIC_NAVIGATION_ITEMS,
+  WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS,
+} from "@pi-dash/constants";
 import { useTranslation } from "@pi-dash/i18n";
 import { PlusIcon, ChevronRightIcon } from "@pi-dash/propel/icons";
 import { IconButton } from "@pi-dash/propel/icon-button";
@@ -30,8 +36,10 @@ import { useProject } from "@/hooks/store/use-project";
 import { useUserPermissions } from "@/hooks/store/user";
 import { useProjectNavigationPreferences } from "@/hooks/use-navigation-preferences";
 // pi dash web imports
+import { SidebarItem } from "@/pi-dash-web/components/workspace/sidebar/sidebar-item";
 import type { TProject } from "@/pi-dash-web/types";
 // local imports
+import { SidebarItemBase } from "./sidebar-item";
 import { SidebarProjectsListItem } from "./projects-list-item";
 
 export const SidebarProjectsList = observer(function SidebarProjectsList() {
@@ -68,13 +76,12 @@ export const SidebarProjectsList = observer(function SidebarProjectsList() {
   const hasMoreProjects =
     projectPreferences.showLimitedProjects && joinedProjects.length > projectPreferences.limitedProjectsCount;
 
-  const handleCopyText = (projectId: string) => {
-    copyUrlToClipboard(`${workspaceSlug}/projects/${projectId}/issues`).then(() => {
-      setToast({
-        type: TOAST_TYPE.SUCCESS,
-        title: t("link_copied"),
-        message: t("project_link_copied_to_clipboard"),
-      });
+  const handleCopyText = async (projectId: string) => {
+    await copyUrlToClipboard(`${workspaceSlug}/projects/${projectId}/issues`);
+    setToast({
+      type: TOAST_TYPE.SUCCESS,
+      title: t("link_copied"),
+      message: t("project_link_copied_to_clipboard"),
     });
   };
 
@@ -229,14 +236,26 @@ export const SidebarProjectsList = observer(function SidebarProjectsList() {
             >
               {loader === "init-loader" && (
                 <Loader className="w-full space-y-1.5">
-                  {Array.from({ length: 4 }).map((_, index) => (
-                    <Loader.Item key={index} height="28px" />
+                  {["a", "b", "c", "d"].map((id) => (
+                    <Loader.Item key={`loader-${id}`} height="28px" />
                   ))}
                 </Loader>
               )}
               {isAllProjectsListOpen && (
                 <Disclosure.Panel as="div" className="flex flex-col gap-0.5" static>
                   <>
+                    {WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS["drafts"] && (
+                      <SidebarItem item={WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS["drafts"]} />
+                    )}
+                    {WORKSPACE_SIDEBAR_DYNAMIC_NAVIGATION_ITEMS["views"] && (
+                      <SidebarItemBase
+                        item={{
+                          ...WORKSPACE_SIDEBAR_DYNAMIC_NAVIGATION_ITEMS["views"],
+                          labelTranslationKey: "sidebar.work_items",
+                        }}
+                        additionalStaticItems={["views"]}
+                      />
+                    )}
                     {displayedProjects.map((projectId, index) => (
                       <SidebarProjectsListItem
                         key={projectId}

--- a/apps/web/core/components/workspace/sidebar/projects-list.tsx
+++ b/apps/web/core/components/workspace/sidebar/projects-list.tsx
@@ -163,8 +163,11 @@ export const SidebarProjectsList = observer(function SidebarProjectsList() {
     setIsAllProjectsListOpen(isOpen);
     localStorage.setItem("isAllProjectsListOpen", isOpen.toString());
   };
+  // The Projects disclosure also hosts Drafts and Work Items; auto-open it
+  // whenever the user lands on any of those routes so the active row is not
+  // hidden behind a collapsed disclosure.
   useEffect(() => {
-    if (pathname.includes("projects")) {
+    if (pathname.includes("projects") || pathname.includes("/drafts") || pathname.includes("/workspace-views")) {
       setIsAllProjectsListOpen(true);
       localStorage.setItem("isAllProjectsListOpen", "true");
     }
@@ -261,6 +264,11 @@ export const SidebarProjectsList = observer(function SidebarProjectsList() {
                         item={{
                           ...WORKSPACE_SIDEBAR_DYNAMIC_NAVIGATION_ITEMS["views"],
                           labelTranslationKey: "sidebar.work_items",
+                          // The base highlight only matches /workspace-views/all-issues/.
+                          // Since this row is now labelled "Work Items" (the section,
+                          // not a single page) it should stay active on every
+                          // /workspace-views/* route.
+                          highlight: (path: string) => path.includes("/workspace-views"),
                         }}
                         additionalStaticItems={["views"]}
                       />

--- a/apps/web/core/components/workspace/sidebar/sidebar-menu-items.tsx
+++ b/apps/web/core/components/workspace/sidebar/sidebar-menu-items.tsx
@@ -5,9 +5,8 @@
  */
 
 import React, { useMemo } from "react";
+import { orderBy } from "lodash-es";
 import { observer } from "mobx-react";
-import { Ellipsis } from "lucide-react";
-import { Disclosure, Transition } from "@headlessui/react";
 // pi dash imports
 import {
   WORKSPACE_SIDEBAR_DYNAMIC_NAVIGATION_ITEMS_LINKS,
@@ -15,14 +14,7 @@ import {
   WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS_LINKS,
   WORKSPACE_SIDEBAR_STATIC_PINNED_NAVIGATION_ITEMS_LINKS,
 } from "@pi-dash/constants";
-import { useTranslation } from "@pi-dash/i18n";
-import { ChevronRightIcon } from "@pi-dash/propel/icons";
-import { cn } from "@pi-dash/utils";
-// components
-import { SidebarNavItem } from "@/components/sidebar/sidebar-navigation";
 // store hooks
-import { useAppTheme } from "@/hooks/store/use-app-theme";
-import useLocalStorage from "@/hooks/use-local-storage";
 import {
   usePersonalNavigationPreferences,
   useWorkspaceNavigationPreferences,
@@ -30,31 +22,22 @@ import {
 // pi-dash-web imports
 import { SidebarItem } from "@/pi-dash-web/components/workspace/sidebar/sidebar-item";
 
-export const SidebarMenuItems = observer(function SidebarMenuItems() {
-  // routers
-  const { setValue: toggleWorkspaceMenu, storedValue: isWorkspaceMenuOpen } = useLocalStorage<boolean>(
-    "is_workspace_menu_open",
-    true
-  );
+// Items relocated out of this section by the AI-orchestration layout:
+//   - drafts → top of Projects section
+//   - views → "Work Items" row in Projects section
+//   - analytics, prompts, schedulers, archives → new "More" section
+const RELOCATED_KEYS = new Set(["drafts", "views", "analytics", "prompts", "schedulers", "archives"]);
 
-  // store hooks
-  const { isExtendedSidebarOpened, toggleExtendedSidebar } = useAppTheme();
+export const SidebarMenuItems = observer(function SidebarMenuItems() {
   // hooks
   const { preferences: personalPreferences } = usePersonalNavigationPreferences();
   const { preferences: workspacePreferences } = useWorkspaceNavigationPreferences();
-  // translation
-  const { t } = useTranslation();
 
-  const toggleListDisclosure = (isOpen: boolean) => {
-    toggleWorkspaceMenu(isOpen);
-  };
-
-  // Filter static navigation items based on personal preferences
+  // Personal items (Stickies / Your work) gated by user preferences, sorted.
   const filteredStaticNavigationItems = useMemo(() => {
     const items = [...WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS_LINKS];
     const personalItems: Array<(typeof items)[0] & { sort_order: number }> = [];
 
-    // Add personal items based on preferences with their sort_order
     const stickiesItem = WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS["stickies"];
     if (personalPreferences.items.stickies?.enabled && stickiesItem) {
       personalItems.push({
@@ -68,113 +51,39 @@ export const SidebarMenuItems = observer(function SidebarMenuItems() {
         sort_order: personalPreferences.items.your_work.sort_order,
       });
     }
-    if (personalPreferences.items.drafts?.enabled && WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS["drafts"]) {
-      personalItems.push({
-        ...WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS["drafts"],
-        sort_order: personalPreferences.items.drafts.sort_order,
-      });
-    }
-
-    // Sort personal items by sort_order
     personalItems.sort((a, b) => a.sort_order - b.sort_order);
 
-    // Merge static items with sorted personal items
-    return [...items, ...personalItems];
+    return [...items, ...personalItems].filter((item) => !RELOCATED_KEYS.has(item.key));
   }, [personalPreferences]);
 
+  // Workspace-pinned items (projects, runners — prompts/schedulers are relocated).
+  const pinnedNavigationItems = useMemo(
+    () => WORKSPACE_SIDEBAR_STATIC_PINNED_NAVIGATION_ITEMS_LINKS.filter((item) => !RELOCATED_KEYS.has(item.key)),
+    []
+  );
+
+  // User-pinned dynamic items, sorted (views/analytics/archives are relocated).
   const sortedNavigationItems = useMemo(
     () =>
-      WORKSPACE_SIDEBAR_DYNAMIC_NAVIGATION_ITEMS_LINKS.map((item) => {
-        const preference = workspacePreferences.items[item.key];
-        return {
-          ...item,
-          sort_order: preference ? preference.sort_order : 0,
-        };
-      }).sort((a, b) => a.sort_order - b.sort_order),
+      orderBy(
+        WORKSPACE_SIDEBAR_DYNAMIC_NAVIGATION_ITEMS_LINKS.filter((item) => !RELOCATED_KEYS.has(item.key)),
+        [(item) => workspacePreferences.items[item.key]?.sort_order ?? 0],
+        ["asc"]
+      ),
     [workspacePreferences]
   );
 
   return (
-    <>
-      <div className="flex flex-col gap-0.5">
-        {filteredStaticNavigationItems.map((item, _index) => (
-          <SidebarItem key={`static_${_index}`} item={item} />
-        ))}
-      </div>
-      <Disclosure as="div" className="flex flex-col" defaultOpen={!!isWorkspaceMenuOpen}>
-        <div className="group flex w-full items-center justify-between rounded-sm px-2 py-1.5 text-placeholder hover:bg-layer-transparent-hover">
-          <Disclosure.Button
-            as="button"
-            type="button"
-            className="flex w-full items-center gap-1 text-left text-13 font-semibold whitespace-nowrap text-placeholder"
-            onClick={() => toggleListDisclosure(!isWorkspaceMenuOpen)}
-            aria-label={t(
-              isWorkspaceMenuOpen
-                ? "aria_labels.app_sidebar.close_workspace_menu"
-                : "aria_labels.app_sidebar.open_workspace_menu"
-            )}
-          >
-            <span className="text-13 font-semibold">{t("workspace")}</span>
-          </Disclosure.Button>
-          <div className="pointer-events-none flex items-center opacity-0 group-hover:pointer-events-auto group-hover:opacity-100">
-            <Disclosure.Button
-              as="button"
-              type="button"
-              className="flex-shrink-0 rounded-sm p-0.5 hover:bg-layer-1"
-              onClick={() => toggleListDisclosure(!isWorkspaceMenuOpen)}
-              aria-label={t(
-                isWorkspaceMenuOpen
-                  ? "aria_labels.app_sidebar.close_workspace_menu"
-                  : "aria_labels.app_sidebar.open_workspace_menu"
-              )}
-            >
-              <ChevronRightIcon
-                className={cn("size-3 flex-shrink-0 transition-all", {
-                  "rotate-90": isWorkspaceMenuOpen,
-                })}
-              />
-            </Disclosure.Button>
-          </div>
-        </div>
-        <Transition
-          show={!!isWorkspaceMenuOpen}
-          enter="transition duration-100 ease-out"
-          enterFrom="transform scale-95 opacity-0"
-          enterTo="transform scale-100 opacity-100"
-          leave="transition duration-75 ease-out"
-          leaveFrom="transform scale-100 opacity-100"
-          leaveTo="transform scale-95 opacity-0"
-        >
-          {isWorkspaceMenuOpen && (
-            <Disclosure.Panel as="div" className="flex flex-col gap-0.5" static>
-              <>
-                {WORKSPACE_SIDEBAR_STATIC_PINNED_NAVIGATION_ITEMS_LINKS.map((item, _index) => (
-                  <SidebarItem key={`static_${_index}`} item={item} />
-                ))}
-                {sortedNavigationItems.map((item, _index) => (
-                  <SidebarItem key={`dynamic_${_index}`} item={item} />
-                ))}
-                <SidebarNavItem>
-                  <button
-                    type="button"
-                    onClick={() => toggleExtendedSidebar()}
-                    className="flex flex-grow items-center gap-1.5 text-13 font-medium text-tertiary"
-                    id="extended-sidebar-toggle"
-                    aria-label={t(
-                      isExtendedSidebarOpened
-                        ? "aria_labels.app_sidebar.close_extended_sidebar"
-                        : "aria_labels.app_sidebar.open_extended_sidebar"
-                    )}
-                  >
-                    <Ellipsis className="size-4 flex-shrink-0" />
-                    <span>{isExtendedSidebarOpened ? "Hide" : "More"}</span>
-                  </button>
-                </SidebarNavItem>
-              </>
-            </Disclosure.Panel>
-          )}
-        </Transition>
-      </Disclosure>
-    </>
+    <div className="flex flex-col gap-0.5">
+      {filteredStaticNavigationItems.map((item) => (
+        <SidebarItem key={`static_${item.key}`} item={item} />
+      ))}
+      {pinnedNavigationItems.map((item) => (
+        <SidebarItem key={`pinned_${item.key}`} item={item} />
+      ))}
+      {sortedNavigationItems.map((item) => (
+        <SidebarItem key={`dynamic_${item.key}`} item={item} />
+      ))}
+    </div>
   );
 });

--- a/apps/web/core/components/workspace/sidebar/sidebar-menu-items.tsx
+++ b/apps/web/core/components/workspace/sidebar/sidebar-menu-items.tsx
@@ -5,20 +5,15 @@
  */
 
 import React, { useMemo } from "react";
-import { orderBy } from "lodash-es";
 import { observer } from "mobx-react";
 // pi dash imports
 import {
-  WORKSPACE_SIDEBAR_DYNAMIC_NAVIGATION_ITEMS_LINKS,
   WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS,
   WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS_LINKS,
   WORKSPACE_SIDEBAR_STATIC_PINNED_NAVIGATION_ITEMS_LINKS,
 } from "@pi-dash/constants";
 // store hooks
-import {
-  usePersonalNavigationPreferences,
-  useWorkspaceNavigationPreferences,
-} from "@/hooks/use-navigation-preferences";
+import { usePersonalNavigationPreferences } from "@/hooks/use-navigation-preferences";
 // pi-dash-web imports
 import { SidebarItem } from "@/pi-dash-web/components/workspace/sidebar/sidebar-item";
 
@@ -26,12 +21,13 @@ import { SidebarItem } from "@/pi-dash-web/components/workspace/sidebar/sidebar-
 //   - drafts → top of Projects section
 //   - views → "Work Items" row in Projects section
 //   - projects, analytics, prompts, schedulers, archives → new "More" section
+// All entries from WORKSPACE_SIDEBAR_DYNAMIC_NAVIGATION_ITEMS_LINKS are relocated,
+// so that list is no longer rendered here.
 const RELOCATED_KEYS = new Set(["drafts", "views", "projects", "analytics", "prompts", "schedulers", "archives"]);
 
 export const SidebarMenuItems = observer(function SidebarMenuItems() {
   // hooks
   const { preferences: personalPreferences } = usePersonalNavigationPreferences();
-  const { preferences: workspacePreferences } = useWorkspaceNavigationPreferences();
 
   // Personal items (Stickies / Your work) gated by user preferences, sorted.
   const filteredStaticNavigationItems = useMemo(() => {
@@ -56,21 +52,12 @@ export const SidebarMenuItems = observer(function SidebarMenuItems() {
     return [...items, ...personalItems].filter((item) => !RELOCATED_KEYS.has(item.key));
   }, [personalPreferences]);
 
-  // Workspace-pinned items (projects, runners — prompts/schedulers are relocated).
+  // Workspace-pinned items (just `runners` after relocation; computed via the
+  // RELOCATED_KEYS filter so the set of survivors stays in lockstep with that
+  // single source of truth).
   const pinnedNavigationItems = useMemo(
     () => WORKSPACE_SIDEBAR_STATIC_PINNED_NAVIGATION_ITEMS_LINKS.filter((item) => !RELOCATED_KEYS.has(item.key)),
     []
-  );
-
-  // User-pinned dynamic items, sorted (views/analytics/archives are relocated).
-  const sortedNavigationItems = useMemo(
-    () =>
-      orderBy(
-        WORKSPACE_SIDEBAR_DYNAMIC_NAVIGATION_ITEMS_LINKS.filter((item) => !RELOCATED_KEYS.has(item.key)),
-        [(item) => workspacePreferences.items[item.key]?.sort_order ?? 0],
-        ["asc"]
-      ),
-    [workspacePreferences]
   );
 
   return (
@@ -80,9 +67,6 @@ export const SidebarMenuItems = observer(function SidebarMenuItems() {
       ))}
       {pinnedNavigationItems.map((item) => (
         <SidebarItem key={`pinned_${item.key}`} item={item} />
-      ))}
-      {sortedNavigationItems.map((item) => (
-        <SidebarItem key={`dynamic_${item.key}`} item={item} />
       ))}
     </div>
   );

--- a/apps/web/core/components/workspace/sidebar/sidebar-menu-items.tsx
+++ b/apps/web/core/components/workspace/sidebar/sidebar-menu-items.tsx
@@ -25,8 +25,8 @@ import { SidebarItem } from "@/pi-dash-web/components/workspace/sidebar/sidebar-
 // Items relocated out of this section by the AI-orchestration layout:
 //   - drafts → top of Projects section
 //   - views → "Work Items" row in Projects section
-//   - analytics, prompts, schedulers, archives → new "More" section
-const RELOCATED_KEYS = new Set(["drafts", "views", "analytics", "prompts", "schedulers", "archives"]);
+//   - projects, analytics, prompts, schedulers, archives → new "More" section
+const RELOCATED_KEYS = new Set(["drafts", "views", "projects", "analytics", "prompts", "schedulers", "archives"]);
 
 export const SidebarMenuItems = observer(function SidebarMenuItems() {
   // hooks

--- a/apps/web/core/components/workspace/sidebar/user-menu-root.tsx
+++ b/apps/web/core/components/workspace/sidebar/user-menu-root.tsx
@@ -54,13 +54,23 @@ export const UserMenuRoot = observer(function UserMenuRoot({ variant = "compact"
     );
   };
 
-  // Toggle sidebar dropdown state when menu is open
+  const isSidebarVariant = variant === "sidebar";
+
+  // Only the sidebar-mounted instance participates in peek coordination. The
+  // top-nav fallback (compact variant) lives outside the sidebar, so it must
+  // not write the global peek flag — doing so would let opening the page-
+  // chrome user menu pin the sidebar peek open (and closing it force-close).
   useEffect(() => {
+    if (!isSidebarVariant) return;
     if (isUserMenuOpen) toggleAnySidebarDropdown(true);
     else toggleAnySidebarDropdown(false);
-  }, [isUserMenuOpen, toggleAnySidebarDropdown]);
-
-  const isSidebarVariant = variant === "sidebar";
+    // Always clear the flag on unmount so a route change with the menu still
+    // open doesn't leak `isAnySidebarDropdownOpen=true` for the rest of the
+    // session.
+    return () => {
+      toggleAnySidebarDropdown(false);
+    };
+  }, [isSidebarVariant, isUserMenuOpen, toggleAnySidebarDropdown]);
 
   // The outer wrapper is rendered as a non-interactive element because
   // CustomMenu already wraps `customButton` in its own <button>; nesting
@@ -105,7 +115,9 @@ export const UserMenuRoot = observer(function UserMenuRoot({ variant = "compact"
 
   return (
     <>
-      <PaidPlanUpgradeModal isOpen={isCommunityModalOpen} handleClose={() => setIsCommunityModalOpen(false)} />
+      {isCommunityModalOpen && (
+        <PaidPlanUpgradeModal isOpen={isCommunityModalOpen} handleClose={() => setIsCommunityModalOpen(false)} />
+      )}
       <CustomMenu
         className={cn("flex items-center", isSidebarVariant && "w-full")}
         customButton={isSidebarVariant ? sidebarTrigger : compactTrigger}
@@ -173,7 +185,7 @@ export const UserMenuRoot = observer(function UserMenuRoot({ variant = "compact"
         </div>
         <CustomMenu.MenuItem onClick={() => setIsCommunityModalOpen(true)} className="flex items-center gap-2">
           <Globe className="size-3.5 shrink-0" />
-          Community
+          {t("sidebar.community")}
         </CustomMenu.MenuItem>
         <CustomMenu.MenuItem onClick={handleSignOut} className="flex items-center gap-2">
           <LogOut className="size-3.5 shrink-0" />

--- a/apps/web/core/components/workspace/sidebar/user-menu-root.tsx
+++ b/apps/web/core/components/workspace/sidebar/user-menu-root.tsx
@@ -7,13 +7,13 @@
 import { useState, useEffect } from "react";
 import { observer } from "mobx-react";
 import { useRouter } from "next/navigation";
-import { LogOut, Settings, Settings2 } from "lucide-react";
+import { ChevronsUpDown, Globe, LogOut, Settings, Settings2 } from "lucide-react";
 // pi dash imports
 import { GOD_MODE_URL } from "@pi-dash/constants";
 import { useTranslation } from "@pi-dash/i18n";
 import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
 import { Avatar, CustomMenu } from "@pi-dash/ui";
-import { getFileURL } from "@pi-dash/utils";
+import { cn, getFileURL } from "@pi-dash/utils";
 // components
 import { CoverImage } from "@/components/common/cover-image";
 import { AppSidebarItem } from "@/components/sidebar/sidebar-item";
@@ -21,10 +21,17 @@ import { AppSidebarItem } from "@/components/sidebar/sidebar-item";
 import { useAppTheme } from "@/hooks/store/use-app-theme";
 import { useCommandPalette } from "@/hooks/store/use-command-palette";
 import { useUser } from "@/hooks/store/user";
+// pi dash web components
+import { PaidPlanUpgradeModal } from "@/pi-dash-web/components/license";
 
-export const UserMenuRoot = observer(function UserMenuRoot() {
+type Props = {
+  variant?: "compact" | "sidebar";
+};
+
+export const UserMenuRoot = observer(function UserMenuRoot({ variant = "compact" }: Props) {
   // states
   const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
+  const [isCommunityModalOpen, setIsCommunityModalOpen] = useState(false);
   // router
   const router = useRouter();
   // store hooks
@@ -53,98 +60,134 @@ export const UserMenuRoot = observer(function UserMenuRoot() {
     else toggleAnySidebarDropdown(false);
   }, [isUserMenuOpen, toggleAnySidebarDropdown]);
 
-  return (
-    <CustomMenu
-      className="flex items-center"
-      customButton={
-        <AppSidebarItem
-          variant="button"
-          item={{
-            icon: (
-              <Avatar
-                name={currentUser?.display_name}
-                src={getFileURL(currentUser?.avatar_url ?? "")}
-                size={20}
-                shape="circle"
-              />
-            ),
-            isActive: isUserMenuOpen,
-          }}
-        />
-      }
-      menuButtonOnClick={() => !isUserMenuOpen && setIsUserMenuOpen(true)}
-      onMenuClose={() => setIsUserMenuOpen(false)}
-      placement="bottom-end"
-      maxHeight="2xl"
-      optionsClassName="w-72 p-3 flex flex-col gap-y-3"
-      closeOnSelect
+  const isSidebarVariant = variant === "sidebar";
+
+  const sidebarTrigger = (
+    <button
+      type="button"
+      className={cn(
+        "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left hover:bg-layer-transparent-hover",
+        isUserMenuOpen && "bg-layer-transparent-selected"
+      )}
+      aria-haspopup="menu"
+      aria-expanded={isUserMenuOpen}
     >
-      <div className="relative h-29 w-full rounded-lg">
-        <CoverImage
-          src={currentUser?.cover_image_url ?? undefined}
-          alt={currentUser?.display_name}
-          className="h-29 w-full rounded-lg"
-          showDefaultWhenEmpty
-        />
-        <div className="absolute inset-0 bg-layer-1/50" />
-        <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
-          <div className="flex flex-col items-center gap-y-2">
-            <div>
-              <Avatar
-                name={currentUser?.display_name}
-                src={getFileURL(currentUser?.avatar_url ?? "")}
-                size={40}
-                shape="circle"
-                className="text-18 font-medium"
-              />
-            </div>
-            <div className="text-center">
-              <p className="text-body-sm-medium">
-                {currentUser?.first_name} {currentUser?.last_name}
-              </p>
-              <p className="text-caption-md-regular">{currentUser?.email}</p>
+      <Avatar
+        name={currentUser?.display_name}
+        src={getFileURL(currentUser?.avatar_url ?? "")}
+        size={24}
+        shape="circle"
+      />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <span className="truncate text-13 font-medium text-primary">{currentUser?.display_name}</span>
+        <span className="truncate text-11 text-tertiary">{currentUser?.email}</span>
+      </div>
+      <ChevronsUpDown className="size-3.5 shrink-0 text-tertiary" />
+    </button>
+  );
+
+  const compactTrigger = (
+    <AppSidebarItem
+      variant="button"
+      item={{
+        icon: (
+          <Avatar
+            name={currentUser?.display_name}
+            src={getFileURL(currentUser?.avatar_url ?? "")}
+            size={20}
+            shape="circle"
+          />
+        ),
+        isActive: isUserMenuOpen,
+      }}
+    />
+  );
+
+  return (
+    <>
+      <PaidPlanUpgradeModal isOpen={isCommunityModalOpen} handleClose={() => setIsCommunityModalOpen(false)} />
+      <CustomMenu
+        className={cn("flex items-center", isSidebarVariant && "w-full")}
+        customButton={isSidebarVariant ? sidebarTrigger : compactTrigger}
+        customButtonClassName={isSidebarVariant ? "w-full" : undefined}
+        menuButtonOnClick={() => !isUserMenuOpen && setIsUserMenuOpen(true)}
+        onMenuClose={() => setIsUserMenuOpen(false)}
+        placement={isSidebarVariant ? "top-start" : "bottom-end"}
+        maxHeight="2xl"
+        optionsClassName="w-72 p-3 flex flex-col gap-y-3"
+        closeOnSelect
+      >
+        <div className="relative h-29 w-full rounded-lg">
+          <CoverImage
+            src={currentUser?.cover_image_url ?? undefined}
+            alt={currentUser?.display_name}
+            className="h-29 w-full rounded-lg"
+            showDefaultWhenEmpty
+          />
+          <div className="absolute inset-0 bg-layer-1/50" />
+          <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
+            <div className="flex flex-col items-center gap-y-2">
+              <div>
+                <Avatar
+                  name={currentUser?.display_name}
+                  src={getFileURL(currentUser?.avatar_url ?? "")}
+                  size={40}
+                  shape="circle"
+                  className="text-18 font-medium"
+                />
+              </div>
+              <div className="text-center">
+                <p className="text-body-sm-medium">
+                  {currentUser?.first_name} {currentUser?.last_name}
+                </p>
+                <p className="text-caption-md-regular">{currentUser?.email}</p>
+              </div>
             </div>
           </div>
         </div>
-      </div>
-      <div>
-        <CustomMenu.MenuItem
-          onClick={() =>
-            toggleProfileSettingsModal({
-              activeTab: "general",
-              isOpen: true,
-            })
-          }
-          className="flex items-center gap-2"
-        >
-          <Settings className="size-3.5 shrink-0" />
-          {t("settings")}
+        <div>
+          <CustomMenu.MenuItem
+            onClick={() =>
+              toggleProfileSettingsModal({
+                activeTab: "general",
+                isOpen: true,
+              })
+            }
+            className="flex items-center gap-2"
+          >
+            <Settings className="size-3.5 shrink-0" />
+            {t("settings")}
+          </CustomMenu.MenuItem>
+          <CustomMenu.MenuItem
+            onClick={() =>
+              toggleProfileSettingsModal({
+                activeTab: "preferences",
+                isOpen: true,
+              })
+            }
+            className="flex items-center gap-2"
+          >
+            <Settings2 className="size-3.5 shrink-0" />
+            {t("preferences")}
+          </CustomMenu.MenuItem>
+        </div>
+        <CustomMenu.MenuItem onClick={() => setIsCommunityModalOpen(true)} className="flex items-center gap-2">
+          <Globe className="size-3.5 shrink-0" />
+          Community
         </CustomMenu.MenuItem>
-        <CustomMenu.MenuItem
-          onClick={() =>
-            toggleProfileSettingsModal({
-              activeTab: "preferences",
-              isOpen: true,
-            })
-          }
-          className="flex items-center gap-2"
-        >
-          <Settings2 className="size-3.5 shrink-0" />
-          {t("preferences")}
+        <CustomMenu.MenuItem onClick={handleSignOut} className="flex items-center gap-2">
+          <LogOut className="size-3.5 shrink-0" />
+          {t("sign_out")}
         </CustomMenu.MenuItem>
-      </div>
-      <CustomMenu.MenuItem onClick={handleSignOut} className="flex items-center gap-2">
-        <LogOut className="size-3.5 shrink-0" />
-        {t("sign_out")}
-      </CustomMenu.MenuItem>
-      {isUserInstanceAdmin && (
-        <CustomMenu.MenuItem
-          onClick={() => router.push(GOD_MODE_URL)}
-          className="bg-accent-primary/20 text-accent-primary hover:bg-accent-primary/30 hover:text-accent-secondary"
-        >
-          {t("enter_god_mode")}
-        </CustomMenu.MenuItem>
-      )}
-    </CustomMenu>
+        {isUserInstanceAdmin && (
+          <CustomMenu.MenuItem
+            onClick={() => router.push(GOD_MODE_URL)}
+            className="bg-accent-primary/20 text-accent-primary hover:bg-accent-primary/30 hover:text-accent-secondary"
+          >
+            {t("enter_god_mode")}
+          </CustomMenu.MenuItem>
+        )}
+      </CustomMenu>
+    </>
   );
 });

--- a/apps/web/core/components/workspace/sidebar/user-menu-root.tsx
+++ b/apps/web/core/components/workspace/sidebar/user-menu-root.tsx
@@ -62,15 +62,15 @@ export const UserMenuRoot = observer(function UserMenuRoot({ variant = "compact"
 
   const isSidebarVariant = variant === "sidebar";
 
+  // The outer wrapper is rendered as a non-interactive element because
+  // CustomMenu already wraps `customButton` in its own <button>; nesting
+  // <button>s would be invalid HTML and break ARIA semantics.
   const sidebarTrigger = (
-    <button
-      type="button"
+    <div
       className={cn(
         "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left hover:bg-layer-transparent-hover",
         isUserMenuOpen && "bg-layer-transparent-selected"
       )}
-      aria-haspopup="menu"
-      aria-expanded={isUserMenuOpen}
     >
       <Avatar
         name={currentUser?.display_name}
@@ -83,7 +83,7 @@ export const UserMenuRoot = observer(function UserMenuRoot({ variant = "compact"
         <span className="truncate text-11 text-tertiary">{currentUser?.email}</span>
       </div>
       <ChevronsUpDown className="size-3.5 shrink-0 text-tertiary" />
-    </button>
+    </div>
   );
 
   const compactTrigger = (

--- a/packages/i18n/src/locales/en/core.ts
+++ b/packages/i18n/src/locales/en/core.ts
@@ -27,6 +27,8 @@ export default {
     prompts: "Prompts",
     schedulers: "Schedulers",
     runners: "AI Agents",
+    more: "More",
+    community: "Community",
     tooltips: {
       projects: "Browse projects",
       runners: "Manage your AI Agent connectivities",

--- a/packages/i18n/src/locales/en/core.ts
+++ b/packages/i18n/src/locales/en/core.ts
@@ -15,7 +15,7 @@ export default {
     workspace: "Workspace",
     views: "Views",
     analytics: "Analytics",
-    work_items: "Work items",
+    work_items: "Work Items",
     cycles: "Cycles",
     modules: "Modules",
     intake: "Intake",


### PR DESCRIPTION
## Summary

Reframes the workspace left panel from a project tool into an AI orchestration center.

**Top level (no more "Workspace" disclosure)**
- Sidebar title renamed `Projects` → `Pi Dash`.
- Flat list: Home / Stickies / Your work / Projects (link) / AI Agents.

**Projects section**
- First item: `Drafts`.
- Second item: `Work Items` (renamed from `Views`, normal styling — no custom background).
- Then project list and existing "More" expand for extra projects.

**New "More" section (below Projects)**
- Collapsible: `Prompts`, `Schedulers`, `Analytics`, `Archives`.

**Bottom of the panel**
- User menu now sits at the bottom of the left panel (full panel width, avatar + name/email + chevron).
- Old standalone `Community` badge removed; same modal trigger is folded into the user menu as a sub-item.
- User menu removed from the top-right of the top navigation.

**Toggle button**
- Only one sidebar toggle now, kept in the top navigation (always visible — including when the sidebar is collapsed).

**Bug fix included**
- `prompts/layout.tsx` and `schedulers/layout.tsx` were each wrapping their content in `WorkspaceShell`, but the parent `(projects)` route layout already provides one. The redundant inner shell rendered a second copy of the workspace sidebar that appeared as a mirrored middle panel. Removed the inner wrappers; sibling layouts in `(projects)` already follow this convention.

**Implementation notes**
- All changes are layout-only — no behavior changes to individual links/buttons or their routes.
- Filtering of "relocated" items happens in the rendering components (`sidebar-menu-items.tsx`, `projects-list.tsx`, `more-section.tsx`) rather than mutating the shared navigation constants, so other consumers (`ExtendedWorkspaceSidebar`, the customize-navigation dialog) are unaffected.
- New translation key reused: `sidebar.work_items` was updated from "Work items" to "Work Items" and the Views sidebar entry now uses it (the original `views` key is left untouched since it's referenced elsewhere like breadcrumbs).

## Test plan
- [ ] Sidebar header reads "Pi Dash" with the Preferences gear next to it.
- [ ] Top section is a flat list with no "Workspace" header / chevron.
- [ ] Projects section shows Drafts → Work Items → project rows; "More" expand still works for extra projects.
- [ ] More section is collapsible and contains Prompts, Schedulers, Analytics, Archives. Each routes correctly.
- [ ] Clicking Prompts or Schedulers no longer renders a mirrored sidebar in the content area.
- [ ] User-menu button at the bottom spans the panel width; clicking opens the dropdown; Community item opens the upgrade modal; Sign out still works.
- [ ] Top navigation: no avatar/user menu in the top right; sidebar toggle in the top nav still expands/collapses the sidebar.
- [ ] Collapsed-sidebar behaviors (peek on hover, double-click resize handle) still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)