### PR TITLE
fix(runner): drain on heartbeat recovery from stale window

### DIFF
--- a/apps/api/pi_dash/runner/views/sessions.py
+++ b/apps/api/pi_dash/runner/views/sessions.py
@@ -274,11 +274,7 @@ class RunnerSessionPollEndpoint(APIView):
         # nudge, any QUEUED work in the pod sits until a new run is
         # created or the runner reopens its session.
         now_ts = timezone.now()
-        prior_hb = (
-            Runner.objects.filter(pk=runner.id)
-            .values_list("last_heartbeat_at", flat=True)
-            .first()
-        )
+        prior_hb = runner.last_heartbeat_at
         was_stale = prior_hb is None or (now_ts - prior_hb) > HEARTBEAT_GRACE
 
         Runner.objects.filter(pk=runner.id).update(
@@ -290,9 +286,16 @@ class RunnerSessionPollEndpoint(APIView):
             ),
         )
         if was_stale:
-            transaction.on_commit(
-                lambda rid=runner.id: drain_for_runner_by_id(rid)
-            )
+            def _drain_recovered_runner(rid=runner.id):
+                try:
+                    drain_for_runner_by_id(rid)
+                except Exception:
+                    logger.exception(
+                        "drain_for_runner_by_id failed for recovered runner %s",
+                        rid,
+                    )
+
+            transaction.on_commit(_drain_recovered_runner)
         if status_entry:
             session_service.reap_stale_busy_runs(runner, status_entry)
             # Volatile observability snapshot — see

--- a/apps/api/pi_dash/runner/views/sessions.py
+++ b/apps/api/pi_dash/runner/views/sessions.py
@@ -262,15 +262,37 @@ class RunnerSessionPollEndpoint(APIView):
 
         # 3. Update runner.last_heartbeat_at + reap stale busy runs.
         from pi_dash.runner.models import Runner
+        from pi_dash.runner.services.matcher import (
+            HEARTBEAT_GRACE,
+            drain_for_runner_by_id,
+        )
+
+        # Capture prior heartbeat so we can detect "stale -> fresh" recovery.
+        # When a runner has been silent past HEARTBEAT_GRACE, the matcher
+        # has been rejecting it for assignment; resuming polling makes it
+        # eligible again, but nothing else fires a drain — without this
+        # nudge, any QUEUED work in the pod sits until a new run is
+        # created or the runner reopens its session.
+        now_ts = timezone.now()
+        prior_hb = (
+            Runner.objects.filter(pk=runner.id)
+            .values_list("last_heartbeat_at", flat=True)
+            .first()
+        )
+        was_stale = prior_hb is None or (now_ts - prior_hb) > HEARTBEAT_GRACE
 
         Runner.objects.filter(pk=runner.id).update(
-            last_heartbeat_at=timezone.now(),
+            last_heartbeat_at=now_ts,
             status=(
                 RunnerStatus.BUSY
                 if status_entry.get("status") == "busy"
                 else RunnerStatus.ONLINE
             ),
         )
+        if was_stale:
+            transaction.on_commit(
+                lambda rid=runner.id: drain_for_runner_by_id(rid)
+            )
         if status_entry:
             session_service.reap_stale_busy_runs(runner, status_entry)
             # Volatile observability snapshot — see

--- a/apps/api/pi_dash/tests/unit/runner/test_poll_heartbeat_drain.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_poll_heartbeat_drain.py
@@ -21,7 +21,7 @@ These tests guard against:
 
 from __future__ import annotations
 
-import uuid
+from contextlib import contextmanager
 from datetime import timedelta
 from unittest.mock import patch
 
@@ -84,21 +84,15 @@ def _poll(api_client, runner_id, session_id, token, body=None):
     )
 
 
-@pytest.mark.unit
-def test_drain_fires_when_runner_polls_after_stale_window(
-    db, api_client, enrolled_runner, runner_token, runner_session
-):
-    """Stale heartbeat → poll → drain_for_runner_by_id called exactly once."""
-    # Backdate the runner's heartbeat well past HEARTBEAT_GRACE (90s).
-    stale_ts = timezone.now() - timedelta(seconds=600)
-    Runner.objects.filter(pk=enrolled_runner.id).update(last_heartbeat_at=stale_ts)
-
+@contextmanager
+def _patched_poll_dependencies(*, drain_side_effect=None):
     # Patch the matcher's drain + the Redis-touching parts of the poll
-    # path so the test runs without Redis. Patching the symbol at its
-    # source (matcher) — the view does a function-local import.
+    # path so the tests run without Redis. Patching the symbol at its
+    # source (matcher) because the view does a function-local import.
     with (
         patch(
-            "pi_dash.runner.services.matcher.drain_for_runner_by_id"
+            "pi_dash.runner.services.matcher.drain_for_runner_by_id",
+            side_effect=drain_side_effect,
         ) as mock_drain,
         patch("pi_dash.runner.views.sessions.outbox.ack_for_session"),
         patch(
@@ -111,12 +105,25 @@ def test_drain_fires_when_runner_polls_after_stale_window(
         ),
         # Eviction-aware reader's pubsub fallback — short-circuit it.
         patch("pi_dash.settings.redis.redis_instance", return_value=None),
-        # Fire on_commit callbacks inline so the assertion is synchronous.
+        # Fire on_commit callbacks inline so the drain assertion is synchronous.
         patch(
             "django.db.transaction.on_commit",
             side_effect=lambda fn, **_: fn(),
         ),
     ):
+        yield mock_drain
+
+
+@pytest.mark.unit
+def test_drain_fires_when_runner_polls_after_stale_window(
+    db, api_client, enrolled_runner, runner_token, runner_session
+):
+    """Stale heartbeat → poll → drain_for_runner_by_id called exactly once."""
+    # Backdate the runner's heartbeat well past HEARTBEAT_GRACE (90s).
+    stale_ts = timezone.now() - timedelta(seconds=600)
+    Runner.objects.filter(pk=enrolled_runner.id).update(last_heartbeat_at=stale_ts)
+
+    with _patched_poll_dependencies() as mock_drain:
         resp = _poll(
             api_client,
             enrolled_runner.id,
@@ -134,25 +141,7 @@ def test_drain_does_not_fire_on_fresh_heartbeat_poll(
 ):
     """Fresh heartbeat → poll → drain NOT called (no per-poll churn)."""
     # last_heartbeat_at is fresh from the fixture (now()).
-    with (
-        patch(
-            "pi_dash.runner.services.matcher.drain_for_runner_by_id"
-        ) as mock_drain,
-        patch("pi_dash.runner.views.sessions.outbox.ack_for_session"),
-        patch(
-            "pi_dash.runner.views.sessions.outbox.is_pel_drained",
-            return_value=True,
-        ),
-        patch(
-            "pi_dash.runner.views.sessions.outbox.read_for_session",
-            return_value=[],
-        ),
-        patch("pi_dash.settings.redis.redis_instance", return_value=None),
-        patch(
-            "django.db.transaction.on_commit",
-            side_effect=lambda fn, **_: fn(),
-        ),
-    ):
+    with _patched_poll_dependencies() as mock_drain:
         resp = _poll(
             api_client,
             enrolled_runner.id,
@@ -177,25 +166,29 @@ def test_drain_fires_when_runner_has_no_prior_heartbeat(
     """
     Runner.objects.filter(pk=enrolled_runner.id).update(last_heartbeat_at=None)
 
-    with (
-        patch(
-            "pi_dash.runner.services.matcher.drain_for_runner_by_id"
-        ) as mock_drain,
-        patch("pi_dash.runner.views.sessions.outbox.ack_for_session"),
-        patch(
-            "pi_dash.runner.views.sessions.outbox.is_pel_drained",
-            return_value=True,
-        ),
-        patch(
-            "pi_dash.runner.views.sessions.outbox.read_for_session",
-            return_value=[],
-        ),
-        patch("pi_dash.settings.redis.redis_instance", return_value=None),
-        patch(
-            "django.db.transaction.on_commit",
-            side_effect=lambda fn, **_: fn(),
-        ),
-    ):
+    with _patched_poll_dependencies() as mock_drain:
+        resp = _poll(
+            api_client,
+            enrolled_runner.id,
+            runner_session.id,
+            runner_token,
+        )
+
+    assert resp.status_code == 200, resp.data
+    mock_drain.assert_called_once_with(enrolled_runner.id)
+
+
+@pytest.mark.unit
+def test_drain_failure_does_not_fail_poll_response(
+    db, api_client, enrolled_runner, runner_token, runner_session
+):
+    """The recovery drain is best-effort; poll must still return messages."""
+    stale_ts = timezone.now() - timedelta(seconds=600)
+    Runner.objects.filter(pk=enrolled_runner.id).update(last_heartbeat_at=stale_ts)
+
+    with _patched_poll_dependencies(
+        drain_side_effect=RuntimeError("boom")
+    ) as mock_drain:
         resp = _poll(
             api_client,
             enrolled_runner.id,

--- a/apps/api/pi_dash/tests/unit/runner/test_poll_heartbeat_drain.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_poll_heartbeat_drain.py
@@ -1,0 +1,207 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Regression tests for the heartbeat-recovery drain trigger.
+
+The matcher rejects runners whose ``last_heartbeat_at`` is older than
+``HEARTBEAT_GRACE`` (90 seconds). Prior to the fix, when a runner had
+been silent past that window and then resumed polling on its existing
+session, ``last_heartbeat_at`` was refreshed but **nothing triggered a
+drain** — queued runs in the pod sat indefinitely until either a new
+run was created or the runner opened a fresh session.
+
+The fix captures the prior heartbeat before the update and, on a
+stale→fresh transition, schedules ``drain_for_runner_by_id`` on commit.
+These tests guard against:
+
+  * the drain trigger being silently removed
+  * the trigger firing on every poll (regression: per-poll churn)
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+from unittest.mock import patch
+
+import pytest
+from django.utils import timezone
+
+from pi_dash.runner.models import (
+    Pod,
+    Runner,
+    RunnerSession,
+    RunnerStatus,
+)
+from pi_dash.runner.services import tokens
+
+
+@pytest.fixture
+def pod(project):
+    return Pod.default_for_project(project)
+
+
+@pytest.fixture
+def enrolled_runner(db, create_user, workspace, pod):
+    return Runner.objects.create(
+        owner=create_user,
+        workspace=workspace,
+        pod=pod,
+        name="poll-runner",
+        status=RunnerStatus.ONLINE,
+        last_heartbeat_at=timezone.now(),
+        refresh_token_generation=1,
+        enrolled_at=timezone.now(),
+    )
+
+
+@pytest.fixture
+def runner_token(enrolled_runner):
+    return tokens.mint_access_token(
+        runner_id=str(enrolled_runner.id),
+        user_id=str(enrolled_runner.owner_id),
+        workspace_id=str(enrolled_runner.workspace_id),
+        rtg=1,
+    ).raw
+
+
+@pytest.fixture
+def runner_session(enrolled_runner):
+    return RunnerSession.objects.create(
+        runner=enrolled_runner,
+        protocol_version=4,
+        last_seen_at=timezone.now(),
+    )
+
+
+def _poll(api_client, runner_id, session_id, token, body=None):
+    return api_client.post(
+        f"/api/v1/runner/runners/{runner_id}/sessions/{session_id}/poll",
+        body or {},
+        format="json",
+        HTTP_AUTHORIZATION=f"Bearer {token}",
+    )
+
+
+@pytest.mark.unit
+def test_drain_fires_when_runner_polls_after_stale_window(
+    db, api_client, enrolled_runner, runner_token, runner_session
+):
+    """Stale heartbeat → poll → drain_for_runner_by_id called exactly once."""
+    # Backdate the runner's heartbeat well past HEARTBEAT_GRACE (90s).
+    stale_ts = timezone.now() - timedelta(seconds=600)
+    Runner.objects.filter(pk=enrolled_runner.id).update(last_heartbeat_at=stale_ts)
+
+    # Patch the matcher's drain + the Redis-touching parts of the poll
+    # path so the test runs without Redis. Patching the symbol at its
+    # source (matcher) — the view does a function-local import.
+    with (
+        patch(
+            "pi_dash.runner.services.matcher.drain_for_runner_by_id"
+        ) as mock_drain,
+        patch("pi_dash.runner.views.sessions.outbox.ack_for_session"),
+        patch(
+            "pi_dash.runner.views.sessions.outbox.is_pel_drained",
+            return_value=True,
+        ),
+        patch(
+            "pi_dash.runner.views.sessions.outbox.read_for_session",
+            return_value=[],
+        ),
+        # Eviction-aware reader's pubsub fallback — short-circuit it.
+        patch("pi_dash.settings.redis.redis_instance", return_value=None),
+        # Fire on_commit callbacks inline so the assertion is synchronous.
+        patch(
+            "django.db.transaction.on_commit",
+            side_effect=lambda fn, **_: fn(),
+        ),
+    ):
+        resp = _poll(
+            api_client,
+            enrolled_runner.id,
+            runner_session.id,
+            runner_token,
+        )
+
+    assert resp.status_code == 200, resp.data
+    mock_drain.assert_called_once_with(enrolled_runner.id)
+
+
+@pytest.mark.unit
+def test_drain_does_not_fire_on_fresh_heartbeat_poll(
+    db, api_client, enrolled_runner, runner_token, runner_session
+):
+    """Fresh heartbeat → poll → drain NOT called (no per-poll churn)."""
+    # last_heartbeat_at is fresh from the fixture (now()).
+    with (
+        patch(
+            "pi_dash.runner.services.matcher.drain_for_runner_by_id"
+        ) as mock_drain,
+        patch("pi_dash.runner.views.sessions.outbox.ack_for_session"),
+        patch(
+            "pi_dash.runner.views.sessions.outbox.is_pel_drained",
+            return_value=True,
+        ),
+        patch(
+            "pi_dash.runner.views.sessions.outbox.read_for_session",
+            return_value=[],
+        ),
+        patch("pi_dash.settings.redis.redis_instance", return_value=None),
+        patch(
+            "django.db.transaction.on_commit",
+            side_effect=lambda fn, **_: fn(),
+        ),
+    ):
+        resp = _poll(
+            api_client,
+            enrolled_runner.id,
+            runner_session.id,
+            runner_token,
+        )
+
+    assert resp.status_code == 200, resp.data
+    mock_drain.assert_not_called()
+
+
+@pytest.mark.unit
+def test_drain_fires_when_runner_has_no_prior_heartbeat(
+    db, api_client, enrolled_runner, runner_token, runner_session
+):
+    """First-ever heartbeat (prior_hb is NULL) is treated as stale → drain.
+
+    Covers the ``prior_hb is None`` branch of the staleness check, which
+    matters for fresh runners whose initial poll arrives without any
+    historical heartbeat row. Pinned runs from the session-open path may
+    be waiting; the drain trigger is what picks them up.
+    """
+    Runner.objects.filter(pk=enrolled_runner.id).update(last_heartbeat_at=None)
+
+    with (
+        patch(
+            "pi_dash.runner.services.matcher.drain_for_runner_by_id"
+        ) as mock_drain,
+        patch("pi_dash.runner.views.sessions.outbox.ack_for_session"),
+        patch(
+            "pi_dash.runner.views.sessions.outbox.is_pel_drained",
+            return_value=True,
+        ),
+        patch(
+            "pi_dash.runner.views.sessions.outbox.read_for_session",
+            return_value=[],
+        ),
+        patch("pi_dash.settings.redis.redis_instance", return_value=None),
+        patch(
+            "django.db.transaction.on_commit",
+            side_effect=lambda fn, **_: fn(),
+        ),
+    ):
+        resp = _poll(
+            api_client,
+            enrolled_runner.id,
+            runner_session.id,
+            runner_token,
+        )
+
+    assert resp.status_code == 200, resp.data
+    mock_drain.assert_called_once_with(enrolled_runner.id)


### PR DESCRIPTION
## Summary

When a runner's `last_heartbeat_at` ages past the matcher's 90s grace window and then refreshes (the runner resumes polling on an existing session after a transient outage), nothing triggers a drain. Queued runs in the pod sit until either a new run is created, the runner opens a fresh session, or a Celery sweep nudges them.

This adds a one-shot `drain_for_runner_by_id` on the stale → fresh transition inside the long-poll endpoint.

## Why

`matcher.drain_for_runner` selects runners where `last_heartbeat_at >= now - HEARTBEAT_GRACE`. When the heartbeat is stale, the runner is filtered out — correct, because we don't want to dispatch to a likely-dead runner. But there's no symmetric trigger when the runner becomes fresh again. Existing drain triggers:

- New session open (`apply_hello` → `drain_for_runner_by_id`) ✓ but a normal poll-resume doesn't hit this path
- Run terminal/pause via `finalize_run_terminal` on_commit ✓ but only fires if there's a currently-assigned run
- `reap_stale_busy_runs` ✓ but only drains *if* it reaped something — and there's nothing to reap if the runner went silent while idle

Net: a runner that goes silent for >90s and then resumes polling without dying is dead-to-the-matcher until something external pokes it. Confirmed in prod against `ai-republic`: 8 queued runs sitting for up to 14 days while runners were online but had nothing to trigger a drain.

## Implementation

Inside `RunnerSessionPollEndpoint.post`, before updating `last_heartbeat_at`:

1. Read the prior `last_heartbeat_at` via a single `values_list().first()`.
2. If prior is `None` or older than `HEARTBEAT_GRACE`, mark `was_stale = True`.
3. After the heartbeat update, if `was_stale`, schedule `drain_for_runner_by_id(runner.id)` on commit.

The check costs one indexed read per poll and fires the drain at most once per stale-to-fresh transition. Steady-state polls (fresh runner heartbeating every few seconds) are unaffected — they hit the `was_stale = False` branch.

## Related

Cloud-side PR that restores the Celery beat scheduler — without it, the broader recovery story (`mark_offline_runners`, `reconcile_stalled_runs`, `sweep_agent_chat_state`) stays broken in the cloud deploy: <https://github.com/The-AI-Republic/private-pi-dash/pull/new/feat/celery-core-infra>. This OSS PR is independently useful for self-hosters with healthy Celery and just covers the heartbeat-resume gap.

## Test plan

- [ ] Existing matcher / sessions tests still pass
- [ ] Add a test: stale heartbeat → poll → drain fires
- [ ] Add a test: fresh heartbeat → poll → drain does NOT fire (regression guard against per-poll churn)
- [ ] Manual verification against the wedged ai-republic pod once cloud-side Celery PR is in

🤖 Generated with [Claude Code](https://claude.com/claude-code)