### PR TITLE
feat(web): collapse sidebar More section by default

### DIFF
--- a/apps/web/core/components/workspace/sidebar/more-section.tsx
+++ b/apps/web/core/components/workspace/sidebar/more-section.tsx
@@ -34,7 +34,7 @@ export const SidebarMoreSection = observer(function SidebarMoreSection() {
   const pathname = usePathname();
   const { setValue: toggleMoreMenu, storedValue: isMoreMenuOpen } = useLocalStorage<boolean>(
     "is_sidebar_more_menu_open",
-    true
+    false
   );
 
   const items = MORE_ITEM_KEYS.map(


### PR DESCRIPTION
## Summary

- Switch the default of the `is_sidebar_more_menu_open` localStorage flag from `true` to `false` so a fresh browser opens with the sidebar **More** disclosure collapsed.
- Existing users keep their stored preference — the default only applies when no localStorage entry is present.

## Caveats

- `more-section.tsx` has a `useEffect` that force-opens (and persists) the disclosure when the user navigates to any path inside `MORE_PATH_SEGMENTS` (`/prompts`, `/schedulers`, `/ai-dev-machines`, `/analytics`, `/archives`). So a fresh user who visits any of those routes will have their stored value flipped back to `true` and the section will stay open after that. This PR does not change that behavior; if you want the section to remain collapsed even after visiting a More page, that's a separate, larger change.
- To test the new default locally you need to clear the `is_sidebar_more_menu_open` localStorage key (or use a fresh browser profile) — your existing stored `true` will otherwise win.

## Test plan

- [ ] Fresh browser profile → load workspace → **More** is collapsed.
- [ ] Click **More** → expands, persists `true` → reload → still expanded.
- [ ] Clear `is_sidebar_more_menu_open` from localStorage → reload → collapsed again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)