### PR TITLE
feat(web): add AI Dev Machines page under More sidebar section

### DIFF
--- a/apps/web/app/(all)/[workspaceSlug]/ai-dev-machines/layout.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/ai-dev-machines/layout.tsx
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { observer } from "mobx-react";
+import { Outlet, useParams } from "react-router";
+import { EUserPermissions, EUserPermissionsLevel } from "@pi-dash/constants";
+import { NotAuthorizedView } from "@/components/auth-screens/not-authorized-view";
+import { useUserPermissions } from "@/hooks/store/user";
+
+/**
+ * Wrapper for ``/:workspaceSlug/ai-dev-machines``. The parent (projects)
+ * layout already mounts WorkspaceShell; this layout adds the standard
+ * flex-1 + overflow-auto scroll container shared by sibling routes
+ * (Prompts, Schedulers) and gates view access to ADMIN/MEMBER to match
+ * the sidebar entry in ``packages/constants/src/workspace.ts``.
+ *
+ * Loaded-state check uses ``workspaceUserInfo[slug]`` (not the bare
+ * ``workspaceUserInfo`` truthiness) because the store eagerly initialises
+ * the record to ``{}`` — see ``base-permissions.store.ts``. Without the
+ * per-slug check, a legitimate admin briefly sees NotAuthorizedView on
+ * first paint while ``fetchUserWorkspaceInfo`` resolves.
+ */
+const AiDevMachinesLayout = observer(function AiDevMachinesLayout() {
+  const { workspaceSlug } = useParams<{ workspaceSlug: string }>();
+  const { workspaceUserInfo, allowPermissions } = useUserPermissions();
+
+  const isUserInfoLoaded = !!(workspaceSlug && workspaceUserInfo[workspaceSlug]);
+  const canView = allowPermissions([EUserPermissions.ADMIN, EUserPermissions.MEMBER], EUserPermissionsLevel.WORKSPACE);
+
+  if (!isUserInfoLoaded) {
+    return null;
+  }
+
+  if (!canView) {
+    return (
+      <div className="flex-1 overflow-auto">
+        <NotAuthorizedView section="general" className="h-auto" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 overflow-auto">
+      <Outlet />
+    </div>
+  );
+});
+
+export default AiDevMachinesLayout;

--- a/apps/web/app/(all)/[workspaceSlug]/ai-dev-machines/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/ai-dev-machines/page.tsx
@@ -1,0 +1,166 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useState } from "react";
+import { observer } from "mobx-react";
+import { Cpu, Laptop, Terminal } from "lucide-react";
+import { useTranslation } from "@pi-dash/i18n";
+import { Button } from "@pi-dash/propel/button";
+import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
+import { PageHead } from "@/components/core/page-title";
+import { AddRunnerModal } from "@/components/runners/add-runner-modal";
+import { useWorkspace } from "@/hooks/store/use-workspace";
+
+// One-liners point at the GitHub Releases ``latest`` channel. The wrapper
+// installers (install.sh / install.ps1) download the cargo-dist installer,
+// drop ``pidash`` on PATH, and immediately start device-code login. See
+// runner/README.md for the full matrix (tag-pinned, bare installers, etc.).
+const INSTALL_CMD_UNIX = `curl --proto '=https' --tlsv1.2 -LsSf \\
+  https://github.com/The-AI-Republic/pi-dash/releases/latest/download/install.sh | sh`;
+const INSTALL_CMD_WINDOWS = `irm https://github.com/The-AI-Republic/pi-dash/releases/latest/download/install.ps1 | iex`;
+
+// We don't render a runners list on this page, so there's nothing to refetch
+// on success — the modal still requires the callback. The AI Agents page
+// itself shows the newly enrolled row.
+const noopOnCreated = () => {};
+
+const AiDevMachinesPage = observer(function AiDevMachinesPage() {
+  const { currentWorkspace } = useWorkspace();
+  const { t } = useTranslation();
+
+  const workspaceId = currentWorkspace?.id;
+  const workspaceSlug = currentWorkspace?.slug;
+  const pageTitle = currentWorkspace?.name
+    ? t("ai_dev_machines.page_title", { workspace: currentWorkspace.name })
+    : t("ai_dev_machines.title");
+
+  const [addOpen, setAddOpen] = useState(false);
+
+  return (
+    <div className="flex flex-col gap-8 p-6">
+      <PageHead title={pageTitle} />
+
+      <header>
+        <h1 className="text-16 font-semibold text-primary">{t("ai_dev_machines.title")}</h1>
+      </header>
+
+      {/* Intro — what the CLI / daemon / runner each are */}
+      <section className="flex flex-col gap-4">
+        <h2 className="text-14 font-semibold text-primary">{t("ai_dev_machines.intro.heading")}</h2>
+        <p className="text-13 text-secondary">{t("ai_dev_machines.intro.body")}</p>
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+          <ConceptCard
+            icon={<Terminal className="size-4" />}
+            title={t("ai_dev_machines.intro.cli.title")}
+            body={t("ai_dev_machines.intro.cli.body")}
+          />
+          <ConceptCard
+            icon={<Cpu className="size-4" />}
+            title={t("ai_dev_machines.intro.daemon.title")}
+            body={t("ai_dev_machines.intro.daemon.body")}
+          />
+          <ConceptCard
+            icon={<Laptop className="size-4" />}
+            title={t("ai_dev_machines.intro.runner.title")}
+            body={t("ai_dev_machines.intro.runner.body")}
+          />
+        </div>
+      </section>
+
+      {/* Install command — copy / paste */}
+      <section className="flex flex-col gap-3">
+        <h2 className="text-14 font-semibold text-primary">{t("ai_dev_machines.install.heading")}</h2>
+        <p className="text-13 text-secondary">{t("ai_dev_machines.install.body")}</p>
+
+        <InstallCommand label={t("ai_dev_machines.install.macos_linux_label")} command={INSTALL_CMD_UNIX} />
+        <InstallCommand label={t("ai_dev_machines.install.windows_label")} command={INSTALL_CMD_WINDOWS} />
+
+        <p className="text-12 text-secondary">{t("ai_dev_machines.install.prereq")}</p>
+      </section>
+
+      {/* Add AI Agent runner — same modal used on the AI Agents page */}
+      <section className="rounded-md border border-subtle p-4">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <div className="text-13 font-medium text-primary">{t("ai_dev_machines.add_runner.heading")}</div>
+            <p className="mt-1 text-13 text-secondary">{t("ai_dev_machines.add_runner.body")}</p>
+          </div>
+          <Button onClick={() => setAddOpen(true)} disabled={!workspaceId}>
+            {t("ai_dev_machines.add_runner.cta")}
+          </Button>
+        </div>
+      </section>
+
+      {workspaceId && workspaceSlug && (
+        <AddRunnerModal
+          isOpen={addOpen}
+          onClose={() => setAddOpen(false)}
+          workspaceId={workspaceId}
+          workspaceSlug={workspaceSlug}
+          onCreated={noopOnCreated}
+        />
+      )}
+    </div>
+  );
+});
+
+type ConceptCardProps = {
+  icon: React.ReactNode;
+  title: string;
+  body: string;
+};
+
+function ConceptCard({ icon, title, body }: ConceptCardProps) {
+  return (
+    <div className="flex flex-col gap-2 rounded-md border border-subtle bg-layer-1 p-3">
+      <div className="flex items-center gap-2 text-primary">
+        {icon}
+        <span className="text-13 font-medium">{title}</span>
+      </div>
+      <p className="text-12 text-secondary">{body}</p>
+    </div>
+  );
+}
+
+type InstallCommandProps = {
+  label: string;
+  command: string;
+};
+
+function InstallCommand({ label, command }: InstallCommandProps) {
+  const { t } = useTranslation();
+  const [justCopied, setJustCopied] = useState(false);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(command);
+      setJustCopied(true);
+      window.setTimeout(() => setJustCopied(false), 2000);
+    } catch {
+      setToast({
+        type: TOAST_TYPE.ERROR,
+        title: t("runners.toast.error_title"),
+        message: t("ai_dev_machines.install.copy_failed"),
+      });
+    }
+  };
+
+  return (
+    <div className="rounded-md border border-subtle bg-layer-1 p-3">
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <span className="text-12 font-medium text-secondary uppercase">{label}</span>
+        <Button size="sm" variant="secondary" onClick={copy}>
+          {justCopied ? t("ai_dev_machines.install.copied") : t("ai_dev_machines.install.copy_command")}
+        </Button>
+      </div>
+      <pre className="font-mono bg-layer-0 rounded border border-subtle p-2 text-11 whitespace-pre-wrap text-primary select-all">
+        {command}
+      </pre>
+    </div>
+  );
+}
+
+export default AiDevMachinesPage;

--- a/apps/web/app/(all)/[workspaceSlug]/ai-dev-machines/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/ai-dev-machines/page.tsx
@@ -7,14 +7,11 @@
 import { useState } from "react";
 import { observer } from "mobx-react";
 import { Cpu, Laptop, Terminal } from "lucide-react";
-import { EUserPermissions, EUserPermissionsLevel } from "@pi-dash/constants";
 import { useTranslation } from "@pi-dash/i18n";
 import { Button } from "@pi-dash/propel/button";
 import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
-import { NotAuthorizedView } from "@/components/auth-screens/not-authorized-view";
 import { PageHead } from "@/components/core/page-title";
 import { AddRunnerModal } from "@/components/runners/add-runner-modal";
-import { useUserPermissions } from "@/hooks/store/user";
 import { useWorkspace } from "@/hooks/store/use-workspace";
 
 // One-liners point at the GitHub Releases ``latest`` channel. The wrapper
@@ -32,7 +29,6 @@ const noopOnCreated = () => {};
 
 const AiDevMachinesPage = observer(function AiDevMachinesPage() {
   const { currentWorkspace } = useWorkspace();
-  const { workspaceUserInfo, allowPermissions } = useUserPermissions();
   const { t } = useTranslation();
 
   const workspaceId = currentWorkspace?.id;
@@ -41,16 +37,7 @@ const AiDevMachinesPage = observer(function AiDevMachinesPage() {
     ? t("ai_dev_machines.page_title", { workspace: currentWorkspace.name })
     : t("ai_dev_machines.title");
 
-  // Mirror the sidebar entry's `access` field (ADMIN + MEMBER) — guests must
-  // not be able to reach this page by direct URL even though the sidebar
-  // hides the link for them. See packages/constants/src/workspace.ts.
-  const canView = allowPermissions([EUserPermissions.ADMIN, EUserPermissions.MEMBER], EUserPermissionsLevel.WORKSPACE);
-
   const [addOpen, setAddOpen] = useState(false);
-
-  if (workspaceUserInfo && !canView) {
-    return <NotAuthorizedView section="general" className="h-auto" />;
-  }
 
   return (
     <div className="flex flex-col gap-8 p-6">

--- a/apps/web/app/(all)/[workspaceSlug]/ai-dev-machines/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/ai-dev-machines/page.tsx
@@ -7,11 +7,14 @@
 import { useState } from "react";
 import { observer } from "mobx-react";
 import { Cpu, Laptop, Terminal } from "lucide-react";
+import { EUserPermissions, EUserPermissionsLevel } from "@pi-dash/constants";
 import { useTranslation } from "@pi-dash/i18n";
 import { Button } from "@pi-dash/propel/button";
 import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
+import { NotAuthorizedView } from "@/components/auth-screens/not-authorized-view";
 import { PageHead } from "@/components/core/page-title";
 import { AddRunnerModal } from "@/components/runners/add-runner-modal";
+import { useUserPermissions } from "@/hooks/store/user";
 import { useWorkspace } from "@/hooks/store/use-workspace";
 
 // One-liners point at the GitHub Releases ``latest`` channel. The wrapper
@@ -29,6 +32,7 @@ const noopOnCreated = () => {};
 
 const AiDevMachinesPage = observer(function AiDevMachinesPage() {
   const { currentWorkspace } = useWorkspace();
+  const { workspaceUserInfo, allowPermissions } = useUserPermissions();
   const { t } = useTranslation();
 
   const workspaceId = currentWorkspace?.id;
@@ -37,7 +41,16 @@ const AiDevMachinesPage = observer(function AiDevMachinesPage() {
     ? t("ai_dev_machines.page_title", { workspace: currentWorkspace.name })
     : t("ai_dev_machines.title");
 
+  // Mirror the sidebar entry's `access` field (ADMIN + MEMBER) — guests must
+  // not be able to reach this page by direct URL even though the sidebar
+  // hides the link for them. See packages/constants/src/workspace.ts.
+  const canView = allowPermissions([EUserPermissions.ADMIN, EUserPermissions.MEMBER], EUserPermissionsLevel.WORKSPACE);
+
   const [addOpen, setAddOpen] = useState(false);
+
+  if (workspaceUserInfo && !canView) {
+    return <NotAuthorizedView section="general" className="h-auto" />;
+  }
 
   return (
     <div className="flex flex-col gap-8 p-6">
@@ -156,7 +169,7 @@ function InstallCommand({ label, command }: InstallCommandProps) {
           {justCopied ? t("ai_dev_machines.install.copied") : t("ai_dev_machines.install.copy_command")}
         </Button>
       </div>
-      <pre className="font-mono bg-layer-0 rounded border border-subtle p-2 text-11 whitespace-pre-wrap text-primary select-all">
+      <pre className="font-mono rounded border border-subtle bg-layer-2 p-2 text-11 whitespace-pre-wrap text-primary select-all">
         {command}
       </pre>
     </div>

--- a/apps/web/app/routes/core.ts
+++ b/apps/web/app/routes/core.ts
@@ -119,6 +119,12 @@ export const coreRoutes: RouteConfigEntry[] = [
           route(":workspaceSlug/schedulers", "./(all)/[workspaceSlug]/schedulers/page.tsx"),
         ]),
 
+        // AI Dev Machines — explains what pidash CLI / daemon / runner is for and
+        // surfaces the install one-liner + an "add runner" entry point. Lives inside
+        // the (projects) layout so it inherits the workspace sidebar shell, matching
+        // sibling pages like Prompts and Schedulers.
+        route(":workspaceSlug/ai-dev-machines", "./(all)/[workspaceSlug]/ai-dev-machines/page.tsx"),
+
         // Workspace Views
         layout("./(all)/[workspaceSlug]/(projects)/workspace-views/layout.tsx", [
           route(":workspaceSlug/workspace-views", "./(all)/[workspaceSlug]/(projects)/workspace-views/page.tsx"),
@@ -293,10 +299,6 @@ export const coreRoutes: RouteConfigEntry[] = [
         route(":workspaceSlug/runners/approvals", "./(all)/[workspaceSlug]/runners/approvals/page.tsx"),
         route(":workspaceSlug/runners/chat/:runnerId", "./(all)/[workspaceSlug]/runners/chat/[runnerId]/page.tsx"),
       ]),
-
-      // AI Dev Machines — explains what pidash CLI / daemon / runner is for and
-      // surfaces the install one-liner + an "add runner" entry point.
-      route(":workspaceSlug/ai-dev-machines", "./(all)/[workspaceSlug]/ai-dev-machines/page.tsx"),
 
       // ====================================================================
       // SETTINGS SECTION

--- a/apps/web/app/routes/core.ts
+++ b/apps/web/app/routes/core.ts
@@ -122,8 +122,11 @@ export const coreRoutes: RouteConfigEntry[] = [
         // AI Dev Machines — explains what pidash CLI / daemon / runner is for and
         // surfaces the install one-liner + an "add runner" entry point. Lives inside
         // the (projects) layout so it inherits the workspace sidebar shell, matching
-        // sibling pages like Prompts and Schedulers.
-        route(":workspaceSlug/ai-dev-machines", "./(all)/[workspaceSlug]/ai-dev-machines/page.tsx"),
+        // sibling pages like Prompts and Schedulers. Its own layout adds the flex /
+        // scroll wrapper and gates view access to ADMIN/MEMBER.
+        layout("./(all)/[workspaceSlug]/ai-dev-machines/layout.tsx", [
+          route(":workspaceSlug/ai-dev-machines", "./(all)/[workspaceSlug]/ai-dev-machines/page.tsx"),
+        ]),
 
         // Workspace Views
         layout("./(all)/[workspaceSlug]/(projects)/workspace-views/layout.tsx", [

--- a/apps/web/app/routes/core.ts
+++ b/apps/web/app/routes/core.ts
@@ -294,6 +294,10 @@ export const coreRoutes: RouteConfigEntry[] = [
         route(":workspaceSlug/runners/chat/:runnerId", "./(all)/[workspaceSlug]/runners/chat/[runnerId]/page.tsx"),
       ]),
 
+      // AI Dev Machines — explains what pidash CLI / daemon / runner is for and
+      // surfaces the install one-liner + an "add runner" entry point.
+      route(":workspaceSlug/ai-dev-machines", "./(all)/[workspaceSlug]/ai-dev-machines/page.tsx"),
+
       // ====================================================================
       // SETTINGS SECTION
       // ====================================================================

--- a/apps/web/ce/components/workspace/sidebar/helper.tsx
+++ b/apps/web/ce/components/workspace/sidebar/helper.tsx
@@ -4,7 +4,7 @@
  * See the LICENSE file for details.
  */
 
-import { CalendarClock, FileText, Server } from "lucide-react";
+import { CalendarClock, FileText, Laptop, Server } from "lucide-react";
 import {
   AnalyticsIcon,
   ArchiveIcon,
@@ -47,5 +47,7 @@ export const getSidebarNavigationItemIcon = (key: string, className: string = ""
       return <Server className={cn("size-4 flex-shrink-0", className)} />;
     case "schedulers":
       return <CalendarClock className={cn("size-4 flex-shrink-0", className)} />;
+    case "ai_dev_machines":
+      return <Laptop className={cn("size-4 flex-shrink-0", className)} />;
   }
 };

--- a/apps/web/core/components/workspace/sidebar/more-section.tsx
+++ b/apps/web/core/components/workspace/sidebar/more-section.tsx
@@ -21,13 +21,13 @@ import useLocalStorage from "@/hooks/use-local-storage";
 // pi-dash-web imports
 import { SidebarItem } from "@/pi-dash-web/components/workspace/sidebar/sidebar-item";
 
-const MORE_ITEM_KEYS = ["projects", "prompts", "schedulers", "analytics", "archives"];
+const MORE_ITEM_KEYS = ["projects", "prompts", "schedulers", "ai-dev-machines", "analytics", "archives"];
 
-const MORE_STATIC_KEYS = ["analytics", "archives"];
+const MORE_STATIC_KEYS = ["ai_dev_machines", "analytics", "archives"];
 
 // Path segments that, when visited, should auto-open the More disclosure so
 // the active row is visible.
-const MORE_PATH_SEGMENTS = ["/prompts", "/schedulers", "/analytics", "/archives"];
+const MORE_PATH_SEGMENTS = ["/prompts", "/schedulers", "/ai-dev-machines", "/analytics", "/archives"];
 
 export const SidebarMoreSection = observer(function SidebarMoreSection() {
   const { t } = useTranslation();

--- a/packages/constants/src/workspace.ts
+++ b/packages/constants/src/workspace.ts
@@ -300,6 +300,14 @@ export const WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS: Record<string, IWorkspac
     highlight: (pathname: string, url: string) => pathname.includes(url),
     tooltipTranslationKey: "sidebar.tooltips.schedulers",
   },
+  "ai-dev-machines": {
+    key: "ai_dev_machines",
+    labelTranslationKey: "sidebar.ai_dev_machines",
+    href: `/ai-dev-machines/`,
+    access: [EUserWorkspaceRoles.ADMIN, EUserWorkspaceRoles.MEMBER],
+    highlight: (pathname: string, url: string) => pathname.includes(url),
+    tooltipTranslationKey: "sidebar.tooltips.ai_dev_machines",
+  },
 };
 
 export const WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS_LINKS: IWorkspaceSidebarNavigationItem[] = [

--- a/packages/i18n/src/locales/en/core.ts
+++ b/packages/i18n/src/locales/en/core.ts
@@ -27,6 +27,7 @@ export default {
     prompts: "Prompts",
     schedulers: "Schedulers",
     runners: "AI Agents",
+    ai_dev_machines: "AI Dev Machines",
     more: "More",
     community: "Community",
     tooltips: {
@@ -34,6 +35,7 @@ export default {
       runners: "Manage your AI Agent connectivities",
       prompts: "AI Prompt Templates",
       schedulers: "Recurring AI Agent jobs scoped to projects",
+      ai_dev_machines: "Install the pidash CLI and register dev machines as AI agent runners",
     },
   },
 
@@ -664,6 +666,43 @@ export default {
         network_access: "The runner wants to make a network call",
         other: "The runner is requesting approval",
       },
+    },
+  },
+
+  ai_dev_machines: {
+    title: "AI Dev Machines",
+    page_title: "{workspace} - AI Dev Machines",
+    intro: {
+      heading: "What is the pidash CLI, daemon, and runner?",
+      body: "Pi Dash hands AI agents (Claude Code, Codex, …) the keys to a real dev machine so they can pick up work items, write code, and open changes. Three pieces work together to make that possible:",
+      cli: {
+        title: "pidash CLI",
+        body: "The command-line tool installed on each dev machine. Handles authentication with the cloud, manages local config (`~/.pidash/config.toml`), and exposes commands for issues, comments, and runner management (`pidash connect`, `pidash runner ls`, `pidash doctor`, …).",
+      },
+      daemon: {
+        title: "pidash daemon",
+        body: "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.",
+      },
+      runner: {
+        title: "AI Agent runner",
+        body: "A cloud-side row that represents one agent instance bound to a project (and optionally a pod). Adding a runner mints a single-use enrollment token; running the token on the machine binds that machine as the host. A machine can host many runners.",
+      },
+    },
+    install: {
+      heading: "Install the pidash CLI",
+      body: "Run the one-liner on the machine that will host your AI agent. The installer downloads the latest signed binary, drops `pidash` on your PATH, and walks you through the device-code login.",
+      macos_linux_label: "macOS / Linux",
+      windows_label: "Windows (PowerShell)",
+      copy_command: "Copy command",
+      copied: "Copied!",
+      copy_failed: "Could not copy to clipboard",
+      prereq:
+        "Prerequisite: the agent CLI you plan to use (`codex` or `claude`) must already be installed and on PATH. Run `pidash doctor` after install to verify.",
+    },
+    add_runner: {
+      heading: "Add an AI Agent runner",
+      body: "Pair this workspace with a runner on your machine. We'll mint a one-time enrollment token and show the `pidash connect` command to paste on the host.",
+      cta: "Add runner",
     },
   },
 } as const;


### PR DESCRIPTION
## Summary

- New **AI Dev Machines** entry in the workspace sidebar under the *More* section, sitting alongside Prompts / Schedulers / Analytics / Archives. Visible to admins and members.
- New page at `/:workspaceSlug/ai-dev-machines` that:
  - Explains what the **pidash CLI**, **daemon**, and **AI Agent runner** each are (three concept cards).
  - Surfaces copy/paste install one-liners for macOS/Linux (`curl … install.sh | sh`) and Windows (`irm … install.ps1 | iex`), matching the URLs documented in `runner/README.md`.
  - Embeds the existing `AddRunnerModal` so users can mint an enrollment token without bouncing to the AI Agents page.
- Wires up the icon (Laptop), route, and English i18n strings. Other locales fall back to the key, same as `sidebar.runners` / `sidebar.more`.

## Test plan

- [ ] Sidebar: expand *More* and confirm **AI Dev Machines** appears with the Laptop icon, between *Schedulers* and *Analytics*.
- [ ] Navigate to `/:workspaceSlug/ai-dev-machines` — *More* disclosure should auto-open and the row should highlight as active.
- [ ] Page renders the three concept cards, both install commands, and the "Add an AI Agent runner" section.
- [ ] Click *Copy command* on each install block — clipboard contains the expected one-liner, button flips to *Copied!* for ~2s.
- [ ] Click *Add runner* — `AddRunnerModal` opens. Submitting mints an enrollment token and shows the `pidash connect …` command (same as the AI Agents page).
- [ ] Verify a guest user (or signed-out) doesn't see the sidebar item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)