### PR TITLE
[codex] automate runner version advisory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -290,6 +290,45 @@ jobs:
           sed -i "s|/releases/latest/download/pidash-installer.ps1|/releases/download/${{ needs.plan.outputs.tag }}/pidash-installer.ps1|" runner/install.ps1
           gh release upload "${{ needs.plan.outputs.tag }}" runner/install.sh runner/install.ps1 --clobber
 
+  publish-runner-version-advisory:
+    # Publish the Cloud advisory source of truth only. Do not restart EC2,
+    # redeploy the API, or mutate MIN_RUNNER_VERSION from a normal release.
+    needs:
+      - plan
+      - host
+    if: ${{ always() && needs.host.result == 'success' && fromJson(needs.host.outputs.val).announcement_is_prerelease == false }}
+    runs-on: "ubuntu-22.04"
+    env:
+      AWS_REGION: us-west-2
+      RELEASE_TAG: ${{ needs.plan.outputs.tag }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Publish latest runner version to Cloud SSM
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${RELEASE_TAG#pidash-v}"
+          if [ -z "$VERSION" ] || [ "$VERSION" = "$RELEASE_TAG" ]; then
+            echo "::error::expected runner tag shaped pidash-vX.Y.Z, got '$RELEASE_TAG'"
+            exit 1
+          fi
+
+          for target in test prod; do
+            aws ssm put-parameter \
+              --region "$AWS_REGION" \
+              --name "/pidash/config/${target}/LATEST_RUNNER_VERSION" \
+              --type String \
+              --value "$VERSION" \
+              --overwrite
+            echo "Published LATEST_RUNNER_VERSION=$VERSION to /pidash/config/${target}/"
+          done
+
   announce:
     needs:
       - plan

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -38,15 +38,17 @@ gets a fix or feature on its own cadence.
 5. When green, the GitHub Release will be at
    `https://github.com/The-AI-Republic/pi-dash/releases/tag/pidash-v0.1.2`
    with a `pidash-installer.sh` and platform-specific archives.
-6. Announce the new version to running runners by setting
-   `LATEST_RUNNER_VERSION=0.1.2` (and optionally `MIN_RUNNER_VERSION=0.1.2`
-   if this is a breaking-protocol or security release) on the Pi Dash
-   API service. Runners with `auto_update` enabled — the default — will
-   swap the on-disk binary on their next session bootstrap and surface
+6. The release workflow automatically writes
+   `LATEST_RUNNER_VERSION=0.1.2` to the Cloud SSM parameters for test and
+   prod. It does not restart or redeploy the API; the currently running
+   containers pick the value up on their next normal restart/deploy. Set
+   `MIN_RUNNER_VERSION=0.1.2` manually only for a breaking-protocol or
+   security release. Runners with `auto_update` enabled — the default —
+   will swap the on-disk binary on their next session bootstrap and surface
    a "restart to apply" advisory in `pidash status` / the TUI. Runners
-   with `auto_update` disabled show an "update available — run `pidash
-update`" banner instead. See `runner/README.md` (Auto-update) for
-   the full rendering matrix.
+   with `auto_update` disabled show an "update available — run
+   `pidash update --restart`" banner instead. See `runner/README.md`
+   (Auto-update) for the full rendering matrix.
 
 ## Cutting a platform release
 
@@ -89,6 +91,16 @@ Release is marked as a prerelease, and Docker images skip the `:stable` /
 `:latest` tags (they only get the explicit version tag).
 
 ## What you need set up before the first real release
+
+For runner release advisories:
+
+1. **AWS SSM credentials in GitHub Actions secrets for this repo**
+   - `AWS_ACCESS_KEY_ID`
+   - `AWS_SECRET_ACCESS_KEY`
+   - IAM permission: `ssm:PutParameter` on
+     `/pidash/config/test/LATEST_RUNNER_VERSION` and
+     `/pidash/config/prod/LATEST_RUNNER_VERSION`.
+   - The workflow intentionally does not restart EC2 or redeploy the API.
 
 For platform releases (cargo-dist runner releases already work):
 

--- a/docs/wiki/02-cloud-quickstart.md
+++ b/docs/wiki/02-cloud-quickstart.md
@@ -74,7 +74,7 @@ pidash runner list         # runners on this host
 pidash runner add --project <ID>
 pidash runner remove <name>
 pidash restart / stop
-pidash update              # self-update
+pidash update --restart    # self-update and restart when idle
 pidash --help
 ```
 

--- a/docs/wiki/07-runner-architecture.md
+++ b/docs/wiki/07-runner-architecture.md
@@ -119,7 +119,7 @@ On Windows, everything goes under the user profile and IPC is via a named pipe.
 
 The cloud's `welcome` frame can include `latest_runner_version` and `min_runner_version` (driven by the cloud's `LATEST_RUNNER_VERSION` / `MIN_RUNNER_VERSION` env vars). With auto-update enabled, the daemon swaps the on-disk `pidash` binary in place; the **running process is never disturbed** — it keeps its loaded copy until the next natural restart (`pidash restart`, host reboot, service-manager respawn).
 
-`pidash update` only works for installs from cargo-dist installers (`pidash-installer.sh`, `pidash-installer.ps1`, MSI) — those leave an install receipt the updater reads. Source builds and `cargo install` builds get a clear "reinstall via the installer if you want self-update" error. See [15 — Releasing](./15-releasing.md).
+`pidash update --restart` is the one-command manual path: swap the binary, restart the daemon, and wait for it to reconnect. `pidash update` without `--restart` only swaps the binary and applies on the next natural restart. Both paths only work for installs from cargo-dist installers (`pidash-installer.sh`, `pidash-installer.ps1`, MSI) — those leave an install receipt the updater reads. Source builds and `cargo install` builds get a clear "reinstall via the installer if you want self-update" error. See [15 — Releasing](./15-releasing.md).
 
 ## Where to read next
 

--- a/docs/wiki/08-cloud-runner-protocol.md
+++ b/docs/wiki/08-cloud-runner-protocol.md
@@ -27,19 +27,19 @@ When the runner opens a session, the cloud returns a `welcome` payload. Key fiel
 | `latest_runner_version` | env `LATEST_RUNNER_VERSION` | Newest runner version that exists. Drives the yellow "update available" advisory and, with auto-update on, triggers in-place binary swap.                                                                          |
 | `min_runner_version`    | env `MIN_RUNNER_VERSION`    | Cloud-set floor. Below this version, runner shows a red "update required" banner. Advisory in the current implementation — does **not** refuse new tasks yet, but it's the signal that the floor is about to bite. |
 
-Both version envs are optional. Leave them unset to skip the announcement.
+Both version envs are optional. In non-Cloud environments, leave them unset to skip the announcement.
 
 ## Auto-update advisory states
 
 What the runner shows in TUI / `pidash status` based on the welcome contents:
 
-| Running version vs. cloud advisory                 | Banner                                                 |
-| -------------------------------------------------- | ------------------------------------------------------ |
-| `>= latest_announced` and `>= min_required`        | (nothing)                                              |
-| `< latest_announced`, swap already on disk         | yellow `⚠ Restart to apply vX.Y.Z`                     |
-| `< latest_announced`, auto-update on, swap pending | yellow `⚠ Update vX.Y.Z pending swap`                  |
-| `< latest_announced`, auto-update off              | yellow `⚠ Update vX.Y.Z available — run pidash update` |
-| `< min_required`                                   | red `⛔ Update required: cloud floor vX.Y.Z`           |
+| Running version vs. cloud advisory                 | Banner                                                           |
+| -------------------------------------------------- | ---------------------------------------------------------------- |
+| `>= latest_announced` and `>= min_required`        | (nothing)                                                        |
+| `< latest_announced`, swap already on disk         | yellow `⚠ Restart to apply vX.Y.Z`                               |
+| `< latest_announced`, auto-update on, swap pending | yellow `⚠ Update vX.Y.Z pending swap`                            |
+| `< latest_announced`, auto-update off              | yellow `⚠ Update vX.Y.Z available — run pidash update --restart` |
+| `< min_required`                                   | red `⛔ Update required: cloud floor vX.Y.Z`                     |
 
 The toggle lives in TUI → General → Daemon settings → `auto_update`. Default **on**.
 
@@ -71,7 +71,7 @@ Schemas are typed in `pi_dash/runner/serializers.py` and mirrored in `runner/src
 
 - **Additive** (new optional fields) → no bump. The other side just ignores them.
 - **Renamed / repurposed / removed required field** → bump.
-- When you bump, **ship both sides in the same release window** and update `LATEST_RUNNER_VERSION` / `MIN_RUNNER_VERSION` envs on the cloud so old runners get nudged forward.
+- When you bump, **ship both sides in the same release window**. Stable runner releases update Cloud's `LATEST_RUNNER_VERSION` SSM parameter automatically; set `MIN_RUNNER_VERSION` manually only when old runners must be forced forward.
 - The Rust `protocol.rs` test (`tests/protocol_roundtrip.rs`) round-trips every variant — keep it green.
 
 ## Where to read next

--- a/docs/wiki/15-releasing.md
+++ b/docs/wiki/15-releasing.md
@@ -54,13 +54,15 @@ The Django backend reads two env vars and folds them into every `welcome` sessio
 | `LATEST_RUNNER_VERSION` | Drives the yellow "update available" advisory. With auto-update on (default), triggers in-place binary swap. |
 | `MIN_RUNNER_VERSION`    | Drives the red "update required" advisory.                                                                   |
 
-After cutting a runner release, set `LATEST_RUNNER_VERSION` on the cloud so opted-in runners auto-update. Leave `MIN_RUNNER_VERSION` alone unless you're forcing a floor (e.g. shedding an EOL wire version).
+For stable runner releases, `.github/workflows/release.yml` automatically writes the tag version to `/pidash/config/test/LATEST_RUNNER_VERSION` and `/pidash/config/prod/LATEST_RUNNER_VERSION` in SSM. It does **not** restart or redeploy the API; running containers pick up the value on their next normal restart/deploy. Leave `MIN_RUNNER_VERSION` alone unless you're forcing a floor (e.g. shedding an EOL wire version). Runners with auto-update disabled see a `pidash update --restart` hint so they can install and apply the release in one command.
 
-Leave both unset to skip the announcement entirely.
+For self-hosted or non-Cloud environments, leave both unset to skip the announcement entirely.
 
 ### In-place updates
 
 `pidash` swaps its on-disk binary while running; the **running process is never disturbed**. The new binary takes effect on the next natural restart (`pidash restart`, host reboot, service-manager respawn after crash).
+
+`pidash update --restart` swaps the binary and restarts the daemon in one command. `pidash update` without `--restart` only swaps the binary.
 
 `pidash update` only works for installs done via cargo-dist installers (they leave a receipt). Source builds and `cargo install` builds get a clear "reinstall via the installer if you want self-update" error.
 

--- a/docs/wiki/17-cli-reference.md
+++ b/docs/wiki/17-cli-reference.md
@@ -228,6 +228,8 @@ pidash update [--check] [--restart]
 
 Without `--restart`, the swap only takes effect on the next natural restart (`pidash restart`, reboot, service respawn). The running process is never disturbed.
 
+For a one-command manual upgrade, run `pidash update --restart` when the runner is idle.
+
 ### `pidash remove --all`
 
 Full teardown: stop service → uninstall service unit → deregister with cloud → delete local `config.toml` + credentials.

--- a/runner/README.md
+++ b/runner/README.md
@@ -130,22 +130,22 @@ This path is kept as a fallback; the device-code flow above is the recommended p
 The toggle lives in the General tab's **Daemon settings** card (`pidash tui` → `auto_update`). Default is **on**; press Enter to flip, then `[w]` to save. With auto-update off, the runner instead surfaces a yellow `⚠ Update v0.1.x available` advisory in the Connection card and on `pidash status`, and you apply updates manually:
 
 ```bash
-pidash update              # swap binary; tells you to run pidash restart
-pidash update --check      # report whether an update is available
 pidash update --restart    # swap and restart the daemon in one shot
+pidash update              # swap binary only; apply on the next restart
+pidash update --check      # report whether an update is available
 ```
 
 `pidash update` only works for binaries installed via cargo-dist installers such as `pidash-installer.sh`, `pidash-installer.ps1`, or the Windows MSI (it reads the cargo-dist install receipt). Source builds, zip-only installs, and `cargo install`'d binaries don't have a receipt and get a clear "reinstall via the installer if you want self-update" error.
 
 ### What the advisory states mean
 
-| State                                                     | TUI / `pidash status`                                  |
-| --------------------------------------------------------- | ------------------------------------------------------ |
-| Running version ≥ `latest_announced` and ≥ `min_required` | nothing shown                                          |
-| Newer `latest_announced`, swap already on disk            | yellow `⚠ Restart to apply v0.1.x`                     |
-| Newer `latest_announced`, auto-update on, swap pending    | yellow `⚠ Update v0.1.x pending swap`                  |
-| Newer `latest_announced`, auto-update off                 | yellow `⚠ Update v0.1.x available — run pidash update` |
-| Running version below `min_required` (cloud-set floor)    | red `⛔ Update required: cloud floor v0.1.x`           |
+| State                                                     | TUI / `pidash status`                                            |
+| --------------------------------------------------------- | ---------------------------------------------------------------- |
+| Running version ≥ `latest_announced` and ≥ `min_required` | nothing shown                                                    |
+| Newer `latest_announced`, swap already on disk            | yellow `⚠ Restart to apply v0.1.x`                               |
+| Newer `latest_announced`, auto-update on, swap pending    | yellow `⚠ Update v0.1.x pending swap`                            |
+| Newer `latest_announced`, auto-update off                 | yellow `⚠ Update v0.1.x available — run pidash update --restart` |
+| Running version below `min_required` (cloud-set floor)    | red `⛔ Update required: cloud floor v0.1.x`                     |
 
 `min_required` is advisory in the current implementation — the daemon does not refuse new tasks below the floor. The red banner is the user-facing signal that they should act before the cloud bumps the wire-protocol floor and disconnects them.
 
@@ -158,7 +158,7 @@ The Pi Dash backend reads two optional environment variables and folds them into
 | `LATEST_RUNNER_VERSION` | Drives the yellow "update available" advisory and triggers auto-swap on opted-in runners. |
 | `MIN_RUNNER_VERSION`    | Drives the red "update required" advisory.                                                |
 
-Set both after cutting a runner release (`RELEASING.md` walks through tagging). Leave them unset to skip the announcement.
+Stable runner releases set `LATEST_RUNNER_VERSION` in Cloud SSM automatically (`RELEASING.md` walks through tagging). Set `MIN_RUNNER_VERSION` manually only when you need to force a floor. Leave both unset to skip the announcement in non-Cloud environments.
 
 ## Design docs
 

--- a/runner/src/cli/update.rs
+++ b/runner/src/cli/update.rs
@@ -49,7 +49,7 @@ pub async fn run(args: Args, paths: &Paths) -> Result<()> {
         SwapOutcome::UpdateAvailable { new_version } => {
             // --check path: print and exit without touching disk.
             println!(
-                "update available: v{new_version} (running v{RUNNER_VERSION}). run `pidash update` to install."
+                "update available: v{new_version} (running v{RUNNER_VERSION}). run `pidash update --restart` to install and apply now, or `pidash update` to install without restarting."
             );
         }
         SwapOutcome::Swapped {
@@ -74,7 +74,9 @@ pub async fn run(args: Args, paths: &Paths) -> Result<()> {
                 }
                 println!("daemon restarted on the new binary ({}).", outcome.summary);
             } else {
-                println!("run `pidash restart` to apply (the running daemon is still on v{old}).");
+                println!(
+                    "run `pidash restart` to apply now, or let the next reboot/service restart pick it up (the running daemon is still on v{old})."
+                );
             }
         }
     }

--- a/runner/src/config/schema.rs
+++ b/runner/src/config/schema.rs
@@ -72,7 +72,7 @@ pub struct DaemonConfig {
     /// daemon is never disturbed — the new code only takes effect on
     /// the next natural restart. When `false`, the daemon surfaces an
     /// advisory in `pidash status` / TUI and waits for the operator to
-    /// run `pidash update` manually.
+    /// run `pidash update --restart` (or `pidash update` to defer restart).
     #[serde(default = "default_auto_update")]
     pub auto_update: bool,
 }

--- a/runner/src/ipc/protocol.rs
+++ b/runner/src/ipc/protocol.rs
@@ -169,7 +169,7 @@ pub struct UpdateAdvisory {
     pub min_required: Option<String>,
     /// Whether the user has the auto-update toggle enabled. Surfaced
     /// here so the TUI's banner can phrase itself appropriately
-    /// ("restart to apply" vs. "update available — run pidash update").
+    /// ("restart to apply" vs. "update available — run pidash update --restart").
     /// `#[serde(default)]` defaults to `false` for older daemons that
     /// didn't populate it.
     #[serde(default)]
@@ -255,7 +255,7 @@ impl UpdateAdvisory {
             } else if self.auto_update_enabled {
                 println!("  update: REQUIRED — cloud floor v{min}; swap pending");
             } else {
-                println!("  update: REQUIRED — cloud floor v{min}; run `pidash update`");
+                println!("  update: REQUIRED — cloud floor v{min}; run `pidash update --restart`");
             }
             return;
         }
@@ -268,7 +268,7 @@ impl UpdateAdvisory {
             } else if self.auto_update_enabled {
                 println!("  update: v{latest} pending swap (running v{running})");
             } else {
-                println!("  update: v{latest} available — run `pidash update`");
+                println!("  update: v{latest} available — run `pidash update --restart`");
             }
         }
     }

--- a/runner/src/tui/views/general.rs
+++ b/runner/src/tui/views/general.rs
@@ -746,7 +746,7 @@ fn update_advisory_line(adv: &crate::ipc::protocol::UpdateAdvisory) -> Option<Li
         } else if adv.auto_update_enabled {
             format!("⛔ Update required: cloud floor v{min}; swap pending")
         } else {
-            format!("⛔ Update required: cloud floor v{min} — run `pidash update`")
+            format!("⛔ Update required: cloud floor v{min} — run `pidash update --restart`")
         };
         return Some(Line::from(Span::styled(
             msg,
@@ -764,7 +764,7 @@ fn update_advisory_line(adv: &crate::ipc::protocol::UpdateAdvisory) -> Option<Li
         } else if adv.auto_update_enabled {
             format!("⚠ Update v{latest} pending swap (running v{running})")
         } else {
-            format!("⚠ Update v{latest} available — run `pidash update`")
+            format!("⚠ Update v{latest} available — run `pidash update --restart`")
         };
         return Some(Line::from(Span::styled(
             msg,


### PR DESCRIPTION
## Summary

- Add a post-release workflow job that publishes stable runner release versions to Cloud SSM for test and prod.
- Keep the job advisory-only: it does not restart EC2, redeploy the API, or mutate `MIN_RUNNER_VERSION`.
- Update runner status/TUI/manual-update copy to point users at `pidash update --restart` for one-command manual upgrades.
- Refresh release docs to describe the automatic `LATEST_RUNNER_VERSION` SSM update and remaining manual floor-setting behavior.

## Why

Runner auto-update already depends on Cloud announcing `latest_runner_version`, but future releases still required a human to update SSM. This wires that announcement into the stable runner release flow while leaving API restart/deploy timing unchanged.

## Validation

- `python3` YAML parse for `.github/workflows/release.yml`
- `CARGO_TARGET_DIR=/tmp/pidash-cargo-target cargo test -p pidash version_lt`
- `CARGO_TARGET_DIR=/tmp/pidash-cargo-target cargo test -p pidash update_advisory_round_trips_to_daemon_info`