### PR TITLE
[codex] Fix issue agent status visibility

### DIFF
--- a/apps/api/pi_dash/runner/views/sessions.py
+++ b/apps/api/pi_dash/runner/views/sessions.py
@@ -267,35 +267,32 @@ class RunnerSessionPollEndpoint(APIView):
             drain_for_runner_by_id,
         )
 
-        # Capture prior heartbeat so we can detect "stale -> fresh" recovery.
-        # When a runner has been silent past HEARTBEAT_GRACE, the matcher
-        # has been rejecting it for assignment; resuming polling makes it
-        # eligible again, but nothing else fires a drain — without this
-        # nudge, any QUEUED work in the pod sits until a new run is
-        # created or the runner reopens its session.
+        # Capture prior heartbeat/status so we can detect when this poll makes
+        # the runner eligible for queued work again. Stale recovery and
+        # busy->idle transitions otherwise leave QUEUED runs sitting until a
+        # new run is created or the runner reopens its session.
         now_ts = timezone.now()
         prior_hb = runner.last_heartbeat_at
+        prior_status = runner.status
         was_stale = prior_hb is None or (now_ts - prior_hb) > HEARTBEAT_GRACE
+        reports_busy = status_entry.get("status") == "busy"
+        became_available = prior_status == RunnerStatus.BUSY and not reports_busy
 
         Runner.objects.filter(pk=runner.id).update(
             last_heartbeat_at=now_ts,
-            status=(
-                RunnerStatus.BUSY
-                if status_entry.get("status") == "busy"
-                else RunnerStatus.ONLINE
-            ),
+            status=RunnerStatus.BUSY if reports_busy else RunnerStatus.ONLINE,
         )
-        if was_stale:
-            def _drain_recovered_runner(rid=runner.id):
+        if was_stale or became_available:
+            def _drain_available_runner(rid=runner.id):
                 try:
                     drain_for_runner_by_id(rid)
                 except Exception:
                     logger.exception(
-                        "drain_for_runner_by_id failed for recovered runner %s",
+                        "drain_for_runner_by_id failed for available runner %s",
                         rid,
                     )
 
-            transaction.on_commit(_drain_recovered_runner)
+            transaction.on_commit(_drain_available_runner)
         if status_entry:
             session_service.reap_stale_busy_runs(runner, status_entry)
             # Volatile observability snapshot — see

--- a/apps/api/pi_dash/runner/views/sessions.py
+++ b/apps/api/pi_dash/runner/views/sessions.py
@@ -272,29 +272,43 @@ class RunnerSessionPollEndpoint(APIView):
         # busy->idle transitions otherwise leave QUEUED runs sitting until a
         # new run is created or the runner reopens its session.
         now_ts = timezone.now()
-        prior_hb = runner.last_heartbeat_at
-        prior_status = runner.status
-        was_stale = prior_hb is None or (now_ts - prior_hb) > HEARTBEAT_GRACE
-        reports_busy = status_entry.get("status") == "busy"
-        became_available = prior_status == RunnerStatus.BUSY and not reports_busy
+        with transaction.atomic():
+            runner_snapshot = (
+                Runner.objects.select_for_update()
+                .filter(pk=runner.id)
+                .values("last_heartbeat_at", "status")
+                .get()
+            )
+            prior_hb = runner_snapshot["last_heartbeat_at"]
+            prior_status = runner_snapshot["status"]
+            was_stale = (
+                prior_hb is None or (now_ts - prior_hb) > HEARTBEAT_GRACE
+            )
+            reported_status = status_entry.get("status")
+            reports_busy = reported_status == "busy"
+            reports_idle = reported_status == "idle"
+            became_available = (
+                prior_status == RunnerStatus.BUSY and reports_idle
+            )
 
-        Runner.objects.filter(pk=runner.id).update(
-            last_heartbeat_at=now_ts,
-            status=RunnerStatus.BUSY if reports_busy else RunnerStatus.ONLINE,
-        )
-        if was_stale or became_available:
-            def _drain_available_runner(rid=runner.id):
-                try:
-                    drain_for_runner_by_id(rid)
-                except Exception:
-                    logger.exception(
-                        "drain_for_runner_by_id failed for available runner %s",
-                        rid,
-                    )
+            Runner.objects.filter(pk=runner.id).update(
+                last_heartbeat_at=now_ts,
+                status=RunnerStatus.BUSY if reports_busy else RunnerStatus.ONLINE,
+            )
+            if status_entry:
+                session_service.reap_stale_busy_runs(runner, status_entry)
+            if was_stale or became_available:
+                def _drain_available_runner(rid=runner.id):
+                    try:
+                        drain_for_runner_by_id(rid)
+                    except Exception:
+                        logger.exception(
+                            "drain_for_runner_by_id failed for available runner %s",
+                            rid,
+                        )
 
-            transaction.on_commit(_drain_available_runner)
+                transaction.on_commit(_drain_available_runner)
         if status_entry:
-            session_service.reap_stale_busy_runs(runner, status_entry)
             # Volatile observability snapshot — see
             # `.ai_design/runner_agent_bridge/design.md` §4.5.2.
             # Pre-observability runners send no snapshot fields and the

--- a/apps/api/pi_dash/tests/unit/runner/test_poll_heartbeat_drain.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_poll_heartbeat_drain.py
@@ -11,16 +11,17 @@ session, ``last_heartbeat_at`` was refreshed but **nothing triggered a
 drain** — queued runs in the pod sat indefinitely until either a new
 run was created or the runner opened a fresh session.
 
-The poll path also needs a drain when the daemon reports it has become
-idle after a busy run. Otherwise a ticker-created follow-up can land while
-the cloud still has the runner marked BUSY and then sit QUEUED forever.
+The poll path also needs a drain when the daemon explicitly reports it has
+become idle after a busy run. Otherwise a ticker-created follow-up can land
+while the cloud still has the runner marked BUSY and then sit QUEUED forever.
 
 The fix captures prior heartbeat/status before the update and schedules
-``drain_for_runner_by_id`` on commit for stale→fresh and busy→online
+``drain_for_runner_by_id`` on commit for stale→fresh and busy→idle
 transitions. These tests guard against:
 
   * the drain trigger being silently removed
   * the trigger firing on every poll (regression: per-poll churn)
+  * status-less polls being treated as an idle report
 """
 
 from __future__ import annotations
@@ -164,7 +165,18 @@ def test_drain_fires_when_runner_reports_idle_after_busy(
     """Busy runner → idle poll → drain once for queued follow-up work."""
     Runner.objects.filter(pk=enrolled_runner.id).update(status=RunnerStatus.BUSY)
 
-    with _patched_poll_dependencies() as mock_drain:
+    events = []
+
+    def _record_drain(runner_id):
+        events.append(("drain", runner_id))
+
+    with (
+        patch(
+            "pi_dash.runner.views.sessions.session_service.reap_stale_busy_runs",
+            side_effect=lambda *_: events.append(("reap", enrolled_runner.id)),
+        ),
+        _patched_poll_dependencies(drain_side_effect=_record_drain) as mock_drain,
+    ):
         resp = _poll(
             api_client,
             enrolled_runner.id,
@@ -175,6 +187,7 @@ def test_drain_fires_when_runner_reports_idle_after_busy(
 
     assert resp.status_code == 200, resp.data
     mock_drain.assert_called_once_with(enrolled_runner.id)
+    assert events == [("reap", enrolled_runner.id), ("drain", enrolled_runner.id)]
 
 
 @pytest.mark.unit
@@ -191,6 +204,26 @@ def test_drain_does_not_fire_while_runner_reports_busy(
             runner_session.id,
             runner_token,
             body={"status": {"status": "busy"}},
+        )
+
+    assert resp.status_code == 200, resp.data
+    mock_drain.assert_not_called()
+
+
+@pytest.mark.unit
+def test_statusless_busy_runner_poll_does_not_trigger_available_drain(
+    db, api_client, enrolled_runner, runner_token, runner_session
+):
+    """Busy runner must explicitly report idle before the availability drain fires."""
+    Runner.objects.filter(pk=enrolled_runner.id).update(status=RunnerStatus.BUSY)
+
+    with _patched_poll_dependencies() as mock_drain:
+        resp = _poll(
+            api_client,
+            enrolled_runner.id,
+            runner_session.id,
+            runner_token,
+            body={"ack": []},
         )
 
     assert resp.status_code == 200, resp.data

--- a/apps/api/pi_dash/tests/unit/runner/test_poll_heartbeat_drain.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_poll_heartbeat_drain.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # See the LICENSE file for details.
 
-"""Regression tests for the heartbeat-recovery drain trigger.
+"""Regression tests for runner poll drain triggers.
 
 The matcher rejects runners whose ``last_heartbeat_at`` is older than
 ``HEARTBEAT_GRACE`` (90 seconds). Prior to the fix, when a runner had
@@ -11,9 +11,13 @@ session, ``last_heartbeat_at`` was refreshed but **nothing triggered a
 drain** — queued runs in the pod sat indefinitely until either a new
 run was created or the runner opened a fresh session.
 
-The fix captures the prior heartbeat before the update and, on a
-stale→fresh transition, schedules ``drain_for_runner_by_id`` on commit.
-These tests guard against:
+The poll path also needs a drain when the daemon reports it has become
+idle after a busy run. Otherwise a ticker-created follow-up can land while
+the cloud still has the runner marked BUSY and then sit QUEUED forever.
+
+The fix captures prior heartbeat/status before the update and schedules
+``drain_for_runner_by_id`` on commit for stale→fresh and busy→online
+transitions. These tests guard against:
 
   * the drain trigger being silently removed
   * the trigger firing on every poll (regression: per-poll churn)
@@ -147,6 +151,46 @@ def test_drain_does_not_fire_on_fresh_heartbeat_poll(
             enrolled_runner.id,
             runner_session.id,
             runner_token,
+        )
+
+    assert resp.status_code == 200, resp.data
+    mock_drain.assert_not_called()
+
+
+@pytest.mark.unit
+def test_drain_fires_when_runner_reports_idle_after_busy(
+    db, api_client, enrolled_runner, runner_token, runner_session
+):
+    """Busy runner → idle poll → drain once for queued follow-up work."""
+    Runner.objects.filter(pk=enrolled_runner.id).update(status=RunnerStatus.BUSY)
+
+    with _patched_poll_dependencies() as mock_drain:
+        resp = _poll(
+            api_client,
+            enrolled_runner.id,
+            runner_session.id,
+            runner_token,
+            body={"status": {"status": "idle"}},
+        )
+
+    assert resp.status_code == 200, resp.data
+    mock_drain.assert_called_once_with(enrolled_runner.id)
+
+
+@pytest.mark.unit
+def test_drain_does_not_fire_while_runner_reports_busy(
+    db, api_client, enrolled_runner, runner_token, runner_session
+):
+    """Busy runner that is still busy must not be drained."""
+    Runner.objects.filter(pk=enrolled_runner.id).update(status=RunnerStatus.BUSY)
+
+    with _patched_poll_dependencies() as mock_drain:
+        resp = _poll(
+            api_client,
+            enrolled_runner.id,
+            runner_session.id,
+            runner_token,
+            body={"status": {"status": "busy"}},
         )
 
     assert resp.status_code == 200, resp.data

--- a/apps/web/core/components/issues/issue-detail/agent-status.tsx
+++ b/apps/web/core/components/issues/issue-detail/agent-status.tsx
@@ -315,6 +315,9 @@ export function IssueAgentStatusPanel({ workspaceSlug, projectId, issueId, issue
   const activeRun = status?.active_run;
   const activeRunId = activeRun?.id;
   const activeRunStatus = activeRun?.status;
+  const shouldPollAgentStatus = Boolean(
+    ticker?.enabled || (activeRunStatus && ACTIVE_RUN_STATUSES.has(activeRunStatus))
+  );
   const view = useMemo(() => getAgentStatusView(issue, now, t), [issue, now, t]);
 
   useEffect(() => {
@@ -323,12 +326,13 @@ export function IssueAgentStatusPanel({ workspaceSlug, projectId, issueId, issue
   }, []);
 
   useEffect(() => {
-    if (!activeRunStatus || !ACTIVE_RUN_STATUSES.has(activeRunStatus)) return;
+    if (!shouldPollAgentStatus) return;
+    void issueOperations.fetch(workspaceSlug, projectId, issueId);
     const timer = window.setInterval(() => {
       void issueOperations.fetch(workspaceSlug, projectId, issueId);
     }, 15_000);
     return () => window.clearInterval(timer);
-  }, [activeRunId, activeRunStatus, issueId, issueOperations, projectId, workspaceSlug]);
+  }, [activeRunId, issueId, issueOperations, projectId, shouldPollAgentStatus, workspaceSlug]);
 
   if (!view) return null;
 

--- a/apps/web/core/components/issues/issue-detail/agent-status.tsx
+++ b/apps/web/core/components/issues/issue-detail/agent-status.tsx
@@ -43,6 +43,8 @@ const ACTIVE_RUN_STATUSES = new Set<TAgentRunStatus>([
   "awaiting_reauth",
   "paused_awaiting_input",
 ]);
+const AGENT_STATUS_POLL_INTERVAL_MS = 15_000;
+const MAX_SCHEDULED_REFRESH_DELAY_MS = 2_147_483_647;
 
 function truncate(value: string, maxLength = 140): string {
   if (value.length <= maxLength) return value;
@@ -313,11 +315,8 @@ export function IssueAgentStatusPanel({ workspaceSlug, projectId, issueId, issue
   const status = issue.agent_status;
   const ticker = status?.ticker ?? issue.agent_ticker;
   const activeRun = status?.active_run;
-  const activeRunId = activeRun?.id;
   const activeRunStatus = activeRun?.status;
-  const shouldPollAgentStatus = Boolean(
-    ticker?.enabled || (activeRunStatus && ACTIVE_RUN_STATUSES.has(activeRunStatus))
-  );
+  const hasActiveAgentRun = Boolean(activeRunStatus && ACTIVE_RUN_STATUSES.has(activeRunStatus));
   const view = useMemo(() => getAgentStatusView(issue, now, t), [issue, now, t]);
 
   useEffect(() => {
@@ -326,13 +325,23 @@ export function IssueAgentStatusPanel({ workspaceSlug, projectId, issueId, issue
   }, []);
 
   useEffect(() => {
-    if (!shouldPollAgentStatus) return;
-    void issueOperations.fetch(workspaceSlug, projectId, issueId);
+    if (!hasActiveAgentRun) return;
     const timer = window.setInterval(() => {
       void issueOperations.fetch(workspaceSlug, projectId, issueId);
-    }, 15_000);
+    }, AGENT_STATUS_POLL_INTERVAL_MS);
     return () => window.clearInterval(timer);
-  }, [activeRunId, issueId, issueOperations, projectId, shouldPollAgentStatus, workspaceSlug]);
+  }, [hasActiveAgentRun, issueId, issueOperations, projectId, workspaceSlug]);
+
+  useEffect(() => {
+    if (hasActiveAgentRun || !ticker?.enabled || !ticker.next_run_at) return;
+    const nextRunAt = new Date(ticker.next_run_at).getTime();
+    if (Number.isNaN(nextRunAt)) return;
+    const refreshDelay = Math.min(Math.max(nextRunAt - Date.now(), 0), MAX_SCHEDULED_REFRESH_DELAY_MS);
+    const timer = window.setTimeout(() => {
+      void issueOperations.fetch(workspaceSlug, projectId, issueId);
+    }, refreshDelay);
+    return () => window.clearTimeout(timer);
+  }, [hasActiveAgentRun, issueId, issueOperations, projectId, ticker?.enabled, ticker?.next_run_at, workspaceSlug]);
 
   if (!view) return null;
 

--- a/apps/web/core/components/issues/issue-detail/main-content.tsx
+++ b/apps/web/core/components/issues/issue-detail/main-content.tsx
@@ -32,6 +32,7 @@ import { IssueDetailWidgets } from "../issue-detail-widgets";
 import { NameDescriptionUpdateStatus } from "../issue-update-status";
 import { PeekOverviewProperties } from "../peek-overview/properties";
 import { IssueTitleInput } from "../title-input";
+import { IssueAgentStatusPanel } from "./agent-status";
 import { IssueActivity } from "./issue-activity";
 import { IssueParentDetail } from "./parent";
 import { IssueReaction } from "./reactions";
@@ -206,13 +207,22 @@ export const IssueMainContent = observer(function IssueMainContent(props: Props)
       />
 
       {windowSize[0] < 768 && (
-        <PeekOverviewProperties
-          workspaceSlug={workspaceSlug}
-          projectId={projectId}
-          issueId={issueId}
-          issueOperations={issueOperations}
-          disabled={!isEditable || isArchived}
-        />
+        <div className="space-y-5">
+          <IssueAgentStatusPanel
+            workspaceSlug={workspaceSlug}
+            projectId={projectId}
+            issueId={issueId}
+            issue={issue}
+            issueOperations={issueOperations}
+          />
+          <PeekOverviewProperties
+            workspaceSlug={workspaceSlug}
+            projectId={projectId}
+            issueId={issueId}
+            issueOperations={issueOperations}
+            disabled={!isEditable || isArchived}
+          />
+        </div>
       )}
 
       <IssueActivity workspaceSlug={workspaceSlug} projectId={projectId} issueId={issueId} disabled={isArchived} />

--- a/apps/web/core/components/issues/issue-detail/sidebar.tsx
+++ b/apps/web/core/components/issues/issue-detail/sidebar.tsx
@@ -35,6 +35,7 @@ import { useIssueDetail } from "@/hooks/store/use-issue-detail";
 import { useMember } from "@/hooks/store/use-member";
 import { useProject } from "@/hooks/store/use-project";
 import { useProjectState } from "@/hooks/store/use-project-state";
+import useSize from "@/hooks/use-window-size";
 // pi dash web components
 // components
 import { WorkItemAdditionalSidebarProperties } from "@/pi-dash-web/components/issues/issue-details/additional-properties";
@@ -68,8 +69,10 @@ export const IssueDetailsSidebar = observer(function IssueDetailsSidebar(props: 
   } = useIssueDetail();
   const { getUserDetails } = useMember();
   const { getStateById } = useProjectState();
+  const windowSize = useSize();
   const issue = getIssueById(issueId);
   if (!issue) return <></>;
+  const shouldRenderAgentStatus = windowSize[0] >= 768;
 
   const createdByDetails = getUserDetails(issue.created_by);
 
@@ -87,13 +90,15 @@ export const IssueDetailsSidebar = observer(function IssueDetailsSidebar(props: 
     <>
       <div className="flex h-full w-full flex-col items-center divide-y-2 divide-subtle-1 overflow-hidden">
         <div className="h-full w-full overflow-y-auto px-6">
-          <IssueAgentStatusPanel
-            workspaceSlug={workspaceSlug}
-            projectId={projectId}
-            issueId={issueId}
-            issue={issue}
-            issueOperations={issueOperations}
-          />
+          {shouldRenderAgentStatus && (
+            <IssueAgentStatusPanel
+              workspaceSlug={workspaceSlug}
+              projectId={projectId}
+              issueId={issueId}
+              issue={issue}
+              issueOperations={issueOperations}
+            />
+          )}
           <h5 className="mt-5 text-body-xs-medium">{t("common.properties")}</h5>
           <div className={`mt-4 mb-2 space-y-2.5 truncate ${!isEditable ? "opacity-60" : ""}`}>
             <SidebarPropertyListItem icon={StatePropertyIcon} label={t("common.state")}>

--- a/apps/web/core/components/issues/peek-overview/properties.tsx
+++ b/apps/web/core/components/issues/peek-overview/properties.tsx
@@ -42,6 +42,7 @@ import { DateAlert } from "@/pi-dash-web/components/issues/issue-details/sidebar
 import { TransferHopInfo } from "@/pi-dash-web/components/issues/issue-details/sidebar/transfer-hop-info";
 import { IssueWorklogProperty } from "@/pi-dash-web/components/issues/worklog/property";
 import type { TIssueOperations } from "../issue-detail";
+import { IssueAgentStatusPanel } from "../issue-detail/agent-status";
 import { IssueCycleSelect } from "../issue-detail/cycle-select";
 import { IssueLabel } from "../issue-detail/label";
 import { IssueModuleSelect } from "../issue-detail/module-select";
@@ -79,195 +80,204 @@ export const PeekOverviewProperties = observer(function PeekOverviewProperties(p
   maxDate?.setDate(maxDate.getDate());
 
   return (
-    <div>
-      <h6 className="text-body-xs-medium">{t("common.properties")}</h6>
-      <div className={`mt-3 w-full space-y-3 ${disabled ? "opacity-60" : ""}`}>
-        <SidebarPropertyListItem icon={StatePropertyIcon} label={t("common.state")}>
-          <StateDropdown
-            value={issue?.state_id}
-            onChange={(val) => issueOperations.update(workspaceSlug, projectId, issueId, { state_id: val })}
-            projectId={projectId}
-            disabled={disabled}
-            buttonVariant="transparent-with-text"
-            className="group w-full grow"
-            buttonContainerClassName="w-full text-left h-7.5"
-            buttonClassName={`text-body-xs-medium ${issue?.state_id ? "" : "text-placeholder"}`}
-            dropdownArrow
-            dropdownArrowClassName="h-3.5 w-3.5 hidden group-hover:inline"
-          />
-        </SidebarPropertyListItem>
-
-        <SidebarPropertyListItem icon={MembersPropertyIcon} label={t("common.assignees")}>
-          <MemberDropdown
-            value={issue?.assignee_ids ?? undefined}
-            onChange={(val) => issueOperations.update(workspaceSlug, projectId, issueId, { assignee_ids: val })}
-            disabled={disabled}
-            projectId={projectId}
-            placeholder={t("issue.add.assignee")}
-            multiple
-            buttonVariant={issue?.assignee_ids?.length > 1 ? "transparent-without-text" : "transparent-with-text"}
-            className="group w-full grow"
-            buttonContainerClassName="w-full text-left h-7.5"
-            buttonClassName={`text-body-xs-medium justify-between ${issue?.assignee_ids?.length > 0 ? "" : "text-placeholder"}`}
-            hideIcon={issue.assignee_ids?.length === 0}
-            dropdownArrow
-            dropdownArrowClassName="h-3.5 w-3.5 hidden group-hover:inline"
-          />
-        </SidebarPropertyListItem>
-
-        <SidebarPropertyListItem icon={PriorityPropertyIcon} label={t("common.priority")}>
-          <PriorityDropdown
-            value={issue?.priority}
-            onChange={(val) => issueOperations.update(workspaceSlug, projectId, issueId, { priority: val })}
-            disabled={disabled}
-            buttonVariant="transparent-with-text"
-            className="h-7.5 w-full grow rounded-sm"
-            buttonContainerClassName="w-full text-left h-7.5"
-            buttonClassName={`text-body-xs-medium whitespace-nowrap [&_svg]:size-3.5 ${!issue?.priority || issue?.priority === "none" ? "text-placeholder" : ""}`}
-          />
-        </SidebarPropertyListItem>
-
-        {createdByDetails && (
-          <SidebarPropertyListItem
-            icon={UserCirclePropertyIcon}
-            label={t("common.created_by")}
-            childrenClassName="px-2"
-          >
-            <ButtonAvatars
-              showTooltip
-              userIds={createdByDetails?.display_name.includes("-intake") ? null : createdByDetails?.id}
-            />
-            <span className="grow truncate text-body-xs-medium leading-5 text-secondary">
-              {createdByDetails?.display_name.includes("-intake") ? "Pi Dash" : createdByDetails?.display_name}
-            </span>
-          </SidebarPropertyListItem>
-        )}
-
-        <SidebarPropertyListItem icon={StartDatePropertyIcon} label={t("common.order_by.start_date")}>
-          <DateDropdown
-            value={issue.start_date}
-            onChange={(val) =>
-              issueOperations.update(workspaceSlug, projectId, issueId, {
-                start_date: val ? renderFormattedPayloadDate(val) : null,
-              })
-            }
-            placeholder={t("issue.add.start_date")}
-            buttonVariant="transparent-with-text"
-            maxDate={maxDate ?? undefined}
-            disabled={disabled}
-            className="group w-full grow"
-            buttonContainerClassName="w-full text-left h-7.5"
-            buttonClassName={`text-body-xs-medium ${issue?.start_date ? "" : "text-placeholder"}`}
-            hideIcon
-            clearIconClassName="h-3 w-3 hidden group-hover:inline"
-          />
-        </SidebarPropertyListItem>
-
-        <SidebarPropertyListItem icon={DueDatePropertyIcon} label={t("common.order_by.due_date")}>
-          <div className="flex w-full items-center gap-2">
-            <DateDropdown
-              value={issue.target_date}
-              onChange={(val) =>
-                issueOperations.update(workspaceSlug, projectId, issueId, {
-                  target_date: val ? renderFormattedPayloadDate(val) : null,
-                })
-              }
-              placeholder={t("issue.add.due_date")}
-              buttonVariant="transparent-with-text"
-              minDate={minDate ?? undefined}
-              disabled={disabled}
-              className="group w-full grow"
-              buttonContainerClassName="w-full text-left h-7.5"
-              buttonClassName={cn("text-body-xs-medium", {
-                "text-placeholder": !issue.target_date,
-                "text-danger-primary": shouldHighlightIssueDueDate(issue.target_date, stateDetails?.group),
-              })}
-              hideIcon
-              clearIconClassName="h-3 w-3 hidden group-hover:inline text-primary"
-            />
-            {issue.target_date && <DateAlert date={issue.target_date} workItem={issue} projectId={projectId} />}
-          </div>
-        </SidebarPropertyListItem>
-
-        {isEstimateEnabled && (
-          <SidebarPropertyListItem icon={EstimatePropertyIcon} label={t("common.estimate")}>
-            <EstimateDropdown
-              value={issue.estimate_point ?? undefined}
-              onChange={(val) => issueOperations.update(workspaceSlug, projectId, issueId, { estimate_point: val })}
+    <div className="space-y-5">
+      <IssueAgentStatusPanel
+        workspaceSlug={workspaceSlug}
+        projectId={projectId}
+        issueId={issueId}
+        issue={issue}
+        issueOperations={issueOperations}
+      />
+      <div>
+        <h6 className="text-body-xs-medium">{t("common.properties")}</h6>
+        <div className={`mt-3 w-full space-y-3 ${disabled ? "opacity-60" : ""}`}>
+          <SidebarPropertyListItem icon={StatePropertyIcon} label={t("common.state")}>
+            <StateDropdown
+              value={issue?.state_id}
+              onChange={(val) => issueOperations.update(workspaceSlug, projectId, issueId, { state_id: val })}
               projectId={projectId}
               disabled={disabled}
               buttonVariant="transparent-with-text"
               className="group w-full grow"
               buttonContainerClassName="w-full text-left h-7.5"
-              buttonClassName={`text-body-xs-medium ${issue?.estimate_point !== undefined ? "" : "text-placeholder"}`}
-              placeholder="None"
-              hideIcon
+              buttonClassName={`text-body-xs-medium ${issue?.state_id ? "" : "text-placeholder"}`}
               dropdownArrow
               dropdownArrowClassName="h-3.5 w-3.5 hidden group-hover:inline"
             />
           </SidebarPropertyListItem>
-        )}
 
-        {projectDetails?.module_view && (
-          <SidebarPropertyListItem icon={ModuleIcon} label={t("common.modules")}>
-            <IssueModuleSelect
-              className="w-full grow"
-              workspaceSlug={workspaceSlug}
-              projectId={projectId}
-              issueId={issueId}
-              issueOperations={issueOperations}
+          <SidebarPropertyListItem icon={MembersPropertyIcon} label={t("common.assignees")}>
+            <MemberDropdown
+              value={issue?.assignee_ids ?? undefined}
+              onChange={(val) => issueOperations.update(workspaceSlug, projectId, issueId, { assignee_ids: val })}
               disabled={disabled}
+              projectId={projectId}
+              placeholder={t("issue.add.assignee")}
+              multiple
+              buttonVariant={issue?.assignee_ids?.length > 1 ? "transparent-without-text" : "transparent-with-text"}
+              className="group w-full grow"
+              buttonContainerClassName="w-full text-left h-7.5"
+              buttonClassName={`text-body-xs-medium justify-between ${issue?.assignee_ids?.length > 0 ? "" : "text-placeholder"}`}
+              hideIcon={issue.assignee_ids?.length === 0}
+              dropdownArrow
+              dropdownArrowClassName="h-3.5 w-3.5 hidden group-hover:inline"
             />
           </SidebarPropertyListItem>
-        )}
 
-        {projectDetails?.cycle_view && (
-          <SidebarPropertyListItem
-            icon={CycleIcon}
-            label={t("common.cycle")}
-            appendElement={<TransferHopInfo workItem={issue} />}
-          >
-            <IssueCycleSelect
+          <SidebarPropertyListItem icon={PriorityPropertyIcon} label={t("common.priority")}>
+            <PriorityDropdown
+              value={issue?.priority}
+              onChange={(val) => issueOperations.update(workspaceSlug, projectId, issueId, { priority: val })}
+              disabled={disabled}
+              buttonVariant="transparent-with-text"
+              className="h-7.5 w-full grow rounded-sm"
+              buttonContainerClassName="w-full text-left h-7.5"
+              buttonClassName={`text-body-xs-medium whitespace-nowrap [&_svg]:size-3.5 ${!issue?.priority || issue?.priority === "none" ? "text-placeholder" : ""}`}
+            />
+          </SidebarPropertyListItem>
+
+          {createdByDetails && (
+            <SidebarPropertyListItem
+              icon={UserCirclePropertyIcon}
+              label={t("common.created_by")}
+              childrenClassName="px-2"
+            >
+              <ButtonAvatars
+                showTooltip
+                userIds={createdByDetails?.display_name.includes("-intake") ? null : createdByDetails?.id}
+              />
+              <span className="grow truncate text-body-xs-medium leading-5 text-secondary">
+                {createdByDetails?.display_name.includes("-intake") ? "Pi Dash" : createdByDetails?.display_name}
+              </span>
+            </SidebarPropertyListItem>
+          )}
+
+          <SidebarPropertyListItem icon={StartDatePropertyIcon} label={t("common.order_by.start_date")}>
+            <DateDropdown
+              value={issue.start_date}
+              onChange={(val) =>
+                issueOperations.update(workspaceSlug, projectId, issueId, {
+                  start_date: val ? renderFormattedPayloadDate(val) : null,
+                })
+              }
+              placeholder={t("issue.add.start_date")}
+              buttonVariant="transparent-with-text"
+              maxDate={maxDate ?? undefined}
+              disabled={disabled}
+              className="group w-full grow"
+              buttonContainerClassName="w-full text-left h-7.5"
+              buttonClassName={`text-body-xs-medium ${issue?.start_date ? "" : "text-placeholder"}`}
+              hideIcon
+              clearIconClassName="h-3 w-3 hidden group-hover:inline"
+            />
+          </SidebarPropertyListItem>
+
+          <SidebarPropertyListItem icon={DueDatePropertyIcon} label={t("common.order_by.due_date")}>
+            <div className="flex w-full items-center gap-2">
+              <DateDropdown
+                value={issue.target_date}
+                onChange={(val) =>
+                  issueOperations.update(workspaceSlug, projectId, issueId, {
+                    target_date: val ? renderFormattedPayloadDate(val) : null,
+                  })
+                }
+                placeholder={t("issue.add.due_date")}
+                buttonVariant="transparent-with-text"
+                minDate={minDate ?? undefined}
+                disabled={disabled}
+                className="group w-full grow"
+                buttonContainerClassName="w-full text-left h-7.5"
+                buttonClassName={cn("text-body-xs-medium", {
+                  "text-placeholder": !issue.target_date,
+                  "text-danger-primary": shouldHighlightIssueDueDate(issue.target_date, stateDetails?.group),
+                })}
+                hideIcon
+                clearIconClassName="h-3 w-3 hidden group-hover:inline text-primary"
+              />
+              {issue.target_date && <DateAlert date={issue.target_date} workItem={issue} projectId={projectId} />}
+            </div>
+          </SidebarPropertyListItem>
+
+          {isEstimateEnabled && (
+            <SidebarPropertyListItem icon={EstimatePropertyIcon} label={t("common.estimate")}>
+              <EstimateDropdown
+                value={issue.estimate_point ?? undefined}
+                onChange={(val) => issueOperations.update(workspaceSlug, projectId, issueId, { estimate_point: val })}
+                projectId={projectId}
+                disabled={disabled}
+                buttonVariant="transparent-with-text"
+                className="group w-full grow"
+                buttonContainerClassName="w-full text-left h-7.5"
+                buttonClassName={`text-body-xs-medium ${issue?.estimate_point !== undefined ? "" : "text-placeholder"}`}
+                placeholder="None"
+                hideIcon
+                dropdownArrow
+                dropdownArrowClassName="h-3.5 w-3.5 hidden group-hover:inline"
+              />
+            </SidebarPropertyListItem>
+          )}
+
+          {projectDetails?.module_view && (
+            <SidebarPropertyListItem icon={ModuleIcon} label={t("common.modules")}>
+              <IssueModuleSelect
+                className="w-full grow"
+                workspaceSlug={workspaceSlug}
+                projectId={projectId}
+                issueId={issueId}
+                issueOperations={issueOperations}
+                disabled={disabled}
+              />
+            </SidebarPropertyListItem>
+          )}
+
+          {projectDetails?.cycle_view && (
+            <SidebarPropertyListItem
+              icon={CycleIcon}
+              label={t("common.cycle")}
+              appendElement={<TransferHopInfo workItem={issue} />}
+            >
+              <IssueCycleSelect
+                className="h-7.5 w-full grow"
+                workspaceSlug={workspaceSlug}
+                projectId={projectId}
+                issueId={issueId}
+                issueOperations={issueOperations}
+                disabled={disabled}
+              />
+            </SidebarPropertyListItem>
+          )}
+
+          <SidebarPropertyListItem icon={ParentPropertyIcon} label={t("common.parent")}>
+            <IssueParentSelectRoot
               className="h-7.5 w-full grow"
-              workspaceSlug={workspaceSlug}
-              projectId={projectId}
+              disabled={disabled}
               issueId={issueId}
               issueOperations={issueOperations}
-              disabled={disabled}
+              projectId={projectId}
+              workspaceSlug={workspaceSlug}
             />
           </SidebarPropertyListItem>
-        )}
 
-        <SidebarPropertyListItem icon={ParentPropertyIcon} label={t("common.parent")}>
-          <IssueParentSelectRoot
-            className="h-7.5 w-full grow"
-            disabled={disabled}
+          <SidebarPropertyListItem icon={LabelPropertyIcon} label={t("common.labels")}>
+            <IssueLabel workspaceSlug={workspaceSlug} projectId={projectId} issueId={issueId} disabled={disabled} />
+          </SidebarPropertyListItem>
+
+          <IssueWorklogProperty
+            workspaceSlug={workspaceSlug}
+            projectId={projectId}
             issueId={issueId}
-            issueOperations={issueOperations}
+            disabled={disabled}
+          />
+
+          <WorkItemAdditionalSidebarProperties
+            workItemId={issue.id}
+            workItemTypeId={issue.type_id}
             projectId={projectId}
             workspaceSlug={workspaceSlug}
+            isEditable={!disabled}
+            isPeekView
           />
-        </SidebarPropertyListItem>
-
-        <SidebarPropertyListItem icon={LabelPropertyIcon} label={t("common.labels")}>
-          <IssueLabel workspaceSlug={workspaceSlug} projectId={projectId} issueId={issueId} disabled={disabled} />
-        </SidebarPropertyListItem>
-
-        <IssueWorklogProperty
-          workspaceSlug={workspaceSlug}
-          projectId={projectId}
-          issueId={issueId}
-          disabled={disabled}
-        />
-
-        <WorkItemAdditionalSidebarProperties
-          workItemId={issue.id}
-          workItemTypeId={issue.type_id}
-          projectId={projectId}
-          workspaceSlug={workspaceSlug}
-          isEditable={!disabled}
-          isPeekView
-        />
+        </div>
       </div>
     </div>
   );

--- a/apps/web/core/components/issues/peek-overview/properties.tsx
+++ b/apps/web/core/components/issues/peek-overview/properties.tsx
@@ -42,7 +42,6 @@ import { DateAlert } from "@/pi-dash-web/components/issues/issue-details/sidebar
 import { TransferHopInfo } from "@/pi-dash-web/components/issues/issue-details/sidebar/transfer-hop-info";
 import { IssueWorklogProperty } from "@/pi-dash-web/components/issues/worklog/property";
 import type { TIssueOperations } from "../issue-detail";
-import { IssueAgentStatusPanel } from "../issue-detail/agent-status";
 import { IssueCycleSelect } from "../issue-detail/cycle-select";
 import { IssueLabel } from "../issue-detail/label";
 import { IssueModuleSelect } from "../issue-detail/module-select";
@@ -81,13 +80,6 @@ export const PeekOverviewProperties = observer(function PeekOverviewProperties(p
 
   return (
     <div className="space-y-5">
-      <IssueAgentStatusPanel
-        workspaceSlug={workspaceSlug}
-        projectId={projectId}
-        issueId={issueId}
-        issue={issue}
-        issueOperations={issueOperations}
-      />
       <div>
         <h6 className="text-body-xs-medium">{t("common.properties")}</h6>
         <div className={`mt-3 w-full space-y-3 ${disabled ? "opacity-60" : ""}`}>


### PR DESCRIPTION
## Summary

- Show the issue AI agent status panel in the normal issue peek properties view, above Properties.
- Keep the panel polling while an issue ticker is enabled so queued/running/completed state changes are picked up without a refresh.
- Drain queued runner work when a runner reports busy -> idle so pinned ticker runs do not remain stuck in queued.

## Root Cause

The original UI placement only covered the full issue details sidebar. The project issues page opens issues through the peek overview path, which renders `PeekOverviewProperties`, so the panel was absent there. Separately, ticker-created follow-up runs could be queued while a runner was marked busy and then not drained when the runner became idle.

## Validation

- `docker compose -f docker-compose-local.yml exec -T api pytest pi_dash/tests/unit/runner/test_poll_heartbeat_drain.py`
- `docker compose -f docker-compose-local.yml exec -T api ruff check pi_dash/runner/views/sessions.py pi_dash/tests/unit/runner/test_poll_heartbeat_drain.py`
- `docker compose -f docker-compose-local.yml exec -T api python manage.py check`
- `pnpm --filter web exec react-router typegen`
- `pnpm --filter web exec oxlint core/components/issues/peek-overview/properties.tsx core/components/issues/issue-detail/agent-status.tsx`
- `pnpm --filter web exec oxfmt --check core/components/issues/peek-overview/properties.tsx core/components/issues/issue-detail/agent-status.tsx`