### PR TITLE
docs(wiki): add initial wiki under docs/wiki/

### DIFF
--- a/docs/wiki/01-architecture-overview.md
+++ b/docs/wiki/01-architecture-overview.md
@@ -1,0 +1,81 @@
+# 01 — Architecture Overview
+
+Pi Dash is an **AI agent orchestration platform** built for "As Coding" (asynchronous vibe coding): you define what needs to be built, agents implement it in the background, and you spend your time scoping and reviewing rather than watching terminals.
+
+The product is the orchestration layer. It does **not** ship its own coding agent — you bring `claude` or `codex`, and Pi Dash drives them.
+
+## The three components
+
+```
+┌───────────────────────────┐         ┌────────────────────────────┐
+│   Pi Dash Platform        │         │    Pi Dash Runner          │
+│   (cloud / self-hosted)   │  ◀─────▶│    (on your dev machine)   │
+│                           │  HTTPS  │                            │
+│ • Web UI (React Router 7) │  + WS   │ • Rust daemon (`pidash`)   │
+│ • Django REST API         │         │ • Supervisor + state mach. │
+│ • Channels / WebSockets   │         │ • Codex / Claude bridge    │
+│ • Celery (background)     │         │ • Local TUI + IPC socket   │
+│ • Live editor (Hocuspocus)│         │                            │
+└───────────────────────────┘         └─────────────┬──────────────┘
+                                                    │ subprocess
+                                                    ▼
+                                      ┌────────────────────────────┐
+                                      │   AI Agent (BYO)           │
+                                      │                            │
+                                      │ • `claude`  (Anthropic)    │
+                                      │ • `codex`   (OpenAI)       │
+                                      └────────────────────────────┘
+```
+
+### 1. Pi Dash Platform (cloud or self-hosted)
+
+The orchestration hub: work items, cycles, modules, views, pages, analytics — plus the cloud side of the runner protocol. Lives under `apps/` and the Django backend in `apps/api/`.
+
+See [05 — Frontend architecture](./05-frontend-architecture.md) and [06 — Backend architecture](./06-backend-architecture.md).
+
+### 2. Pi Dash Runner
+
+A single Rust binary (`pidash`) installed on a developer machine. It authenticates against the platform, polls for assigned tasks, dispatches each one to the user's configured AI agent as a subprocess, and reports results back. Lives under `runner/`.
+
+See [07 — Runner architecture](./07-runner-architecture.md) and [08 — Cloud ↔ runner protocol](./08-cloud-runner-protocol.md).
+
+### 3. AI Agent (user-provided)
+
+Pi Dash is agent-agnostic. The runner ships first-class support for **Claude Code** (`claude`) and **Codex** (`codex`); the dispatch layer is designed so other agents can be wired in without changing the orchestration model. Users install the agent binary themselves; `pidash doctor` checks it.
+
+## End-to-end task lifecycle
+
+1. **User creates a work item** in the web UI (`apps/web`).
+2. **Platform assigns** the work item to a project that has at least one connected runner.
+3. **Orchestration layer** (`apps/api/pi_dash/orchestration/`) produces an agent run plan — phase, prompt, working dir, approval policy — and persists it.
+4. **Runner polls** the cloud for new runs over HTTPS long-poll (wire protocol v4, see [08](./08-cloud-runner-protocol.md)).
+5. **Runner spawns** the configured agent (`codex app-server` or `claude`) in the project's workspace, streaming the JSON-RPC bridge into the daemon.
+6. **Approval router** (first-writer-wins between TUI / cloud / policy) handles any approval prompts the agent emits.
+7. **Run transcripts** (JSONL) are written locally under the runner's data dir, and progress events are pushed back to the platform.
+8. **User reviews** results in the web UI — diff, transcript, approval decisions, follow-up.
+
+## The three seams to know
+
+When a change spans more than one layer, you almost always cross one of these:
+
+| Seam                                                         | Files                                                            | Versioned?                                                             |
+| ------------------------------------------------------------ | ---------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| **REST API** (browser ↔ Django)                              | `apps/api/pi_dash/{app,api}/urls/` + `packages/services/` client | No (internal, deploy together)                                         |
+| **Channels WebSocket** (live editor, runner WS in legacy v3) | `apps/api/pi_dash/runner/consumers.py`, `apps/live/`             | Yes for runner — bumped on incompatible shape changes                  |
+| **Runner ↔ cloud protocol**                                  | `runner/src/cloud/protocol.rs`, `apps/api/pi_dash/runner/views/` | **Yes** — wire version pinned, see [08](./08-cloud-runner-protocol.md) |
+
+Internal REST is allowed to change freely because the web frontend and the API ship together. The runner protocol is the one external contract — it gates auto-update behavior. Bump deliberately.
+
+## Where state lives
+
+- **Postgres** — primary OLTP store (work items, users, runs, approvals, etc.). Django ORM models in `apps/api/pi_dash/db/` and per-app `models.py`.
+- **Redis / Valkey** — Django Channels layer, cache, throttling, ephemeral pub/sub between web ↔ runner.
+- **RabbitMQ** — Celery broker for background tasks (`apps/api/pi_dash/bgtasks/`).
+- **MinIO / S3** — file/attachment object storage.
+- **Local runner state** — TOML config + JSONL transcripts under the platform config/data dirs (`~/.config/pidash/...` on Linux). All on-disk secrets and the IPC socket are `0600`.
+
+## What this wiki does **not** cover
+
+- API endpoint reference — see DRF Spectacular at `/api/schema/swagger-ui/` when running locally.
+- Frontend component catalog — see Storybook (`pnpm --filter @pi-dash/ui storybook`).
+- The closed-source `private-pi-dash` cloud overlay — that lives in a separate repo and is documented there.

--- a/docs/wiki/02-cloud-quickstart.md
+++ b/docs/wiki/02-cloud-quickstart.md
@@ -1,0 +1,91 @@
+# 02 — Pi Dash Cloud Quickstart
+
+## 1. Sign up
+
+1. Open <https://pidash.airepublic.com>.
+2. Click **Sign up**, complete sign-up, verify your email.
+
+## 2. Create workspace + project
+
+1. Create your workspace when prompted.
+2. **Projects → + Add project**. Fill in:
+   - **Name**, **Identifier**
+   - **Repository URL** — git clone URL (e.g. `git@github.com:acme/web.git`)
+   - **Default branch** — usually `main`
+3. Open **Project → Settings → General** and copy the **project ID**.
+
+## 3. Install an AI agent
+
+Pick one:
+
+- **Claude Code** — install per <https://docs.anthropic.com/en/docs/claude-code>, verify `claude --version`.
+- **Codex** — install per <https://github.com/openai/codex>, verify `codex --version`.
+
+## 4. Install `pidash`
+
+**macOS / Linux:**
+
+```bash
+curl --proto '=https' --tlsv1.2 -LsSf \
+  https://github.com/The-AI-Republic/pi-dash/releases/latest/download/install.sh | sh
+```
+
+**Windows (PowerShell):**
+
+```powershell
+irm https://github.com/The-AI-Republic/pi-dash/releases/latest/download/install.ps1 | iex
+```
+
+When prompted, enter `https://pidash.airepublic.com` and approve the device-code in the browser.
+
+## 5. Register this machine as a runner
+
+```bash
+pidash runner add --project <PROJECT_ID>
+pidash doctor
+pidash status
+```
+
+`pidash doctor` must be clean before continuing.
+
+## 6. Run your first work item
+
+1. In Pi Dash, **Work items → + Create work item**.
+2. Write a specific title + description + acceptance criteria.
+3. Click **Run agent**.
+4. Watch in the work item's **Run** panel or `pidash tui`.
+5. Approve prompts as they appear (use **Approve always** for safe commands).
+
+## 7. Review
+
+1. Open the work item → review **diff**, **transcript**, **summary**.
+2. To commit: `cd` into the runner working dir (`pidash status` shows the path), then `git` as normal.
+
+---
+
+## Common commands
+
+```bash
+pidash status              # daemon + runner state
+pidash tui                 # interactive dashboard
+pidash doctor              # preflight checks
+pidash auth status         # who am I logged in as
+pidash runner list         # runners on this host
+pidash runner add --project <ID>
+pidash runner remove <name>
+pidash restart / stop
+pidash update              # self-update
+pidash --help
+```
+
+Full command + flag reference: [17 — `pidash` CLI reference](./17-cli-reference.md).
+
+## If something breaks
+
+- **Run stuck pending** → `pidash status`, then `pidash restart`.
+- **Run fails immediately** → `pidash doctor` (usually agent not on `PATH`, or git clone auth).
+- **Command not found** → open a new terminal.
+- **Browser auth not approving** → use the same browser you signed up in.
+- **Headless host** → use enrollment token: in web UI **Runners → Add connection**, then `pidash connect --url https://pidash.airepublic.com --token <TOKEN>`.
+
+Discussions: <https://github.com/The-AI-Republic/pi-dash/discussions> · Bugs: <https://github.com/The-AI-Republic/pi-dash/issues>

--- a/docs/wiki/03-repository-layout.md
+++ b/docs/wiki/03-repository-layout.md
@@ -1,0 +1,84 @@
+# 03 — Repository Layout
+
+Pi Dash is a polyglot monorepo with three independent toolchains coexisting at the top level. Knowing which "stack" a directory belongs to is the fastest way to decide which commands to reach for.
+
+```
+pi-dash/
+├── apps/                ← TS/React frontends + Django backend + Node live server
+│   ├── web/             ← main product UI            (React Router 7)         :3000
+│   ├── admin/           ← instance-admin UI (/god-mode/)                       :3001
+│   ├── space/           ← public "spaces" (guest views)                        :3002
+│   ├── live/            ← Node/Express + Hocuspocus (Yjs realtime)
+│   ├── api/             ← Django 4 / DRF / Channels backend (Python, separate)
+│   └── proxy/           ← Caddy reverse proxy (production only)
+│
+├── packages/            ← shared TS workspace packages (consumed by apps/web|admin|space)
+│   ├── ui/              ← component library + Storybook
+│   ├── shared-state/    ← MobX stores (canonical client state)
+│   ├── services/        ← API client
+│   ├── editor/          ← Tiptap / ProseMirror integration
+│   ├── i18n/            ← locales + key sync tools
+│   ├── constants/  hooks/  types/  utils/  logger/  propel/  decorators/
+│   ├── codemods/        ← jscodeshift transforms for repo-wide refactors
+│   ├── tailwind-config/   typescript-config/    ← shared base configs
+│
+├── runner/              ← Rust binary crate (the `pidash` CLI + daemon)
+│   ├── src/{cli,daemon,cloud,codex,approval,workspace,ipc,history,service,tui,config,util}
+│   ├── install.sh / install.ps1   ← wrapper installers (auto-auth)
+│   └── wix/             ← Windows MSI metadata
+│
+├── deployments/         ← reference deploys
+│   ├── aio/community/   ← single-container all-in-one
+│   ├── cli/community/   ← docker-compose self-host
+│   ├── swarm/           ← Docker Swarm
+│   └── kubernetes/community/  ← k8s manifests (Helm chart planned)
+│
+├── docs/                ← docs (you are here)
+│   ├── wiki/            ← internal wiki — architecture / contributor guide
+│   └── linting.md
+│
+├── images/              ← assets used in README / marketing
+├── docker-compose.yml          ← production-flavored
+├── docker-compose-local.yml    ← infra-only stack for `pnpm dev`
+├── turbo.json                  ← Turborepo task graph
+├── pnpm-workspace.yaml         ← workspace + dep catalog
+├── dist-workspace.toml         ← cargo-dist (runner release packaging)
+├── setup.sh                    ← first-time env bootstrap
+├── CLAUDE.md / AGENTS.md       ← in-repo guidance for coding agents
+└── ...                         ← LICENSE / SECURITY / RELEASING / CODEOWNERS
+```
+
+## The three toolchains
+
+| Stack                                 | Manifest                                                             | Manager          | Lockfile                        |
+| ------------------------------------- | -------------------------------------------------------------------- | ---------------- | ------------------------------- |
+| TS/React frontends + Node live server | `package.json`, `pnpm-workspace.yaml`, `turbo.json`                  | pnpm + Turborepo | `pnpm-lock.yaml`                |
+| Django backend                        | `apps/api/pyproject.toml`, `apps/api/requirements.txt`               | pip / virtualenv | (none — pinned in requirements) |
+| Rust runner                           | `runner/Cargo.toml`, `Cargo.toml` (workspace), `rust-toolchain.toml` | cargo            | `Cargo.lock`                    |
+
+**Important:** `pnpm-workspace.yaml` explicitly excludes `apps/api` (Django) and `apps/proxy` (Caddy). They live inside `apps/` for proximity, but they are **not** in the pnpm workspace — root `pnpm` commands skip them. Treat them as their own projects with their own commands.
+
+The `runner/` crate is similarly outside Turborepo. `cargo build` is the only way to build it.
+
+## Dependency conventions (TS workspace)
+
+From `AGENTS.md`:
+
+- **Internal packages** use `"workspace:*"` — e.g. `"@pi-dash/ui": "workspace:*"`.
+- **External deps** use `"catalog:"` — versions are pinned in the `catalog:` block of `pnpm-workspace.yaml`. Don't add a direct version for anything that's already in the catalog.
+
+When you upgrade a catalog dep, you upgrade it for every package in the workspace at once. That's the point.
+
+## App vs package — when to put code where
+
+- **An app (`apps/*`)** owns routes, top-level providers, and user-facing pages. Keep app folders thin — push reusable logic out.
+- **A package (`packages/*`)** is everything reusable across two or more apps. Stores, API client, components, hooks, types, constants.
+
+New code starts in an app and graduates to a package the second time it's needed somewhere else. Don't pre-create packages.
+
+## Where the wiki points
+
+- Want to change a UI route? → `apps/web/app/routes/` + [05](./05-frontend-architecture.md).
+- Want to add an API endpoint? → `apps/api/pi_dash/{app,api}/views/` + [06](./06-backend-architecture.md).
+- Want to teach the runner a new agent? → `runner/src/agent/` + `runner/src/codex/` + [07](./07-runner-architecture.md).
+- Want to ship the runner? → [15 — Releasing](./15-releasing.md).

--- a/docs/wiki/04-getting-started.md
+++ b/docs/wiki/04-getting-started.md
@@ -1,0 +1,75 @@
+# 04 — Getting Started Locally
+
+This is the from-zero contributor onboarding. For the production install paths see the top-level `README.md`.
+
+## Requirements
+
+- **Docker Engine** running locally
+- **Node.js ≥ 22.18 LTS**
+- **Python 3.12+** (Django backend runs in its own venv)
+- **Postgres 15+** (provided by docker-compose-local)
+- **Valkey 7+** (or Redis 7+, drop-in compatible — also provided)
+- **RAM ≥ 12 GB** — 8 GB will OOM during Docker build / pnpm install
+- **Rust toolchain** (only needed if you'll touch `runner/`; `rust-toolchain.toml` pins the version)
+
+## First-time bootstrap
+
+```bash
+git clone https://github.com/The-AI-Republic/pi-dash.git
+cd pi-dash
+chmod +x setup.sh
+./setup.sh
+```
+
+`setup.sh` does three things:
+
+1. **Copies every `.env.example` to `.env`** — repo root plus `apps/{web,api,space,admin,live}`. The defaults work out of the box for loopback dev (localhost URLs, `pi-dash` Postgres creds, local MinIO endpoint). Only edit `.env` files if you're binding to a non-default host or wiring in external services.
+2. **Generates a unique Django `SECRET_KEY`** and appends it to `apps/api/.env`.
+3. **Runs `pnpm install`** for the TS workspace.
+
+## Start the infra
+
+```bash
+docker compose -f docker-compose-local.yml up
+```
+
+This brings up just the dependencies — Postgres, Redis/Valkey, RabbitMQ, MinIO. The app processes themselves run on your host so you keep hot reload.
+
+## Start the apps
+
+```bash
+pnpm dev
+```
+
+Turbo launches every dev server concurrently. Watch the output for any one that failed to start.
+
+### Ports
+
+| App     | Port                      | Purpose                           |
+| ------- | ------------------------- | --------------------------------- |
+| `web`   | **3000**                  | Main product UI                   |
+| `admin` | **3001**                  | Instance admin ("god mode")       |
+| `space` | **3002**                  | Published public spaces           |
+| `live`  | per `.env`                | Hocuspocus realtime editor server |
+| `api`   | (Django, port per `.env`) | REST + Channels backend           |
+
+## First-run flow
+
+1. Open **`http://localhost:3001/god-mode/`** and register yourself as the **instance admin**. You only do this once per instance.
+2. Open **`http://localhost:3000`** and log in with the same credentials. This is the actual product.
+3. Create a workspace → create a project → invite yourself.
+4. (Optional, for runner work) install the `pidash` CLI and point it at `http://localhost:8000` (or whatever the API exposes locally) — see [11 — Authentication](./11-authentication.md) for device-code login.
+
+## Common gotchas
+
+- **Django defaults to `production` settings.** `manage.py` sets `DJANGO_SETTINGS_MODULE=pi_dash.settings.production`. For local work either export `DJANGO_SETTINGS_MODULE=pi_dash.settings.local` or use the helper scripts under `apps/api/`.
+- **Turbo concurrency = 18.** If `pnpm dev` is choking your machine, lower it: `pnpm turbo run dev --concurrency=8`.
+- **OxLint warning ceilings will block your commit.** Each app pins a `--max-warnings` ceiling in its `package.json`. Adding warnings past the ceiling fails `check:lint` and trips the pre-commit hook. Either fix the warning or — if you legitimately removed some — _lower_ the ceiling, don't raise it.
+- **Husky + lint-staged run `oxfmt` and `oxlint --fix --deny-warnings` on commit.** A hook failure means the commit didn't happen — fix the underlying issue and re-commit, do **not** `--no-verify`.
+- **Postgres data persists** in the named Docker volume from `docker-compose-local.yml`. `docker compose down -v` will wipe it; that's how you get a clean slate.
+
+## Where to go next
+
+- [13 — Development workflow](./13-development-workflow.md) — pnpm/turbo/lint/format day-to-day commands
+- [14 — Testing](./14-testing.md) — running pytest / vitest / cargo test
+- [05](./05-frontend-architecture.md), [06](./06-backend-architecture.md), [07](./07-runner-architecture.md) — the per-stack deep dives

--- a/docs/wiki/05-frontend-architecture.md
+++ b/docs/wiki/05-frontend-architecture.md
@@ -1,0 +1,104 @@
+# 05 — Frontend Architecture
+
+The browser side of Pi Dash is **four React Router 7 apps** sharing a common workspace of TypeScript packages. State is managed with **MobX** (not Redux, not Zustand). Styling is Tailwind + the in-house `@pi-dash/ui` component library.
+
+## The four apps
+
+| App     | Folder        | Port       | Role                                                                                                                           |
+| ------- | ------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `web`   | `apps/web/`   | 3000       | The main product UI — work items, cycles, modules, views, pages, analytics                                                     |
+| `admin` | `apps/admin/` | 3001       | "God mode" instance admin (mounted at `/god-mode/`)                                                                            |
+| `space` | `apps/space/` | 3002       | Public-facing "spaces" — published views accessible without login                                                              |
+| `live`  | `apps/live/`  | per `.env` | **Backend service**, not a React app — Hocuspocus/Yjs realtime collaboration server (see [10](./10-realtime-collaboration.md)) |
+
+`web`, `admin`, and `space` are structured similarly: `app/` for routes, `components/` for app-local components, `store/` for MobX root composition, `helpers/`, `hooks/`, `lib/`, plus `vite.config.ts`, `react-router.config.ts`, `Dockerfile.*`, `nginx/` (for prod static serving).
+
+`apps/web/ce/` is the **Community Edition split**: code that's compiled-in for OSS builds but can be overridden in the proprietary build of Pi Dash Cloud (`private-pi-dash`). Treat `ce/` as the OSS implementation; do not fork it into private code.
+
+## Shared packages (`packages/`)
+
+```
+ui/              ← component library + Storybook (pnpm --filter @pi-dash/ui storybook → :6006)
+shared-state/    ← MobX stores: user, workspace, filters — the canonical client state
+services/        ← API client (fetch wrappers, typed endpoints)
+editor/          ← Tiptap/ProseMirror — collab editor (used with live server)
+i18n/            ← locale dictionaries + `i18n:sync` / `i18n:translate` scripts
+constants/       ← cross-app enums and string keys
+hooks/           ← reusable React hooks
+types/           ← cross-app TypeScript types
+utils/           ← pure helpers
+logger/          ← structured client logging
+propel/          ← analytics / event tracking shim
+decorators/      ← MobX/route decorators
+tailwind-config/ ← shared Tailwind preset
+typescript-config/ ← shared tsconfig bases
+codemods/        ← jscodeshift transforms for repo-wide refactors
+```
+
+Apps consume packages via `"@pi-dash/<name>": "workspace:*"`. **External** deps go through the `catalog:` block in `pnpm-workspace.yaml` — see [03 — Repository layout](./03-repository-layout.md).
+
+## State: MobX shared-state
+
+The single source of truth for client state is `packages/shared-state`. Top-level stores include:
+
+- `user.store.ts` — current user, session, preferences
+- `workspace.store.ts` — current workspace, members, settings
+- `work-item-filters/`, `rich-filters/` — UI filter state
+
+Each app composes these stores in its own `store/` directory (a thin root store that wires the shared stores to app-specific stores). Components consume them via MobX observer / `useContext` — not React Context for the data itself, only for the root store handle.
+
+**Convention:** any state that isn't strictly local to one component lives in a store, not in `useState`. Reactive patterns over prop drilling.
+
+## Routing
+
+Each app uses **React Router v7** (file-based + programmatic).
+
+- Route files live under `apps/<app>/app/routes/`.
+- Layout, root provider, error boundary in `apps/<app>/app/{root.tsx,layout.tsx,provider.tsx,error/}`.
+- `routes.ts` and `routes/core.ts`/`extended.ts` define the route tree.
+
+## Build & dev tooling
+
+- **Vite** for dev server + bundling (`vite.config.ts` in each app).
+- **`react-router.config.ts`** for RR7-specific config (SSR mode, route discovery).
+- **Turborepo** drives `dev` / `build` / `check` across the workspace. `pnpm dev` runs `turbo run dev --concurrency=18`.
+- **`packages/*` build** with `tsdown` (Rust-based, fast).
+- **Storybook** is run inside `@pi-dash/ui` only — `pnpm --filter @pi-dash/ui storybook` → `:6006`. Build components there in isolation before wiring them into an app.
+
+## Linting & formatting
+
+The entire TS workspace shares **one** root config:
+
+- `.oxlintrc.json` — OxLint rules
+- `.oxfmtrc.json` — oxfmt formatter
+
+Both tools are Rust-based, replacing ESLint + Prettier. `eslint-disable` comments still work for back-compat.
+
+**Per-app `--max-warnings` ceilings** (pinned in each `package.json`):
+
+| App           | Ceiling |
+| ------------- | ------- |
+| `web`         | 11957   |
+| `space`       | 676     |
+| `admin`       | 759     |
+| `live`        | 119     |
+| `@pi-dash/ui` | 66      |
+
+Crossing the ceiling fails `pnpm check:lint`. After cleanups, **lower** the ceiling instead of leaving headroom. See [13 — Development workflow](./13-development-workflow.md) for the full toolchain.
+
+## i18n
+
+Translations live in `packages/i18n/src/locales/<lang>/`. When you add a key, add it to **every** language file (English as placeholder is fine) — the loader asserts nested-structure parity and will fail at runtime if a key is missing in some language.
+
+Useful scripts:
+
+```bash
+pnpm i18n:sync         # propagate new keys across all locales
+pnpm i18n:translate    # auto-translate missing keys
+```
+
+## Where to read next
+
+- [06 — Backend architecture](./06-backend-architecture.md) — the REST/WS surface the frontend consumes
+- [10 — Realtime collaboration](./10-realtime-collaboration.md) — `apps/live` and the editor
+- `apps/web/app/routes/core.ts` for the actual route tree

--- a/docs/wiki/06-backend-architecture.md
+++ b/docs/wiki/06-backend-architecture.md
@@ -1,0 +1,146 @@
+# 06 — Backend Architecture
+
+The backend lives in `apps/api/` and is a **Django 4 / DRF / Channels** application. It is **not** in the pnpm workspace — separate venv, separate test runner, separate dependency manifest (`pyproject.toml` + `requirements.txt`).
+
+## Top-level layout
+
+```
+apps/api/
+├── manage.py
+├── pyproject.toml                ← Python package metadata + ruff config
+├── requirements.txt              ← pinned deps
+├── pytest.ini                    ← --reuse-db --nomigrations
+├── run_tests.py / run_tests.sh   ← test entrypoints (markers: unit | contract | smoke)
+├── apple_pi_dash/                ← legacy Django project name (settings module path)
+└── pi_dash/                      ← actual Django app modules (importable as `pi_dash.*`)
+```
+
+> Note: the Python package is named `pi_dash`, but `DJANGO_SETTINGS_MODULE` historically references `apple_pi_dash.settings.*` and you'll still see `apple_pi_dash` referenced in some files. They co-exist — don't rename them in a single PR.
+
+## Django modules (`pi_dash/`)
+
+```
+app/             ← main product API (workspaces, projects, work items, cycles, modules, …)
+api/             ← public v1 REST API (under /api/v1/)
+authentication/  ← login, sign-up, OIDC, sessions
+space/           ← published "spaces" — public/guest content (/api/public/)
+license/         ← instance license verification (/api/instances/)
+runner/          ← cloud side of the runner protocol — HTTP + WebSocket
+orchestration/   ← AI agent run scheduling, phases, workpad (see 08)
+prompting/       ← prompt composition, fragments, rendering (see 08)
+scheduler/       ← built-in run/scheduling signals
+analytics/       ← analytics endpoints, charts, exports
+bgtasks/         ← Celery tasks
+db/              ← shared DB utilities and mixins
+logs/            ← request/audit logging
+middleware/      ← throttling, CORS, auth, sentry hooks
+throttles/       ← DRF throttle classes
+seeds/           ← initial data, e.g. seed projects/labels
+settings/        ← env-split settings (see below)
+tests/           ← pytest test suite
+utils/           ← shared helpers
+web/             ← server-rendered/static catch-all
+```
+
+## URL tree
+
+`pi_dash/urls.py`:
+
+```
+api/                    → pi_dash.app.urls          ← internal app API (consumed by web/admin/space)
+api/public/             → pi_dash.space.urls        ← guest views of published content
+api/instances/          → pi_dash.license.urls
+api/runners/            → pi_dash.runner.web_urls   ← web UI calls for runner admin
+api/v1/                 → pi_dash.api.urls          ← public versioned REST API
+api/                    → pi_dash.prompting.urls    ← prompt templates
+api/v1/runner/          → pi_dash.runner.urls       ← runner HTTP + WS endpoints
+auth/                   → pi_dash.authentication.urls
+/                       → pi_dash.web.urls          ← static / catch-all
+```
+
+OpenAPI/Swagger is exposed at `/api/schema/swagger-ui/` and `/api/schema/redoc/` when `ENABLE_DRF_SPECTACULAR` is true. Use that as the live endpoint reference — this wiki intentionally does not duplicate it.
+
+## ASGI + Channels
+
+`pi_dash/asgi.py` wires a `ProtocolTypeRouter`:
+
+```python
+application = ProtocolTypeRouter({
+    "http": django_asgi_app,
+    "websocket": URLRouter(runner_ws_urls),
+})
+```
+
+- **HTTP** → standard Django view tree.
+- **WebSocket** → routed by `pi_dash/runner/routing.py` to the runner consumers in `pi_dash/runner/consumers.py`.
+
+The runner WebSocket path is the legacy v3 transport; the current wire protocol (v4) uses per-runner HTTPS long-poll — see [08 — Cloud ↔ runner protocol](./08-cloud-runner-protocol.md).
+
+## Settings layering
+
+`pi_dash/settings/`:
+
+| File                                                  | Used for                                                      |
+| ----------------------------------------------------- | ------------------------------------------------------------- |
+| `common.py`                                           | Shared base — installed apps, middleware, DRF/Channels config |
+| `local.py`                                            | Local dev overrides                                           |
+| `production.py`                                       | Production defaults — `manage.py` defaults to this            |
+| `test.py`                                             | Test-only overrides — referenced by `pytest.ini`              |
+| `mongo.py` / `redis.py` / `storage.py` / `openapi.py` | Subsystem-specific bundles imported by the env files          |
+
+`manage.py` sets `DJANGO_SETTINGS_MODULE=apple_pi_dash.settings.production` as the default. For local work, export `apple_pi_dash.settings.local`.
+
+## Runner backend module (`pi_dash/runner/`)
+
+This is the Django half of the runner integration — distinct from the Rust crate at the repo root. Highlights:
+
+```
+models.py              ← Runner, Run, Pod, Token models
+views/
+  register.py          ← runner enrollment (legacy token flow)
+  runners.py           ← runner CRUD
+  pods.py              ← pod (sub-resource) management
+  runs.py / run_endpoints.py  ← run lifecycle endpoints
+  approvals.py         ← approval router
+  chat.py              ← chat / message endpoints
+  sessions.py          ← session create / welcome frame
+  enrollment.py        ← device-code endpoints
+services/
+  session_service.py   ← welcome-frame generation, version advisory
+  run_lifecycle.py     ← state transitions
+  tokens.py            ← refresh ↔ access token pair
+  matcher.py           ← assign runs to runners
+  outbox.py            ← outbound message queue
+  pubsub.py            ← Redis pub/sub bridge for live updates
+consumers.py           ← Channels WS consumer (legacy v3 + still-live editor channels)
+routing.py             ← WS URL routes
+```
+
+The session service is responsible for the `welcome` frame the runner receives on connect — including `latest_runner_version` / `min_runner_version` advisories (see [15 — Releasing](./15-releasing.md)).
+
+## Background work (Celery)
+
+- Entry: `pi_dash/celery.py`.
+- Broker: **RabbitMQ** (per `.env.example`).
+- Tasks live in `pi_dash/bgtasks/` plus task modules under feature apps.
+
+## Database
+
+- **Postgres 15+** is the primary store.
+- `pytest.ini` configures `--reuse-db --nomigrations` — tests reuse the DB across runs and **skip migrations**. This makes the test suite fast but means schema-altering work has to be tested explicitly with `--create-db`.
+
+## Linting & formatting
+
+Ruff handles Python format + lint (line-length **120**, `known-first-party = ["apple_pi_dash"]`). Ruff is **not** wired into the root `pnpm fix` — run it explicitly:
+
+```bash
+cd apps/api
+ruff format .
+ruff check . --fix
+```
+
+## Where to read next
+
+- [08 — Cloud ↔ runner protocol](./08-cloud-runner-protocol.md) — the wire contract `pi_dash/runner/` implements
+- [09 — Agent orchestration](./09-agent-orchestration.md) — how `orchestration/` + `prompting/` produce runs
+- [11 — Authentication](./11-authentication.md) — the `authentication/` module + runner token model

--- a/docs/wiki/07-runner-architecture.md
+++ b/docs/wiki/07-runner-architecture.md
@@ -1,0 +1,129 @@
+# 07 — Runner Architecture
+
+The runner is the agent on the developer's machine: a single Rust binary (`pidash`) that authenticates to Pi Dash cloud, pulls assigned runs, and drives an AI agent (`codex` or `claude`) as a subprocess.
+
+It lives at `runner/` and is an **independent Cargo crate** — not part of the Turborepo workspace. Edition 2024, MSRV 1.93 (`rust-toolchain.toml` pins the toolchain).
+
+## Module layout
+
+```
+runner/src/
+├── main.rs               ← tokio entrypoint
+├── lib.rs                ← module root
+├── cli/                  ← clap subcommands
+├── daemon/               ← supervisor + state machine (mod, observability, runner_instance, runner_out, state, supervisor)
+├── cloud/                ← WS client + HTTP + message schemas (http, mod, projects, protocol, runners, ws)
+├── codex/                ← `codex app-server` subprocess + JSON-RPC bridge (app_server, bridge, jsonrpc, mod, schema)
+├── claude_code/          ← Claude Code adapter
+├── agent/                ← generic agent trait (so new agents can be wired in)
+├── approval/             ← policy engine + first-writer-wins router
+├── workspace/            ← per-project working dir + `git clone` on first task
+├── ipc/                  ← Unix socket / Windows named pipe between daemon and TUI/CLI
+├── history/              ← JSONL per-run transcripts + recent-runs index
+├── service/              ← systemd / launchd / Windows scheduled-task installers
+├── tui/                  ← Ratatui UI (Status / Runs / Config / Approvals views)
+├── config/               ← TOML config + credential files (0600 on Unix)
+├── api_client.rs         ← HTTP API client (registration, status, version checks)
+└── util/                 ← paths, logging, backoff, signal handling
+```
+
+## CLI surface (`cli/`)
+
+The `pidash` binary is a clap subcommand router:
+
+```
+pidash auth login / logout / status      ← device-code login, token mgmt
+pidash runner add / list / remove        ← register a runner on this host
+pidash connect                            ← legacy enrollment-token flow
+pidash configure                          ← (re)write config
+pidash install / uninstall                ← install OS service unit
+pidash start / stop / restart             ← daemon lifecycle
+pidash status                             ← service + daemon status
+pidash tui                                ← interactive TUI
+pidash doctor                             ← preflight checks (agent on PATH, cloud reachable)
+pidash update [--check|--restart]         ← self-update via cargo-dist receipt
+pidash issue / comment / state / workspace ← assorted helper commands
+pidash __run                              ← hidden internal run wrapper
+```
+
+Bare `pidash` (no subcommand) drops into `auth login` when no config exists — useful as the first-run path after MSI install.
+
+## Daemon (`daemon/`)
+
+The daemon is the long-lived process. Its responsibilities:
+
+1. **Supervisor** (`supervisor.rs`) — drives the state machine: connect → register → poll for runs → dispatch → report.
+2. **Runner instance** (`runner_instance.rs`) — one daemon can manage multiple runner registrations (one per project on this host).
+3. **Observability** (`observability.rs`) — structured logging + metrics.
+4. **State** (`state.rs`) — in-memory state shared between IPC, TUI, and supervisor.
+
+The daemon talks to the cloud via `cloud/` (HTTPS + WS) and to the local TUI via `ipc/` (Unix socket on Unix, named pipe on Windows — both `0600`).
+
+## Codex / Claude Code bridges
+
+Codex (`codex/`) is the first-class integration:
+
+- `app_server.rs` spawns `codex app-server` as a subprocess.
+- `jsonrpc.rs` is the JSON-RPC client side of the bridge.
+- `bridge.rs` mediates between the cloud-side run state and the agent process.
+- `schema.rs` types the JSON-RPC messages.
+
+Claude Code (`claude_code/`) and the generic `agent/` trait are the abstraction that lets additional agents be wired in without re-doing the orchestration layer. Adding a new agent kind means implementing the trait and wiring it into the supervisor's dispatch.
+
+## Approval router (`approval/`)
+
+When the agent asks for approval (run command, write file, fetch URL — depends on agent policy), the runner has three potential decision sources:
+
+1. The **TUI** (interactive operator on this host)
+2. The **cloud** (web UI operator)
+3. The local **policy engine** (rules in the runner's config)
+
+Decisions race; **first writer wins**. The router enforces this. The policy engine can pre-approve common patterns to avoid bombing the operator with prompts.
+
+## Workspace (`workspace/`)
+
+A runner can be registered to a project. On the first run for that project, the runner `git clone`s the project's repo into a configured working dir. Subsequent runs reuse the clone (fetch + checkout, not re-clone).
+
+This is also where path constraints live — the runner refuses to operate on paths outside the configured workspace root.
+
+## IPC (`ipc/`)
+
+- **Unix:** Unix domain socket under `$XDG_RUNTIME_DIR/...`, `0600`.
+- **Windows:** local named pipe.
+
+Used by:
+
+- TUI ↔ daemon — push state updates, send approval decisions
+- CLI subcommands ↔ daemon — `pidash status`, `pidash stop`, etc.
+
+## TUI (`tui/`)
+
+Built on Ratatui. Views:
+
+- **Status** — connection state, version banner, agent path
+- **Runs** — recent runs + their phase + transcripts
+- **Config** — editable daemon settings (auto-update toggle lives here)
+- **Approvals** — pending prompts, decision UI
+
+## On-disk layout (Linux example)
+
+```
+~/.config/pidash/             ← config.toml, credentials (0600)
+$XDG_DATA_HOME/pidash/        ← per-run JSONL transcripts, recent-runs index
+$XDG_RUNTIME_DIR/pidash/      ← IPC socket, PID file
+```
+
+On Windows, everything goes under the user profile and IPC is via a named pipe.
+
+## Auto-update
+
+The cloud's `welcome` frame can include `latest_runner_version` and `min_runner_version` (driven by the cloud's `LATEST_RUNNER_VERSION` / `MIN_RUNNER_VERSION` env vars). With auto-update enabled, the daemon swaps the on-disk `pidash` binary in place; the **running process is never disturbed** — it keeps its loaded copy until the next natural restart (`pidash restart`, host reboot, service-manager respawn).
+
+`pidash update` only works for installs from cargo-dist installers (`pidash-installer.sh`, `pidash-installer.ps1`, MSI) — those leave an install receipt the updater reads. Source builds and `cargo install` builds get a clear "reinstall via the installer if you want self-update" error. See [15 — Releasing](./15-releasing.md).
+
+## Where to read next
+
+- [08 — Cloud ↔ runner protocol](./08-cloud-runner-protocol.md) — the wire schema for `cloud/`
+- [11 — Authentication](./11-authentication.md) — device-code login + token rotation
+- `runner/README.md` — install one-liners, paths, manual QA matrix
+- `runner/.ai_design/implement_runner/` (if present) — design docs and committed decisions

--- a/docs/wiki/08-cloud-runner-protocol.md
+++ b/docs/wiki/08-cloud-runner-protocol.md
@@ -1,0 +1,82 @@
+# 08 — Cloud ↔ Runner Protocol
+
+This is the one **external, versioned contract** in Pi Dash. The web frontend ↔ Django REST surface ships together and can change freely. The runner does not — it lives on user machines, may be running an older release than the cloud, and must keep working long enough to auto-update.
+
+The schema lives in `runner/src/cloud/protocol.rs` (Rust side) and is consumed by `apps/api/pi_dash/runner/views/sessions.py` and friends (Django side). Both sides ship together when version bumps happen — but they tolerate version skew for the auto-update grace period.
+
+## Wire version
+
+**Current wire version: `4`.**
+
+History:
+
+- **v1 – v3** — WebSocket transport. Long-lived connection from runner to cloud carrying session frames and run dispatches.
+- **v4** — moved to **per-runner HTTPS long-poll**. Runner authenticates per request with a short-lived access token; long-poll holds open for new work. No persistent WS connection from the runner side.
+
+The Channels WebSocket routing in `apps/api/pi_dash/runner/routing.py` still exists for backward compatibility and for editor channels — but new runners ride on the HTTP path.
+
+**Bump the wire version on incompatible shape changes only.** Additive optional fields don't need a bump. Removing or repurposing a required field does.
+
+## The handshake — `welcome` frame
+
+When the runner opens a session, the cloud returns a `welcome` payload. Key fields:
+
+| Field                   | Source                      | Meaning                                                                                                                                                                                                            |
+| ----------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `protocol_version`      | echoed by server            | Confirms the version the cloud is willing to speak. Runner refuses if mismatched beyond compat range.                                                                                                              |
+| `latest_runner_version` | env `LATEST_RUNNER_VERSION` | Newest runner version that exists. Drives the yellow "update available" advisory and, with auto-update on, triggers in-place binary swap.                                                                          |
+| `min_runner_version`    | env `MIN_RUNNER_VERSION`    | Cloud-set floor. Below this version, runner shows a red "update required" banner. Advisory in the current implementation — does **not** refuse new tasks yet, but it's the signal that the floor is about to bite. |
+
+Both version envs are optional. Leave them unset to skip the announcement.
+
+## Auto-update advisory states
+
+What the runner shows in TUI / `pidash status` based on the welcome contents:
+
+| Running version vs. cloud advisory                 | Banner                                                 |
+| -------------------------------------------------- | ------------------------------------------------------ |
+| `>= latest_announced` and `>= min_required`        | (nothing)                                              |
+| `< latest_announced`, swap already on disk         | yellow `⚠ Restart to apply vX.Y.Z`                     |
+| `< latest_announced`, auto-update on, swap pending | yellow `⚠ Update vX.Y.Z pending swap`                  |
+| `< latest_announced`, auto-update off              | yellow `⚠ Update vX.Y.Z available — run pidash update` |
+| `< min_required`                                   | red `⛔ Update required: cloud floor vX.Y.Z`           |
+
+The toggle lives in TUI → General → Daemon settings → `auto_update`. Default **on**.
+
+## Authentication
+
+The runner does **not** carry a long-lived password. Authentication is a two-token model:
+
+1. **Refresh token** — issued during enrollment (device-code or legacy enrollment-token), stored on disk at `0600`.
+2. **Access token** — short-lived, derived from the refresh token, used per request to the cloud.
+
+`pidash runner add` mints the runner-side credentials cloud-side using the CLI token from `pidash auth login`. The legacy `pidash connect --token <ONE_TIME_TOKEN>` flow is still supported for headless / scripted hosts where the browser flow is awkward.
+
+See [11 — Authentication](./11-authentication.md) for the full flow.
+
+## Endpoints (Django side, `pi_dash/runner/`)
+
+| URL path                                 | Purpose                                                     |
+| ---------------------------------------- | ----------------------------------------------------------- |
+| `POST /api/v1/runner/sessions/`          | Open a session — returns the welcome frame                  |
+| `GET  /api/v1/runner/runs/` (long-poll)  | Wait for the next assigned run                              |
+| `POST /api/v1/runner/runs/<id>/...`      | Stream run events back to the cloud                         |
+| `POST /api/v1/runner/approvals/<id>/...` | Submit an approval decision                                 |
+| `POST /api/v1/runner/enroll/...`         | Device-code enrollment endpoints                            |
+| `GET/POST /api/runners/...`              | Web-UI side of runner admin (CRUD, "add connection" tokens) |
+
+Schemas are typed in `pi_dash/runner/serializers.py` and mirrored in `runner/src/cloud/protocol.rs`. Treat the two as the contract.
+
+## Versioning discipline
+
+- **Additive** (new optional fields) → no bump. The other side just ignores them.
+- **Renamed / repurposed / removed required field** → bump.
+- When you bump, **ship both sides in the same release window** and update `LATEST_RUNNER_VERSION` / `MIN_RUNNER_VERSION` envs on the cloud so old runners get nudged forward.
+- The Rust `protocol.rs` test (`tests/protocol_roundtrip.rs`) round-trips every variant — keep it green.
+
+## Where to read next
+
+- `runner/src/cloud/protocol.rs` — the authoritative schema
+- [07 — Runner architecture](./07-runner-architecture.md) — what consumes this protocol on the runner side
+- [06 — Backend architecture](./06-backend-architecture.md) — `pi_dash/runner/` is the cloud side
+- [15 — Releasing](./15-releasing.md) — how the version envs get set on cloud after a runner tag

--- a/docs/wiki/09-agent-orchestration.md
+++ b/docs/wiki/09-agent-orchestration.md
@@ -1,0 +1,103 @@
+# 09 — Agent Orchestration
+
+This page covers the cloud-side logic that turns a user's work item into a concrete run on a runner. The work happens across three Django modules:
+
+```
+pi_dash/orchestration/   ← phases, scheduling, workpad, done signals
+pi_dash/prompting/       ← prompt fragments, composition, rendering, context
+pi_dash/scheduler/       ← built-in scheduling hooks + signals
+```
+
+Plus the runner-side glue in `pi_dash/runner/services/` (matcher, run lifecycle, outbox, scheduler hook).
+
+## Concept map
+
+- **Work item** — the user-facing thing (issue/task/sub-issue) tracked in `app/`.
+- **Run** — one execution attempt against a work item, persisted in `runner/models.py`. A work item can have many runs (retries, follow-ups).
+- **Phase** — runs progress through ordered phases (`orchestration/agent_phases.py`). Each phase has its own prompt template and expected outputs.
+- **Workpad** — the durable scratchpad attached to a run that the agent reads/writes structured artifacts into (`orchestration/workpad.py`).
+- **Done signal** — explicit completion contract the agent emits to mark a phase done (`orchestration/done_signal.py`).
+- **Pod** — a grouping primitive on the runner side (`runner/models.py`, `services/pod_naming.py`). Think of it as the namespace a run lives in on a particular runner.
+
+## `orchestration/`
+
+```
+agent_phases.py   ← phase definitions + transitions
+scheduling.py     ← decides when a run is eligible to dispatch
+service.py        ← high-level "create a run from a work item" entrypoint
+signals.py        ← Django signals fired during the run lifecycle
+done_signal.py    ← parsing / validating the agent's "I'm done" frame
+workpad.py        ← workpad CRUD + lifecycle
+```
+
+`service.py` is the canonical entrypoint. Most product code that wants to "kick off an agent on this work item" goes through it; it composes prompt → phase → run → persists.
+
+## `prompting/`
+
+```
+composer.py       ← assembles a final prompt from fragments + context
+context.py        ← gathers context (work item, project state, prior runs)
+renderer.py       ← template render
+fragments/        ← reusable prompt fragments
+models.py         ← persisted prompt templates / fragment overrides
+seed.py           ← seed default prompts
+views.py / urls.py / serializers.py  ← admin API for editing prompts
+```
+
+Prompts are not hard-coded — they live in DB rows seeded by `seed.py`. Instance admins can override fragments from the admin UI, which is why `prompting/` ships a full REST surface.
+
+## `scheduler/`
+
+`scheduler/builtins/` holds the default scheduling rules; `signals.py` wires them into the run lifecycle. This is the layer that asks "is now a good time to dispatch?" — it can defer runs based on quotas, project state, manual gating, etc.
+
+The runner-side scheduler hook (`pi_dash/runner/services/scheduler_hook.py`) is the bridge between this layer and the runner's HTTP long-poll: when a run becomes eligible, the matcher hands it to the next runner that asks.
+
+## Runner-side dispatch services (`pi_dash/runner/services/`)
+
+```
+matcher.py            ← match an eligible run to a runner (project, capabilities, availability)
+run_lifecycle.py      ← state-machine transitions (assigned → running → completed/failed)
+session_service.py    ← welcome frame (incl. version advisories — see 07)
+outbox.py             ← outbound message queue for cloud → runner notifications
+pubsub.py             ← Redis pub/sub bridge for live status updates to web UI
+chat.py               ← in-run chat messages
+permissions.py        ← who can mutate which run / runner
+pod_naming.py         ← derive pod names from project / runner / config
+tokens.py             ← refresh/access token pair lifecycle
+validation.py         ← payload validation helpers
+runner_delete.py      ← runner removal — coordinates cloud + runner-side cleanup
+```
+
+## End-to-end (cloud's view)
+
+```
+User opens work item  →  triggers orchestration.service.create_run(work_item, phase)
+                       ├─ prompting.composer.compose(work_item, phase, context)  → prompt text
+                       ├─ persist Run row (status=pending) + workpad init
+                       └─ scheduler.signals fire → eligibility set
+
+Run becomes eligible   →  matcher.assign(run, available_runners)  → Run.assigned_to = runner
+
+Runner long-polls      →  GET /api/v1/runner/runs/   (per-runner, see 07)
+                       ←  yields the assigned Run + its prompt + workpad ref
+
+Runner executes        →  POSTs events / approvals / outputs back
+                       →  run_lifecycle transitions state
+                       →  pubsub broadcasts to web UI for live progress
+
+Agent emits done_signal → orchestration parses + validates → phase complete
+                       →  advance to next phase OR finalize run
+```
+
+## Extending the system
+
+- **New phase** — add to `orchestration/agent_phases.py` and a matching prompt template in `prompting/fragments/` + `seed.py`.
+- **Custom scheduling rule** — add a rule under `scheduler/builtins/` and wire it via `scheduler/signals.py`.
+- **New agent** — implement the agent trait in `runner/src/agent/` (Rust) and a matching dispatch path in `runner/src/codex/`-equivalent module. The cloud side is agent-agnostic: it only cares about the prompt and the done-signal contract.
+
+## Where to read next
+
+- [06 — Backend architecture](./06-backend-architecture.md) — the modules referenced here in context
+- [07 — Runner architecture](./07-runner-architecture.md) — the runner's view of dispatch
+- [08 — Cloud ↔ runner protocol](./08-cloud-runner-protocol.md) — the wire schema runs flow over
+- `pi_dash/orchestration/service.py` — the canonical entrypoint

--- a/docs/wiki/10-realtime-collaboration.md
+++ b/docs/wiki/10-realtime-collaboration.md
@@ -1,0 +1,91 @@
+# 10 — Realtime Collaboration
+
+Pi Dash supports realtime multi-user editing of rich-text content (pages, work item descriptions, comments). This is done by a dedicated **Node service**, not by Django Channels — Django's WS layer is reserved for the runner protocol and per-feature notifications.
+
+## The two pieces
+
+### 1. `apps/live` — Hocuspocus server (backend)
+
+Located at `apps/live/`. This is a **Node + Express server** that hosts a [Hocuspocus](https://tiptap.dev/hocuspocus/introduction) collaboration backend on top of [Yjs](https://github.com/yjs/yjs) CRDTs.
+
+```
+apps/live/
+├── src/                  ← server entry, persistence, auth hooks
+├── tests/                ← vitest test suite
+├── tsdown.config.ts      ← Rust-based bundler config
+├── vitest.config.ts
+├── Dockerfile.live
+└── Dockerfile.dev
+```
+
+Runs with `node --env-file=.env`. Builds via `tsdown`. The default OxLint ceiling is **119** warnings.
+
+**Responsibilities:**
+
+- Accept WebSocket connections from editor clients (`@pi-dash/editor`).
+- Sync Yjs documents between clients (CRDT merge — conflict-free).
+- Authenticate each connection against the Pi Dash session.
+- Persist document snapshots back to the main store (so reopening a page picks up where you left off).
+- Broadcast presence (cursors, selections).
+
+### 2. `@pi-dash/editor` — Tiptap/ProseMirror editor (frontend)
+
+Located at `packages/editor/`. This is the React component layer that:
+
+- Wraps Tiptap (which wraps ProseMirror) for the editing UI.
+- Wraps the Hocuspocus client to talk to `apps/live`.
+- Exposes typed editor instances to `apps/web`, `apps/space`, and (where applicable) `apps/admin`.
+
+Pages, rich descriptions, and inline comment editors all consume this package.
+
+## How it connects
+
+```
+Browser tab                       apps/live                    Postgres
+┌─────────────────┐  WS (Yjs)  ┌──────────────┐   persist   ┌──────────┐
+│ @pi-dash/editor │ ─────────▶ │ Hocuspocus   │ ──────────▶ │ docs/    │
+│  (Tiptap)       │            │  + Express   │             │ pages    │
+└─────────────────┘            └──────────────┘             └──────────┘
+       ▲                              │
+       │  WS (presence + ops)         │ Pi Dash session auth
+       ▼                              ▼
+┌─────────────────┐            ┌──────────────┐
+│ Other tabs /    │            │ Pi Dash API  │  (apps/api)
+│ collaborators   │            │ /auth/...    │
+└─────────────────┘            └──────────────┘
+```
+
+- Clients **do not** talk to Django for live edits — only `apps/live`.
+- `apps/live` validates the session with the Django API on connect.
+- Persistence is async: ops flow over WS in real time; snapshots are flushed to Postgres at intervals / on disconnect.
+
+## Why a separate Node service?
+
+- Django Channels is single-process per worker and not ideal for the steady WS load of many open editors.
+- Hocuspocus + Yjs are mature Node libraries — reimplementing in Python would buy nothing.
+- Keeps the realtime concern out of the REST request hot path.
+
+The trade-off: `apps/live` is **deployed alongside** the other web apps. In Docker, it's its own service container.
+
+## Dev loop
+
+`pnpm dev` (root) starts `apps/live` along with the other apps. Port is set per `.env` (`apps/live/.env`).
+
+Test it in isolation:
+
+```bash
+pnpm --filter live dev
+pnpm --filter live test
+```
+
+## Production
+
+- Caddy (`apps/proxy/Caddyfile.*`) fronts `apps/live` and upgrades the WS connection.
+- In `deployments/cli/community/` and Swarm/K8s, `apps/live` is a separate service alongside `web`/`admin`/`space`/`api`.
+- In the AIO single-container build, `supervisord` keeps the Node process up next to Django/Caddy/Postgres.
+
+## Where to read next
+
+- [05 — Frontend architecture](./05-frontend-architecture.md) — how `@pi-dash/editor` plugs into apps
+- [12 — Deployment](./12-deployment.md) — where `apps/live` sits in each topology
+- `apps/live/src/` — the server entry, persistence hooks, auth bridge

--- a/docs/wiki/11-authentication.md
+++ b/docs/wiki/11-authentication.md
@@ -1,0 +1,98 @@
+# 11 — Authentication
+
+Three distinct identity flows live in Pi Dash. They all terminate at the Django `authentication/` module, but they have very different user experiences and security models.
+
+| Flow                                               | Who uses it                                            | Where it lives                                            |
+| -------------------------------------------------- | ------------------------------------------------------ | --------------------------------------------------------- |
+| **Instance admin** ("god mode")                    | The person who first stood up the self-hosted instance | `apps/admin` UI + `pi_dash.authentication`                |
+| **User login** (password, magic link, OIDC)        | Day-to-day product users                               | `apps/web` + `apps/space` + `pi_dash.authentication`      |
+| **Runner enrollment** (device-code + legacy token) | The Rust `pidash` daemon                               | `runner/src/cli/auth` + `pi_dash.runner.views.enrollment` |
+
+## 1. Instance admin (one-time bootstrap)
+
+The very first thing you do on a fresh self-hosted instance:
+
+```
+http://<your-instance>/god-mode/   ← register the instance admin
+```
+
+This is served by `apps/admin/` (port `3001` in dev). Once registered, the admin's credentials are also valid user credentials on the main app — you log into `apps/web` with the same identity.
+
+There is no "create admin" CLI command — it's deliberately a one-shot web flow tied to "the first request to god-mode wins".
+
+## 2. User login (web + space)
+
+Lives in `pi_dash/authentication/` (mounted at `/auth/`):
+
+```
+authentication/
+├── views/         ← sign-in, sign-up, password reset, OIDC callbacks
+├── serializers/
+├── permissions/
+├── middleware/
+└── urls/
+```
+
+Mechanisms supported (configurable per instance):
+
+- **Email + password** (always available)
+- **Magic-link / email OTP**
+- **OIDC / SSO** — when configured. Cloud Pi Dash uses the **home-page OIDC** as the plan source-of-truth: the JWT `plan` claim is cached on `Account` and gates Cloud-specific features. There are **no plan webhooks** — plan updates flow through subsequent OIDC logins. Upgrade UI in the app deep-links back to the home-page user center.
+
+The `space` app (public/guest views) reuses the same auth module but can serve content without a session.
+
+## 3. Runner enrollment
+
+The runner (`pidash` CLI) needs to authenticate to the cloud without a human at the keyboard for every request. There are two paths:
+
+### A. Device-code flow (recommended)
+
+```bash
+pidash auth login --url https://your-pidash-instance.com
+```
+
+1. CLI requests a device code from the cloud (`/api/v1/runner/enroll/...`).
+2. CLI shows the user a short code + URL to open in a browser.
+3. User approves in the browser (signed in via flow #2 above).
+4. CLI polls until the code is approved → cloud mints a **CLI token**.
+5. CLI persists token at `~/.config/pidash/config.toml` (`0600`).
+6. CLI prompts to add a runner inline if none exists on this host.
+
+This is the same UX as `gh auth login` or `stripe login`. Bare `pidash` (no subcommand) drops into this flow when no config exists — useful after MSI install on Windows.
+
+### B. Legacy enrollment-token flow
+
+For headless / scripted hosts where the browser flow is awkward:
+
+```bash
+# In the Pi Dash web UI: Runners admin → "Add connection" → copy one-time token
+pidash connect --url https://pidash.example.com --token <ONE_TIME_TOKEN>
+```
+
+The token is one-shot — it's burned on first use cloud-side.
+
+## Runner credential model
+
+After enrollment, the runner holds a **refresh / access token pair**:
+
+| Token                          | Lifetime              | Use                                                                                                        |
+| ------------------------------ | --------------------- | ---------------------------------------------------------------------------------------------------------- |
+| **CLI token**                  | Long-lived            | Identifies the _user_ on this host. Authorizes `runner add`. Stored once at login.                         |
+| **Refresh token** (per-runner) | Long-lived, rotatable | Identifies the _runner registration_. Stored at `0600`. Minted by `pidash runner add` using the CLI token. |
+| **Access token** (per-runner)  | Short-lived           | Derived from refresh token. Sent on each cloud request.                                                    |
+
+Cloud-side, refresh/access lifecycle is handled by `pi_dash/runner/services/tokens.py`.
+
+`pidash auth logout` revokes the CLI token cloud-side. `pidash runner remove` revokes the runner credentials.
+
+## On-disk security
+
+- Config + credential files: `0600` on Unix.
+- IPC socket between daemon and TUI: `0600`.
+- On Windows: files under the user profile, IPC over a local named pipe with appropriate ACLs.
+
+## Where to read next
+
+- [08 — Cloud ↔ runner protocol](./08-cloud-runner-protocol.md) — how the access token is presented per request
+- [07 — Runner architecture](./07-runner-architecture.md) — `runner/src/cli/auth/` and `runner/src/config/`
+- [06 — Backend architecture](./06-backend-architecture.md) — `pi_dash/authentication/` module structure

--- a/docs/wiki/12-deployment.md
+++ b/docs/wiki/12-deployment.md
@@ -1,0 +1,80 @@
+# 12 — Deployment Topologies
+
+Pi Dash ships three deploy paths plus a planned Kubernetes one. Pick by how much you want to manage yourself.
+
+All paths require external **Postgres**, **Redis / Valkey**, **RabbitMQ**, and **S3-compatible** object storage — Pi Dash does not bundle data stores into the deploy artifacts.
+
+| Path                                    | Best for                                | Trade-off                                                                                   |
+| --------------------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------- |
+| All-in-One (AIO) container              | Demos, homelab, evaluation, small teams | One container, internal `supervisord` — can't scale services independently                  |
+| Docker Compose / Swarm                  | Anything beyond evaluation              | Real microservices stack: 6 service containers — more config, more flexibility              |
+| Kubernetes / Helm                       | Production at scale                     | Helm chart **planned, not yet shipped** — see `deployments/kubernetes/community/README.md`  |
+| Pi Dash Cloud (`pidash.airepublic.com`) | Don't want to run anything              | Hosted by the AI Republic team — see [pidash.airepublic.com](https://pidash.airepublic.com) |
+
+## All-in-One Docker image
+
+Folder: `deployments/aio/community/`.
+
+A single container that bundles every Pi Dash service (web, admin, space, api, live, proxy), supervised internally by `supervisord`. Simplest path: a single `docker run`.
+
+**You still need to provide:**
+
+- Postgres
+- Redis / Valkey
+- RabbitMQ
+- S3-compatible storage (e.g. MinIO)
+
+Use cases: demos, homelab, evaluation, small teams. The internal `supervisord` keeps everything alive but you can't scale individual services — the whole container scales as one unit.
+
+See `deployments/aio/community/README.md` for the exact `docker run` invocation and env vars.
+
+## Docker Compose / Swarm self-hosting
+
+Folder: `deployments/cli/community/` (Compose), `deployments/swarm/` (Swarm).
+
+The full microservices stack: each app gets its own container, plus the data services. Independent scaling, rolling updates per service, easier debugging.
+
+Services:
+
+- `web` — main UI (React Router 7, served via nginx in prod)
+- `admin` — instance admin UI
+- `space` — public spaces
+- `api` — Django + Channels backend
+- `live` — Hocuspocus realtime server (see [10](./10-realtime-collaboration.md))
+- `proxy` — Caddy reverse proxy (terminates TLS, fronts everything)
+
+Recommended for anything beyond evaluation.
+
+See `deployments/cli/community/README.md` for the Compose file walkthrough.
+
+## Kubernetes / Helm
+
+Folder: `deployments/kubernetes/community/`.
+
+Helm chart publishing is **planned but not yet shipped**. Raw manifests / kustomize bases are in the folder; treat them as a starting point rather than a turnkey deploy. See the folder's README for current status.
+
+## Production reverse proxy: Caddy
+
+`apps/proxy/` ships Caddyfiles for both topologies:
+
+- `Caddyfile.aio.ce` — AIO single-container
+- `Caddyfile.ce` — full Compose / Swarm
+
+Caddy handles TLS termination automatically (Let's Encrypt). It is **not** part of the pnpm workspace.
+
+## docker-compose files at the repo root
+
+| File                       | Purpose                                                                                                                                                       |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `docker-compose.yml`       | Production-flavored (you'll typically copy + edit this)                                                                                                       |
+| `docker-compose-local.yml` | **Local dev infra only** — Postgres + Redis + RabbitMQ + MinIO. `pnpm dev` attaches app processes to it. See [04 — Getting started](./04-getting-started.md). |
+
+## Cloud overlay (`private-pi-dash`)
+
+Pi Dash Cloud is the hosted SaaS. Its proprietary additions live in a separate repo (`private-pi-dash`) and are **not** part of this OSS repo. Cloud-only features are gated by the OIDC `plan` claim (see [11 — Authentication](./11-authentication.md)). Do not fork OSS files into the private repo — extend, don't duplicate.
+
+## Where to read next
+
+- [13 — Development workflow](./13-development-workflow.md) — local commands that mirror prod containers
+- `deployments/*/README.md` — per-topology install instructions
+- `apps/proxy/Caddyfile.*` — the production routing rules

--- a/docs/wiki/13-development-workflow.md
+++ b/docs/wiki/13-development-workflow.md
@@ -1,0 +1,147 @@
+# 13 — Development Workflow
+
+Day-to-day commands, what runs them, and the quality gates you'll bump into.
+
+## TS workspace (root)
+
+```bash
+pnpm dev                         # start all dev servers concurrently
+pnpm build                       # turbo run build across workspace
+pnpm check                       # format + lint + types
+pnpm check:lint                  # OxLint only
+pnpm check:format                # oxfmt check
+pnpm check:types                 # tsc --noEmit across workspace
+pnpm fix                         # auto-fix format + lint
+pnpm fix:format                  # oxfmt
+pnpm fix:lint                    # oxlint --fix
+
+# Target a single package or app:
+pnpm turbo run <task> --filter=<pkg>
+pnpm --filter web dev
+pnpm --filter @pi-dash/ui storybook    # Storybook on :6006
+
+# i18n:
+pnpm i18n:sync                   # propagate new keys across all locales
+pnpm i18n:translate              # auto-translate missing keys
+```
+
+## Django backend (`apps/api/`)
+
+```bash
+cd apps/api
+
+# Server commands (DJANGO_SETTINGS_MODULE defaults to ...production):
+python manage.py runserver
+python manage.py migrate
+python manage.py createsuperuser
+# For local work, point at local settings:
+DJANGO_SETTINGS_MODULE=apple_pi_dash.settings.local python manage.py runserver
+
+# Tests:
+./run_tests.sh                   # wrapper around tests/run_tests.sh
+python run_tests.py -u           # unit tests only (markers: unit | contract | smoke)
+python run_tests.py -u -o -p     # unit + coverage + parallel (-n auto)
+pytest -m smoke                  # direct pytest with markers
+
+# Lint / format (Ruff, NOT wired into root pnpm fix):
+ruff format .
+ruff check . --fix
+```
+
+`pytest.ini` configures `--reuse-db --nomigrations`. Tests reuse the DB across runs and skip migrations — fast, but you must run `pytest --create-db` to validate schema-altering work.
+
+See [14 — Testing](./14-testing.md) for the full test layout.
+
+## Rust runner (`runner/`)
+
+```bash
+cd runner
+cargo build                      # debug build
+cargo test                       # unit + integration tests
+cargo check                      # quick type-check
+cargo clippy -- -D warnings      # lint — treat warnings as errors
+
+# From a debug build, run via:
+./target/debug/pidash <subcommand>
+```
+
+`rust-toolchain.toml` pins the Rust version. `cargo-dist` packages release artifacts — see [15 — Releasing](./15-releasing.md).
+
+## OxLint + oxfmt (TS workspace)
+
+The entire TS workspace shares **one** root config:
+
+- `.oxlintrc.json`
+- `.oxfmtrc.json`
+
+Both are Rust-based. OxLint is 50-100x faster than ESLint, with zero Node.js dependencies at runtime. `eslint-disable` comments still work for back-compat.
+
+### Per-app `--max-warnings` ceilings
+
+Each app pins its own ceiling in its `package.json`:
+
+| App           | Ceiling |
+| ------------- | ------- |
+| `web`         | 11957   |
+| `space`       | 676     |
+| `admin`       | 759     |
+| `live`        | 119     |
+| `@pi-dash/ui` | 66      |
+
+Crossing the ceiling fails `pnpm check:lint`. **After a cleanup, lower the ceiling** — leaving headroom defeats the gate.
+
+### What gets linted
+
+```
+apps/{web,admin,space,live}/**
+packages/**
+```
+
+Ignored:
+
+```
+node_modules/, dist/, build/, .next/, .turbo/, **/coverage/, **/storybook-static/
+*.config.{js,mjs,cjs,ts}
+```
+
+## Husky + lint-staged (pre-commit hook)
+
+`.husky/` registers a pre-commit hook that runs **lint-staged** on every commit:
+
+1. `oxfmt --no-error-on-unmatched-pattern` formats staged files (`.{js,jsx,ts,tsx,cjs,mjs,cts,mts,json,css,md}`).
+2. `oxlint --fix --deny-warnings` lints staged code files.
+
+A warning that trips `--deny-warnings` blocks the commit. **Fix the warning** — do **not** `--no-verify`. Per repo policy on destructive actions: investigate and fix, don't bypass.
+
+If a commit fails because of a hook, the commit didn't happen — fix the issue, re-stage, and create a **new** commit (don't `--amend`, you'd modify the wrong commit).
+
+## Turborepo
+
+- Config: `turbo.json` at repo root.
+- Build outputs cached under `dist/**`, `build/**`, `.react-router/**`.
+- `dev` and `clean` tasks bypass the cache (you want fresh dev servers).
+- Remote cache is **disabled** in `turbo.json`.
+
+Useful Turbo commands:
+
+```bash
+pnpm turbo run build --filter=web
+pnpm turbo run build --filter=...web         # build web + everything web depends on
+pnpm turbo run build --filter=web^...        # build everything that depends on web
+pnpm turbo run build --dry                   # show the task graph without executing
+```
+
+## Dependency conventions
+
+From `AGENTS.md`:
+
+- **Internal packages** — `"workspace:*"`.
+- **External deps** — `"catalog:"`, pinned in the `catalog:` block of `pnpm-workspace.yaml`.
+
+Don't add a direct version for anything in the catalog. Upgrading a catalog entry upgrades it for every package at once — that's the point.
+
+## Where to read next
+
+- [14 — Testing](./14-testing.md) — test runners + conventions per stack
+- [15 — Releasing](./15-releasing.md) — runner cargo-dist + version envs
+- [docs/linting.md](../linting.md) — deeper OxLint docs (rules, suppressions, IDE integration)

--- a/docs/wiki/14-testing.md
+++ b/docs/wiki/14-testing.md
@@ -1,0 +1,106 @@
+# 14 — Testing
+
+Each stack has its own test runner. There is **no** unified "pnpm test" — root `pnpm check` covers JS/TS lint+format+types, but not Python tests and not the Rust runner.
+
+## TS workspace (Vitest)
+
+Vitest runs per-app and per-package where tests exist.
+
+```bash
+# Per app / package:
+pnpm --filter web test
+pnpm --filter live test
+pnpm --filter @pi-dash/ui test
+
+# Across workspace via Turbo:
+pnpm turbo run test
+```
+
+Test files live next to source (`*.test.ts` / `*.test.tsx`) or in app-local `tests/` dirs (e.g. `apps/web/tests/`, `apps/live/tests/`).
+
+### Storybook
+
+`@pi-dash/ui` ships Storybook for component-in-isolation development:
+
+```bash
+pnpm --filter @pi-dash/ui storybook   # http://localhost:6006
+```
+
+Build new components in Storybook first, wire them into an app second.
+
+## Django backend (pytest)
+
+`apps/api/pytest.ini` configures:
+
+- `--reuse-db --nomigrations` — DB persists between runs; migrations are skipped.
+- Markers: `unit | contract | smoke`.
+
+```bash
+cd apps/api
+
+./run_tests.sh                   # wraps tests/run_tests.sh
+python run_tests.py -u           # unit only
+python run_tests.py -u -o -p     # unit + coverage + parallel (-n auto)
+python run_tests.py              # full suite
+
+pytest -m smoke                  # direct pytest, smoke marker only
+pytest --create-db               # rebuild DB — required for schema-altering changes
+pytest apps/api/pi_dash/runner/tests/test_session.py::test_welcome_frame  # one test
+```
+
+### Markers
+
+| Marker     | Meaning                                                       |
+| ---------- | ------------------------------------------------------------- |
+| `unit`     | Fast, isolated. Default for new tests.                        |
+| `contract` | Cross-module contract tests — wire-format, serializer parity. |
+| `smoke`    | Coarse-grained end-to-end happy-path.                         |
+
+Tests live under `apps/api/pi_dash/tests/` and per-module `tests/` (e.g. `pi_dash/runner/tests/`).
+
+### Test settings
+
+`apple_pi_dash.settings.test` is the test settings module — it tweaks middleware and disables some prod-only services so tests don't need RabbitMQ etc.
+
+## Rust runner (cargo test)
+
+```bash
+cd runner
+cargo test                       # unit + integration
+cargo test --release             # release mode (slower compile, runtime closer to shipped binary)
+cargo test test_name             # filter
+cargo clippy -- -D warnings      # lint as a quality gate
+```
+
+Test layout:
+
+- **Unit tests** — inline `#[cfg(test)] mod tests { ... }` in each module. Deterministic, table-driven where possible (protocol serde, approval policy, reconnect backoff, workspace resolve, config roundtrip).
+- **Integration tests** — `runner/tests/protocol_roundtrip.rs` and friends. Every client/server protocol variant round-trips; router state machine invariants get exercised.
+
+### Manual QA matrix (per release)
+
+Per `runner/README.md`, every runner release is manually QA'd:
+
+> macOS arm64 / x64 + Linux x64 + Windows x64 → first-run `configure` → `install` → `start` → TUI shows connected → synthetic run via `/api/runners/runs/` → approval prompt → decision.
+
+## Quality gates summary
+
+| Gate          | Command                        | When it runs                                                       |
+| ------------- | ------------------------------ | ------------------------------------------------------------------ |
+| TS format     | `oxfmt`                        | Pre-commit (lint-staged) + `pnpm check:format`                     |
+| TS lint       | `oxlint --fix --deny-warnings` | Pre-commit + `pnpm check:lint` (per-app `--max-warnings` ceilings) |
+| TS types      | `tsc --noEmit`                 | `pnpm check:types` (per-package)                                   |
+| TS unit       | `vitest`                       | `pnpm test` / per-package                                          |
+| Python format | `ruff format`                  | Manual (not wired to root)                                         |
+| Python lint   | `ruff check`                   | Manual                                                             |
+| Python tests  | `pytest`                       | `./run_tests.sh`                                                   |
+| Rust lint     | `cargo clippy -- -D warnings`  | Manual                                                             |
+| Rust tests    | `cargo test`                   | Manual                                                             |
+
+Everything is run in CI on PRs — the `--deny-warnings` and `-D warnings` settings make sure no warning slips through unreviewed.
+
+## Where to read next
+
+- [13 — Development workflow](./13-development-workflow.md) — the full command reference
+- `apps/api/tests/` and `apps/api/run_tests.py` — Python test harness
+- `runner/tests/` — Rust integration tests

--- a/docs/wiki/15-releasing.md
+++ b/docs/wiki/15-releasing.md
@@ -1,0 +1,88 @@
+# 15 — Releasing
+
+Pi Dash has two independent release streams:
+
+1. **Runner** (`pidash` binary) — versioned, tag-driven, packaged by cargo-dist. **External contract** with installed users.
+2. **Platform** (web + Django) — internal versioning; cloud and self-host follow their own paths.
+
+## Runner releases
+
+### Tooling
+
+- `cargo-dist` — orchestrates the build matrix and packaging. Config in `dist-workspace.toml`.
+- `.github/workflows/release.yml` — the GitHub Actions workflow triggered by SemVer tags.
+- `runner/install.sh` / `runner/install.ps1` — opinionated wrapper installers (do auto-auth after install).
+- The bare cargo-dist installers (`pidash-installer.sh`, `pidash-installer.ps1`, MSI) are also published — used by CI / base images that want to install without auto-auth.
+
+### Build matrix
+
+Each tagged release produces binaries for:
+
+- macOS arm64 (Apple Silicon)
+- macOS x86_64 (Intel)
+- Linux arm64
+- Linux x86_64
+- Windows x86_64 (zip + MSI)
+
+Plus shell, PowerShell, and MSI installer scripts.
+
+### Tag & ship
+
+```bash
+# In runner/Cargo.toml, bump version to X.Y.Z, commit.
+git tag pidash-vX.Y.Z          # tag prefix matters — workflow filters on it
+git push origin pidash-vX.Y.Z
+```
+
+The workflow builds, signs, and publishes to GitHub Releases.
+
+### Prereleases
+
+Tags with a SemVer suffix (`-rc.1`, `-alpha.1`, `-beta.1`) are deliberately **excluded** from `/releases/latest/`. The public install one-liners always serve the last stable release. To install a prerelease, use the tag-pinned URL:
+
+```bash
+curl --proto '=https' --tlsv1.2 -LsSf \
+  https://github.com/The-AI-Republic/pi-dash/releases/download/pidash-vX.Y.Z-rc.1/install.sh | sh
+```
+
+### Announce the release to runners
+
+The Django backend reads two env vars and folds them into every `welcome` session response (see [08 — Cloud ↔ runner protocol](./08-cloud-runner-protocol.md)):
+
+| Env var                 | Effect                                                                                                       |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `LATEST_RUNNER_VERSION` | Drives the yellow "update available" advisory. With auto-update on (default), triggers in-place binary swap. |
+| `MIN_RUNNER_VERSION`    | Drives the red "update required" advisory.                                                                   |
+
+After cutting a runner release, set `LATEST_RUNNER_VERSION` on the cloud so opted-in runners auto-update. Leave `MIN_RUNNER_VERSION` alone unless you're forcing a floor (e.g. shedding an EOL wire version).
+
+Leave both unset to skip the announcement entirely.
+
+### In-place updates
+
+`pidash` swaps its on-disk binary while running; the **running process is never disturbed**. The new binary takes effect on the next natural restart (`pidash restart`, host reboot, service-manager respawn after crash).
+
+`pidash update` only works for installs done via cargo-dist installers (they leave a receipt). Source builds and `cargo install` builds get a clear "reinstall via the installer if you want self-update" error.
+
+## Platform releases (web + Django)
+
+The OSS platform (this repo) uses standard SemVer in `package.json` (currently `1.3.0`). The cut process is intentionally lightweight — see `RELEASING.md` at the repo root for the current procedure.
+
+### Pi Dash Cloud (`private-pi-dash`)
+
+The hosted Cloud overlay lives in a separate repo. Its release tags are **date-based**: `vYYYY.M.D` (no zero-pad), starting from 2026-05-24. Prior cloud releases used SemVer. This OSS repo does not produce those tags.
+
+## Versioning summary
+
+| Component               | Scheme                                               | Where tag lives                   |
+| ----------------------- | ---------------------------------------------------- | --------------------------------- |
+| Runner (`pidash`)       | SemVer with `pidash-v` prefix (e.g. `pidash-v0.1.4`) | This repo                         |
+| Runner wire protocol    | Integer (currently `4`)                              | `runner/src/cloud/protocol.rs`    |
+| Platform (web + Django) | SemVer, root `package.json`                          | This repo                         |
+| Cloud overlay           | Date tags `vYYYY.M.D`                                | `private-pi-dash` (separate repo) |
+
+## Where to read next
+
+- `RELEASING.md` at the repo root — current platform release procedure
+- `runner/README.md` — install one-liners, version pinning recipes, advisory states
+- [08 — Cloud ↔ runner protocol](./08-cloud-runner-protocol.md) — how the version advisories propagate

--- a/docs/wiki/16-glossary.md
+++ b/docs/wiki/16-glossary.md
@@ -1,0 +1,111 @@
+# 16 — Glossary
+
+Terms you'll see across the wiki, code, UI, and tickets. Where a term has a Pi-Dash-specific meaning, it's noted.
+
+## Product
+
+**Workspace**
+The top-level container a user logs into. Holds projects, members, settings. A user can belong to many workspaces.
+
+**Project**
+A discrete unit of work inside a workspace — a codebase, a team's board, etc. Owns work items, cycles, modules, members. A project can be connected to runners.
+
+**Work item** (a.k.a. _issue_, _task_)
+The user-facing unit of tracked work. Has a title, description, state, assignee, labels, parent/sub-issue links, etc. Lives in `apps/api/pi_dash/app/`.
+
+**Cycle**
+A time-boxed iteration (sprint). Work items can be assigned to a cycle. Has start/end dates, progress analytics.
+
+**Module**
+A grouping of work items by theme (epic / feature area). Cuts across cycles.
+
+**View**
+A saved filter / sort / display configuration over work items.
+
+**Page**
+A rich-text document inside a project (docs, RFCs, retros). Real-time collaboratively editable via `apps/live` — see [10](./10-realtime-collaboration.md).
+
+**Space**
+A _public_ view of project content. Served by `apps/space/`. Accessible without login when published.
+
+**Instance admin** ("god mode")
+The first user registered against a self-hosted instance. Lives in `apps/admin/` at `/god-mode/`. Has cross-workspace privileges. See [11](./11-authentication.md).
+
+## Agent execution
+
+**Runner**
+A registered instance of the `pidash` daemon on a developer machine, scoped to a project. One host can run multiple runners (one per project). Model in `pi_dash/runner/models.py`.
+
+**Pod**
+A grouping primitive on the runner side — a namespace a run lives in on a particular runner. Naming logic in `pi_dash/runner/services/pod_naming.py`.
+
+**Run**
+One execution attempt of an agent against a work item. Persisted server-side; transcripts persisted locally on the runner under its data dir. A work item can have many runs (retries, follow-ups).
+
+**Phase**
+A step within a run. Runs progress through ordered phases (defined in `pi_dash/orchestration/agent_phases.py`); each phase has its own prompt template and expected outputs.
+
+**Workpad**
+The durable scratchpad attached to a run that the agent reads/writes structured artifacts into. Defined in `pi_dash/orchestration/workpad.py`.
+
+**Done signal**
+The explicit completion contract the agent emits to mark a phase done. Parsed by `pi_dash/orchestration/done_signal.py`.
+
+**Approval**
+A user decision the agent is waiting on (run command, write file, fetch URL). Decision sources race; **first writer wins** (TUI vs cloud vs local policy). Router in `runner/src/approval/`.
+
+**Matcher**
+Server-side logic that assigns an eligible run to an available runner. `pi_dash/runner/services/matcher.py`.
+
+## Protocol / wire
+
+**Wire version**
+Integer identifying the runner ↔ cloud protocol shape. Currently `4`. Bumped only on incompatible changes. Source: `runner/src/cloud/protocol.rs`.
+
+**Welcome frame**
+The first response the cloud returns when a runner opens a session. Includes the accepted `protocol_version` plus optional `latest_runner_version` and `min_runner_version` advisories. See [08](./08-cloud-runner-protocol.md).
+
+**Long-poll**
+The v4 transport — runner holds an HTTP request open until the cloud has work or the timeout fires. Replaced the v1–v3 persistent WebSocket.
+
+**Auto-update**
+The runner's ability to swap its on-disk binary in place when the cloud advertises a newer `latest_runner_version`. Running process is **never** disturbed; the new binary takes effect on the next natural restart.
+
+## Auth
+
+**CLI token**
+The user-identifying token minted by `pidash auth login` (device-code flow). Stored at `~/.config/pidash/config.toml` (`0600`). Authorizes `pidash runner add`.
+
+**Refresh token / access token (per runner)**
+Token pair held by each registered runner. Refresh is long-lived and rotatable; access is short-lived and used per request. Logic in `pi_dash/runner/services/tokens.py`.
+
+**Device-code flow**
+Browser-based login that requires no token paste. Same UX as `gh auth login` / `stripe login`. Recommended.
+
+**Enrollment token** (legacy)
+One-shot token generated from the web UI ("Add connection"). Used by the legacy `pidash connect` flow on headless hosts.
+
+**Plan**
+The current subscription tier of an account on Pi Dash Cloud. Source-of-truth is the home-page OIDC; cached as a JWT `plan` claim on `Account`. No webhooks. Upgrade UI deep-links back to home-page.
+
+## Tooling / repo
+
+**Catalog dep**
+An external dep version pinned in the `catalog:` block of `pnpm-workspace.yaml`. Apps and packages reference these via `"catalog:"` rather than a literal version. See [03](./03-repository-layout.md) and `AGENTS.md`.
+
+**Max-warnings ceiling**
+A pinned OxLint warning count per app (e.g. `web: 11957`). `pnpm check:lint` fails if warnings exceed the ceiling. After cleanup, **lower** the ceiling; never raise it as a workaround.
+
+**God mode**
+Casual name for the instance admin UI (`apps/admin`, mounted at `/god-mode/`).
+
+**Pi Dash CE**
+Community Edition — the OSS variant. Code under `apps/web/ce/` is the OSS implementation that can be overridden in the Cloud build.
+
+**`private-pi-dash`**
+The closed-source repo that overlays Pi Dash Cloud features on top of this OSS repo. Don't fork OSS files into it.
+
+## Where to read next
+
+- [01 — Architecture overview](./01-architecture-overview.md) — how the moving parts above fit together
+- [09 — Agent orchestration](./09-agent-orchestration.md) — the run → phase → workpad → done-signal pipeline in depth

--- a/docs/wiki/17-cli-reference.md
+++ b/docs/wiki/17-cli-reference.md
@@ -1,0 +1,429 @@
+# 17 — `pidash` CLI Reference
+
+Complete reference for the `pidash` binary. All commands, all flags, brief examples.
+
+For the _guided_ setup walkthrough use [02 — Cloud Quickstart](./02-cloud-quickstart.md). For the runner's internals see [07 — Runner architecture](./07-runner-architecture.md).
+
+## Global flags
+
+Available on every command:
+
+| Flag                  | Env                 | Default        | Purpose                                              |
+| --------------------- | ------------------- | -------------- | ---------------------------------------------------- |
+| `--config-dir <PATH>` | `PIDASH_CONFIG_DIR` | XDG config dir | Override config location                             |
+| `--data-dir <PATH>`   | `PIDASH_DATA_DIR`   | XDG data dir   | Override data location                               |
+| `--log <LEVEL>`       | `PIDASH_LOG`        | `info`         | Log level: `trace`, `debug`, `info`, `warn`, `error` |
+| `--help`              | —                   | —              | Show help for any command                            |
+| `--version`           | —                   | —              | Print version                                        |
+
+## `pidash` (no subcommand)
+
+First-run launcher. If no config exists, drops into `pidash auth login`. Otherwise prints help.
+
+---
+
+## Setup & auth
+
+### `pidash auth login`
+
+Browser-based device-code login. Same UX as `gh auth login` / `stripe login`.
+
+```
+pidash auth login [--url <URL>] [--no-browser] [--no-runner-prompt]
+```
+
+| Flag                 | Purpose                                                                                    |
+| -------------------- | ------------------------------------------------------------------------------------------ |
+| `--url <URL>`        | Cloud base URL (e.g. `https://pidash.airepublic.com`). Optional if config already has one. |
+| `--no-browser`       | Don't try to open the verification URL automatically.                                      |
+| `--no-runner-prompt` | Skip the post-login "add a runner now?" prompt.                                            |
+
+Writes the CLI token to `config.toml`. On a TTY with no runners yet, offers to register one inline.
+
+### `pidash auth status`
+
+Show who you're logged in as and which runners are registered on this host.
+
+```
+pidash auth status
+```
+
+### `pidash auth logout`
+
+Revoke the CLI token server-side and clear it locally. `[[runner]]` blocks are left intact — the daemon keeps running under its own identity.
+
+```
+pidash auth logout [--local-only]
+```
+
+| Flag           | Purpose                                                                            |
+| -------------- | ---------------------------------------------------------------------------------- |
+| `--local-only` | Skip server-side revoke, just clear local token. Useful when cloud is unreachable. |
+
+### `pidash connect` _(legacy enrollment-token flow)_
+
+Original pairing flow. Use only when device-code login isn't an option (headless / scripted hosts). Generate the token in the cloud UI: **Runners → Add connection**.
+
+```
+pidash connect --url <URL> --token <TOKEN> [--host-label <LABEL>]
+               [--working-dir <PATH>] [--agent codex|claude-code]
+               [--skip-service] [--skip-linger]
+```
+
+| Flag                   | Purpose                                                               |
+| ---------------------- | --------------------------------------------------------------------- |
+| `--url <URL>`          | Cloud base URL (required).                                            |
+| `--token <TOKEN>`      | One-time enrollment token (required, single-use).                     |
+| `--host-label <LABEL>` | Free-form host label. Defaults to hostname.                           |
+| `--working-dir <PATH>` | Runner's working dir. Defaults to `data_dir/runners/<rid>/workspace`. |
+| `--agent <KIND>`       | `codex` or `claude-code`. Defaults to `codex`.                        |
+| `--skip-service`       | Skip the post-enroll doctor + service install (CI).                   |
+| `--skip-linger`        | Skip `loginctl enable-linger` on Linux (avoid sudo prompt).           |
+
+---
+
+## Local config
+
+### `pidash config set default-project <PROJECT>`
+
+Set the local default project for non-interactive CLI calls (e.g. `pidash issue list` without `--project`).
+
+```
+pidash config set default-project <PROJECT_IDENTIFIER_OR_UUID>
+```
+
+---
+
+## Runner management
+
+### `pidash runner add`
+
+Register a new runner. Uses the CLI token from `pidash auth login`.
+
+```
+pidash runner add --project <PROJECT> [--name <NAME>] [--workspace <SLUG>]
+                  [--pod <POD>] [--working-dir <PATH>] [--agent codex|claude-code]
+```
+
+| Flag                | Purpose                                                            |
+| ------------------- | ------------------------------------------------------------------ |
+| `--project <P>`     | Project identifier (slug or UUID). **Required.**                   |
+| `--name <N>`        | Human-friendly runner name. Auto-generated if omitted.             |
+| `--workspace <S>`   | Workspace slug. Required if you belong to multiple workspaces.     |
+| `--pod <P>`         | Pod within the project. Defaults to project's default pod.         |
+| `--working-dir <P>` | Local working dir for clones. Defaults to a path under `data_dir`. |
+| `--agent <K>`       | `codex` (default) or `claude-code`.                                |
+
+On the first runner: installs the OS service (systemd user unit / launchd agent / Windows scheduled task) and starts the daemon.
+
+### `pidash runner list`
+
+List runners configured on this machine.
+
+```
+pidash runner list
+```
+
+### `pidash runner remove`
+
+Deregister a runner (cloud + local).
+
+```
+pidash runner remove <NAME> [--local-only] [-y|--yes]
+```
+
+| Flag           | Purpose                                                                            |
+| -------------- | ---------------------------------------------------------------------------------- |
+| `<NAME>`       | Runner name from `pidash runner list`. Must match a `[[runner]]` in `config.toml`. |
+| `--local-only` | Skip cloud-side delete; just clean local config + data dir.                        |
+| `-y`, `--yes`  | Skip the y/N confirm. Required for scripted callers.                               |
+
+---
+
+## Service lifecycle
+
+### `pidash install`
+
+Write or refresh the OS service unit. Safe to re-run after binary upgrades.
+
+```
+pidash install [--skip-linger]
+```
+
+| Flag            | Purpose                                                                                                       |
+| --------------- | ------------------------------------------------------------------------------------------------------------- |
+| `--skip-linger` | Linux only — skip `sudo loginctl enable-linger`. Without linger the daemon only starts at login, not at boot. |
+
+### `pidash uninstall`
+
+Remove the OS service unit. Local config + runner credentials are kept.
+
+```
+pidash uninstall
+```
+
+### `pidash start` / `pidash stop` / `pidash restart`
+
+Control the installed service.
+
+```
+pidash start
+pidash stop
+pidash restart
+```
+
+### `pidash status`
+
+Combined service-level + daemon-runtime status.
+
+```
+pidash status [--json]
+```
+
+| Flag     | Purpose                                |
+| -------- | -------------------------------------- |
+| `--json` | Print JSON instead of a human summary. |
+
+If the daemon isn't running, prints just the service-level state and a note (instead of an IPC error).
+
+### `pidash tui`
+
+Attach the interactive Ratatui UI to the running daemon.
+
+```
+pidash tui [--tab <TAB>]
+```
+
+| Flag          | Purpose                                                                                                      |
+| ------------- | ------------------------------------------------------------------------------------------------------------ |
+| `--tab <TAB>` | Open directly to a tab: `runner` (default), `config`, `runs`, or `approvals`. Accepts 1-based index `1`–`4`. |
+
+Press `q` to quit; the daemon keeps running in the background.
+
+### `pidash doctor`
+
+Preflight checks: agent installed + on `PATH`, agent authed, git configured, cloud reachable.
+
+```
+pidash doctor [--json] [--runner <NAME>]
+```
+
+| Flag              | Purpose                                                                  |
+| ----------------- | ------------------------------------------------------------------------ |
+| `--json`          | Machine-readable report.                                                 |
+| `--runner <NAME>` | Restrict per-runner checks to one runner. Daemon-wide checks always run. |
+
+### `pidash update`
+
+Swap the on-disk `pidash` binary for the latest GitHub release. Only works for cargo-dist installs (those leave an install receipt).
+
+```
+pidash update [--check] [--restart]
+```
+
+| Flag        | Purpose                                                                    |
+| ----------- | -------------------------------------------------------------------------- |
+| `--check`   | Report whether an update is available, don't swap.                         |
+| `--restart` | After swap, restart the daemon so the new binary takes effect immediately. |
+
+Without `--restart`, the swap only takes effect on the next natural restart (`pidash restart`, reboot, service respawn). The running process is never disturbed.
+
+### `pidash remove --all`
+
+Full teardown: stop service → uninstall service unit → deregister with cloud → delete local `config.toml` + credentials.
+
+```
+pidash remove --all [--local-only]
+```
+
+| Flag           | Purpose                                                                             |
+| -------------- | ----------------------------------------------------------------------------------- |
+| `--all`        | **Required.** Explicit confirmation that you want to wipe ALL runners on this host. |
+| `--local-only` | Delete local state without contacting the cloud.                                    |
+
+> To drop a single runner instead, use `pidash runner remove <name>`.
+
+---
+
+## Workspace / project / context
+
+### `pidash workspace me`
+
+Verify CLI credentials end-to-end (token + cloud reachability + TLS + active user). The probe `pidash doctor` uses.
+
+```
+pidash workspace me
+```
+
+### `pidash project list`
+
+List projects in the active workspace. Prints JSON.
+
+```
+pidash project list
+```
+
+### `pidash context init`
+
+Write `.pidash/context.md` for a local workspace directory.
+
+```
+pidash context init --project <PROJECT> [--workspace <PATH>]
+```
+
+| Flag              | Purpose                                             |
+| ----------------- | --------------------------------------------------- |
+| `--project <P>`   | Project identifier or UUID. **Required.**           |
+| `--workspace <P>` | Local workspace dir. Defaults to current directory. |
+
+---
+
+## Work items
+
+### `pidash issue get <IDENTIFIER>`
+
+Fetch one work item. Prints full JSON.
+
+```
+pidash issue get ENG-42
+```
+
+### `pidash issue create`
+
+Create a work item under a project.
+
+```
+pidash issue create --title <TITLE> [--project <P>] [--description <D>]
+                    [--priority <P>] [--state <S>]
+```
+
+| Flag                | Purpose                                                                                                        |
+| ------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `--title <T>`       | **Required.**                                                                                                  |
+| `--project <P>`     | Project identifier or UUID. If omitted: `PIDASH_PROJECT_ID` env → local `default_project` → workspace default. |
+| `--description <D>` | Plain text or markdown.                                                                                        |
+| `--priority <P>`    | `none` \| `low` \| `medium` \| `high` \| `urgent`.                                                             |
+| `--state <S>`       | Initial state — name (case-insensitive) or UUID.                                                               |
+
+### `pidash issue list --project <P>`
+
+List work items in a project. Returns the paginated envelope `{count, next_cursor, prev_cursor, results}`.
+
+```
+pidash issue list --project <P> [--cursor <C>] [--per-page <N>] [--order-by <F>]
+```
+
+| Flag             | Purpose                                                              |
+| ---------------- | -------------------------------------------------------------------- |
+| `--project <P>`  | **Required.**                                                        |
+| `--cursor <C>`   | Pagination cursor from a prior page's `next_cursor`.                 |
+| `--per-page <N>` | Items per page. Server default if omitted.                           |
+| `--order-by <F>` | Sort field, e.g. `-created_at` (default), `priority`, `state__name`. |
+
+### `pidash issue patch <IDENTIFIER>`
+
+Update fields. Pass only the fields you want to change.
+
+```
+pidash issue patch ENG-42 [--state <S>] [--title <T>] [--description <D>] [--priority <P>]
+```
+
+| Flag                | Purpose                                            |
+| ------------------- | -------------------------------------------------- |
+| `--state <S>`       | State name (case-insensitive) or UUID.             |
+| `--title <T>`       | New title.                                         |
+| `--description <D>` | New description.                                   |
+| `--priority <P>`    | `none` \| `low` \| `medium` \| `high` \| `urgent`. |
+
+### `pidash issue move <IDENTIFIER> --project <P>`
+
+Move a work item into another project in the same workspace.
+
+```
+pidash issue move ENG-42 --project OPS
+```
+
+---
+
+## Comments
+
+### `pidash comment list <IDENTIFIER>`
+
+List comments on a work item.
+
+```
+pidash comment list ENG-42
+```
+
+### `pidash comment add <IDENTIFIER>`
+
+Post a new comment.
+
+```
+pidash comment add ENG-42 (--body <BODY> | --body-file <PATH>)
+```
+
+| Flag                 | Purpose                                |
+| -------------------- | -------------------------------------- |
+| `--body <B>`         | Comment body (plain text or markdown). |
+| `--body-file <PATH>` | Read body from file.                   |
+
+### `pidash comment update <IDENTIFIER> <COMMENT_UUID>`
+
+Edit an existing comment owned by you.
+
+```
+pidash comment update ENG-42 <COMMENT_UUID> (--body <BODY> | --body-file <PATH>)
+```
+
+---
+
+## States
+
+### `pidash state list [PROJECT_OR_ISSUE]`
+
+List workflow states for a project. Without an argument, uses the current issue context from `PIDASH_ISSUE_IDENTIFIER`.
+
+```
+pidash state list             # uses current issue context
+pidash state list ENG         # project slug
+pidash state list ENG-42      # via work-item identifier
+pidash state list <UUID>      # project UUID
+```
+
+---
+
+## Hidden / internal
+
+### `pidash __run`
+
+Internal daemon entry point. Invoked by systemd / launchd / Windows scheduled task via the generated unit file. **Not a user-facing command.**
+
+---
+
+## Exit codes
+
+`issue`, `comment`, `state`, `workspace`, `project`, `context` print JSON on stdout and JSON on stderr for errors. Their exit codes follow `api_client::EXIT_*` constants — non-zero on any error.
+
+Other commands return `0` on success and surface anyhow errors on failure (non-zero exit).
+
+## Common environment variables
+
+| Variable                  | Used by        | Purpose                                  |
+| ------------------------- | -------------- | ---------------------------------------- |
+| `PIDASH_CONFIG_DIR`       | All            | Override config dir                      |
+| `PIDASH_DATA_DIR`         | All            | Override data dir                        |
+| `PIDASH_LOG`              | All            | Log level                                |
+| `PIDASH_PROJECT_ID`       | `issue create` | Default project when `--project` omitted |
+| `PIDASH_ISSUE_IDENTIFIER` | `state list`   | Default issue context                    |
+
+## Common file locations
+
+| What                   | Linux / macOS                               | Windows                                     |
+| ---------------------- | ------------------------------------------- | ------------------------------------------- |
+| Config + CLI token     | `~/.config/pidash/config.toml`              | `%APPDATA%\pidash\config.toml`              |
+| Per-runner credentials | `<data_dir>/runners/<rid>/credentials.toml` | `<data_dir>\runners\<rid>\credentials.toml` |
+| Run transcripts        | `<data_dir>/runners/<rid>/history/`         | `<data_dir>\runners\<rid>\history\`         |
+| IPC socket / pipe      | `$XDG_RUNTIME_DIR/pidash/...`               | local named pipe                            |
+
+All secrets and the IPC socket are `0600` on Unix.

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -1,0 +1,46 @@
+# Pi Dash Wiki
+
+Internal reference docs for contributors and operators of Pi Dash — the AI agent orchestration platform.
+
+These pages explain how the system fits together. They complement (not replace) the top-level `README.md` (user-facing install + product pitch) and `CLAUDE.md` (terse repo cheatsheet for coding agents).
+
+> **New to Pi Dash as a user?** Jump straight to **[02 — Pi Dash Cloud Quickstart](./02-cloud-quickstart.md)** — a 15-minute, task-oriented walkthrough from "I just signed up" to "my first agent run shipped a diff." The rest of this wiki is for contributors who want to understand or change the codebase.
+
+## Start here
+
+| Doc                                                         | What it covers                                                                 |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| [01 — Architecture overview](./01-architecture-overview.md) | The three Pi Dash components, how a task flows end-to-end, where the seams are |
+| [02 — Pi Dash Cloud Quickstart](./02-cloud-quickstart.md)   | User-facing: sign up → install CLI → connect runner → first agent run          |
+| [03 — Repository layout](./03-repository-layout.md)         | Polyglot monorepo tour: `apps/`, `packages/`, `runner/`, `deployments/`        |
+| [04 — Getting started locally](./04-getting-started.md)     | First-time `setup.sh`, `docker compose`, `pnpm dev`, key URLs, god-mode        |
+
+## Per-stack deep dives
+
+| Doc                                                           | What it covers                                                                       |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| [05 — Frontend architecture](./05-frontend-architecture.md)   | React Router 7 apps, shared `packages/`, MobX stores, conventions                    |
+| [06 — Backend architecture](./06-backend-architecture.md)     | Django apps, URL tree, ASGI + Channels, Celery, settings layering                    |
+| [07 — Runner architecture](./07-runner-architecture.md)       | Rust crate layout, daemon supervisor, Codex bridge, IPC, TUI                         |
+| [08 — Cloud ↔ runner protocol](./08-cloud-runner-protocol.md) | Wire version, welcome frame, auto-update, version pinning                            |
+| [09 — Agent orchestration](./09-agent-orchestration.md)       | `orchestration/` + `prompting/` + `scheduler/`: how a work item becomes an agent run |
+| [10 — Realtime collaboration](./10-realtime-collaboration.md) | `apps/live` Yjs/Hocuspocus server and the Tiptap editor                              |
+| [11 — Authentication](./11-authentication.md)                 | Instance admin, OIDC, device-code login, runner enrollment & token rotation          |
+
+## Operating Pi Dash
+
+| Doc                                                       | What it covers                                                          |
+| --------------------------------------------------------- | ----------------------------------------------------------------------- |
+| [12 — Deployment topologies](./12-deployment.md)          | AIO container vs Compose/Swarm vs Kubernetes                            |
+| [13 — Development workflow](./13-development-workflow.md) | pnpm/turbo, OxLint + oxfmt, max-warning ceilings, Husky, catalog deps   |
+| [14 — Testing](./14-testing.md)                           | pytest markers, vitest, cargo test, Storybook                           |
+| [15 — Releasing](./15-releasing.md)                       | Runner cargo-dist tags, web release flow, env-var version announcements |
+| [16 — Glossary](./16-glossary.md)                         | Workspace, project, work item, cycle, module, runner, pod, run          |
+| [17 — `pidash` CLI reference](./17-cli-reference.md)      | Complete reference for every `pidash` subcommand and flag               |
+
+## How to contribute to the wiki
+
+- Edit existing pages in place rather than adding new ones unless a topic needs its own home.
+- Keep each page focused on a single subsystem or workflow. Cross-link aggressively.
+- Code-level docstrings and `CLAUDE.md`/`AGENTS.md` are still the source of truth for day-to-day commands. The wiki is for _why_ and _how it fits together_.
+- When you rename a directory or rip out a module, grep this wiki and update the references.


### PR DESCRIPTION
### Description

Introduces an 18-page wiki under `docs/wiki/` to give contributors and users a single source-of-truth landing for Pi Dash architecture, workflows, and reference material.

Structure:

- **Index + landing:** `README.md` (TOC), `01 — Architecture overview`, `02 — Cloud quickstart` (user-facing, no-install-needed walkthrough).
- **Repo + getting started:** `03 — Repository layout`, `04 — Getting started locally`.
- **Per-stack deep dives:** `05 — Frontend`, `06 — Backend (Django)`, `07 — Runner (Rust)`, `08 — Cloud ↔ runner protocol`, `09 — Agent orchestration`, `10 — Realtime collaboration`, `11 — Authentication`.
- **Operating:** `12 — Deployment`, `13 — Development workflow`, `14 — Testing`, `15 — Releasing`.
- **Reference:** `16 — Glossary`, `17 — \`pidash\` CLI reference`.

Cross-linked throughout. Pages reference authoritative source files (`runner/src/cloud/protocol.rs`, `pi_dash/urls.py`, etc.) rather than duplicating per-endpoint detail — the wiki is for _why_ and _how it fits together_.

### Type of Change

- [x] Documentation update

### Test Scenarios

- Read-through of each page for consistency.
- `02 — Cloud quickstart` walked through end-to-end (sign up → install CLI → connect runner → first agent run) mentally against the actual product flow.
- `17 — CLI reference` cross-checked against `runner/src/cli/` source for every subcommand and flag.

### References

This wiki will be consumed by a companion `home-page` sync workflow that pulls these files into the public docs at `airepublic.com/docs/pi-dash/...`. Source of truth stays here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)