### PR TITLE
feat(runner): diagnose dead daemon when restart's IPC wait fails

### DIFF
--- a/runner/src/service/launchd.rs
+++ b/runner/src/service/launchd.rs
@@ -301,10 +301,10 @@ fn parse_loaded_pid(stdout: &str) -> Option<i32> {
 }
 
 /// Extract `LastExitStatus` from `launchctl list LABEL`'s plist-style
-/// stdout. macOS launchd encodes signals as the raw signal number here:
-/// 9 means SIGKILL, 6 means SIGABRT, 11 means SIGSEGV, etc. A clean
-/// `exit(0)` is `0`. Returns `None` when the field is absent (label is
-/// loaded but has never exited).
+/// stdout. launchd exposes the wait-status integer: signal deaths live
+/// in the low bits (`9` means SIGKILL), while ordinary exits are shifted
+/// (`exit(78)` shows up as `19968`). Returns `None` when the field is
+/// absent (label is loaded but has never exited).
 fn parse_last_exit_status(stdout: &str) -> Option<i32> {
     parse_int_field(stdout, "LastExitStatus")
 }
@@ -350,18 +350,53 @@ pub async fn diagnose_recent_exit() -> Option<String> {
     if matches!(pid, Some(p) if p > 0) {
         return None;
     }
-    let status = parse_last_exit_status(&stdout)?;
-    if status == 0 {
+    let raw_status = parse_last_exit_status(&stdout)?;
+    let status = decode_launchd_exit_status(raw_status);
+    if status == LaunchdExitStatus::Exited(0) {
         return None; // clean exit — IPC must have failed for another reason
     }
-    Some(describe_exit_status(status))
+    Some(describe_exit_status(status, raw_status))
 }
 
-/// Translate a launchctl `LastExitStatus` integer into an
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LaunchdExitStatus {
+    Exited(i32),
+    Signaled { signal: i32, core_dumped: bool },
+    Other(i32),
+}
+
+/// Decode launchd's `LastExitStatus` as the raw wait status it reports
+/// in the per-label plist-style output. For example, SIGKILL is `9`,
+/// SIGABRT with a core flag is `134`, and `exit(78)` is `19968`.
+fn decode_launchd_exit_status(raw_status: i32) -> LaunchdExitStatus {
+    // Be tolerant of callers passing the legacy `launchctl list` status
+    // column form, where a signal can be represented as `-SIGNAL`.
+    if raw_status < 0 {
+        return LaunchdExitStatus::Signaled {
+            signal: -raw_status,
+            core_dumped: false,
+        };
+    }
+
+    let termsig = raw_status & 0x7f;
+    if termsig == 0 {
+        return LaunchdExitStatus::Exited((raw_status >> 8) & 0xff);
+    }
+    if termsig != 0x7f {
+        return LaunchdExitStatus::Signaled {
+            signal: termsig,
+            core_dumped: raw_status & 0x80 != 0,
+        };
+    }
+    LaunchdExitStatus::Other(raw_status)
+}
+
+/// Translate a decoded launchd `LastExitStatus` into an
 /// operator-actionable message. Pure function so it's unit-testable.
-fn describe_exit_status(status: i32) -> String {
+fn describe_exit_status(status: LaunchdExitStatus, raw_status: i32) -> String {
     match status {
-        9 => "Daemon was killed by SIGKILL (LastExitStatus=9) shortly after launchd \
+        LaunchdExitStatus::Signaled { signal: 9, .. } => format!(
+            "Daemon was killed by SIGKILL (LastExitStatus={raw_status}) shortly after launchd \
              exec'd it. On macOS this is almost always a code-signing rejection by \
              AMFI — common when a freshly built binary's signature isn't trusted \
              for launchd-spawned processes even though it runs fine from the shell. \
@@ -371,24 +406,39 @@ fn describe_exit_status(status: i32) -> String {
              Re-sign locally with `codesign --force --sign - <binary>` if needed; \
              release builds shipped via `pidash-installer.sh` are Developer-ID \
              signed and unaffected."
-            .to_string(),
-        6 => "Daemon aborted (LastExitStatus=6 = SIGABRT) shortly after launch. \
+        ),
+        LaunchdExitStatus::Signaled {
+            signal: 6,
+            core_dumped,
+        } => format!(
+            "Daemon aborted (LastExitStatus={raw_status} = SIGABRT{}) shortly after launch. \
              Most likely a Rust panic or a libc assertion. Check the daemon's \
              stderr log at `~/Library/Application Support/so.pidash.pidash/logs/runner.err.log` \
-             (macOS) for the panic message."
-            .to_string(),
-        11 => "Daemon segfaulted (LastExitStatus=11 = SIGSEGV) shortly after \
-              launch. Likely a native crash. Check the stderr log and consider \
-              running with `RUST_BACKTRACE=1` baked into the launchd plist."
-            .to_string(),
-        n if (1..32).contains(&n) => format!(
-            "Daemon was killed by signal {n} (LastExitStatus={n}) shortly after \
-             launch. Check the daemon's stderr log for context."
+             (macOS) for the panic message.",
+            if core_dumped { ", core dumped" } else { "" }
         ),
-        n => format!(
-            "Daemon exited with non-zero status {n} shortly after launch. \
+        LaunchdExitStatus::Signaled {
+            signal: 11,
+            core_dumped,
+        } => format!(
+            "Daemon segfaulted (LastExitStatus={raw_status} = SIGSEGV{}) shortly after \
+              launch. Likely a native crash. Check the stderr log and consider \
+              running with `RUST_BACKTRACE=1` baked into the launchd plist.",
+            if core_dumped { ", core dumped" } else { "" }
+        ),
+        LaunchdExitStatus::Signaled { signal, .. } => format!(
+            "Daemon was killed by signal {signal} (LastExitStatus={raw_status}) shortly after \
+             launch. Check the daemon's stderr log for context.",
+        ),
+        LaunchdExitStatus::Exited(code) => format!(
+            "Daemon exited with non-zero status {code} (LastExitStatus={raw_status}) shortly \
+             after launch. \
              Usually a config / credential error — check the daemon's stderr \
              log at `~/Library/Application Support/so.pidash.pidash/logs/runner.err.log`."
+        ),
+        LaunchdExitStatus::Other(raw) => format!(
+            "Daemon stopped with unrecognized launchd LastExitStatus={raw}. \
+             Check the daemon's stderr log at `~/Library/Application Support/so.pidash.pidash/logs/runner.err.log`."
         ),
     }
 }
@@ -628,7 +678,7 @@ mod tests {
 
     #[test]
     fn describe_exit_status_calls_out_sigkill_amfi() {
-        let msg = describe_exit_status(9);
+        let msg = describe_exit_status(decode_launchd_exit_status(9), 9);
         // The SIGKILL message MUST point at AMFI / codesign — that's
         // the load-bearing user-facing diagnosis. If someone edits
         // the message and loses that hint, this test should fail.
@@ -639,7 +689,7 @@ mod tests {
 
     #[test]
     fn describe_exit_status_calls_out_sigabrt_panic() {
-        let msg = describe_exit_status(6);
+        let msg = describe_exit_status(decode_launchd_exit_status(6), 6);
         assert!(msg.contains("SIGABRT") || msg.contains("aborted"));
         assert!(
             msg.to_lowercase().contains("panic"),
@@ -648,14 +698,52 @@ mod tests {
     }
 
     #[test]
+    fn decode_launchd_exit_status_handles_raw_wait_statuses() {
+        assert_eq!(decode_launchd_exit_status(0), LaunchdExitStatus::Exited(0));
+        // launchd's plist-style LastExitStatus uses the raw wait status:
+        // exit code 1 is 1 << 8, not plain 1.
+        assert_eq!(
+            decode_launchd_exit_status(256),
+            LaunchdExitStatus::Exited(1)
+        );
+        assert_eq!(
+            decode_launchd_exit_status(19968),
+            LaunchdExitStatus::Exited(78)
+        );
+        // Signals occupy the low bits; the core-dump bit may also be set.
+        assert_eq!(
+            decode_launchd_exit_status(9),
+            LaunchdExitStatus::Signaled {
+                signal: 9,
+                core_dumped: false
+            }
+        );
+        assert_eq!(
+            decode_launchd_exit_status(134),
+            LaunchdExitStatus::Signaled {
+                signal: 6,
+                core_dumped: true
+            }
+        );
+        assert_eq!(
+            decode_launchd_exit_status(139),
+            LaunchdExitStatus::Signaled {
+                signal: 11,
+                core_dumped: true
+            }
+        );
+    }
+
+    #[test]
     fn describe_exit_status_handles_arbitrary_signals_and_exit_codes() {
         // SIGTERM = 15: signal range, but no canned message — fall
         // through to the "killed by signal N" branch.
-        let sig = describe_exit_status(15);
+        let sig = describe_exit_status(decode_launchd_exit_status(15), 15);
         assert!(sig.contains("signal 15"));
         // Non-signal exit (e.g. config error, status 78 = EX_CONFIG).
-        let cfg = describe_exit_status(78);
+        let cfg = describe_exit_status(decode_launchd_exit_status(19968), 19968);
         assert!(cfg.contains("78"));
+        assert!(cfg.contains("19968"));
         assert!(
             cfg.to_lowercase().contains("config") || cfg.to_lowercase().contains("non-zero"),
             "high exit codes should suggest config/credential errors; got: {cfg}"

--- a/runner/src/service/launchd.rs
+++ b/runner/src/service/launchd.rs
@@ -297,16 +297,100 @@ async fn probe_loaded_pid() -> Option<i32> {
 /// (registered but not yet exec'd, or just-exited). Pulled out as a pure
 /// function so the parser has unit tests independent of launchctl.
 fn parse_loaded_pid(stdout: &str) -> Option<i32> {
+    parse_int_field(stdout, "PID")
+}
+
+/// Extract `LastExitStatus` from `launchctl list LABEL`'s plist-style
+/// stdout. macOS launchd encodes signals as the raw signal number here:
+/// 9 means SIGKILL, 6 means SIGABRT, 11 means SIGSEGV, etc. A clean
+/// `exit(0)` is `0`. Returns `None` when the field is absent (label is
+/// loaded but has never exited).
+fn parse_last_exit_status(stdout: &str) -> Option<i32> {
+    parse_int_field(stdout, "LastExitStatus")
+}
+
+/// Shared parser for `"<KEY>" = <int>;` lines in launchctl's output.
+fn parse_int_field(stdout: &str, key: &str) -> Option<i32> {
+    let prefix = format!("\"{key}\" = ");
     for line in stdout.lines() {
         let trimmed = line.trim();
-        if let Some(rest) = trimmed.strip_prefix("\"PID\" = ") {
-            let pid_str = rest.trim_end_matches(';').trim();
-            if let Ok(pid) = pid_str.parse::<i32>() {
-                return Some(pid);
+        if let Some(rest) = trimmed.strip_prefix(prefix.as_str()) {
+            let val = rest.trim_end_matches(';').trim();
+            if let Ok(n) = val.parse::<i32>() {
+                return Some(n);
             }
         }
     }
     None
+}
+
+/// Inspect `launchctl list LABEL` and, if the daemon is currently NOT
+/// running and its last exit looks problematic (signal-killed or
+/// non-zero), return a human-readable diagnosis pointing the operator
+/// at the likely cause. Returns `None` when the daemon is currently
+/// running, when the label isn't loaded, or when the previous exit was
+/// a clean `exit(0)`.
+///
+/// Called from `restart_and_verify` when the IPC verification times
+/// out, so users see "AMFI killed the daemon — try resigning" instead
+/// of the generic "Daemon did not answer IPC within 5s" when the
+/// underlying problem is that the daemon crashed during startup.
+pub async fn diagnose_recent_exit() -> Option<String> {
+    let out = Command::new("launchctl")
+        .args(["list", LABEL])
+        .output()
+        .await
+        .ok()?;
+    if !out.status.success() {
+        return None; // label not loaded — nothing to diagnose
+    }
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let pid = parse_loaded_pid(&stdout);
+    // If the daemon is currently running, this isn't a "daemon died" case.
+    if matches!(pid, Some(p) if p > 0) {
+        return None;
+    }
+    let status = parse_last_exit_status(&stdout)?;
+    if status == 0 {
+        return None; // clean exit — IPC must have failed for another reason
+    }
+    Some(describe_exit_status(status))
+}
+
+/// Translate a launchctl `LastExitStatus` integer into an
+/// operator-actionable message. Pure function so it's unit-testable.
+fn describe_exit_status(status: i32) -> String {
+    match status {
+        9 => "Daemon was killed by SIGKILL (LastExitStatus=9) shortly after launchd \
+             exec'd it. On macOS this is almost always a code-signing rejection by \
+             AMFI — common when a freshly built binary's signature isn't trusted \
+             for launchd-spawned processes even though it runs fine from the shell. \
+             Verify with: `codesign -v /Users/<you>/.local/bin/pidash`. \
+             For details: `log show --last 5m --predicate \
+             'subsystem == \"com.apple.kernel.amfi\"'`. \
+             Re-sign locally with `codesign --force --sign - <binary>` if needed; \
+             release builds shipped via `pidash-installer.sh` are Developer-ID \
+             signed and unaffected."
+            .to_string(),
+        6 => "Daemon aborted (LastExitStatus=6 = SIGABRT) shortly after launch. \
+             Most likely a Rust panic or a libc assertion. Check the daemon's \
+             stderr log at `~/Library/Application Support/so.pidash.pidash/logs/runner.err.log` \
+             (macOS) for the panic message."
+            .to_string(),
+        11 => "Daemon segfaulted (LastExitStatus=11 = SIGSEGV) shortly after \
+              launch. Likely a native crash. Check the stderr log and consider \
+              running with `RUST_BACKTRACE=1` baked into the launchd plist."
+            .to_string(),
+        n if (1..32).contains(&n) => format!(
+            "Daemon was killed by signal {n} (LastExitStatus={n}) shortly after \
+             launch. Check the daemon's stderr log for context."
+        ),
+        n => format!(
+            "Daemon exited with non-zero status {n} shortly after launch. \
+             Usually a config / credential error — check the daemon's stderr \
+             log at `~/Library/Application Support/so.pidash.pidash/logs/runner.err.log`."
+        ),
+    }
 }
 
 /// Pattern-match `launchctl bootstrap` stderr to decide whether the
@@ -504,6 +588,78 @@ mod tests {
 };
 "#;
         assert_eq!(parse_loaded_pid(stdout), None);
+    }
+
+    #[test]
+    fn parse_last_exit_status_extracts_signal_value() {
+        // Exact shape of `launchctl list so.pidash.daemon` after a
+        // daemon dies from SIGKILL — the AMFI repro that motivated
+        // the diagnosis path.
+        let stdout = r#"{
+	"Label" = "so.pidash.daemon";
+	"OnDemand" = false;
+	"LastExitStatus" = 9;
+	"Program" = "/Users/u/.local/bin/pidash";
+};
+"#;
+        assert_eq!(parse_last_exit_status(stdout), Some(9));
+    }
+
+    #[test]
+    fn parse_last_exit_status_returns_none_when_absent() {
+        // Fresh load, no prior exit yet — no LastExitStatus line at all.
+        let stdout = r#"{
+	"Label" = "so.pidash.daemon";
+	"OnDemand" = false;
+};
+"#;
+        assert_eq!(parse_last_exit_status(stdout), None);
+    }
+
+    #[test]
+    fn parse_last_exit_status_handles_clean_zero() {
+        let stdout = r#"{
+	"Label" = "so.pidash.daemon";
+	"LastExitStatus" = 0;
+};
+"#;
+        assert_eq!(parse_last_exit_status(stdout), Some(0));
+    }
+
+    #[test]
+    fn describe_exit_status_calls_out_sigkill_amfi() {
+        let msg = describe_exit_status(9);
+        // The SIGKILL message MUST point at AMFI / codesign — that's
+        // the load-bearing user-facing diagnosis. If someone edits
+        // the message and loses that hint, this test should fail.
+        assert!(msg.contains("SIGKILL"));
+        assert!(msg.contains("AMFI") || msg.to_lowercase().contains("code-sign"));
+        assert!(msg.contains("codesign"));
+    }
+
+    #[test]
+    fn describe_exit_status_calls_out_sigabrt_panic() {
+        let msg = describe_exit_status(6);
+        assert!(msg.contains("SIGABRT") || msg.contains("aborted"));
+        assert!(
+            msg.to_lowercase().contains("panic"),
+            "SIGABRT message should mention Rust panic as the likely cause; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn describe_exit_status_handles_arbitrary_signals_and_exit_codes() {
+        // SIGTERM = 15: signal range, but no canned message — fall
+        // through to the "killed by signal N" branch.
+        let sig = describe_exit_status(15);
+        assert!(sig.contains("signal 15"));
+        // Non-signal exit (e.g. config error, status 78 = EX_CONFIG).
+        let cfg = describe_exit_status(78);
+        assert!(cfg.contains("78"));
+        assert!(
+            cfg.to_lowercase().contains("config") || cfg.to_lowercase().contains("non-zero"),
+            "high exit codes should suggest config/credential errors; got: {cfg}"
+        );
     }
 
     #[test]

--- a/runner/src/service/mod.rs
+++ b/runner/src/service/mod.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use crate::util::paths::Paths;
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", test))]
 pub mod launchd;
 pub mod reload;
 #[cfg(target_os = "linux")]

--- a/runner/src/service/mod.rs
+++ b/runner/src/service/mod.rs
@@ -204,4 +204,22 @@ impl Service {
             Service::WindowsTask => windows::status().await,
         }
     }
+
+    /// Inspect service-manager state and, when the daemon recently
+    /// died with a problematic exit, return a human-readable diagnosis.
+    /// Returns `None` when the daemon is up, the service backend has
+    /// nothing useful to add, or the previous exit looked clean.
+    /// Called by `restart_and_verify` when IPC verification times out
+    /// so users see the actual cause (signal, exit code, missing
+    /// dependency) instead of just "Daemon did not answer IPC."
+    pub async fn diagnose_recent_exit(&self) -> Option<String> {
+        match self {
+            #[cfg(target_os = "linux")]
+            Service::Systemd => systemd::diagnose_recent_exit().await,
+            #[cfg(target_os = "macos")]
+            Service::Launchd => launchd::diagnose_recent_exit().await,
+            #[cfg(windows)]
+            Service::WindowsTask => windows::diagnose_recent_exit().await,
+        }
+    }
 }

--- a/runner/src/service/reload.rs
+++ b/runner/src/service/reload.rs
@@ -90,15 +90,30 @@ where
         Some(s) => s,
         None => {
             let state = svc.status().await.unwrap_or_else(|_| "unknown".into());
+            // Ask the backend whether the daemon died with a recognizable
+            // signature (SIGKILL = AMFI on macOS, SIGABRT = panic, etc.).
+            // Surface that ahead of the raw launchctl/systemctl dump so the
+            // operator's first read points them at the actual cause rather
+            // than "the IPC didn't answer."
+            let diagnosis = svc.diagnose_recent_exit().await;
             let journal = capture_service_detail(&svc).await;
-            return ReloadOutcome {
-                ok: false,
-                summary: "runner failed to come up".into(),
-                detail: Some(format!(
+            let detail = match diagnosis {
+                Some(diag) => format!(
+                    "Daemon did not answer IPC within {}s after restart.\n\n\
+                     Diagnosis: {diag}\n\n\
+                     Service state: {state}\n\n{journal}",
+                    IPC_TIMEOUT.as_secs()
+                ),
+                None => format!(
                     "Daemon did not answer IPC within {}s after restart.\n\
                      Service state: {state}\n\n{journal}",
                     IPC_TIMEOUT.as_secs()
-                )),
+                ),
+            };
+            return ReloadOutcome {
+                ok: false,
+                summary: "runner failed to come up".into(),
+                detail: Some(detail),
                 service_state: state,
             };
         }

--- a/runner/src/service/systemd.rs
+++ b/runner/src/service/systemd.rs
@@ -186,6 +186,18 @@ pub async fn status() -> Result<String> {
     Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
 }
 
+/// Best-effort diagnosis of a recently-dead daemon. On systemd we lean
+/// on `systemctl status` (rich exit-code/signal reporting + the last
+/// few journal lines) since that's already what operators reach for
+/// here; reload.rs's existing journal capture covers the common cases
+/// well enough that a hand-rolled translator would mostly duplicate it.
+/// Returns `None` so the caller falls back to its generic IPC-timeout
+/// message — we deliberately don't compete with systemd's own diagnostic
+/// output on Linux.
+pub async fn diagnose_recent_exit() -> Option<String> {
+    None
+}
+
 fn unit_path() -> Result<PathBuf> {
     let home = dirs_home()?;
     Ok(home.join(".config/systemd/user").join(UNIT_NAME))

--- a/runner/src/service/windows.rs
+++ b/runner/src/service/windows.rs
@@ -56,6 +56,14 @@ pub async fn status() -> Result<String> {
     run_schtasks(&["/Query", "/TN", TASK_NAME, "/FO", "LIST", "/V"]).await
 }
 
+/// Stub on Windows — `schtasks /Query` doesn't surface a comparable
+/// "LastExitStatus" field, and we don't have a Windows-specific
+/// diagnostic library shipped yet. Returns `None` so the caller falls
+/// back to its generic message.
+pub async fn diagnose_recent_exit() -> Option<String> {
+    None
+}
+
 fn validate_exe_path(path: &Path) -> Result<&str> {
     let s = path
         .to_str()


### PR DESCRIPTION
## Summary
When the daemon dies during launchd's exec or shortly after start, `pidash restart` previously reported a generic `Daemon did not answer IPC within 5s after restart` with a raw launchctl dump appended. Users had to interpret a `LastExitStatus = 9` line buried in plist output themselves.

Discovered while testing #178 against a locally-built (non-Apple-signed) pidash binary — the daemon was being SIGKILL'd by macOS AMFI on exec, but the error message gave no hint that AMFI was the cause. The same opaque error fires for any startup-time failure: Rust panic (SIGABRT), segfault (SIGSEGV), bad config (non-zero exit).

This PR adds `Service::diagnose_recent_exit()` which inspects the service backend, and when the daemon is currently down with a problematic last exit, returns a human-readable diagnosis. `restart_and_verify`'s IPC-timeout error path surfaces that diagnosis ahead of the raw dump.

## Translations (macOS)
| LastExitStatus | Diagnosis |
|----------------|-----------|
| `9` (SIGKILL) | AMFI / code-sign rejection. Suggests `codesign -v` to inspect, the `log show ... AMFI` predicate to confirm, and `codesign --force --sign -` to recover (with note that `pidash-installer.sh` releases are Developer-ID signed and unaffected) |
| `6` (SIGABRT) | Rust panic / libc assertion → check `runner.err.log` |
| `11` (SIGSEGV) | Native crash → check log; suggests `RUST_BACKTRACE=1` |
| `1..32` (other signal) | Generic "killed by signal N" |
| Other non-zero | Usually config / credential error → check log |

## Scope by platform
- **macOS**: full implementation (parses `launchctl list` for PID + LastExitStatus, translates via `describe_exit_status`).
- **Linux**: returns `None`. Reload's existing journal capture (`systemctl status` output) already includes systemd's own exit-code/signal reporting; we deliberately don't compete with it.
- **Windows**: returns `None`. `schtasks /Query` doesn't surface a comparable field.

## Test plan
- [x] `cargo test -p pidash --lib service::launchd::` — 15/15 pass (6 new: parser × 3 + translator × 3, including a load-bearing assertion that the SIGKILL message specifically mentions AMFI / codesign so a future edit can't silently lose that hint)
- [x] `cargo check -p pidash` — clean
- [ ] On macOS: trigger the original repro (unsigned local build → daemon SIGKILL'd on launchd exec) and confirm `pidash restart` now prints the AMFI diagnosis ahead of the raw launchctl dump
- [ ] On macOS happy path: a clean restart still succeeds with no spurious diagnosis text
- [ ] On Linux: smoke-test that returning `None` from systemd's stub doesn't break the failure path — the generic message + journal capture should look identical to pre-PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)