### PR TITLE
feat(web): add project-level schedulers entry to sidebar

### DIFF
--- a/apps/web/app/(all)/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/schedulers/header.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/schedulers/header.tsx
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { observer } from "mobx-react";
+import { useParams } from "next/navigation";
+import { CalendarClock } from "lucide-react";
+import { useTranslation } from "@pi-dash/i18n";
+import { Breadcrumbs, Header } from "@pi-dash/ui";
+import { BreadcrumbLink } from "@/components/common/breadcrumb-link";
+import { useProject } from "@/hooks/store/use-project";
+import { CommonProjectBreadcrumbs } from "@/pi-dash-web/components/breadcrumbs/common";
+
+export const ProjectSchedulersHeader = observer(function ProjectSchedulersHeader() {
+  const { workspaceSlug, projectId } = useParams();
+  const { currentProjectDetails, loader } = useProject();
+  const { t } = useTranslation();
+
+  return (
+    <Header>
+      <Header.LeftItem>
+        <Breadcrumbs isLoading={loader === "init-loader"}>
+          <CommonProjectBreadcrumbs workspaceSlug={workspaceSlug?.toString()} projectId={projectId?.toString()} />
+          <Breadcrumbs.Item
+            component={
+              <BreadcrumbLink
+                label={t("sidebar.schedulers")}
+                href={`/${workspaceSlug}/projects/${currentProjectDetails?.id}/schedulers`}
+                icon={<CalendarClock className="size-4 text-tertiary" />}
+                isLast
+              />
+            }
+            isLast
+          />
+        </Breadcrumbs>
+      </Header.LeftItem>
+    </Header>
+  );
+});

--- a/apps/web/app/(all)/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/schedulers/header.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/schedulers/header.tsx
@@ -15,7 +15,7 @@ import { CommonProjectBreadcrumbs } from "@/pi-dash-web/components/breadcrumbs/c
 
 export const ProjectSchedulersHeader = observer(function ProjectSchedulersHeader() {
   const { workspaceSlug, projectId } = useParams();
-  const { currentProjectDetails, loader } = useProject();
+  const { loader } = useProject();
   const { t } = useTranslation();
 
   return (
@@ -27,7 +27,7 @@ export const ProjectSchedulersHeader = observer(function ProjectSchedulersHeader
             component={
               <BreadcrumbLink
                 label={t("sidebar.schedulers")}
-                href={`/${workspaceSlug}/projects/${currentProjectDetails?.id}/schedulers`}
+                href={`/${workspaceSlug}/projects/${projectId}/schedulers`}
                 icon={<CalendarClock className="size-4 text-tertiary" />}
                 isLast
               />

--- a/apps/web/app/(all)/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/schedulers/layout.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/schedulers/layout.tsx
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { Outlet } from "react-router";
+import { AppHeader } from "@/components/core/app-header";
+import { ContentWrapper } from "@/components/core/content-wrapper";
+import { ProjectSchedulersHeader } from "./header";
+
+export default function ProjectSchedulersLayout() {
+  return (
+    <>
+      <AppHeader header={<ProjectSchedulersHeader />} />
+      <ContentWrapper>
+        <Outlet />
+      </ContentWrapper>
+    </>
+  );
+}

--- a/apps/web/app/(all)/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/schedulers/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/schedulers/page.tsx
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { observer } from "mobx-react";
+import { useTranslation } from "@pi-dash/i18n";
+import { PageHead } from "@/components/core/page-title";
+import { SchedulerBindingsPanel } from "@/components/project/scheduler-bindings/bindings-panel";
+import { useProject } from "@/hooks/store/use-project";
+import type { Route } from "./+types/page";
+
+function ProjectSchedulersPage({ params }: Route.ComponentProps) {
+  const { workspaceSlug, projectId } = params;
+  const { t } = useTranslation();
+  const { getProjectById } = useProject();
+  const project = getProjectById(projectId);
+  const pageTitle = project?.name
+    ? `${project.name} - ${t("scheduler_bindings.title")}`
+    : t("scheduler_bindings.title");
+
+  return (
+    <>
+      <PageHead title={pageTitle} />
+      <SchedulerBindingsPanel workspaceSlug={workspaceSlug} projectId={projectId} />
+    </>
+  );
+}
+
+export default observer(ProjectSchedulersPage);

--- a/apps/web/app/(all)/[workspaceSlug]/(settings)/settings/projects/[projectId]/schedulers/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/(settings)/settings/projects/[projectId]/schedulers/page.tsx
@@ -4,30 +4,20 @@
  * See the LICENSE file for details.
  */
 
-import { useState } from "react";
 import { observer } from "mobx-react";
 import { useParams } from "react-router";
-import useSWR from "swr";
 // pi dash imports
 import { EUserPermissions, EUserPermissionsLevel } from "@pi-dash/constants";
 import { useTranslation } from "@pi-dash/i18n";
-import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
-import type { IScheduler, ISchedulerBinding } from "@pi-dash/services";
-import { SchedulerService } from "@pi-dash/services";
-import { Button, ToggleSwitch } from "@pi-dash/ui";
 // components
 import { NotAuthorizedView } from "@/components/auth-screens/not-authorized-view";
 import { PageHead } from "@/components/core/page-title";
-import { EditSchedulerBindingModal } from "@/components/project/scheduler-bindings/edit-binding-modal";
-import { InstallSchedulerBindingModal } from "@/components/project/scheduler-bindings/install-binding-modal";
-import { UninstallSchedulerBindingModal } from "@/components/project/scheduler-bindings/uninstall-binding-modal";
+import { SchedulerBindingsPanel } from "@/components/project/scheduler-bindings/bindings-panel";
 import { SettingsContentWrapper } from "@/components/settings/content-wrapper";
 // hooks
 import { useProject } from "@/hooks/store/use-project";
 import { useUserPermissions } from "@/hooks/store/user";
 import { SchedulersProjectSettingsHeader } from "./header";
-
-const schedulerService = new SchedulerService();
 
 const SchedulerBindingsSettingsPage = observer(function SchedulerBindingsSettingsPage() {
   const { workspaceSlug, projectId } = useParams<{ workspaceSlug: string; projectId: string }>();
@@ -38,26 +28,11 @@ const SchedulerBindingsSettingsPage = observer(function SchedulerBindingsSetting
   const slug = workspaceSlug ?? "";
   const project = projectId ?? "";
 
-  // Project admin only — matches the route's access list and the
-  // backend's project-admin gate on binding mutations. Surfacing the
-  // page to non-admins would only show a read-only list with no
-  // actions, which adds no value over the workspace catalog view.
+  // Project-settings UX is admin-only: keeps the legacy behavior intact so
+  // members aren't routed here from the settings sidebar. The matching
+  // project-level page at /projects/:id/schedulers is what surfaces a
+  // read-only view to non-admins.
   const canManage = allowPermissions([EUserPermissions.ADMIN], EUserPermissionsLevel.PROJECT, slug, project);
-
-  // Bindings: per-project. Workspace schedulers: needed to populate the
-  // install picker. Both keys include the workspace + project so a
-  // navigation between projects refetches.
-  const { data: bindings, mutate: mutateBindings } = useSWR<ISchedulerBinding[]>(
-    slug && project ? ["scheduler-bindings", slug, project] : null,
-    () => schedulerService.listBindings(slug, project)
-  );
-  const { data: schedulers } = useSWR<IScheduler[]>(slug ? ["schedulers", slug] : null, () =>
-    schedulerService.listSchedulers(slug)
-  );
-
-  const [installOpen, setInstallOpen] = useState(false);
-  const [editTarget, setEditTarget] = useState<ISchedulerBinding | null>(null);
-  const [uninstallTarget, setUninstallTarget] = useState<ISchedulerBinding | null>(null);
 
   const pageTitle = currentProjectDetails?.name
     ? `${currentProjectDetails.name} · ${t("scheduler_bindings.title")}`
@@ -67,202 +42,12 @@ const SchedulerBindingsSettingsPage = observer(function SchedulerBindingsSetting
     return <NotAuthorizedView section="settings" isProjectView className="h-auto" />;
   }
 
-  const rows = bindings ?? [];
-
   return (
     <SettingsContentWrapper header={<SchedulersProjectSettingsHeader />}>
       <PageHead title={pageTitle} />
-
-      <div className="flex flex-col gap-6 p-6">
-        <header className="flex items-start justify-between gap-4">
-          <div>
-            <h1 className="text-16 font-semibold text-primary">{t("scheduler_bindings.title")}</h1>
-            <p className="mt-1 text-13 text-secondary">{t("scheduler_bindings.subtitle")}</p>
-          </div>
-          <Button onClick={() => setInstallOpen(true)}>{t("scheduler_bindings.install")}</Button>
-        </header>
-
-        <section className="rounded-md border border-subtle">
-          <table className="w-full text-13">
-            <thead className="bg-layer-1 text-left text-secondary">
-              <tr>
-                <th className="px-3 py-2">{t("scheduler_bindings.columns.name")}</th>
-                <th className="px-3 py-2">{t("scheduler_bindings.columns.cron")}</th>
-                <th className="px-3 py-2">{t("scheduler_bindings.columns.next_run")}</th>
-                <th className="px-3 py-2">{t("scheduler_bindings.columns.last_run")}</th>
-                <th className="px-3 py-2">{t("scheduler_bindings.columns.status")}</th>
-                <th className="px-3 py-2">{t("scheduler_bindings.columns.updated")}</th>
-                <th className="px-3 py-2"></th>
-              </tr>
-            </thead>
-            <tbody>
-              {rows.map((b) => (
-                <BindingRow
-                  key={b.id}
-                  binding={b}
-                  onEdit={() => setEditTarget(b)}
-                  onUninstall={() => setUninstallTarget(b)}
-                  onToggle={async (next) => {
-                    // Optimistic toggle — flip the cached row immediately, run
-                    // the PATCH, swap in the canonical server response on
-                    // success, roll back on error. SWR's optimisticData /
-                    // rollbackOnError handle the cache surgery; we just
-                    // surface the toast.
-                    try {
-                      await mutateBindings(
-                        async (current) => {
-                          const updated = await schedulerService.updateBinding(slug, project, b.id, {
-                            enabled: next,
-                          });
-                          return (current ?? []).map((row) => (row.id === b.id ? updated : row));
-                        },
-                        {
-                          // SWR diffs optimisticData by reference, so we
-                          // need a fresh array AND a fresh object for the
-                          // changed row. The spread-in-map pattern oxlint
-                          // flags as "inefficient" is the standard idiom
-                          // for immutable updates here. Build the new
-                          // array imperatively to dodge the rule and avoid
-                          // a mid-iteration spread.
-                          optimisticData: (current) => {
-                            const arr = current ?? [];
-                            const idx = arr.findIndex((row) => row.id === b.id);
-                            if (idx === -1) return arr;
-                            const out = arr.slice();
-                            out[idx] = Object.assign({}, arr[idx], { enabled: next });
-                            return out;
-                          },
-                          rollbackOnError: true,
-                          revalidate: false,
-                        }
-                      );
-                      setToast({
-                        type: TOAST_TYPE.SUCCESS,
-                        title: t("scheduler_bindings.toast.updated_title"),
-                        message: next
-                          ? t("scheduler_bindings.toast.enabled_message")
-                          : t("scheduler_bindings.toast.disabled_message"),
-                      });
-                    } catch (e: unknown) {
-                      const err = e as { error?: string } | null;
-                      setToast({
-                        type: TOAST_TYPE.ERROR,
-                        title: t("scheduler_bindings.toast.error_title"),
-                        message: err?.error ?? t("scheduler_bindings.toast.update_failed"),
-                      });
-                    }
-                  }}
-                />
-              ))}
-              {rows.length === 0 && (
-                <tr>
-                  <td colSpan={7} className="px-3 py-8 text-center text-secondary">
-                    {t("scheduler_bindings.list.empty")}
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-        </section>
-      </div>
-
-      <InstallSchedulerBindingModal
-        isOpen={installOpen}
-        onClose={() => setInstallOpen(false)}
-        workspaceSlug={slug}
-        projectId={project}
-        availableSchedulers={schedulers ?? []}
-        existingBindings={rows}
-        onInstalled={() => mutateBindings()}
-      />
-      <EditSchedulerBindingModal
-        isOpen={!!editTarget}
-        onClose={() => setEditTarget(null)}
-        workspaceSlug={slug}
-        projectId={project}
-        binding={editTarget}
-        onUpdated={() => mutateBindings()}
-      />
-      <UninstallSchedulerBindingModal
-        isOpen={!!uninstallTarget}
-        onClose={() => setUninstallTarget(null)}
-        workspaceSlug={slug}
-        projectId={project}
-        binding={uninstallTarget}
-        onUninstalled={() => mutateBindings()}
-      />
+      <SchedulerBindingsPanel workspaceSlug={slug} projectId={project} />
     </SettingsContentWrapper>
   );
 });
-
-type RowProps = {
-  binding: ISchedulerBinding;
-  onEdit: () => void;
-  onUninstall: () => void;
-  onToggle: (next: boolean) => Promise<void>;
-};
-
-function BindingRow({ binding, onEdit, onUninstall, onToggle }: RowProps) {
-  const { t } = useTranslation();
-  const [toggling, setToggling] = useState(false);
-
-  const formatTs = (ts: string | null) => (ts ? new Date(ts).toLocaleString() : t("scheduler_bindings.list.none_yet"));
-
-  // Wraps the parent's onToggle so the switch can render a disabled
-  // state during the in-flight PATCH (prevents a double-click from
-  // racing two requests). The optimistic / rollback bookkeeping lives
-  // in the parent because the SWR cache key does too.
-  const handleToggle = async (next: boolean) => {
-    if (toggling) return;
-    setToggling(true);
-    try {
-      await onToggle(next);
-    } finally {
-      setToggling(false);
-    }
-  };
-
-  return (
-    <tr className="border-t border-subtle">
-      <td className="px-3 py-2 font-medium text-primary">
-        {binding.scheduler_name}
-        <div className="text-12 text-secondary">
-          <code>{binding.scheduler_slug}</code>
-        </div>
-      </td>
-      <td className="px-3 py-2 text-secondary">
-        <code className="text-12">{binding.cron}</code>
-      </td>
-      <td className="px-3 py-2 text-secondary">{formatTs(binding.next_run_at)}</td>
-      <td className="px-3 py-2 text-secondary">{formatTs(binding.last_run_ended_at)}</td>
-      <td className="px-3 py-2">
-        <div className="flex items-center gap-2">
-          <ToggleSwitch
-            value={binding.enabled}
-            onChange={handleToggle}
-            disabled={toggling}
-            aria-label={
-              binding.enabled ? t("scheduler_bindings.actions.disable") : t("scheduler_bindings.actions.enable")
-            }
-          />
-          <span className="text-12 text-secondary">
-            {binding.enabled ? t("scheduler_bindings.status.enabled") : t("scheduler_bindings.status.disabled")}
-          </span>
-        </div>
-      </td>
-      <td className="px-3 py-2 text-secondary">{new Date(binding.updated_at).toLocaleString()}</td>
-      <td className="px-3 py-2 text-right">
-        <div className="flex items-center justify-end gap-2">
-          <Button variant="link-neutral" size="sm" onClick={onEdit}>
-            {t("scheduler_bindings.actions.edit")}
-          </Button>
-          <Button variant="tertiary-danger" size="sm" onClick={onUninstall}>
-            {t("scheduler_bindings.actions.uninstall")}
-          </Button>
-        </div>
-      </td>
-    </tr>
-  );
-}
 
 export default SchedulerBindingsSettingsPage;

--- a/apps/web/app/routes/core.ts
+++ b/apps/web/app/routes/core.ts
@@ -230,6 +230,14 @@ export const coreRoutes: RouteConfigEntry[] = [
               "./(all)/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/intake/page.tsx"
             ),
           ]),
+
+          // Schedulers list (project-scoped scheduler bindings)
+          layout("./(all)/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/schedulers/layout.tsx", [
+            route(
+              ":workspaceSlug/projects/:projectId/schedulers",
+              "./(all)/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/schedulers/page.tsx"
+            ),
+          ]),
         ]),
 
         // Project Archives - Issues, Cycles, Modules

--- a/apps/web/ce/components/navigations/use-navigation-items.ts
+++ b/apps/web/ce/components/navigations/use-navigation-items.ts
@@ -6,6 +6,7 @@
 
 import { useMemo, useCallback } from "react";
 // pi dash imports
+import { CalendarClock } from "lucide-react";
 import { EUserPermissions, EUserPermissionsLevel } from "@pi-dash/constants";
 import { CycleIcon, IntakeIcon, ModuleIcon, PageIcon, ViewsIcon, WorkItemsIcon } from "@pi-dash/propel/icons";
 import type { EUserProjectRoles, IPartialProject } from "@pi-dash/types";
@@ -31,7 +32,7 @@ export const useNavigationItems = ({
 }: UseNavigationItemsProps): TNavigationItem[] => {
   // Base navigation items
   const baseNavigation = useCallback(
-    (workspaceSlug: string, projectId: string): TNavigationItem[] => [
+    (): TNavigationItem[] => [
       {
         i18n_key: "sidebar.work_items",
         key: "work_items",
@@ -92,13 +93,23 @@ export const useNavigationItems = ({
         shouldRender: !!project?.inbox_view,
         sortOrder: 6,
       },
+      {
+        i18n_key: "sidebar.schedulers",
+        key: "schedulers",
+        name: "Schedulers",
+        href: `/${workspaceSlug}/projects/${projectId}/schedulers`,
+        icon: CalendarClock,
+        access: [EUserPermissions.ADMIN, EUserPermissions.MEMBER, EUserPermissions.GUEST],
+        shouldRender: true,
+        sortOrder: 7,
+      },
     ],
-    [project]
+    [project, workspaceSlug, projectId]
   );
 
   // Combine, filter, and sort navigation items
   const navigationItems = useMemo(() => {
-    const navItems = baseNavigation(workspaceSlug, projectId);
+    const navItems = baseNavigation();
 
     // Filter by permissions and shouldRender
     const filteredItems = navItems.filter((item) => {
@@ -108,8 +119,8 @@ export const useNavigationItems = ({
     });
 
     // Sort by sortOrder
-    return filteredItems.sort((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0));
-  }, [workspaceSlug, projectId, baseNavigation, allowPermissions, project?.id]);
+    return filteredItems.toSorted((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0));
+  }, [workspaceSlug, baseNavigation, allowPermissions, project?.id]);
 
   return navigationItems;
 };

--- a/apps/web/ce/components/navigations/use-navigation-items.ts
+++ b/apps/web/ce/components/navigations/use-navigation-items.ts
@@ -118,8 +118,10 @@ export const useNavigationItems = ({
       return hasAccess;
     });
 
-    // Sort by sortOrder
-    return filteredItems.toSorted((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0));
+    // Sort by sortOrder. Use sort() because toSorted() isn't in this app's
+    // tsconfig lib (ES2022) — see scheduler.store.ts for the same workaround.
+    // eslint-disable-next-line unicorn/no-array-sort
+    return [...filteredItems].sort((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0));
   }, [workspaceSlug, baseNavigation, allowPermissions, project?.id]);
 
   return navigationItems;

--- a/apps/web/core/components/project/scheduler-bindings/bindings-panel.tsx
+++ b/apps/web/core/components/project/scheduler-bindings/bindings-panel.tsx
@@ -1,0 +1,244 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useState } from "react";
+import { observer } from "mobx-react";
+import useSWR from "swr";
+// pi dash imports
+import { EUserPermissions, EUserPermissionsLevel } from "@pi-dash/constants";
+import { useTranslation } from "@pi-dash/i18n";
+import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
+import type { IScheduler, ISchedulerBinding } from "@pi-dash/services";
+import { SchedulerService } from "@pi-dash/services";
+import { Button, ToggleSwitch } from "@pi-dash/ui";
+// components
+import { EditSchedulerBindingModal } from "@/components/project/scheduler-bindings/edit-binding-modal";
+import { InstallSchedulerBindingModal } from "@/components/project/scheduler-bindings/install-binding-modal";
+import { UninstallSchedulerBindingModal } from "@/components/project/scheduler-bindings/uninstall-binding-modal";
+// hooks
+import { useUserPermissions } from "@/hooks/store/user";
+
+const schedulerService = new SchedulerService();
+
+type Props = {
+  workspaceSlug: string;
+  projectId: string;
+};
+
+/**
+ * Shared scheduler-bindings UI rendered from both the project settings page
+ * and the project sidebar entry. Mutations (install/edit/uninstall/toggle)
+ * are gated on PROJECT ADMIN; non-admins see a read-only list.
+ */
+export const SchedulerBindingsPanel = observer(function SchedulerBindingsPanel(props: Props) {
+  const { workspaceSlug, projectId } = props;
+  const { allowPermissions } = useUserPermissions();
+  const { t } = useTranslation();
+
+  const canManage = allowPermissions([EUserPermissions.ADMIN], EUserPermissionsLevel.PROJECT, workspaceSlug, projectId);
+
+  const { data: bindings, mutate: mutateBindings } = useSWR<ISchedulerBinding[]>(
+    workspaceSlug && projectId ? ["scheduler-bindings", workspaceSlug, projectId] : null,
+    () => schedulerService.listBindings(workspaceSlug, projectId)
+  );
+  const { data: schedulers } = useSWR<IScheduler[]>(workspaceSlug ? ["schedulers", workspaceSlug] : null, () =>
+    schedulerService.listSchedulers(workspaceSlug)
+  );
+
+  const [installOpen, setInstallOpen] = useState(false);
+  const [editTarget, setEditTarget] = useState<ISchedulerBinding | null>(null);
+  const [uninstallTarget, setUninstallTarget] = useState<ISchedulerBinding | null>(null);
+
+  const rows = bindings ?? [];
+
+  return (
+    <>
+      <div className="flex flex-col gap-6 p-6">
+        <header className="flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-16 font-semibold text-primary">{t("scheduler_bindings.title")}</h1>
+            <p className="mt-1 text-13 text-secondary">{t("scheduler_bindings.subtitle")}</p>
+          </div>
+          {canManage && <Button onClick={() => setInstallOpen(true)}>{t("scheduler_bindings.install")}</Button>}
+        </header>
+
+        <section className="rounded-md border border-subtle">
+          <table className="w-full text-13">
+            <thead className="bg-layer-1 text-left text-secondary">
+              <tr>
+                <th className="px-3 py-2">{t("scheduler_bindings.columns.name")}</th>
+                <th className="px-3 py-2">{t("scheduler_bindings.columns.cron")}</th>
+                <th className="px-3 py-2">{t("scheduler_bindings.columns.next_run")}</th>
+                <th className="px-3 py-2">{t("scheduler_bindings.columns.last_run")}</th>
+                <th className="px-3 py-2">{t("scheduler_bindings.columns.status")}</th>
+                <th className="px-3 py-2">{t("scheduler_bindings.columns.updated")}</th>
+                <th className="px-3 py-2"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((b) => (
+                <BindingRow
+                  key={b.id}
+                  binding={b}
+                  canManage={canManage}
+                  onEdit={() => setEditTarget(b)}
+                  onUninstall={() => setUninstallTarget(b)}
+                  onToggle={async (next) => {
+                    try {
+                      await mutateBindings(
+                        async (current) => {
+                          const updated = await schedulerService.updateBinding(workspaceSlug, projectId, b.id, {
+                            enabled: next,
+                          });
+                          return (current ?? []).map((row) => (row.id === b.id ? updated : row));
+                        },
+                        {
+                          // SWR diffs optimisticData by reference, so we need a
+                          // fresh array AND a fresh object for the changed row.
+                          // Build the new array imperatively to dodge oxlint's
+                          // spread-in-map rule.
+                          optimisticData: (current) => {
+                            const arr = current ?? [];
+                            const idx = arr.findIndex((row) => row.id === b.id);
+                            if (idx === -1) return arr;
+                            const out = arr.slice();
+                            out[idx] = Object.assign({}, arr[idx], { enabled: next });
+                            return out;
+                          },
+                          rollbackOnError: true,
+                          revalidate: false,
+                        }
+                      );
+                      setToast({
+                        type: TOAST_TYPE.SUCCESS,
+                        title: t("scheduler_bindings.toast.updated_title"),
+                        message: next
+                          ? t("scheduler_bindings.toast.enabled_message")
+                          : t("scheduler_bindings.toast.disabled_message"),
+                      });
+                    } catch (e: unknown) {
+                      const err = e as { error?: string } | null;
+                      setToast({
+                        type: TOAST_TYPE.ERROR,
+                        title: t("scheduler_bindings.toast.error_title"),
+                        message: err?.error ?? t("scheduler_bindings.toast.update_failed"),
+                      });
+                    }
+                  }}
+                />
+              ))}
+              {rows.length === 0 && (
+                <tr>
+                  <td colSpan={7} className="px-3 py-8 text-center text-secondary">
+                    {t("scheduler_bindings.list.empty")}
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </section>
+      </div>
+
+      <InstallSchedulerBindingModal
+        isOpen={installOpen}
+        onClose={() => setInstallOpen(false)}
+        workspaceSlug={workspaceSlug}
+        projectId={projectId}
+        availableSchedulers={schedulers ?? []}
+        existingBindings={rows}
+        onInstalled={() => mutateBindings()}
+      />
+      <EditSchedulerBindingModal
+        isOpen={!!editTarget}
+        onClose={() => setEditTarget(null)}
+        workspaceSlug={workspaceSlug}
+        projectId={projectId}
+        binding={editTarget}
+        onUpdated={() => mutateBindings()}
+      />
+      <UninstallSchedulerBindingModal
+        isOpen={!!uninstallTarget}
+        onClose={() => setUninstallTarget(null)}
+        workspaceSlug={workspaceSlug}
+        projectId={projectId}
+        binding={uninstallTarget}
+        onUninstalled={() => mutateBindings()}
+      />
+    </>
+  );
+});
+
+type RowProps = {
+  binding: ISchedulerBinding;
+  canManage: boolean;
+  onEdit: () => void;
+  onUninstall: () => void;
+  onToggle: (next: boolean) => Promise<void>;
+};
+
+function BindingRow({ binding, canManage, onEdit, onUninstall, onToggle }: RowProps) {
+  const { t } = useTranslation();
+  const [toggling, setToggling] = useState(false);
+
+  const formatTs = (ts: string | null) => (ts ? new Date(ts).toLocaleString() : t("scheduler_bindings.list.none_yet"));
+
+  // Wraps the parent's onToggle so the switch can render a disabled state
+  // during the in-flight PATCH (prevents a double-click from racing two
+  // requests).
+  const handleToggle = async (next: boolean) => {
+    if (toggling) return;
+    setToggling(true);
+    try {
+      await onToggle(next);
+    } finally {
+      setToggling(false);
+    }
+  };
+
+  return (
+    <tr className="border-t border-subtle">
+      <td className="px-3 py-2 font-medium text-primary">
+        {binding.scheduler_name}
+        <div className="text-12 text-secondary">
+          <code>{binding.scheduler_slug}</code>
+        </div>
+      </td>
+      <td className="px-3 py-2 text-secondary">
+        <code className="text-12">{binding.cron}</code>
+      </td>
+      <td className="px-3 py-2 text-secondary">{formatTs(binding.next_run_at)}</td>
+      <td className="px-3 py-2 text-secondary">{formatTs(binding.last_run_ended_at)}</td>
+      <td className="px-3 py-2">
+        <div className="flex items-center gap-2">
+          <ToggleSwitch
+            value={binding.enabled}
+            onChange={handleToggle}
+            disabled={toggling || !canManage}
+            aria-label={
+              binding.enabled ? t("scheduler_bindings.actions.disable") : t("scheduler_bindings.actions.enable")
+            }
+          />
+          <span className="text-12 text-secondary">
+            {binding.enabled ? t("scheduler_bindings.status.enabled") : t("scheduler_bindings.status.disabled")}
+          </span>
+        </div>
+      </td>
+      <td className="px-3 py-2 text-secondary">{new Date(binding.updated_at).toLocaleString()}</td>
+      <td className="px-3 py-2 text-right">
+        {canManage && (
+          <div className="flex items-center justify-end gap-2">
+            <Button variant="link-neutral" size="sm" onClick={onEdit}>
+              {t("scheduler_bindings.actions.edit")}
+            </Button>
+            <Button variant="tertiary-danger" size="sm" onClick={onUninstall}>
+              {t("scheduler_bindings.actions.uninstall")}
+            </Button>
+          </div>
+        )}
+      </td>
+    </tr>
+  );
+}

--- a/apps/web/core/components/workspace/sidebar/project-navigation.tsx
+++ b/apps/web/core/components/workspace/sidebar/project-navigation.tsx
@@ -10,6 +10,7 @@ import Link from "next/link";
 import { useParams, usePathname } from "next/navigation";
 import { EUserPermissionsLevel, EUserPermissions } from "@pi-dash/constants";
 import { useTranslation } from "@pi-dash/i18n";
+import { CalendarClock } from "lucide-react";
 import { CycleIcon, IntakeIcon, ModuleIcon, PageIcon, ViewsIcon, WorkItemsIcon } from "@pi-dash/propel/icons";
 import type { EUserProjectRoles } from "@pi-dash/types";
 // pi dash ui
@@ -69,7 +70,7 @@ export const ProjectNavigation = observer(function ProjectNavigation(props: TPro
   };
 
   const baseNavigation = useCallback(
-    (workspaceSlug: string, projectId: string): TNavigationItem[] => [
+    (): TNavigationItem[] => [
       {
         i18n_key: "sidebar.work_items",
         key: "work_items",
@@ -130,28 +131,30 @@ export const ProjectNavigation = observer(function ProjectNavigation(props: TPro
         shouldRender: project?.inbox_view ?? false,
         sortOrder: 6,
       },
+      {
+        i18n_key: "sidebar.schedulers",
+        key: "schedulers",
+        name: "Schedulers",
+        href: `/${workspaceSlug}/projects/${projectId}/schedulers`,
+        icon: CalendarClock,
+        access: [EUserPermissions.ADMIN, EUserPermissions.MEMBER, EUserPermissions.GUEST],
+        shouldRender: true,
+        sortOrder: 7,
+      },
     ],
-    [project]
+    [project, workspaceSlug, projectId]
   );
 
   // memoized navigation items and adding additional navigation items
   const navigationItemsMemo = useMemo(() => {
-    const navigationItems = (workspaceSlug: string, projectId: string): TNavigationItem[] => {
-      const navItems = baseNavigation(workspaceSlug, projectId);
+    const navItems = baseNavigation();
 
-      if (additionalNavigationItems) {
-        navItems.push(...additionalNavigationItems(workspaceSlug, projectId));
-      }
-
-      return navItems;
-    };
+    if (additionalNavigationItems) {
+      navItems.push(...additionalNavigationItems(workspaceSlug, projectId));
+    }
 
     // sort navigation items by sortOrder
-    const sortedNavigationItems = navigationItems(workspaceSlug, projectId).sort(
-      (a, b) => (a.sortOrder || 0) - (b.sortOrder || 0)
-    );
-
-    return sortedNavigationItems;
+    return navItems.toSorted((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0));
   }, [workspaceSlug, projectId, baseNavigation, additionalNavigationItems]);
 
   const isActive = useCallback(

--- a/apps/web/core/components/workspace/sidebar/project-navigation.tsx
+++ b/apps/web/core/components/workspace/sidebar/project-navigation.tsx
@@ -153,8 +153,10 @@ export const ProjectNavigation = observer(function ProjectNavigation(props: TPro
       navItems.push(...additionalNavigationItems(workspaceSlug, projectId));
     }
 
-    // sort navigation items by sortOrder
-    return navItems.toSorted((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0));
+    // sort navigation items by sortOrder. Use sort() because toSorted() isn't
+    // in this app's tsconfig lib (ES2022).
+    // eslint-disable-next-line unicorn/no-array-sort
+    return [...navItems].sort((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0));
   }, [workspaceSlug, projectId, baseNavigation, additionalNavigationItems]);
 
   const isActive = useCallback(


### PR DESCRIPTION
## Summary
- New route `/:workspaceSlug/projects/:projectId/schedulers` so per-project scheduler bindings are reachable from the left sidebar (and the tabbed project header), not just from Project Settings.
- Adds a `Schedulers` entry to the per-project nav for admin/member/guest; non-admins see the bindings list read-only (install/edit/uninstall/toggle hidden), matching the backend's existing admin-only mutation gate on `ProjectSchedulerBindingListEndpoint` / `…DetailEndpoint`.
- Extracts the bindings UI into a shared `SchedulerBindingsPanel` consumed by both the new project-level page and the existing `/settings/projects/:id/schedulers` page, so the two locations can't drift.
- Drive-by: drops two redundant inner `workspaceSlug`/`projectId` callback params in the project-nav hooks that were shadowing the outer scope and tripping `lint-staged --deny-warnings` once those files were touched.

## Test plan
- [ ] Expand a project in the left sidebar (accordion mode) → confirm `Schedulers` appears under Intake.
- [ ] Switch to TABBED nav mode → confirm `Schedulers` shows in the project header tab bar (overflow menu if it doesn't fit).
- [ ] As a project admin, navigate to `/<workspace>/projects/<id>/schedulers` → install/edit/disable/uninstall a binding → confirm parity with the settings page.
- [ ] As a member/guest, navigate to the same URL → confirm the list renders read-only with no Install / Edit / Uninstall buttons and the toggle is disabled.
- [ ] Open `/<workspace>/settings/projects/<id>/schedulers` (legacy location) → confirm it still works and renders the same data as the new page.
- [ ] Verify `/<workspace>/schedulers` (workspace catalog) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)