### PR TITLE
[codex] record agent run usage metadata

### DIFF
--- a/apps/api/pi_dash/app/serializers/issue.py
+++ b/apps/api/pi_dash/app/serializers/issue.py
@@ -1093,6 +1093,7 @@ class IssueDetailSerializer(IssueSerializer):
             "input_tokens": state.input_tokens,
             "output_tokens": state.output_tokens,
             "total_tokens": state.total_tokens,
+            "llm_model": state.llm_model,
             "turn_count": state.turn_count,
             "updated_at": self._serialize_datetime(state.updated_at),
         }
@@ -1120,6 +1121,10 @@ class IssueDetailSerializer(IssueSerializer):
             "ended_at": self._serialize_datetime(run.ended_at),
             "done_payload": run.done_payload,
             "error": run.error,
+            "llm_model": run.llm_model,
+            "input_tokens": run.input_tokens,
+            "output_tokens": run.output_tokens,
+            "total_tokens": run.total_tokens,
             "live_state": self._serialize_agent_live_state(live_state),
         }
 

--- a/apps/api/pi_dash/runner/admin.py
+++ b/apps/api/pi_dash/runner/admin.py
@@ -82,9 +82,18 @@ class MachineTokenAdmin(admin.ModelAdmin):
 
 @admin.register(AgentRun)
 class AgentRunAdmin(admin.ModelAdmin):
-    list_display = ("id", "status", "runner", "owner", "started_at", "ended_at")
+    list_display = (
+        "id",
+        "status",
+        "runner",
+        "owner",
+        "llm_model",
+        "total_tokens",
+        "started_at",
+        "ended_at",
+    )
     list_filter = ("status",)
-    search_fields = ("id", "runner__name")
+    search_fields = ("id", "runner__name", "llm_model")
 
 
 @admin.register(AgentRunEvent)

--- a/apps/api/pi_dash/runner/migrations/0014_agent_run_usage.py
+++ b/apps/api/pi_dash/runner/migrations/0014_agent_run_usage.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("runner", "0013_agent_chat"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="agentrun",
+            name="input_tokens",
+            field=models.BigIntegerField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="agentrun",
+            name="llm_model",
+            field=models.CharField(blank=True, default="", max_length=128),
+        ),
+        migrations.AddField(
+            model_name="agentrun",
+            name="output_tokens",
+            field=models.BigIntegerField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="agentrun",
+            name="total_tokens",
+            field=models.BigIntegerField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="runnerlivestate",
+            name="llm_model",
+            field=models.CharField(blank=True, max_length=128, null=True),
+        ),
+    ]

--- a/apps/api/pi_dash/runner/models.py
+++ b/apps/api/pi_dash/runner/models.py
@@ -714,6 +714,10 @@ class AgentRun(models.Model):
     lease_expires_at = models.DateTimeField(null=True, blank=True)
     done_payload = models.JSONField(null=True, blank=True)
     error = models.TextField(blank=True, default="")
+    llm_model = models.CharField(max_length=128, blank=True, default="")
+    input_tokens = models.BigIntegerField(null=True, blank=True)
+    output_tokens = models.BigIntegerField(null=True, blank=True)
+    total_tokens = models.BigIntegerField(null=True, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
     assigned_at = models.DateTimeField(null=True, blank=True)
     started_at = models.DateTimeField(null=True, blank=True)
@@ -1068,7 +1072,7 @@ class RunnerLiveState(models.Model):
     Holds the descriptive scalars the runner emits on every poll
     (``last_event_at``, ``last_event_kind``, ``last_event_summary``,
     ``agent_pid``, ``agent_subprocess_alive``, ``approvals_pending``,
-    streaming token counts, ``turn_count``). All fields are nullable;
+    streaming token counts, ``llm_model``, ``turn_count``). All fields are nullable;
     NULL is the canonical "unknown" sentinel for both the watchdog and
     the UI. See ``.ai_design/runner_agent_bridge/design.md`` §4.5.1.
 
@@ -1105,6 +1109,7 @@ class RunnerLiveState(models.Model):
     input_tokens = models.BigIntegerField(null=True, blank=True)
     output_tokens = models.BigIntegerField(null=True, blank=True)
     total_tokens = models.BigIntegerField(null=True, blank=True)
+    llm_model = models.CharField(max_length=128, null=True, blank=True)
     turn_count = models.PositiveIntegerField(null=True, blank=True)
     updated_at = models.DateTimeField(auto_now=True)
 

--- a/apps/api/pi_dash/runner/serializers.py
+++ b/apps/api/pi_dash/runner/serializers.py
@@ -90,6 +90,7 @@ class RunnerLiveStateSerializer(serializers.ModelSerializer):
             "input_tokens",
             "output_tokens",
             "total_tokens",
+            "llm_model",
             "turn_count",
             "updated_at",
         ]
@@ -203,6 +204,10 @@ class AgentRunSerializer(serializers.ModelSerializer):
             "ended_at",
             "done_payload",
             "error",
+            "llm_model",
+            "input_tokens",
+            "output_tokens",
+            "total_tokens",
         ]
         read_only_fields = fields
 

--- a/apps/api/pi_dash/runner/services/run_lifecycle.py
+++ b/apps/api/pi_dash/runner/services/run_lifecycle.py
@@ -27,6 +27,7 @@ from pi_dash.runner.models import (
     AgentRun,
     AgentRunStatus,
     Runner,
+    RunnerLiveState,
 )
 
 logger = logging.getLogger(__name__)
@@ -37,6 +38,67 @@ TERMINAL_RUN_STATUSES = (
     AgentRunStatus.CANCELLED,
     AgentRunStatus.BLOCKED,
 )
+
+
+def _normalize_model(raw: Any) -> str:
+    return str(raw or "").strip()[:128]
+
+
+def _coerce_token(raw: Any) -> Optional[int]:
+    if raw is None or raw == "":
+        return None
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return None
+    if value < 0:
+        return None
+    return value
+
+
+def _token_updates(tokens: Any) -> Dict[str, int]:
+    if not isinstance(tokens, dict):
+        return {}
+    fields = {
+        "input_tokens": _coerce_token(
+            tokens.get("input", tokens.get("input_tokens"))
+        ),
+        "output_tokens": _coerce_token(
+            tokens.get("output", tokens.get("output_tokens"))
+        ),
+        "total_tokens": _coerce_token(
+            tokens.get("total", tokens.get("total_tokens"))
+        ),
+    }
+    return {key: value for key, value in fields.items() if value is not None}
+
+
+def _payload_usage(payload: Any) -> Any:
+    if isinstance(payload, dict):
+        return payload.get("usage")
+    return None
+
+
+def _matching_live_state(runner: Runner, run_id: UUID | str) -> Optional[RunnerLiveState]:
+    return RunnerLiveState.objects.filter(
+        runner=runner,
+        observed_run_id=run_id,
+    ).first()
+
+
+def _usage_updates_from_live_state(state: Optional[RunnerLiveState]) -> Dict[str, Any]:
+    if state is None:
+        return {}
+    updates: Dict[str, Any] = {}
+    if state.input_tokens is not None:
+        updates["input_tokens"] = state.input_tokens
+    if state.output_tokens is not None:
+        updates["output_tokens"] = state.output_tokens
+    if state.total_tokens is not None:
+        updates["total_tokens"] = state.total_tokens
+    if state.llm_model:
+        updates["llm_model"] = state.llm_model[:128]
+    return updates
 
 
 def _apply_post_run_orchestration(run: AgentRun) -> None:
@@ -77,18 +139,34 @@ def _apply_post_run_orchestration(run: AgentRun) -> None:
 
 
 def apply_run_paused(
-    runner: Runner, run_id: UUID | str, payload: Dict[str, Any]
+    runner: Runner,
+    run_id: UUID | str,
+    payload: Dict[str, Any],
+    *,
+    tokens: Any = None,
+    model: Any = None,
 ) -> None:
     """Mark run paused, post the agent's question to the issue thread,
     apply deferred-pause workspace transitions, and re-fire drain.
 
     See legacy ``RunnerConsumer._handle_run_paused``.
     """
-    updated = AgentRun.objects.filter(id=run_id, runner=runner).exclude(
-        status__in=TERMINAL_RUN_STATUSES
-    ).update(
-        status=AgentRunStatus.PAUSED_AWAITING_INPUT,
-        done_payload=payload,
+    live_state = _matching_live_state(runner, run_id)
+    usage_updates = _usage_updates_from_live_state(live_state)
+    usage_updates.update(_token_updates(_payload_usage(payload)))
+    usage_updates.update(_token_updates(tokens))
+    model_value = _normalize_model(model)
+    if model_value:
+        usage_updates["llm_model"] = model_value
+
+    updated = (
+        AgentRun.objects.filter(id=run_id, runner=runner)
+        .exclude(status__in=TERMINAL_RUN_STATUSES)
+        .update(
+            status=AgentRunStatus.PAUSED_AWAITING_INPUT,
+            done_payload=payload,
+            **usage_updates,
+        )
     )
     if not updated:
         return
@@ -268,6 +346,8 @@ def finalize_run_terminal(
     *,
     done_payload: Any = None,
     error_detail: str = "",
+    tokens: Any = None,
+    model: Any = None,
 ) -> None:
     """Stamp a terminal status and re-fire drain after commit.
 
@@ -291,6 +371,13 @@ def finalize_run_terminal(
         updates["error"] = ""
     if new_status == AgentRunStatus.FAILED and error_detail:
         updates["error"] = error_detail[:16000]
+    live_state = _matching_live_state(runner, run_id)
+    updates.update(_usage_updates_from_live_state(live_state))
+    updates.update(_token_updates(_payload_usage(done_payload)))
+    updates.update(_token_updates(tokens))
+    model_value = _normalize_model(model)
+    if model_value:
+        updates["llm_model"] = model_value
     updated = AgentRun.objects.filter(id=run_id, runner=runner).exclude(
         status__in=TERMINAL_RUN_STATUSES
     ).update(**updates)

--- a/apps/api/pi_dash/runner/services/run_lifecycle.py
+++ b/apps/api/pi_dash/runner/services/run_lifecycle.py
@@ -38,6 +38,7 @@ TERMINAL_RUN_STATUSES = (
     AgentRunStatus.CANCELLED,
     AgentRunStatus.BLOCKED,
 )
+BIGINT_MAX = 2**63 - 1
 
 
 def _normalize_model(raw: Any) -> str:
@@ -51,7 +52,7 @@ def _coerce_token(raw: Any) -> Optional[int]:
         value = int(raw)
     except (TypeError, ValueError):
         return None
-    if value < 0:
+    if value < 0 or value > BIGINT_MAX:
         return None
     return value
 

--- a/apps/api/pi_dash/runner/services/session_service.py
+++ b/apps/api/pi_dash/runner/services/session_service.py
@@ -153,8 +153,9 @@ def reap_stale_busy_runs(runner: Runner, body: Dict[str, Any]) -> None:
 
 # Snapshot fields stored on RunnerLiveState. Does NOT include
 # `observed_run_id` (that field drives the wipe, it is not a wipe target).
-# Tokens travel as a nested `tokens.{input,output,total}` object on the
-# wire; they are unpacked into the three flat columns by the upsert.
+# Tokens travel as a nested `tokens.{input,output,total}` object and the
+# selected LLM travels as top-level `model`; both are unpacked into flat
+# columns by the upsert.
 SNAPSHOT_FIELDS = (
     "last_event_at",
     "last_event_kind",
@@ -165,6 +166,7 @@ SNAPSHOT_FIELDS = (
     "input_tokens",
     "output_tokens",
     "total_tokens",
+    "llm_model",
     "turn_count",
 )
 
@@ -201,7 +203,7 @@ def upsert_runner_live_state(
     if not status_entry:
         return
     has_snapshot = "observed_run_id" in status_entry or any(
-        key in status_entry for key in (*SNAPSHOT_FIELDS, "tokens")
+        key in status_entry for key in (*SNAPSHOT_FIELDS, "tokens", "model")
     )
     if not has_snapshot:
         return
@@ -243,6 +245,10 @@ def upsert_runner_live_state(
         state.output_tokens = tokens.get("output")
         state.total_tokens = tokens.get("total")
         update_fields.extend(["input_tokens", "output_tokens", "total_tokens"])
+    if "model" in status_entry:
+        model = (status_entry.get("model") or "").strip()
+        state.llm_model = model[:128] or None
+        update_fields.append("llm_model")
 
     if update_fields:
         state.save(

--- a/apps/api/pi_dash/runner/services/session_service.py
+++ b/apps/api/pi_dash/runner/services/session_service.py
@@ -246,7 +246,7 @@ def upsert_runner_live_state(
         state.total_tokens = tokens.get("total")
         update_fields.extend(["input_tokens", "output_tokens", "total_tokens"])
     if "model" in status_entry:
-        model = (status_entry.get("model") or "").strip()
+        model = str(status_entry.get("model") or "").strip()
         state.llm_model = model[:128] or None
         update_fields.append("llm_model")
 

--- a/apps/api/pi_dash/runner/services/session_service.py
+++ b/apps/api/pi_dash/runner/services/session_service.py
@@ -200,7 +200,7 @@ def upsert_runner_live_state(
     rather than raised so a buggy runner can't take down the cloud's
     poll handler.
     """
-    if not status_entry:
+    if not isinstance(status_entry, dict) or not status_entry:
         return
     has_snapshot = "observed_run_id" in status_entry or any(
         key in status_entry for key in (*SNAPSHOT_FIELDS, "tokens", "model")

--- a/apps/api/pi_dash/runner/views/run_endpoints.py
+++ b/apps/api/pi_dash/runner/views/run_endpoints.py
@@ -143,7 +143,7 @@ class RunStartedEndpoint(_RunEndpointBase):
                 "thread_id": thread_id,
                 "started_at": timezone.now(),
             }
-            model = (request.data.get("model") or "").strip()
+            model = str(request.data.get("model") or "").strip()
             if model:
                 updates["llm_model"] = model[:128]
             AgentRun.objects.filter(pk=locked.pk).update(**updates)

--- a/apps/api/pi_dash/runner/views/run_endpoints.py
+++ b/apps/api/pi_dash/runner/views/run_endpoints.py
@@ -138,11 +138,15 @@ class RunStartedEndpoint(_RunEndpointBase):
             if closed:
                 return closed
             thread_id = (request.data.get("thread_id") or "")[:128]
-            AgentRun.objects.filter(pk=locked.pk).update(
-                status=AgentRunStatus.RUNNING,
-                thread_id=thread_id,
-                started_at=timezone.now(),
-            )
+            updates = {
+                "status": AgentRunStatus.RUNNING,
+                "thread_id": thread_id,
+                "started_at": timezone.now(),
+            }
+            model = (request.data.get("model") or "").strip()
+            if model:
+                updates["llm_model"] = model[:128]
+            AgentRun.objects.filter(pk=locked.pk).update(**updates)
         return Response({"ok": True})
 
 
@@ -257,6 +261,8 @@ class RunCompletedEndpoint(_RunEndpointBase):
                     run.id,
                     AgentRunStatus.COMPLETED,
                     done_payload=request.data.get("done_payload"),
+                    tokens=request.data.get("tokens") or request.data.get("usage"),
+                    model=request.data.get("model"),
                 )
         return Response({"ok": True})
 
@@ -279,7 +285,13 @@ class RunPausedEndpoint(_RunEndpointBase):
             # Posts the agent's question to the issue thread,
             # applies deferred-pause workspace transitions, and re-fires
             # drain. See run_lifecycle.apply_run_paused.
-            run_lifecycle.apply_run_paused(runner, run.id, payload)
+            run_lifecycle.apply_run_paused(
+                runner,
+                run.id,
+                payload,
+                tokens=request.data.get("tokens") or request.data.get("usage"),
+                model=request.data.get("model"),
+            )
         return Response({"ok": True})
 
 
@@ -313,6 +325,8 @@ class RunFailedEndpoint(_RunEndpointBase):
                 run.id,
                 AgentRunStatus.FAILED,
                 error_detail=request.data.get("detail") or "",
+                tokens=request.data.get("tokens") or request.data.get("usage"),
+                model=request.data.get("model"),
             )
         return Response({"ok": True})
 
@@ -328,7 +342,11 @@ class RunCancelledEndpoint(_RunEndpointBase):
             runner = getattr(request, "auth_runner", None)
             if runner is not None:
                 run_lifecycle.finalize_run_terminal(
-                    runner, run.id, AgentRunStatus.CANCELLED
+                    runner,
+                    run.id,
+                    AgentRunStatus.CANCELLED,
+                    tokens=request.data.get("tokens") or request.data.get("usage"),
+                    model=request.data.get("model"),
                 )
         return Response({"ok": True})
 

--- a/apps/api/pi_dash/runner/views/sessions.py
+++ b/apps/api/pi_dash/runner/views/sessions.py
@@ -239,7 +239,8 @@ class RunnerSessionPollEndpoint(APIView):
 
         body = request.data or {}
         ack_ids: List[str] = list(body.get("ack") or [])
-        status_entry: Dict[str, Any] = body.get("status") or {}
+        raw_status = body.get("status") or {}
+        status_entry: Dict[str, Any] = raw_status if isinstance(raw_status, dict) else {}
 
         # 2. Update session.last_seen_at.
         session.last_seen_at = timezone.now()

--- a/apps/api/pi_dash/tests/unit/runner/test_failure_comment.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_failure_comment.py
@@ -36,6 +36,7 @@ from pi_dash.runner.models import (
     AgentRunStatus,
     Pod,
     Runner,
+    RunnerLiveState,
     RunnerStatus,
 )
 from pi_dash.runner.services.run_lifecycle import finalize_run_terminal
@@ -308,3 +309,84 @@ def test_failed_finalize_with_orphan_run_no_workitem_does_not_crash(
     # Total comment count across the whole DB doesn't change for a run
     # with no work_item.
     assert IssueComment.objects.count() == 0
+
+
+@pytest.mark.unit
+def test_finalize_persists_direct_usage_metadata(
+    db, create_user, workspace, pod, issue
+):
+    runner = _make_runner(create_user, workspace, pod)
+    run = _make_run(create_user, workspace, pod, runner, issue)
+
+    finalize_run_terminal(
+        runner,
+        run.id,
+        AgentRunStatus.COMPLETED,
+        done_payload={"conclusion": "success"},
+        tokens={"input": 1000, "output": 250, "total": 1250},
+        model="gpt-5.1-codex",
+    )
+
+    run.refresh_from_db()
+    assert run.status == AgentRunStatus.COMPLETED
+    assert run.llm_model == "gpt-5.1-codex"
+    assert run.input_tokens == 1000
+    assert run.output_tokens == 250
+    assert run.total_tokens == 1250
+
+
+@pytest.mark.unit
+def test_finalize_persists_done_payload_usage_metadata(
+    db, create_user, workspace, pod, issue
+):
+    runner = _make_runner(create_user, workspace, pod)
+    run = _make_run(create_user, workspace, pod, runner, issue)
+
+    finalize_run_terminal(
+        runner,
+        run.id,
+        AgentRunStatus.COMPLETED,
+        done_payload={
+            "conclusion": "success",
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 30,
+                "total_tokens": 130,
+            },
+        },
+    )
+
+    run.refresh_from_db()
+    assert run.status == AgentRunStatus.COMPLETED
+    assert run.input_tokens == 100
+    assert run.output_tokens == 30
+    assert run.total_tokens == 130
+
+
+@pytest.mark.unit
+def test_finalize_falls_back_to_matching_live_state_usage(
+    db, create_user, workspace, pod, issue
+):
+    runner = _make_runner(create_user, workspace, pod)
+    run = _make_run(create_user, workspace, pod, runner, issue)
+    RunnerLiveState.objects.create(
+        runner=runner,
+        observed_run_id=run.id,
+        input_tokens=10,
+        output_tokens=20,
+        total_tokens=30,
+        llm_model="claude-sonnet-4-6",
+    )
+
+    finalize_run_terminal(
+        runner,
+        run.id,
+        AgentRunStatus.CANCELLED,
+    )
+
+    run.refresh_from_db()
+    assert run.status == AgentRunStatus.CANCELLED
+    assert run.llm_model == "claude-sonnet-4-6"
+    assert run.input_tokens == 10
+    assert run.output_tokens == 20
+    assert run.total_tokens == 30

--- a/apps/api/pi_dash/tests/unit/runner/test_failure_comment.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_failure_comment.py
@@ -336,6 +336,28 @@ def test_finalize_persists_direct_usage_metadata(
 
 
 @pytest.mark.unit
+def test_finalize_ignores_out_of_range_usage_metadata(
+    db, create_user, workspace, pod, issue
+):
+    runner = _make_runner(create_user, workspace, pod)
+    run = _make_run(create_user, workspace, pod, runner, issue)
+
+    finalize_run_terminal(
+        runner,
+        run.id,
+        AgentRunStatus.COMPLETED,
+        done_payload={"conclusion": "success"},
+        tokens={"input": 2**63, "output": 250, "total": 2**63},
+    )
+
+    run.refresh_from_db()
+    assert run.status == AgentRunStatus.COMPLETED
+    assert run.input_tokens is None
+    assert run.output_tokens == 250
+    assert run.total_tokens is None
+
+
+@pytest.mark.unit
 def test_finalize_persists_done_payload_usage_metadata(
     db, create_user, workspace, pod, issue
 ):

--- a/apps/api/pi_dash/tests/unit/runner/test_poll_heartbeat_drain.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_poll_heartbeat_drain.py
@@ -158,6 +158,24 @@ def test_drain_does_not_fire_on_fresh_heartbeat_poll(db, api_client, enrolled_ru
 
 
 @pytest.mark.unit
+def test_poll_ignores_non_object_status_payload(
+    db, api_client, enrolled_runner, runner_token, runner_session
+):
+    """Malformed status payloads should not fail the poll heartbeat path."""
+    with _patched_poll_dependencies() as mock_drain:
+        resp = _poll(
+            api_client,
+            enrolled_runner.id,
+            runner_session.id,
+            runner_token,
+            body={"status": 1},
+        )
+
+    assert resp.status_code == 200, resp.data
+    mock_drain.assert_not_called()
+
+
+@pytest.mark.unit
 def test_drain_fires_when_runner_reports_idle_after_busy(db, api_client, enrolled_runner, runner_token, runner_session):
     """Busy runner → idle poll → drain once for queued follow-up work."""
     Runner.objects.filter(pk=enrolled_runner.id).update(status=RunnerStatus.BUSY)

--- a/apps/api/pi_dash/tests/unit/runner/test_runner_live_state.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_runner_live_state.py
@@ -143,6 +143,25 @@ def test_upsert_creates_row_on_first_snapshot(
 
 
 @pytest.mark.unit
+def test_upsert_coerces_non_string_model(
+    db, create_user, workspace, pod
+):
+    runner = _make_runner(create_user, workspace, pod)
+    rid = uuid.uuid4()
+
+    upsert_runner_live_state(
+        runner,
+        {
+            "observed_run_id": str(rid),
+            "model": 123,
+        },
+    )
+
+    state = RunnerLiveState.objects.get(runner=runner)
+    assert state.llm_model == "123"
+
+
+@pytest.mark.unit
 def test_upsert_partial_update_preserves_unsent_fields(
     db, create_user, workspace, pod
 ):

--- a/apps/api/pi_dash/tests/unit/runner/test_runner_live_state.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_runner_live_state.py
@@ -125,6 +125,7 @@ def test_upsert_creates_row_on_first_snapshot(
             "agent_subprocess_alive": True,
             "approvals_pending": 0,
             "tokens": {"input": 100, "output": 200, "total": 300},
+            "model": "gpt-5.1-codex",
             "turn_count": 1,
         },
     )
@@ -137,6 +138,7 @@ def test_upsert_creates_row_on_first_snapshot(
     assert state.input_tokens == 100
     assert state.output_tokens == 200
     assert state.total_tokens == 300
+    assert state.llm_model == "gpt-5.1-codex"
     assert state.turn_count == 1
 
 
@@ -184,6 +186,7 @@ def test_upsert_run_id_change_wipes_snapshot_then_applies_incoming(
             "agent_pid": 1111,
             "turn_count": 5,
             "tokens": {"input": 10, "output": 20, "total": 30},
+            "model": "claude-sonnet-4-6",
         },
     )
     # Run B begins. Carries some new fields; the *unspecified* fields
@@ -204,6 +207,7 @@ def test_upsert_run_id_change_wipes_snapshot_then_applies_incoming(
     assert state.input_tokens is None
     assert state.output_tokens is None
     assert state.total_tokens is None
+    assert state.llm_model is None
 
 
 @pytest.mark.unit

--- a/apps/api/pi_dash/tests/unit/runner/test_runner_live_state.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_runner_live_state.py
@@ -108,6 +108,17 @@ def test_upsert_no_op_for_pre_observability_poll(
 
 
 @pytest.mark.unit
+def test_upsert_no_op_for_non_object_status(
+    db, create_user, workspace, pod
+):
+    runner = _make_runner(create_user, workspace, pod)
+
+    upsert_runner_live_state(runner, 1)
+
+    assert not RunnerLiveState.objects.filter(runner=runner).exists()
+
+
+@pytest.mark.unit
 def test_upsert_creates_row_on_first_snapshot(
     db, create_user, workspace, pod
 ):

--- a/apps/web/core/components/runners/runner-agent-status-panel.tsx
+++ b/apps/web/core/components/runners/runner-agent-status-panel.tsx
@@ -112,6 +112,7 @@ export function RunnerAgentStatusPanel({ runner, liveState }: RunnerAgentStatusP
 
   const lastEventLabel = formatRelative(liveState?.last_event_at ?? null);
   const tokensLabel = liveState?.total_tokens != null ? formatNumber(liveState.total_tokens) : "—";
+  const modelLabel = liveState?.llm_model?.trim() || "—";
 
   return (
     <div className="border-custom-border-200 space-y-3 rounded border p-4">
@@ -145,6 +146,11 @@ export function RunnerAgentStatusPanel({ runner, liveState }: RunnerAgentStatusP
 
         <dt className="text-custom-text-300">Tokens</dt>
         <dd className="font-mono">{tokensLabel}</dd>
+
+        <dt className="text-custom-text-300">Model</dt>
+        <dd className="font-mono truncate" title={modelLabel === "—" ? undefined : modelLabel}>
+          {modelLabel}
+        </dd>
 
         <dt className="text-custom-text-300">Turn</dt>
         <dd className="font-mono">{liveState?.turn_count != null ? liveState.turn_count : "—"}</dd>

--- a/packages/types/src/issues/issue.ts
+++ b/packages/types/src/issues/issue.ts
@@ -121,6 +121,10 @@ export type TIssueAgentRunSummary = {
   ended_at: string | null;
   done_payload: Record<string, unknown> | null;
   error: string;
+  llm_model: string;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  total_tokens: number | null;
   live_state?: IRunnerLiveState | null;
 };
 

--- a/packages/types/src/runner.ts
+++ b/packages/types/src/runner.ts
@@ -47,6 +47,7 @@ export interface IRunnerLiveState {
   input_tokens: number | null;
   output_tokens: number | null;
   total_tokens: number | null;
+  llm_model: string | null;
   turn_count: number | null;
   updated_at: string;
 }
@@ -169,6 +170,10 @@ export interface IAgentRun {
   ended_at: string | null;
   done_payload: Record<string, unknown> | null;
   error: string;
+  llm_model: string;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  total_tokens: number | null;
   events?: IAgentRunEvent[];
 }
 

--- a/runner/src/agent/mod.rs
+++ b/runner/src/agent/mod.rs
@@ -267,6 +267,13 @@ impl AgentCursor {
             AgentCursor::ClaudeCode(c) => &c.thread_id,
         }
     }
+
+    pub fn model(&self) -> Option<&str> {
+        match self {
+            AgentCursor::Codex(c) => c.model.as_deref(),
+            AgentCursor::ClaudeCode(c) => c.model.as_deref(),
+        }
+    }
 }
 
 impl AgentBridge {
@@ -413,8 +420,7 @@ fn selected_model(
 #[cfg(test)]
 mod tests {
     use super::{
-        STDERR_LINE_CAP_BYTES, StderrBuffer, sanitize_stderr_line, selected_model,
-        strip_ansi_codes,
+        STDERR_LINE_CAP_BYTES, StderrBuffer, sanitize_stderr_line, selected_model, strip_ansi_codes,
     };
 
     #[test]
@@ -469,8 +475,7 @@ mod tests {
     fn sanitize_drops_codex_info_tracing_lines() {
         // The exact pattern that flooded the failure-comment field —
         // codex's per-event INFO log, ANSI-colored. Should be dropped.
-        let input =
-            "\x1b[2m2026-05-03T07:27:06.636239Z\x1b[0m \x1b[32m INFO\x1b[0m \
+        let input = "\x1b[2m2026-05-03T07:27:06.636239Z\x1b[0m \x1b[32m INFO\x1b[0m \
              session_loop{thread_id=abc}: codex.sse_event";
         assert_eq!(sanitize_stderr_line(input), None);
     }
@@ -485,11 +490,7 @@ mod tests {
         // useful diagnostic content.
         for level in ["INFO", "DEBUG", "TRACE", "WARN"] {
             let input = format!("2026-05-03T07:27:06.636239Z {level} something");
-            assert_eq!(
-                sanitize_stderr_line(&input),
-                None,
-                "should drop {level}",
-            );
+            assert_eq!(sanitize_stderr_line(&input), None, "should drop {level}",);
         }
     }
 

--- a/runner/src/claude_code/bridge.rs
+++ b/runner/src/claude_code/bridge.rs
@@ -36,6 +36,7 @@ pub struct Bridge {
     /// `--resume`. The process can receive multiple user turns on stdin; the
     /// session id belongs to that process, not to an individual turn.
     session_id: Option<String>,
+    model: Option<String>,
     init_seen: bool,
     /// Events received while we were waiting synchronously for `system/init`
     /// on the first real turn. Drained by `next_events` before touching the
@@ -67,6 +68,7 @@ impl Bridge {
             session_id: resume_session_id
                 .filter(|s| !s.is_empty())
                 .map(ToOwned::to_owned),
+            model: model_default.filter(|s| !s.is_empty()),
             init_seen: false,
             pending: VecDeque::new(),
         })
@@ -78,6 +80,7 @@ impl Bridge {
         Self {
             proc,
             session_id: None,
+            model: _model_default.filter(|s| !s.is_empty()),
             init_seen: false,
             pending: VecDeque::new(),
         }
@@ -112,6 +115,7 @@ impl Bridge {
         Ok(BridgeCursor {
             run_id: payload.run_id,
             thread_id,
+            model: self.model.clone(),
             suppress_init: true,
             terminal: false,
             seq: 0,
@@ -140,6 +144,13 @@ impl Bridge {
                         .session_id
                         .clone()
                         .unwrap_or_else(|| format!("claude-{run_id}"));
+                    self.model = sys
+                        .rest
+                        .get("model")
+                        .and_then(|v| v.as_str())
+                        .filter(|s| !s.is_empty())
+                        .map(ToOwned::to_owned)
+                        .or_else(|| self.model.clone());
                     self.session_id = Some(thread_id.clone());
                     self.init_seen = true;
                     return Ok(thread_id);
@@ -215,6 +226,7 @@ impl Bridge {
 pub struct BridgeCursor {
     pub run_id: Uuid,
     pub thread_id: String,
+    pub model: Option<String>,
     /// Drop `system/init` if Claude emits it again on a later turn. The bridge
     /// already recorded the session id and the cloud does not need a duplicate
     /// raw init event in the chat stream.

--- a/runner/src/cloud/http.rs
+++ b/runner/src/cloud/http.rs
@@ -1014,6 +1014,8 @@ pub struct PollStatus {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tokens: Option<TokenUsage>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub turn_count: Option<u32>,
 }
 
@@ -1090,6 +1092,7 @@ impl PollStatus {
             agent_subprocess_alive: None,
             approvals_pending: None,
             tokens: None,
+            model: None,
             turn_count: None,
         }
     }
@@ -1113,6 +1116,7 @@ impl PollStatus {
             agent_subprocess_alive: None,
             approvals_pending: None,
             tokens: None,
+            model: None,
             turn_count: None,
         }
     }
@@ -1142,6 +1146,7 @@ impl PollStatus {
         me.agent_subprocess_alive = snapshot.agent_subprocess_alive;
         me.approvals_pending = Some(u32::try_from(approvals_pending).unwrap_or(u32::MAX));
         me.tokens = snapshot.tokens.map(TokenUsage::from);
+        me.model = snapshot.model;
         me.turn_count = snapshot.turn_count;
         me
     }
@@ -2030,6 +2035,7 @@ mod tests {
                 output: 200,
                 total: 300,
             }),
+            model: Some("gpt-5.1-codex".into()),
             turn_count: Some(2),
             last_exec_command: None,
         };
@@ -2044,6 +2050,7 @@ mod tests {
         );
         assert_eq!(obj.get("approvals_pending"), Some(&serde_json::json!(1)));
         assert_eq!(obj.get("turn_count"), Some(&serde_json::json!(2)));
+        assert_eq!(obj.get("model"), Some(&serde_json::json!("gpt-5.1-codex")));
         let tokens = obj.get("tokens").unwrap().as_object().unwrap();
         assert_eq!(tokens.get("input"), Some(&serde_json::json!(100)));
         assert_eq!(tokens.get("output"), Some(&serde_json::json!(200)));

--- a/runner/src/cloud/protocol.rs
+++ b/runner/src/cloud/protocol.rs
@@ -77,6 +77,13 @@ pub struct RunEventRecord {
     pub payload: serde_json::Value,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TokenUsage {
+    pub input: u64,
+    pub output: u64,
+    pub total: u64,
+}
+
 /// Messages the runner sends to the cloud.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -111,6 +118,8 @@ pub enum ClientMsg {
         run_id: Uuid,
         thread_id: String,
         started_at: DateTime<Utc>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        model: Option<String>,
     },
     RunEvent {
         run_id: Uuid,
@@ -138,6 +147,10 @@ pub enum ClientMsg {
         run_id: Uuid,
         done_payload: serde_json::Value,
         ended_at: DateTime<Utc>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tokens: Option<TokenUsage>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        model: Option<String>,
     },
     /// Agent yielded with a question for the human (Codex tool-call path).
     /// Cloud transitions the run to PAUSED_AWAITING_INPUT and waits for a
@@ -148,16 +161,28 @@ pub enum ClientMsg {
         run_id: Uuid,
         payload: serde_json::Value,
         paused_at: DateTime<Utc>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tokens: Option<TokenUsage>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        model: Option<String>,
     },
     RunFailed {
         run_id: Uuid,
         reason: FailureReason,
         detail: Option<String>,
         ended_at: DateTime<Utc>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tokens: Option<TokenUsage>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        model: Option<String>,
     },
     RunCancelled {
         run_id: Uuid,
         cancelled_at: DateTime<Utc>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tokens: Option<TokenUsage>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        model: Option<String>,
     },
     RunResumed {
         run_id: Uuid,

--- a/runner/src/codex/bridge.rs
+++ b/runner/src/codex/bridge.rs
@@ -83,6 +83,7 @@ impl Bridge {
         Ok(BridgeCursor {
             run_id: payload.run_id,
             thread_id,
+            model: payload.model.clone().or_else(|| self.model_default.clone()),
             seq: 0,
             pending_command: None,
             pending_command_approval_id: None,
@@ -212,6 +213,7 @@ impl Bridge {
 pub struct BridgeCursor {
     pub run_id: Uuid,
     pub thread_id: String,
+    pub model: Option<String>,
     pub seq: u64,
     /// Most recent in-progress `commandExecution` item observed on
     /// `item/started`. Captured so we can synthesize an `ApprovalRequest`
@@ -318,7 +320,9 @@ impl BridgeCursor {
                                 .or_else(|| {
                                     conclusion.map(|c| format!("turn ended with conclusion={c:?}"))
                                 })
-                                .or_else(|| turn_error.map(|e| format!("turn completed with error: {e}")))
+                                .or_else(|| {
+                                    turn_error.map(|e| format!("turn completed with error: {e}"))
+                                })
                                 .or_else(|| Some("turn/completed without conclusion".to_string())),
                         }]
                     }
@@ -495,6 +499,7 @@ mod translate_tests {
         BridgeCursor {
             run_id: Uuid::new_v4(),
             thread_id: "th_test".into(),
+            model: None,
             seq: 0,
             pending_command: None,
             pending_command_approval_id: None,

--- a/runner/src/daemon/state.rs
+++ b/runner/src/daemon/state.rs
@@ -45,6 +45,8 @@ pub struct ObservabilitySnapshot {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tokens: Option<TokenUsage>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub turn_count: Option<u32>,
     /// Last shell command the agent kicked off (for failure-detail enrichment).
     /// Reset on rid change like the other per-run scalars; never serialised
@@ -269,6 +271,11 @@ impl StateHandle {
         self.tick();
     }
 
+    pub async fn set_model(&self, model: Option<String>) {
+        self.inner.run_snapshot.lock().await.model = model.filter(|s| !s.is_empty());
+        self.tick();
+    }
+
     pub async fn incr_turn(&self) {
         let mut snap = self.inner.run_snapshot.lock().await;
         snap.turn_count = Some(snap.turn_count.unwrap_or(0).saturating_add(1));
@@ -368,20 +375,18 @@ impl StateHandle {
         // Only synthesise `update` when the cloud has actually announced
         // something. A "no advisory" daemon should not surface an empty
         // banner — keep `update: None` in that case.
-        let update = if latest_announced.is_some()
-            || min_required.is_some()
-            || on_disk_version.is_some()
-        {
-            Some(crate::ipc::protocol::UpdateAdvisory {
-                running_version: crate::RUNNER_VERSION.to_string(),
-                on_disk_version,
-                latest_announced,
-                min_required,
-                auto_update_enabled,
-            })
-        } else {
-            None
-        };
+        let update =
+            if latest_announced.is_some() || min_required.is_some() || on_disk_version.is_some() {
+                Some(crate::ipc::protocol::UpdateAdvisory {
+                    running_version: crate::RUNNER_VERSION.to_string(),
+                    on_disk_version,
+                    latest_announced,
+                    min_required,
+                    auto_update_enabled,
+                })
+            } else {
+                None
+            };
         crate::ipc::protocol::DaemonInfo {
             cloud_url,
             connected,
@@ -394,11 +399,7 @@ impl StateHandle {
     /// or both fields may be `None`; production callers pass `None` when
     /// the cloud has no `LATEST_RUNNER_VERSION` / `MIN_RUNNER_VERSION`
     /// announcement, which clears any prior advisory.
-    pub async fn set_update_advisory(
-        &self,
-        latest: Option<String>,
-        min: Option<String>,
-    ) {
+    pub async fn set_update_advisory(&self, latest: Option<String>, min: Option<String>) {
         let mut guard = self.inner.update_advisory.lock().await;
         *guard = (latest, min);
     }
@@ -547,9 +548,7 @@ mod tests {
             })
             .await;
         state.incr_turn().await;
-        state
-            .note_agent_event(Utc::now(), "raw", Some("a"))
-            .await;
+        state.note_agent_event(Utc::now(), "raw", Some("a")).await;
 
         state.set_current_run(Some(summary(rid_b, "running"))).await;
         let snap = state.observability_snapshot().await;

--- a/runner/src/daemon/supervisor.rs
+++ b/runner/src/daemon/supervisor.rs
@@ -13,7 +13,8 @@ use crate::cloud::http::{
     RunnerCloudClient, SharedHttpTransport,
 };
 use crate::cloud::protocol::{
-    ClientMsg, FailureReason, RunnerStatus, ServerMsg, WIRE_VERSION, WorkspaceState,
+    ClientMsg, FailureReason, RunnerStatus, ServerMsg, TokenUsage as WireTokenUsage, WIRE_VERSION,
+    WorkspaceState,
 };
 use crate::config::schema::{AgentKind, Config, Credentials};
 use crate::daemon::run_event_mirror::RunEventMirror;
@@ -328,33 +329,37 @@ async fn drain_in_flight_runs(runners: Arc<RwLock<HelloRunnerMap>>) -> usize {
             .collect()
     };
     let now = Utc::now();
-    let drains = snapshot.into_iter().filter_map(|(runner_id, in_flight, out)| {
-        let run_id = in_flight?;
-        let msg = ClientMsg::RunFailed {
-            run_id,
-            reason: FailureReason::DaemonRestart,
-            detail: Some("daemon shutdown requested".to_string()),
-            ended_at: now,
-        };
-        Some(async move {
-            // Per-attempt timeout so one stuck cloud client can't keep
-            // a parallel sibling from completing in time.
-            match tokio::time::timeout(Duration::from_secs(2), out.send(msg)).await {
-                Ok(Ok(())) => {
-                    tracing::info!(%runner_id, %run_id, "drained in-flight run on shutdown");
-                    true
+    let drains = snapshot
+        .into_iter()
+        .filter_map(|(runner_id, in_flight, out)| {
+            let run_id = in_flight?;
+            let msg = ClientMsg::RunFailed {
+                run_id,
+                reason: FailureReason::DaemonRestart,
+                detail: Some("daemon shutdown requested".to_string()),
+                ended_at: now,
+                tokens: None,
+                model: None,
+            };
+            Some(async move {
+                // Per-attempt timeout so one stuck cloud client can't keep
+                // a parallel sibling from completing in time.
+                match tokio::time::timeout(Duration::from_secs(2), out.send(msg)).await {
+                    Ok(Ok(())) => {
+                        tracing::info!(%runner_id, %run_id, "drained in-flight run on shutdown");
+                        true
+                    }
+                    Ok(Err(e)) => {
+                        tracing::warn!(%runner_id, %run_id, "drain send failed: {e:#}");
+                        false
+                    }
+                    Err(_) => {
+                        tracing::warn!(%runner_id, %run_id, "drain send timed out at 2s");
+                        false
+                    }
                 }
-                Ok(Err(e)) => {
-                    tracing::warn!(%runner_id, %run_id, "drain send failed: {e:#}");
-                    false
-                }
-                Err(_) => {
-                    tracing::warn!(%runner_id, %run_id, "drain send timed out at 2s");
-                    false
-                }
-            }
-        })
-    });
+            })
+        });
     futures_util::future::join_all(drains)
         .await
         .into_iter()
@@ -817,6 +822,8 @@ impl RunnerLoop {
                                     reason: FailureReason::Internal,
                                     detail: Some(format!("{e:#}")),
                                     ended_at: Utc::now(),
+                                    tokens: None,
+                                    model: None,
                                 })
                                 .await;
                             worker.state.set_current_run(None).await;
@@ -1215,10 +1222,7 @@ async fn wait_chat_done(current: &mut Option<CurrentChat>) {
     }
 }
 
-fn chat_resume_id(
-    local_session_id: Option<&str>,
-    local_thread_id: Option<&str>,
-) -> Option<String> {
+fn chat_resume_id(local_session_id: Option<&str>, local_thread_id: Option<&str>) -> Option<String> {
     local_session_id
         .filter(|s| !s.is_empty())
         .or_else(|| local_thread_id.filter(|s| !s.is_empty()))
@@ -1989,7 +1993,24 @@ struct AssignWorker {
     cancel: std::sync::Arc<tokio::sync::Notify>,
 }
 
+struct RunMetadata {
+    tokens: Option<WireTokenUsage>,
+    model: Option<String>,
+}
+
 impl AssignWorker {
+    async fn run_metadata(&self) -> RunMetadata {
+        let snapshot = self.state.observability_snapshot().await;
+        RunMetadata {
+            tokens: snapshot.tokens.map(|t| WireTokenUsage {
+                input: t.input,
+                output: t.output,
+                total: t.total,
+            }),
+            model: snapshot.model,
+        }
+    }
+
     /// Pick the right `FailureReason` when the agent subprocess crashes or
     /// exits abnormally. Codex stays on `CodexCrash` so dashboards that
     /// already filter on `"codex_crash"` keep working; Claude (and any
@@ -2051,6 +2072,8 @@ impl AssignWorker {
                     reason,
                     detail: Some(e.to_string()),
                     ended_at: Utc::now(),
+                    tokens: None,
+                    model: None,
                 })
                 .await;
                 // The supervisor stamped ``rx_in_flight = Some(run_id)``
@@ -2087,6 +2110,8 @@ impl AssignWorker {
                 reason: FailureReason::WorkspaceSetup,
                 detail: Some(format!("checkout {branch}: {e:#}")),
                 ended_at: Utc::now(),
+                tokens: None,
+                model: None,
             })
             .await;
             // Same reason as above: clear the early-stamp on failure.
@@ -2155,6 +2180,8 @@ impl AssignWorker {
                     reason,
                     detail: Some(format!("{e:#}")),
                     ended_at: Utc::now(),
+                    tokens: None,
+                    model: None,
                 })
                 .await;
                 self.state.set_current_run(None).await;
@@ -2193,6 +2220,8 @@ impl AssignWorker {
                     reason: self.crash_reason(),
                     detail: Some(detail),
                     ended_at: Utc::now(),
+                    tokens: None,
+                    model: None,
                 })
                 .await;
                 bridge.shutdown(Duration::from_secs(5)).await.ok();
@@ -2200,10 +2229,13 @@ impl AssignWorker {
                 return Ok(());
             }
         };
+        let run_model = cursor.model().map(ToOwned::to_owned);
+        self.state.set_model(run_model.clone()).await;
         self.send(ClientMsg::RunStarted {
             run_id,
             thread_id: cursor.thread_id().to_string(),
             started_at: Utc::now(),
+            model: run_model,
         })
         .await;
         hist.append(&HistoryEntry::Lifecycle {
@@ -2278,9 +2310,12 @@ impl AssignWorker {
                 _ = cancel.notified(), if !cancelled => {
                     run_events.flush_before_lifecycle(&self.out).await;
                     bridge.interrupt().await.ok();
+                    let metadata = self.run_metadata().await;
                     let _ = self.out.send(ClientMsg::RunCancelled {
                         run_id: cursor.run_id(),
                         cancelled_at: Utc::now(),
+                        tokens: metadata.tokens,
+                        model: metadata.model,
                     }).await;
                     hist.append(&HistoryEntry::Lifecycle {
                         ts: Utc::now(),
@@ -2310,11 +2345,14 @@ impl AssignWorker {
                             .build_failure_detail("agent stdout closed", bridge)
                             .await;
                         run_events.flush_before_lifecycle(&self.out).await;
+                        let metadata = self.run_metadata().await;
                         self.send(ClientMsg::RunFailed {
                             run_id: cursor.run_id(),
                             reason,
                             detail: Some(detail.clone()),
                             ended_at: Utc::now(),
+                            tokens: metadata.tokens,
+                            model: metadata.model,
                         }).await;
                         hist.append(&HistoryEntry::Footer {
                             ts: Utc::now(),
@@ -2343,11 +2381,14 @@ impl AssignWorker {
                     let base = format!("no agent frames for {mins} minutes");
                     let detail = self.build_failure_detail(&base, bridge).await;
                     run_events.flush_before_lifecycle(&self.out).await;
+                    let metadata = self.run_metadata().await;
                     self.send(ClientMsg::RunFailed {
                         run_id: cursor.run_id(),
                         reason: FailureReason::Timeout,
                         detail: Some(detail.clone()),
                         ended_at: Utc::now(),
+                        tokens: metadata.tokens,
+                        model: metadata.model,
                     }).await;
                     hist.append(&HistoryEntry::Footer {
                         ts: Utc::now(),
@@ -2632,10 +2673,13 @@ impl AssignWorker {
                 done_payload,
             } => {
                 run_events.flush_before_lifecycle(&self.out).await;
+                let metadata = self.run_metadata().await;
                 self.send(ClientMsg::RunCompleted {
                     run_id,
                     done_payload: done_payload.clone(),
                     ended_at: Utc::now(),
+                    tokens: metadata.tokens,
+                    model: metadata.model,
                 })
                 .await;
                 hist.append(&HistoryEntry::Footer {
@@ -2668,11 +2712,14 @@ impl AssignWorker {
                     .unwrap_or_else(|| "agent reported failure".to_string());
                 let enriched = self.build_failure_detail(&base, bridge).await;
                 run_events.flush_before_lifecycle(&self.out).await;
+                let metadata = self.run_metadata().await;
                 self.send(ClientMsg::RunFailed {
                     run_id,
                     reason,
                     detail: Some(enriched.clone()),
                     ended_at: Utc::now(),
+                    tokens: metadata.tokens,
+                    model: metadata.model,
                 })
                 .await;
                 hist.append(&HistoryEntry::Footer {
@@ -2879,7 +2926,6 @@ mod tests {
                 events: 0,
             }))
             .await;
-
         let runners: Arc<RwLock<HelloRunnerMap>> = Arc::new(RwLock::new(
             [&inst_busy, &inst_idle]
                 .into_iter()

--- a/runner/src/ipc/protocol.rs
+++ b/runner/src/ipc/protocol.rs
@@ -445,6 +445,7 @@ mod tests {
                         output: 20,
                         total: 30,
                     }),
+                    model: Some("gpt-5.1-codex".into()),
                     turn_count: Some(2),
                     last_exec_command: None,
                 }),

--- a/runner/tests/protocol_roundtrip.rs
+++ b/runner/tests/protocol_roundtrip.rs
@@ -35,6 +35,8 @@ fn envelope_roundtrips_all_client_variants() {
             run_id: Uuid::new_v4(),
             done_payload: serde_json::json!({"conclusion": "success"}),
             ended_at: chrono::Utc::now(),
+            tokens: None,
+            model: None,
         },
         ClientMsg::RunEvents {
             run_id: Uuid::new_v4(),


### PR DESCRIPTION
## Summary

Adds best-effort agent-run usage metadata so each `AgentRun` can store the LLM model and token counts when the runner or agent makes them available.

## Changes

- Adds durable `AgentRun` fields for `llm_model`, `input_tokens`, `output_tokens`, and `total_tokens`, plus a migration.
- Adds `RunnerLiveState.llm_model` and surfaces usage/model metadata through runner serializers, issue agent summaries, admin, shared TS types, and the runner live status panel.
- Extends runner lifecycle messages to optionally carry model/token data without enforcing model selection or requiring agents to report usage.
- Persists explicit token/model metadata when present, with a matching live-state fallback for best-effort terminal persistence.

## Validation

- `python3 -m ruff check ...`
- `python3 -m py_compile ...`
- `rustfmt --edition 2024 --check ...`
- `pnpm exec oxfmt --check ...`
- `pnpm --filter @pi-dash/types check:types`
- `cargo test --manifest-path runner/Cargo.toml --test protocol_roundtrip --test cloud_http_run_events --test codex_bridge_fake --test claude_bridge_fake`
- `cargo test --manifest-path runner/Cargo.toml observability`
- `cargo test --manifest-path runner/Cargo.toml poll_status_feature_on_busy_serialises_populated_fields`
- `cargo test --manifest-path runner/Cargo.toml drain_in_flight_runs_sends_run_failed_for_busy_runners_only`

Django pytest could not start in this local environment because `celery` is not installed.
