### PR TITLE
[codex] Default project work items to board layout

### DIFF
--- a/apps/api/pi_dash/bgtasks/workspace_seed_task.py
+++ b/apps/api/pi_dash/bgtasks/workspace_seed_task.py
@@ -133,7 +133,7 @@ def create_project_and_member(workspace: Workspace, bot_user: User) -> Dict[int,
                     user_id=workspace_member["member_id"],
                     workspace_id=workspace.id,
                     display_filters={
-                        "layout": "list",
+                        "layout": "kanban",
                         "calendar": {"layout": "month", "show_weekends": False},
                         "group_by": "state",
                         "order_by": "sort_order",

--- a/apps/api/pi_dash/db/models/issue.py
+++ b/apps/api/pi_dash/db/models/issue.py
@@ -60,12 +60,12 @@ def get_default_filters():
 
 def get_default_display_filters():
     return {
-        "group_by": None,
-        "order_by": "-created_at",
+        "group_by": "state",
+        "order_by": "sort_order",
         "type": None,
         "sub_issue": True,
         "show_empty_groups": True,
-        "layout": "list",
+        "layout": "kanban",
         "calendar_date_range": "",
     }
 

--- a/apps/api/pi_dash/db/models/issue.py
+++ b/apps/api/pi_dash/db/models/issue.py
@@ -61,6 +61,7 @@ def get_default_filters():
 def get_default_display_filters():
     return {
         "group_by": "state",
+        "sub_group_by": None,
         "order_by": "sort_order",
         "type": None,
         "sub_issue": True,

--- a/apps/api/pi_dash/db/models/project.py
+++ b/apps/api/pi_dash/db/models/project.py
@@ -53,19 +53,23 @@ def get_default_props():
             "subscriber": None,
         },
         "display_filters": {
-            "group_by": None,
-            "order_by": "-created_at",
+            "group_by": "state",
+            "order_by": "sort_order",
             "type": None,
             "sub_issue": True,
             "show_empty_groups": True,
-            "layout": "list",
+            "layout": "kanban",
             "calendar_date_range": "",
         },
     }
 
 
 def get_default_preferences():
-    return {"pages": {"block_display": True}, "navigation": {"default_tab": "work_items", "hide_in_more_menu": []}}
+    return {
+        "pages": {"block_display": True},
+        "navigation": {"default_tab": "work_items", "hide_in_more_menu": []},
+        "work_items": {"layout_default_applied": True},
+    }
 
 
 class Project(BaseModel):

--- a/apps/api/pi_dash/db/models/project.py
+++ b/apps/api/pi_dash/db/models/project.py
@@ -54,6 +54,7 @@ def get_default_props():
         },
         "display_filters": {
             "group_by": "state",
+            "sub_group_by": None,
             "order_by": "sort_order",
             "type": None,
             "sub_issue": True,

--- a/apps/web/core/components/navigation/use-tab-preferences.ts
+++ b/apps/web/core/components/navigation/use-tab-preferences.ts
@@ -40,16 +40,16 @@ export const useTabPreferences = (workspaceSlug: string, projectId: string): TTa
 
   // Get preferences from store
   const storePreferences = getProjectUserProperties(projectId);
-  const defaultTab = storePreferences?.preferences?.navigation?.default_tab || DEFAULT_TAB_KEY;
-  const hideInMoreMenu = storePreferences?.preferences?.navigation?.hide_in_more_menu || [];
+  const navigationPreferences = storePreferences?.preferences?.navigation;
 
   // Convert store preferences to component format
-  const tabPreferences: TTabPreferences = useMemo(() => {
-    return {
-      defaultTab,
-      hiddenTabs: hideInMoreMenu,
-    };
-  }, [defaultTab, hideInMoreMenu]);
+  const tabPreferences: TTabPreferences = useMemo(
+    () => ({
+      defaultTab: navigationPreferences?.default_tab || DEFAULT_TAB_KEY,
+      hiddenTabs: navigationPreferences?.hide_in_more_menu || [],
+    }),
+    [navigationPreferences]
+  );
 
   const isLoading = !storePreferences && memberId !== null;
 
@@ -59,6 +59,7 @@ export const useTabPreferences = (workspaceSlug: string, projectId: string): TTa
   const updatePreferences = async (newPreferences: TTabPreferences) => {
     await updateProjectUserProperties(workspaceSlug, projectId, {
       preferences: {
+        ...storePreferences?.preferences,
         pages: storePreferences?.preferences?.pages || { block_display: false },
         navigation: {
           default_tab: newPreferences.defaultTab,

--- a/apps/web/core/store/issue/project/filter.store.ts
+++ b/apps/web/core/store/issue/project/filter.store.ts
@@ -76,6 +76,7 @@ export class ProjectIssuesFilter extends IssueFilterHelperStore implements IProj
   rootIssueStore: IIssueRootStore;
   // services
   projectService;
+  boardDefaultMigrationProjectIds: Set<string> = new Set();
 
   constructor(_rootStore: IIssueRootStore) {
     super();
@@ -157,7 +158,10 @@ export class ProjectIssuesFilter extends IssueFilterHelperStore implements IProj
     const displayFiltersPayload = shouldApplyBoardDefault
       ? {
           ..._filters?.display_filters,
-          ...PROJECT_ISSUES_DEFAULT_DISPLAY_FILTERS,
+          layout: PROJECT_ISSUES_DEFAULT_DISPLAY_FILTERS.layout,
+          group_by: PROJECT_ISSUES_DEFAULT_DISPLAY_FILTERS.group_by,
+          sub_group_by: PROJECT_ISSUES_DEFAULT_DISPLAY_FILTERS.sub_group_by,
+          order_by: PROJECT_ISSUES_DEFAULT_DISPLAY_FILTERS.order_by,
         }
       : _filters?.display_filters;
     const displayFilters = this.computedDisplayFilters(displayFiltersPayload, PROJECT_ISSUES_DEFAULT_DISPLAY_FILTERS);
@@ -187,7 +191,8 @@ export class ProjectIssuesFilter extends IssueFilterHelperStore implements IProj
       set(this.filters, [projectId, "kanbanFilters"], kanbanFilters);
     });
 
-    if (shouldApplyBoardDefault) {
+    if (shouldApplyBoardDefault && !this.boardDefaultMigrationProjectIds.has(projectId)) {
+      this.boardDefaultMigrationProjectIds.add(projectId);
       try {
         await this.projectService.updateProjectUserProperties(workspaceSlug, projectId, {
           display_filters: displayFilters,

--- a/apps/web/core/store/issue/project/filter.store.ts
+++ b/apps/web/core/store/issue/project/filter.store.ts
@@ -31,6 +31,19 @@ import { ProjectService } from "@/services/project";
 // constants
 // services
 
+const PROJECT_ISSUES_DEFAULT_DISPLAY_FILTERS: IIssueDisplayFilterOptions = {
+  calendar: {
+    show_weekends: false,
+    layout: "month",
+  },
+  layout: "kanban",
+  order_by: "sort_order",
+  group_by: "state",
+  sub_group_by: null,
+  sub_issue: true,
+  show_empty_groups: true,
+};
+
 export interface IProjectIssuesFilter extends IBaseIssueFilterStore {
   //helper actions
   getFilterParams: (
@@ -138,7 +151,16 @@ export class ProjectIssuesFilter extends IssueFilterHelperStore implements IProj
     const _filters = await this.projectService.getProjectUserProperties(workspaceSlug, projectId);
 
     const richFilters = _filters?.rich_filters;
-    const displayFilters = this.computedDisplayFilters(_filters?.display_filters);
+    const shouldApplyBoardDefault =
+      !_filters?.preferences?.work_items?.layout_default_applied &&
+      (!_filters?.display_filters?.layout || _filters.display_filters.layout === "list");
+    const displayFiltersPayload = shouldApplyBoardDefault
+      ? {
+          ..._filters?.display_filters,
+          ...PROJECT_ISSUES_DEFAULT_DISPLAY_FILTERS,
+        }
+      : _filters?.display_filters;
+    const displayFilters = this.computedDisplayFilters(displayFiltersPayload, PROJECT_ISSUES_DEFAULT_DISPLAY_FILTERS);
     const displayProperties = this.computedDisplayProperties(_filters?.display_properties);
 
     // fetching the kanban toggle helpers in the local storage
@@ -164,6 +186,23 @@ export class ProjectIssuesFilter extends IssueFilterHelperStore implements IProj
       set(this.filters, [projectId, "displayProperties"], displayProperties);
       set(this.filters, [projectId, "kanbanFilters"], kanbanFilters);
     });
+
+    if (shouldApplyBoardDefault) {
+      try {
+        await this.projectService.updateProjectUserProperties(workspaceSlug, projectId, {
+          display_filters: displayFilters,
+          preferences: {
+            ..._filters.preferences,
+            work_items: {
+              ..._filters.preferences?.work_items,
+              layout_default_applied: true,
+            },
+          },
+        });
+      } catch (error) {
+        console.log("error while applying default project work item layout", error);
+      }
+    }
   };
 
   /**

--- a/apps/web/core/store/issue/project/filter.store.ts
+++ b/apps/web/core/store/issue/project/filter.store.ts
@@ -154,9 +154,10 @@ export class ProjectIssuesFilter extends IssueFilterHelperStore implements IProj
     const richFilters = _filters?.rich_filters;
     const shouldApplyBoardDefault =
       !_filters?.preferences?.work_items?.layout_default_applied &&
-      (!_filters?.display_filters?.layout || _filters.display_filters.layout === "list");
+      (!_filters?.display_filters?.layout || _filters?.display_filters?.layout === "list");
     const displayFiltersPayload = shouldApplyBoardDefault
       ? {
+          ...PROJECT_ISSUES_DEFAULT_DISPLAY_FILTERS,
           ..._filters?.display_filters,
           layout: PROJECT_ISSUES_DEFAULT_DISPLAY_FILTERS.layout,
           group_by: PROJECT_ISSUES_DEFAULT_DISPLAY_FILTERS.group_by,
@@ -192,20 +193,20 @@ export class ProjectIssuesFilter extends IssueFilterHelperStore implements IProj
     });
 
     if (shouldApplyBoardDefault && !this.boardDefaultMigrationProjectIds.has(projectId)) {
-      this.boardDefaultMigrationProjectIds.add(projectId);
       try {
         await this.projectService.updateProjectUserProperties(workspaceSlug, projectId, {
-          display_filters: displayFilters,
+          display_filters: displayFiltersPayload,
           preferences: {
-            ..._filters.preferences,
+            ..._filters?.preferences,
             work_items: {
-              ..._filters.preferences?.work_items,
+              ..._filters?.preferences?.work_items,
               layout_default_applied: true,
             },
           },
         });
+        this.boardDefaultMigrationProjectIds.add(projectId);
       } catch (error) {
-        console.log("error while applying default project work item layout", error);
+        console.error("error while applying default project work item layout", error);
       }
     }
   };

--- a/packages/types/src/view-props.ts
+++ b/packages/types/src/view-props.ts
@@ -208,6 +208,9 @@ export interface IProjectUserPropertiesResponse extends IIssueFiltersResponse {
       block_display: boolean;
     };
     navigation: IProjectMemberNavigationPreferences;
+    work_items?: {
+      layout_default_applied?: boolean;
+    };
   };
 }
 


### PR DESCRIPTION
## Summary

- Default project-level Work Items to Board Layout (`kanban`) grouped by state.
- Apply the new board default once for existing project user properties that are still on the old list default.
- Stamp the migration in project user preferences so a later manual switch back to list persists.
- Update backend defaults and workspace seed data so new project Work Items start on Board Layout.

## Impact

Project Work Items now open in Board Layout by default across projects. Users can still switch layouts; once the new default has been applied, their later layout choice is preserved.

## Validation

- `python3` source compile for touched backend files passed.
- `git diff --check` passed.
- `pnpm --filter @pi-dash/types build` passed.
- `pnpm --filter web check:types` is blocked locally by root-owned generated `.react-router` files.
- `pnpm --filter web exec tsc --noEmit` still reports existing unrelated type errors, but none from this change remain.