### PR TITLE
feat(web): give runners tabs and run detail their own URLs

### DIFF
--- a/apps/web/app/(all)/[workspaceSlug]/runners/approvals/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/approvals/page.tsx
@@ -12,6 +12,7 @@ import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
 import { RunnerService } from "@pi-dash/services";
 import type { IApprovalRequest, TApprovalDecision, TApprovalKind } from "@pi-dash/types";
 import { Button } from "@pi-dash/ui";
+import { RunnersTabs } from "@/components/runners/runners-tabs";
 
 const service = new RunnerService();
 
@@ -51,61 +52,63 @@ export const ApprovalsPage = observer(function ApprovalsPage() {
   }
 
   const rows = approvals ?? [];
-  if (rows.length === 0) {
-    return (
-      <div className="rounded-md border border-subtle p-8 text-center text-13 text-secondary">
-        {t("runners.approvals.empty")}
-      </div>
-    );
-  }
 
   return (
-    <div className="flex flex-col gap-4">
-      {rows.map((a) => (
-        <div key={a.id} className="rounded-md border border-subtle p-4">
-          <div className="flex items-start justify-between">
-            <div>
-              <div className="text-11 text-secondary">
-                {t("runners.approvals.run_meta", {
-                  runId: a.agent_run,
-                  at: new Date(a.requested_at).toLocaleTimeString(),
-                })}
-              </div>
-              <div className="text-13 font-medium text-primary">{t(kindKey(a.kind))}</div>
-              {a.reason && <div className="mt-1 text-13 text-secondary">{a.reason}</div>}
-            </div>
-            {a.expires_at && (
-              <div className="text-11 text-secondary">
-                {t("runners.approvals.expires", { at: new Date(a.expires_at).toLocaleTimeString() })}
-              </div>
-            )}
-          </div>
-          <pre className="font-mono mt-3 max-h-80 overflow-auto rounded bg-layer-1 p-3 text-11 whitespace-pre-wrap">
-            {JSON.stringify(a.payload, null, 2)}
-          </pre>
-          <div className="mt-3 flex gap-2">
-            <Button onClick={() => decide(a.id, "accept")} loading={pending === a.id} size="sm">
-              {t("runners.approvals.accept_once")}
-            </Button>
-            <Button
-              onClick={() => decide(a.id, "accept_for_session")}
-              loading={pending === a.id}
-              variant="accent-primary"
-              size="sm"
-            >
-              {t("runners.approvals.accept_for_session")}
-            </Button>
-            <Button
-              onClick={() => decide(a.id, "decline")}
-              loading={pending === a.id}
-              variant="outline-danger"
-              size="sm"
-            >
-              {t("runners.approvals.decline")}
-            </Button>
-          </div>
+    <div className="flex flex-col gap-6">
+      <RunnersTabs />
+      {rows.length === 0 ? (
+        <div className="rounded-md border border-subtle p-8 text-center text-13 text-secondary">
+          {t("runners.approvals.empty")}
         </div>
-      ))}
+      ) : (
+        <div className="flex flex-col gap-4">
+          {rows.map((a) => (
+            <div key={a.id} className="rounded-md border border-subtle p-4">
+              <div className="flex items-start justify-between">
+                <div>
+                  <div className="text-11 text-secondary">
+                    {t("runners.approvals.run_meta", {
+                      runId: a.agent_run,
+                      at: new Date(a.requested_at).toLocaleTimeString(),
+                    })}
+                  </div>
+                  <div className="text-13 font-medium text-primary">{t(kindKey(a.kind))}</div>
+                  {a.reason && <div className="mt-1 text-13 text-secondary">{a.reason}</div>}
+                </div>
+                {a.expires_at && (
+                  <div className="text-11 text-secondary">
+                    {t("runners.approvals.expires", { at: new Date(a.expires_at).toLocaleTimeString() })}
+                  </div>
+                )}
+              </div>
+              <pre className="font-mono mt-3 max-h-80 overflow-auto rounded bg-layer-1 p-3 text-11 whitespace-pre-wrap">
+                {JSON.stringify(a.payload, null, 2)}
+              </pre>
+              <div className="mt-3 flex gap-2">
+                <Button onClick={() => decide(a.id, "accept")} loading={pending === a.id} size="sm">
+                  {t("runners.approvals.accept_once")}
+                </Button>
+                <Button
+                  onClick={() => decide(a.id, "accept_for_session")}
+                  loading={pending === a.id}
+                  variant="accent-primary"
+                  size="sm"
+                >
+                  {t("runners.approvals.accept_for_session")}
+                </Button>
+                <Button
+                  onClick={() => decide(a.id, "decline")}
+                  loading={pending === a.id}
+                  variant="outline-danger"
+                  size="sm"
+                >
+                  {t("runners.approvals.decline")}
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 });

--- a/apps/web/app/(all)/[workspaceSlug]/runners/approvals/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/approvals/page.tsx
@@ -12,7 +12,9 @@ import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
 import { RunnerService } from "@pi-dash/services";
 import type { IApprovalRequest, TApprovalDecision, TApprovalKind } from "@pi-dash/types";
 import { Button } from "@pi-dash/ui";
+import { PageHead } from "@/components/core/page-title";
 import { RunnersTabs } from "@/components/runners/runners-tabs";
+import { useWorkspace } from "@/hooks/store/use-workspace";
 
 const service = new RunnerService();
 
@@ -29,10 +31,14 @@ function kindKey(kind: TApprovalKind): string {
 
 export const ApprovalsPage = observer(function ApprovalsPage() {
   const { t } = useTranslation();
+  const { currentWorkspace } = useWorkspace();
   const { data: approvals, mutate } = useSWR<IApprovalRequest[]>("runner-approvals", () => service.listApprovals(), {
     refreshInterval: 2_000,
   });
   const [pending, setPending] = useState<string | null>(null);
+  const pageTitle = currentWorkspace?.name
+    ? t("runners.page_title", { workspace: currentWorkspace.name })
+    : t("runners.title");
 
   async function decide(id: string, decision: TApprovalDecision) {
     setPending(id);
@@ -55,6 +61,7 @@ export const ApprovalsPage = observer(function ApprovalsPage() {
 
   return (
     <div className="flex flex-col gap-6">
+      <PageHead title={pageTitle} />
       <RunnersTabs />
       {rows.length === 0 ? (
         <div className="rounded-md border border-subtle p-8 text-center text-13 text-secondary">

--- a/apps/web/app/(all)/[workspaceSlug]/runners/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/page.tsx
@@ -19,10 +19,9 @@ import { PageHead } from "@/components/core/page-title";
 import { AddRunnerModal } from "@/components/runners/add-runner-modal";
 import { CreatePodModal } from "@/components/runners/create-pod-modal";
 import { RunnerEnrollmentCommand } from "@/components/runners/runner-enrollment-command";
+import { RunnersTabs } from "@/components/runners/runners-tabs";
 import { useSelectedPodFilter } from "@/hooks/use-selected-pod-filter";
 import { useWorkspace } from "@/hooks/store/use-workspace";
-import { ApprovalsPage } from "./approvals/page";
-import { RunnerRunsPage } from "./runs/page";
 
 const service = new RunnerService();
 const podService = new PodService();
@@ -33,8 +32,6 @@ const STATUS_BADGE_VARIANT: Record<TRunnerStatus, TBadgeVariant> = {
   offline: "accent-neutral",
   revoked: "accent-warning",
 };
-
-type TOverviewTab = "overview" | "runs" | "approvals";
 
 // A runner is "revivable" when it has never enrolled or has been
 // revoked — i.e., it's not currently holding live credentials.
@@ -79,7 +76,6 @@ const RunnersListPage = observer(function RunnersListPage() {
   const [revoking, setRevoking] = useState(false);
   const [reviving, setReviving] = useState<string | null>(null);
   const [reviveInvite, setReviveInvite] = useState<IRunnerInvite | null>(null);
-  const [activeTab, setActiveTab] = useState<TOverviewTab>("overview");
 
   async function confirmDeleteRunner() {
     if (!deleteRunner) return;
@@ -141,256 +137,229 @@ const RunnersListPage = observer(function RunnersListPage() {
     <div className="flex flex-col gap-6">
       <PageHead title={pageTitle} />
 
-      <div className="flex border-b border-subtle">
-        {[
-          { key: "overview" as const, label: "Overview" },
-          { key: "runs" as const, label: t("runners.tabs.runs") },
-          { key: "approvals" as const, label: t("runners.tabs.approvals") },
-        ].map((tab) => (
-          <button
-            key={tab.key}
-            type="button"
-            onClick={() => setActiveTab(tab.key)}
-            className={`h-9 border-b-2 px-3 text-13 font-medium transition-colors ${
-              activeTab === tab.key
-                ? "border-custom-primary-100 text-primary"
-                : "border-transparent text-secondary hover:text-primary"
-            }`}
-          >
-            {tab.label}
-          </button>
-        ))}
-      </div>
+      <RunnersTabs />
 
-      {activeTab === "overview" ? (
-        <>
-          {/* Header — primary "Add runner" CTA + how-it-works tooltip */}
-          <section className="rounded-md border border-subtle p-4">
-            <div className="flex items-start justify-between gap-3">
-              <div>
-                <div className="flex items-center gap-1.5">
-                  <div className="text-13 font-medium text-primary">{t("runners.list.add_runner")}</div>
-                  <Tooltip
-                    position="bottom"
-                    tooltipContent={
-                      <div className="flex max-w-xs flex-col gap-1 p-1 text-12 whitespace-normal">
-                        <div className="font-medium">{t("runners.list.how_it_works_title")}</div>
-                        <div className="whitespace-pre-line text-secondary">{t("runners.list.how_it_works_body")}</div>
-                      </div>
-                    }
-                  >
-                    <button
-                      type="button"
-                      aria-label={t("runners.list.how_it_works_title")}
-                      className="text-tertiary hover:text-primary"
-                    >
-                      <HelpCircle className="size-4" />
-                    </button>
-                  </Tooltip>
-                </div>
-                <div className="text-13 text-secondary">{t("runners.machine_token_note.body")}</div>
-              </div>
-              <Button onClick={() => setAddOpen(true)} disabled={!workspaceId}>
-                {t("runners.list.add_runner")}
-              </Button>
-            </div>
-          </section>
-
-          {/* Pods (read-only summary) */}
-          <section>
-            <div className="mb-2 text-13 font-medium text-primary">{t("runners.pods.title")}</div>
-            <div className="mb-2 text-12 text-secondary">{t("runners.pods.help")}</div>
-            {podsError ? (
-              <div className="text-destructive text-12">{t("runners.pods.load_failed")}</div>
-            ) : (
-              <div className="flex flex-wrap gap-2">
-                {(pods ?? []).map((p) => {
-                  const isSelected = p.id === selectedPodId;
-                  return (
-                    <button
-                      key={p.id}
-                      type="button"
-                      aria-pressed={isSelected}
-                      aria-label={t("runners.pods.tile_aria", { name: p.name })}
-                      onClick={() => setSelectedPodId(isSelected ? null : p.id)}
-                      className={`rounded-md border px-3 py-2 text-left text-12 transition-colors ${
-                        isSelected
-                          ? "border-custom-primary-100 bg-custom-primary-100/10 ring-custom-primary-100 ring-1"
-                          : "hover:border-primary border-subtle bg-layer-1"
-                      }`}
-                    >
-                      <div className="flex items-center gap-2">
-                        <span className="font-medium text-primary">{p.name}</span>
-                        {p.is_default && (
-                          <Badge variant="accent-neutral" size="sm">
-                            {t("runners.pods.default_badge")}
-                          </Badge>
-                        )}
-                      </div>
-                      <div className="text-secondary">{t("runners.pods.runner_count", { count: p.runner_count })}</div>
-                    </button>
-                  );
-                })}
+      {/* Header — primary "Add runner" CTA + how-it-works tooltip */}
+      <section className="rounded-md border border-subtle p-4">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <div className="flex items-center gap-1.5">
+              <div className="text-13 font-medium text-primary">{t("runners.list.add_runner")}</div>
+              <Tooltip
+                position="bottom"
+                tooltipContent={
+                  <div className="flex max-w-xs flex-col gap-1 p-1 text-12 whitespace-normal">
+                    <div className="font-medium">{t("runners.list.how_it_works_title")}</div>
+                    <div className="whitespace-pre-line text-secondary">{t("runners.list.how_it_works_body")}</div>
+                  </div>
+                }
+              >
                 <button
                   type="button"
-                  onClick={() => setCreatePodOpen(true)}
-                  disabled={!workspaceSlug}
-                  className="hover:border-primary flex items-center gap-1.5 rounded-md border border-dashed border-subtle bg-transparent px-3 py-2 text-12 text-secondary hover:text-primary disabled:cursor-not-allowed disabled:opacity-50"
+                  aria-label={t("runners.list.how_it_works_title")}
+                  className="text-tertiary hover:text-primary"
                 >
-                  <Plus className="size-3.5" />
-                  <span className="font-medium">{t("runners.pods.create_tile")}</span>
+                  <HelpCircle className="size-4" />
                 </button>
-              </div>
-            )}
-          </section>
+              </Tooltip>
+            </div>
+            <div className="text-13 text-secondary">{t("runners.machine_token_note.body")}</div>
+          </div>
+          <Button onClick={() => setAddOpen(true)} disabled={!workspaceId}>
+            {t("runners.list.add_runner")}
+          </Button>
+        </div>
+      </section>
 
-          {/* Runners list — pending rows show as offline until the daemon enrolls */}
-          <section>
-            <div className="mb-2 flex items-center gap-3">
-              <div className="text-13 font-medium text-primary">{t("runners.list.connected_runners")}</div>
-              {selectedPod && (
-                <div className="flex items-center gap-2 text-12 text-secondary">
-                  <span>{t("runners.pods.filter_active", { name: selectedPod.name })}</span>
-                  <button
-                    type="button"
-                    onClick={() => setSelectedPodId(null)}
-                    className="text-custom-primary-100 underline-offset-2 hover:underline"
-                  >
-                    {t("runners.pods.filter_clear")}
-                  </button>
-                </div>
+      {/* Pods (read-only summary) */}
+      <section>
+        <div className="mb-2 text-13 font-medium text-primary">{t("runners.pods.title")}</div>
+        <div className="mb-2 text-12 text-secondary">{t("runners.pods.help")}</div>
+        {podsError ? (
+          <div className="text-destructive text-12">{t("runners.pods.load_failed")}</div>
+        ) : (
+          <div className="flex flex-wrap gap-2">
+            {(pods ?? []).map((p) => {
+              const isSelected = p.id === selectedPodId;
+              return (
+                <button
+                  key={p.id}
+                  type="button"
+                  aria-pressed={isSelected}
+                  aria-label={t("runners.pods.tile_aria", { name: p.name })}
+                  onClick={() => setSelectedPodId(isSelected ? null : p.id)}
+                  className={`rounded-md border px-3 py-2 text-left text-12 transition-colors ${
+                    isSelected
+                      ? "border-custom-primary-100 bg-custom-primary-100/10 ring-custom-primary-100 ring-1"
+                      : "hover:border-primary border-subtle bg-layer-1"
+                  }`}
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium text-primary">{p.name}</span>
+                    {p.is_default && (
+                      <Badge variant="accent-neutral" size="sm">
+                        {t("runners.pods.default_badge")}
+                      </Badge>
+                    )}
+                  </div>
+                  <div className="text-secondary">{t("runners.pods.runner_count", { count: p.runner_count })}</div>
+                </button>
+              );
+            })}
+            <button
+              type="button"
+              onClick={() => setCreatePodOpen(true)}
+              disabled={!workspaceSlug}
+              className="hover:border-primary flex items-center gap-1.5 rounded-md border border-dashed border-subtle bg-transparent px-3 py-2 text-12 text-secondary hover:text-primary disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <Plus className="size-3.5" />
+              <span className="font-medium">{t("runners.pods.create_tile")}</span>
+            </button>
+          </div>
+        )}
+      </section>
+
+      {/* Runners list — pending rows show as offline until the daemon enrolls */}
+      <section>
+        <div className="mb-2 flex items-center gap-3">
+          <div className="text-13 font-medium text-primary">{t("runners.list.connected_runners")}</div>
+          {selectedPod && (
+            <div className="flex items-center gap-2 text-12 text-secondary">
+              <span>{t("runners.pods.filter_active", { name: selectedPod.name })}</span>
+              <button
+                type="button"
+                onClick={() => setSelectedPodId(null)}
+                className="text-custom-primary-100 underline-offset-2 hover:underline"
+              >
+                {t("runners.pods.filter_clear")}
+              </button>
+            </div>
+          )}
+        </div>
+        <div className="overflow-x-auto rounded-md border border-subtle">
+          <table className="w-full text-13">
+            <thead className="bg-layer-1 text-left text-secondary">
+              <tr>
+                <th className="px-3 py-2">{t("runners.list.columns.name")}</th>
+                <th className="px-3 py-2">{t("runners.list.columns_pod")}</th>
+                <th className="px-3 py-2">{t("runners.list.columns.status")}</th>
+                <th className="px-3 py-2">{t("runners.list.columns.os_arch")}</th>
+                <th className="px-3 py-2">{t("runners.list.columns.version")}</th>
+                <th className="px-3 py-2">{t("runners.list.columns.last_heartbeat")}</th>
+                <th className="px-3 py-2"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {(filteredRunners ?? []).map((r) => (
+                <tr key={r.id} className="border-t border-subtle">
+                  <td className="font-mono px-3 py-2 text-11">{r.name}</td>
+                  <td className="px-3 py-2">{r.pod_detail ? r.pod_detail.name : "—"}</td>
+                  <td className="px-3 py-2">
+                    <Badge variant={STATUS_BADGE_VARIANT[r.status]} size="sm">
+                      {t(`runners.list.status.${r.status}`)}
+                    </Badge>
+                  </td>
+                  <td className="px-3 py-2">{r.os ? `${r.os} / ${r.arch}` : "—"}</td>
+                  <td className="px-3 py-2">{r.runner_version || "—"}</td>
+                  <td className="px-3 py-2">
+                    {r.last_heartbeat_at ? new Date(r.last_heartbeat_at).toLocaleString() : "—"}
+                  </td>
+                  <td className="px-3 py-2 text-right">
+                    <div className="flex justify-end gap-2">
+                      {isRevivable(r) && (
+                        <Button
+                          variant="neutral-primary"
+                          size="sm"
+                          onClick={() => reviveRunner(r)}
+                          disabled={reviving === r.id}
+                          loading={reviving === r.id}
+                        >
+                          {t("runners.list.revive")}
+                        </Button>
+                      )}
+                      {isRevocable(r) && (
+                        <Button variant="outline-danger" size="sm" onClick={() => setRevokeRunner(r)}>
+                          {t("runners.list.revoke")}
+                        </Button>
+                      )}
+                      <Button variant="tertiary-danger" size="sm" onClick={() => setDeleteRunner(r)}>
+                        {t("runners.list.delete")}
+                      </Button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+              {(filteredRunners ?? []).length === 0 && (
+                <tr>
+                  <td colSpan={7} className="px-3 py-8 text-center text-secondary">
+                    {t("runners.list.empty")}
+                  </td>
+                </tr>
               )}
-            </div>
-            <div className="overflow-x-auto rounded-md border border-subtle">
-              <table className="w-full text-13">
-                <thead className="bg-layer-1 text-left text-secondary">
-                  <tr>
-                    <th className="px-3 py-2">{t("runners.list.columns.name")}</th>
-                    <th className="px-3 py-2">{t("runners.list.columns_pod")}</th>
-                    <th className="px-3 py-2">{t("runners.list.columns.status")}</th>
-                    <th className="px-3 py-2">{t("runners.list.columns.os_arch")}</th>
-                    <th className="px-3 py-2">{t("runners.list.columns.version")}</th>
-                    <th className="px-3 py-2">{t("runners.list.columns.last_heartbeat")}</th>
-                    <th className="px-3 py-2"></th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {(filteredRunners ?? []).map((r) => (
-                    <tr key={r.id} className="border-t border-subtle">
-                      <td className="font-mono px-3 py-2 text-11">{r.name}</td>
-                      <td className="px-3 py-2">{r.pod_detail ? r.pod_detail.name : "—"}</td>
-                      <td className="px-3 py-2">
-                        <Badge variant={STATUS_BADGE_VARIANT[r.status]} size="sm">
-                          {t(`runners.list.status.${r.status}`)}
-                        </Badge>
-                      </td>
-                      <td className="px-3 py-2">{r.os ? `${r.os} / ${r.arch}` : "—"}</td>
-                      <td className="px-3 py-2">{r.runner_version || "—"}</td>
-                      <td className="px-3 py-2">
-                        {r.last_heartbeat_at ? new Date(r.last_heartbeat_at).toLocaleString() : "—"}
-                      </td>
-                      <td className="px-3 py-2 text-right">
-                        <div className="flex justify-end gap-2">
-                          {isRevivable(r) && (
-                            <Button
-                              variant="neutral-primary"
-                              size="sm"
-                              onClick={() => reviveRunner(r)}
-                              disabled={reviving === r.id}
-                              loading={reviving === r.id}
-                            >
-                              {t("runners.list.revive")}
-                            </Button>
-                          )}
-                          {isRevocable(r) && (
-                            <Button variant="outline-danger" size="sm" onClick={() => setRevokeRunner(r)}>
-                              {t("runners.list.revoke")}
-                            </Button>
-                          )}
-                          <Button variant="tertiary-danger" size="sm" onClick={() => setDeleteRunner(r)}>
-                            {t("runners.list.delete")}
-                          </Button>
-                        </div>
-                      </td>
-                    </tr>
-                  ))}
-                  {(filteredRunners ?? []).length === 0 && (
-                    <tr>
-                      <td colSpan={7} className="px-3 py-8 text-center text-secondary">
-                        {t("runners.list.empty")}
-                      </td>
-                    </tr>
-                  )}
-                </tbody>
-              </table>
-            </div>
-          </section>
+            </tbody>
+          </table>
+        </div>
+      </section>
 
-          {workspaceId && workspaceSlug && (
-            <AddRunnerModal
-              isOpen={addOpen}
-              onClose={() => setAddOpen(false)}
-              workspaceId={workspaceId}
-              workspaceSlug={workspaceSlug}
-              onCreated={() => mutateRunners()}
-            />
-          )}
-          {workspaceSlug && (
-            <CreatePodModal
-              isOpen={createPodOpen}
-              onClose={() => setCreatePodOpen(false)}
-              workspaceSlug={workspaceSlug}
-              onCreated={() => mutatePods()}
-            />
-          )}
-          <AlertModalCore
-            isOpen={!!deleteRunner}
-            handleClose={() => (deleting ? null : setDeleteRunner(null))}
-            handleSubmit={confirmDeleteRunner}
-            isSubmitting={deleting}
-            title={t("runners.list.delete_confirm_title")}
-            content={t("runners.list.delete_confirm_body")}
-            primaryButtonText={{ default: t("runners.list.delete"), loading: t("runners.list.delete") }}
-          />
-          <AlertModalCore
-            isOpen={!!revokeRunner}
-            handleClose={() => (revoking ? null : setRevokeRunner(null))}
-            handleSubmit={confirmRevokeRunner}
-            isSubmitting={revoking}
-            title={t("runners.list.revoke_confirm_title")}
-            content={t("runners.list.revoke_confirm_body")}
-            primaryButtonText={{ default: t("runners.list.revoke"), loading: t("runners.list.revoke") }}
-          />
-          <ModalCore
-            isOpen={!!reviveInvite}
-            handleClose={() => setReviveInvite(null)}
-            position={EModalPosition.CENTER}
-            width={EModalWidth.XXL}
-          >
-            {reviveInvite && (
-              <div className="flex flex-col gap-4 p-5">
-                <div>
-                  <div className="text-18 font-medium text-primary">{t("runners.list.revive_modal_title")}</div>
-                  <p className="mt-1 text-13 text-secondary">
-                    {t("runners.add_modal.runner_id_label")}: <code className="text-12">{reviveInvite.runner_id}</code>
-                    <br />
-                    {reviveInvite.name}
-                  </p>
-                  <p className="mt-2 text-13 text-secondary">{t("runners.list.revive_modal_body")}</p>
-                </div>
-                <RunnerEnrollmentCommand invite={reviveInvite} />
-                <div className="flex justify-end">
-                  <Button onClick={() => setReviveInvite(null)}>{t("runners.add_modal.done")}</Button>
-                </div>
-              </div>
-            )}
-          </ModalCore>
-        </>
-      ) : activeTab === "runs" ? (
-        <RunnerRunsPage />
-      ) : (
-        <ApprovalsPage />
+      {workspaceId && workspaceSlug && (
+        <AddRunnerModal
+          isOpen={addOpen}
+          onClose={() => setAddOpen(false)}
+          workspaceId={workspaceId}
+          workspaceSlug={workspaceSlug}
+          onCreated={() => mutateRunners()}
+        />
       )}
+      {workspaceSlug && (
+        <CreatePodModal
+          isOpen={createPodOpen}
+          onClose={() => setCreatePodOpen(false)}
+          workspaceSlug={workspaceSlug}
+          onCreated={() => mutatePods()}
+        />
+      )}
+      <AlertModalCore
+        isOpen={!!deleteRunner}
+        handleClose={() => (deleting ? null : setDeleteRunner(null))}
+        handleSubmit={confirmDeleteRunner}
+        isSubmitting={deleting}
+        title={t("runners.list.delete_confirm_title")}
+        content={t("runners.list.delete_confirm_body")}
+        primaryButtonText={{ default: t("runners.list.delete"), loading: t("runners.list.delete") }}
+      />
+      <AlertModalCore
+        isOpen={!!revokeRunner}
+        handleClose={() => (revoking ? null : setRevokeRunner(null))}
+        handleSubmit={confirmRevokeRunner}
+        isSubmitting={revoking}
+        title={t("runners.list.revoke_confirm_title")}
+        content={t("runners.list.revoke_confirm_body")}
+        primaryButtonText={{ default: t("runners.list.revoke"), loading: t("runners.list.revoke") }}
+      />
+      <ModalCore
+        isOpen={!!reviveInvite}
+        handleClose={() => setReviveInvite(null)}
+        position={EModalPosition.CENTER}
+        width={EModalWidth.XXL}
+      >
+        {reviveInvite && (
+          <div className="flex flex-col gap-4 p-5">
+            <div>
+              <div className="text-18 font-medium text-primary">{t("runners.list.revive_modal_title")}</div>
+              <p className="mt-1 text-13 text-secondary">
+                {t("runners.add_modal.runner_id_label")}: <code className="text-12">{reviveInvite.runner_id}</code>
+                <br />
+                {reviveInvite.name}
+              </p>
+              <p className="mt-2 text-13 text-secondary">{t("runners.list.revive_modal_body")}</p>
+            </div>
+            <RunnerEnrollmentCommand invite={reviveInvite} />
+            <div className="flex justify-end">
+              <Button onClick={() => setReviveInvite(null)}>{t("runners.add_modal.done")}</Button>
+            </div>
+          </div>
+        )}
+      </ModalCore>
     </div>
   );
 });

--- a/apps/web/app/(all)/[workspaceSlug]/runners/runs/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/runs/page.tsx
@@ -6,6 +6,7 @@
 
 import { useState } from "react";
 import { observer } from "mobx-react";
+import { useNavigate, useParams } from "react-router";
 import useSWR from "swr";
 import { useTranslation } from "@pi-dash/i18n";
 import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
@@ -14,6 +15,7 @@ import type { IAgentRun, TAgentRunStatus } from "@pi-dash/types";
 import { AGENT_RUN_TERMINAL_STATUSES } from "@pi-dash/types";
 import type { TBadgeVariant } from "@pi-dash/ui";
 import { AlertModalCore, Badge, Button } from "@pi-dash/ui";
+import { RunnersTabs } from "@/components/runners/runners-tabs";
 import { useWorkspace } from "@/hooks/store/use-workspace";
 
 const service = new RunnerService();
@@ -36,7 +38,10 @@ function isTerminal(status: TAgentRunStatus): boolean {
 export const RunnerRunsPage = observer(function RunnerRunsPage() {
   const { currentWorkspace } = useWorkspace();
   const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { workspaceSlug, runId } = useParams<{ workspaceSlug: string; runId?: string }>();
   const workspaceId = currentWorkspace?.id;
+  const selected = runId ?? null;
 
   const { data: runs, mutate } = useSWR<IAgentRun[]>(
     workspaceId ? ["runner-runs", workspaceId] : null,
@@ -44,7 +49,6 @@ export const RunnerRunsPage = observer(function RunnerRunsPage() {
     { refreshInterval: 5_000 }
   );
 
-  const [selected, setSelected] = useState<string | null>(null);
   const { data: detail } = useSWR<IAgentRun>(
     selected ? ["runner-run-detail", selected] : null,
     () => service.getRun(selected!, true),
@@ -55,6 +59,11 @@ export const RunnerRunsPage = observer(function RunnerRunsPage() {
 
   const [cancelTarget, setCancelTarget] = useState<IAgentRun | null>(null);
   const [cancelling, setCancelling] = useState(false);
+
+  function selectRun(id: string) {
+    if (!workspaceSlug) return;
+    navigate(`/${workspaceSlug}/runners/runs/${id}`);
+  }
 
   async function confirmCancel() {
     if (!cancelTarget) return;
@@ -76,110 +85,113 @@ export const RunnerRunsPage = observer(function RunnerRunsPage() {
   }
 
   return (
-    <div className="grid grid-cols-[400px_1fr] gap-4">
-      <div className="rounded-md border border-subtle">
-        <table className="w-full text-13">
-          <thead className="bg-layer-1 text-left text-secondary">
-            <tr>
-              <th className="px-3 py-2">{t("runners.runs.columns.started")}</th>
-              <th className="px-3 py-2">{t("runners.runs.columns.status")}</th>
-              <th className="px-3 py-2">{t("runners.runs.columns.prompt")}</th>
-            </tr>
-          </thead>
-          <tbody>
-            {(runs ?? []).map((r) => (
-              <tr
-                key={r.id}
-                onClick={() => setSelected(r.id)}
-                className={`cursor-pointer border-t border-subtle ${
-                  selected === r.id ? "bg-accent-subtle" : "hover:bg-layer-1"
-                }`}
-              >
-                <td className="px-3 py-2 whitespace-nowrap">{new Date(r.created_at).toLocaleString()}</td>
-                <td className="px-3 py-2">
-                  <Badge variant={STATUS_BADGE_VARIANT[r.status]} size="sm">
-                    {t(`runners.runs.status.${r.status}`)}
-                  </Badge>
-                </td>
-                <td className="font-mono max-w-[180px] truncate px-3 py-2 text-11">{r.prompt}</td>
-              </tr>
-            ))}
-            {(runs ?? []).length === 0 && (
+    <div className="flex flex-col gap-6">
+      <RunnersTabs />
+      <div className="grid grid-cols-[400px_1fr] gap-4">
+        <div className="rounded-md border border-subtle">
+          <table className="w-full text-13">
+            <thead className="bg-layer-1 text-left text-secondary">
               <tr>
-                <td colSpan={3} className="px-3 py-8 text-center text-secondary">
-                  {t("runners.runs.empty")}
-                </td>
+                <th className="px-3 py-2">{t("runners.runs.columns.started")}</th>
+                <th className="px-3 py-2">{t("runners.runs.columns.status")}</th>
+                <th className="px-3 py-2">{t("runners.runs.columns.prompt")}</th>
               </tr>
-            )}
-          </tbody>
-        </table>
-      </div>
+            </thead>
+            <tbody>
+              {(runs ?? []).map((r) => (
+                <tr
+                  key={r.id}
+                  onClick={() => selectRun(r.id)}
+                  className={`cursor-pointer border-t border-subtle ${
+                    selected === r.id ? "bg-accent-subtle" : "hover:bg-layer-1"
+                  }`}
+                >
+                  <td className="px-3 py-2 whitespace-nowrap">{new Date(r.created_at).toLocaleString()}</td>
+                  <td className="px-3 py-2">
+                    <Badge variant={STATUS_BADGE_VARIANT[r.status]} size="sm">
+                      {t(`runners.runs.status.${r.status}`)}
+                    </Badge>
+                  </td>
+                  <td className="font-mono max-w-[180px] truncate px-3 py-2 text-11">{r.prompt}</td>
+                </tr>
+              ))}
+              {(runs ?? []).length === 0 && (
+                <tr>
+                  <td colSpan={3} className="px-3 py-8 text-center text-secondary">
+                    {t("runners.runs.empty")}
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
 
-      <div className="rounded-md border border-subtle p-4">
-        {!detail ? (
-          <div className="text-13 text-secondary">{t("runners.runs.select_run")}</div>
-        ) : (
-          <div className="flex flex-col gap-3">
-            <div className="flex items-center justify-between">
-              <div>
-                <div className="font-mono text-11">{detail.id}</div>
-                <div className="mt-1">
-                  <Badge variant={STATUS_BADGE_VARIANT[detail.status]} size="sm">
-                    {t(`runners.runs.status.${detail.status}`)}
-                  </Badge>
+        <div className="rounded-md border border-subtle p-4">
+          {!detail ? (
+            <div className="text-13 text-secondary">{t("runners.runs.select_run")}</div>
+          ) : (
+            <div className="flex flex-col gap-3">
+              <div className="flex items-center justify-between">
+                <div>
+                  <div className="font-mono text-11">{detail.id}</div>
+                  <div className="mt-1">
+                    <Badge variant={STATUS_BADGE_VARIANT[detail.status]} size="sm">
+                      {t(`runners.runs.status.${detail.status}`)}
+                    </Badge>
+                  </div>
+                </div>
+                {!isTerminal(detail.status) && (
+                  <Button variant="tertiary-danger" size="sm" onClick={() => setCancelTarget(detail)}>
+                    {t("runners.runs.cancel")}
+                  </Button>
+                )}
+              </div>
+              <div className="text-13">
+                <div className="text-secondary">{t("runners.runs.prompt")}</div>
+                <pre className="mt-1 rounded bg-layer-1 p-2 text-11 whitespace-pre-wrap">{detail.prompt}</pre>
+              </div>
+              {detail.error && (
+                <div className="text-13">
+                  <div className="text-danger-primary">{t("runners.runs.error")}</div>
+                  <pre className="mt-1 rounded bg-danger-subtle p-2 text-11 whitespace-pre-wrap">{detail.error}</pre>
+                </div>
+              )}
+              {detail.done_payload && (
+                <div className="text-13">
+                  <div className="text-secondary">{t("runners.runs.done_payload")}</div>
+                  <pre className="mt-1 rounded bg-layer-1 p-2 text-11 whitespace-pre-wrap">
+                    {JSON.stringify(detail.done_payload, null, 2)}
+                  </pre>
+                </div>
+              )}
+              <div className="text-13">
+                <div className="text-secondary">
+                  {t("runners.runs.events_count", { count: detail.events?.length ?? 0 })}
+                </div>
+                <div className="mt-1 max-h-[420px] overflow-auto rounded border border-subtle">
+                  <table className="w-full text-11">
+                    <thead className="bg-layer-1 text-left text-secondary">
+                      <tr>
+                        <th className="px-2 py-1">{t("runners.runs.event_columns.seq")}</th>
+                        <th className="px-2 py-1">{t("runners.runs.event_columns.kind")}</th>
+                        <th className="px-2 py-1">{t("runners.runs.event_columns.at")}</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {(detail.events ?? []).map((e) => (
+                        <tr key={e.id} className="border-t border-subtle">
+                          <td className="font-mono px-2 py-1">{e.seq}</td>
+                          <td className="font-mono px-2 py-1">{e.kind}</td>
+                          <td className="px-2 py-1">{new Date(e.created_at).toLocaleTimeString()}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
                 </div>
               </div>
-              {!isTerminal(detail.status) && (
-                <Button variant="tertiary-danger" size="sm" onClick={() => setCancelTarget(detail)}>
-                  {t("runners.runs.cancel")}
-                </Button>
-              )}
             </div>
-            <div className="text-13">
-              <div className="text-secondary">{t("runners.runs.prompt")}</div>
-              <pre className="mt-1 rounded bg-layer-1 p-2 text-11 whitespace-pre-wrap">{detail.prompt}</pre>
-            </div>
-            {detail.error && (
-              <div className="text-13">
-                <div className="text-danger-primary">{t("runners.runs.error")}</div>
-                <pre className="mt-1 rounded bg-danger-subtle p-2 text-11 whitespace-pre-wrap">{detail.error}</pre>
-              </div>
-            )}
-            {detail.done_payload && (
-              <div className="text-13">
-                <div className="text-secondary">{t("runners.runs.done_payload")}</div>
-                <pre className="mt-1 rounded bg-layer-1 p-2 text-11 whitespace-pre-wrap">
-                  {JSON.stringify(detail.done_payload, null, 2)}
-                </pre>
-              </div>
-            )}
-            <div className="text-13">
-              <div className="text-secondary">
-                {t("runners.runs.events_count", { count: detail.events?.length ?? 0 })}
-              </div>
-              <div className="mt-1 max-h-[420px] overflow-auto rounded border border-subtle">
-                <table className="w-full text-11">
-                  <thead className="bg-layer-1 text-left text-secondary">
-                    <tr>
-                      <th className="px-2 py-1">{t("runners.runs.event_columns.seq")}</th>
-                      <th className="px-2 py-1">{t("runners.runs.event_columns.kind")}</th>
-                      <th className="px-2 py-1">{t("runners.runs.event_columns.at")}</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {(detail.events ?? []).map((e) => (
-                      <tr key={e.id} className="border-t border-subtle">
-                        <td className="font-mono px-2 py-1">{e.seq}</td>
-                        <td className="font-mono px-2 py-1">{e.kind}</td>
-                        <td className="px-2 py-1">{new Date(e.created_at).toLocaleTimeString()}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </div>
-          </div>
-        )}
+          )}
+        </div>
       </div>
 
       <AlertModalCore

--- a/apps/web/app/(all)/[workspaceSlug]/runners/runs/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/runs/page.tsx
@@ -15,6 +15,7 @@ import type { IAgentRun, TAgentRunStatus } from "@pi-dash/types";
 import { AGENT_RUN_TERMINAL_STATUSES } from "@pi-dash/types";
 import type { TBadgeVariant } from "@pi-dash/ui";
 import { AlertModalCore, Badge, Button } from "@pi-dash/ui";
+import { PageHead } from "@/components/core/page-title";
 import { RunnersTabs } from "@/components/runners/runners-tabs";
 import { useWorkspace } from "@/hooks/store/use-workspace";
 
@@ -49,11 +50,12 @@ export const RunnerRunsPage = observer(function RunnerRunsPage() {
     { refreshInterval: 5_000 }
   );
 
-  const { data: detail } = useSWR<IAgentRun>(
+  const { data: detail, error: detailError } = useSWR<IAgentRun>(
     selected ? ["runner-run-detail", selected] : null,
     () => service.getRun(selected!, true),
     {
       refreshInterval: (latest) => (latest && isTerminal(latest.status) ? 0 : 3_000),
+      shouldRetryOnError: false,
     }
   );
 
@@ -62,7 +64,7 @@ export const RunnerRunsPage = observer(function RunnerRunsPage() {
 
   function selectRun(id: string) {
     if (!workspaceSlug) return;
-    navigate(`/${workspaceSlug}/runners/runs/${id}`);
+    navigate(`/${workspaceSlug}/runners/runs/${id}`, { replace: true });
   }
 
   async function confirmCancel() {
@@ -84,8 +86,13 @@ export const RunnerRunsPage = observer(function RunnerRunsPage() {
     }
   }
 
+  const pageTitle = currentWorkspace?.name
+    ? t("runners.page_title", { workspace: currentWorkspace.name })
+    : t("runners.title");
+
   return (
     <div className="flex flex-col gap-6">
+      <PageHead title={pageTitle} />
       <RunnersTabs />
       <div className="grid grid-cols-[400px_1fr] gap-4">
         <div className="rounded-md border border-subtle">
@@ -127,7 +134,9 @@ export const RunnerRunsPage = observer(function RunnerRunsPage() {
         </div>
 
         <div className="rounded-md border border-subtle p-4">
-          {!detail ? (
+          {selected && detailError ? (
+            <div className="text-13 text-danger-primary">{t("runners.runs.detail_load_failed")}</div>
+          ) : !detail ? (
             <div className="text-13 text-secondary">{t("runners.runs.select_run")}</div>
           ) : (
             <div className="flex flex-col gap-3">

--- a/apps/web/app/routes/core.ts
+++ b/apps/web/app/routes/core.ts
@@ -289,10 +289,7 @@ export const coreRoutes: RouteConfigEntry[] = [
       // Runners (Pi Dash runner: connect dev machines, review runs, decide approvals)
       layout("./(all)/[workspaceSlug]/runners/layout.tsx", [
         route(":workspaceSlug/runners", "./(all)/[workspaceSlug]/runners/page.tsx"),
-        route(":workspaceSlug/runners/runs", "./(all)/[workspaceSlug]/runners/runs/page.tsx"),
-        route(":workspaceSlug/runners/runs/:runId", "./(all)/[workspaceSlug]/runners/runs/page.tsx", {
-          id: "runner-runs-detail",
-        }),
+        route(":workspaceSlug/runners/runs/:runId?", "./(all)/[workspaceSlug]/runners/runs/page.tsx"),
         route(":workspaceSlug/runners/approvals", "./(all)/[workspaceSlug]/runners/approvals/page.tsx"),
         route(":workspaceSlug/runners/chat/:runnerId", "./(all)/[workspaceSlug]/runners/chat/[runnerId]/page.tsx"),
       ]),

--- a/apps/web/app/routes/core.ts
+++ b/apps/web/app/routes/core.ts
@@ -290,6 +290,9 @@ export const coreRoutes: RouteConfigEntry[] = [
       layout("./(all)/[workspaceSlug]/runners/layout.tsx", [
         route(":workspaceSlug/runners", "./(all)/[workspaceSlug]/runners/page.tsx"),
         route(":workspaceSlug/runners/runs", "./(all)/[workspaceSlug]/runners/runs/page.tsx"),
+        route(":workspaceSlug/runners/runs/:runId", "./(all)/[workspaceSlug]/runners/runs/page.tsx", {
+          id: "runner-runs-detail",
+        }),
         route(":workspaceSlug/runners/approvals", "./(all)/[workspaceSlug]/runners/approvals/page.tsx"),
         route(":workspaceSlug/runners/chat/:runnerId", "./(all)/[workspaceSlug]/runners/chat/[runnerId]/page.tsx"),
       ]),

--- a/apps/web/core/components/runners/runners-tabs.tsx
+++ b/apps/web/core/components/runners/runners-tabs.tsx
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { NavLink, useParams } from "react-router";
+import { useTranslation } from "@pi-dash/i18n";
+
+export function RunnersTabs() {
+  const { workspaceSlug } = useParams<{ workspaceSlug: string }>();
+  const { t } = useTranslation();
+  const base = `/${workspaceSlug}/runners`;
+
+  const tabs: { to: string; label: string; end: boolean }[] = [
+    { to: base, label: "Overview", end: true },
+    { to: `${base}/runs`, label: t("runners.tabs.runs"), end: false },
+    { to: `${base}/approvals`, label: t("runners.tabs.approvals"), end: false },
+  ];
+
+  return (
+    <div className="flex border-b border-subtle">
+      {tabs.map((tab) => (
+        <NavLink
+          key={tab.to}
+          to={tab.to}
+          end={tab.end}
+          className={({ isActive }) =>
+            `flex h-9 items-center border-b-2 px-3 text-13 font-medium transition-colors ${
+              isActive
+                ? "border-custom-primary-100 text-primary"
+                : "border-transparent text-secondary hover:text-primary"
+            }`
+          }
+        >
+          {tab.label}
+        </NavLink>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/core/components/runners/runners-tabs.tsx
+++ b/apps/web/core/components/runners/runners-tabs.tsx
@@ -13,7 +13,7 @@ export function RunnersTabs() {
   const base = `/${workspaceSlug}/runners`;
 
   const tabs: { to: string; label: string; end: boolean }[] = [
-    { to: base, label: "Overview", end: true },
+    { to: base, label: t("runners.tabs.overview"), end: true },
     { to: `${base}/runs`, label: t("runners.tabs.runs"), end: false },
     { to: `${base}/approvals`, label: t("runners.tabs.approvals"), end: false },
   ];

--- a/packages/i18n/src/locales/en/core.ts
+++ b/packages/i18n/src/locales/en/core.ts
@@ -458,6 +458,7 @@ export default {
     },
     tabs: {
       runners: "AI Agents",
+      overview: "Overview",
       runs: "Runs",
       approvals: "Approvals",
     },
@@ -624,6 +625,7 @@ export default {
       },
       empty: "No runs yet.",
       select_run: "Select a run on the left.",
+      detail_load_failed: "This run is not available. It may have been deleted or belong to a different workspace.",
       cancel: "Cancel run",
       cancel_confirm_title: "Cancel run?",
       cancel_confirm_body: "The runner will stop this run as soon as it gets the signal.",


### PR DESCRIPTION
## Summary
- Overview / Runs / Approvals tabs on `/{workspaceSlug}/runners` are now driven by `NavLink` against real routes, so each tab has a copy-pasteable URL.
- An individual agent run is addressable via `/{workspaceSlug}/runners/runs/:runId` — pasting that URL opens the runs list with that run's detail panel populated.
- Tabs are factored into a shared `<RunnersTabs />` component rendered by each of the three pages.

## Test plan
- [ ] Visit `/<slug>/runners` → Overview tab is active, overview content renders.
- [ ] Click **Runs** → URL changes to `/<slug>/runners/runs`, list renders, no detail.
- [ ] Click a run row → URL changes to `/<slug>/runners/runs/<runId>`, detail panel populates.
- [ ] Copy that URL into a new tab → same view (list + that run's detail) loads.
- [ ] Click **Approvals** → URL changes to `/<slug>/runners/approvals`.
- [ ] Use browser back/forward across the above transitions.
- [ ] Runner chat sidebar links (`/runners/chat/:runnerId`) still work; the tab bar does not appear on chat pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)