### PR TITLE
[codex] Clarify command tool failure diagnostics

### DIFF
--- a/runner/src/daemon/observability.rs
+++ b/runner/src/daemon/observability.rs
@@ -125,9 +125,18 @@ pub struct ExecCommandHint {
 /// Plain-data extract for a command-tool completion. Kept separate from
 /// [`ExecCommandHint`] because some protocols echo only the tool id on
 /// completion, not the command text.
+///
+/// `tool_call_id` is non-optional: completion events without an id cannot
+/// be matched against any stored command, so we drop them at parse time
+/// rather than carrying a `None` that would force every consumer to
+/// re-decide what to do with it. `success` is best-effort — `Some(true)`
+/// for a clean completion, `Some(false)` for a non-success terminal state
+/// (codex `failed` status or Claude `is_error: true`), `None` when the
+/// protocol frame doesn't surface an outcome.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExecCommandCompletionHint {
-    pub tool_call_id: Option<String>,
+    pub tool_call_id: String,
+    pub success: Option<bool>,
 }
 
 /// Single dispatch table for "what shell command did the agent just
@@ -176,8 +185,14 @@ pub fn extract_exec_command_hint(
 
 /// Extract command-tool completions from bridge Raw events. This lets the
 /// failure-detail builder say whether the last observed command had already
-/// completed before an agent/API failure occurred. Claude may echo multiple
-/// tool_result blocks in one message, so callers must consider every hint.
+/// completed before an agent/API failure occurred, and whether it ended
+/// cleanly. Claude may echo multiple tool_result blocks in one message, so
+/// callers must consider every hint.
+///
+/// Hints without an explicit tool id are dropped here, not surfaced as
+/// `None`: the only useful operation on a completion hint is matching it
+/// against a stored command's id, and a `None` id can never match
+/// anything meaningful. See also [`crate::daemon::state::StateHandle::note_exec_command_completed`].
 pub fn extract_exec_command_completion_hints(
     method: &str,
     params: &serde_json::Value,
@@ -190,11 +205,21 @@ pub fn extract_exec_command_completion_hints(
             if item.get("type").and_then(|v| v.as_str()) != Some("commandExecution") {
                 return Vec::new();
             }
+            let Some(tool_call_id) = item.get("id").and_then(|v| v.as_str()) else {
+                return Vec::new();
+            };
+            // Codex item/completed carries a status string. Treat any
+            // value other than "completed" (e.g. "failed", "errored") as
+            // an unsuccessful terminal — the command did finish, but the
+            // failure-detail wording should not call it a clean
+            // completion. Missing status leaves success as `None`.
+            let success = item
+                .get("status")
+                .and_then(|v| v.as_str())
+                .map(|status| status == "completed");
             vec![ExecCommandCompletionHint {
-                tool_call_id: item
-                    .get("id")
-                    .and_then(|v| v.as_str())
-                    .map(|s| s.to_string()),
+                tool_call_id: tool_call_id.to_string(),
+                success,
             }]
         }
         "user/toolResult" => parse_claude_tool_results(params),
@@ -214,7 +239,15 @@ pub fn extract_exec_command_completion_hints(
 /// and the only one whose `input.command` resembles a shell command we'd
 /// want to surface verbatim. Future tools can be added as new arms if
 /// they prove to be common stall sources.
-pub fn parse_claude_bash_tool_use(message: &serde_json::Value) -> Option<ExecCommandHint> {
+///
+/// Last-wins limitation: when a single assistant message carries more
+/// than one Bash block, only the trailing one is stored. Earlier Bash
+/// calls in the same message are not tracked for completion — if one of
+/// them is the call that hangs, the failure-detail will name the wrong
+/// command. In practice Claude usually serialises Bash calls across
+/// successive messages, so this is a known acceptable loss of fidelity
+/// rather than a silent bug.
+fn parse_claude_bash_tool_use(message: &serde_json::Value) -> Option<ExecCommandHint> {
     let content = message.get("content")?.as_array()?;
     let mut last_bash: Option<ExecCommandHint> = None;
     for block in content {
@@ -245,23 +278,32 @@ pub fn parse_claude_bash_tool_use(message: &serde_json::Value) -> Option<ExecCom
     last_bash
 }
 
-pub fn parse_claude_tool_results(message: &serde_json::Value) -> Vec<ExecCommandCompletionHint> {
+/// Pull command-tool completion hints out of a Claude `user/toolResult`
+/// raw frame. Blocks without a `tool_use_id` are dropped — they cannot
+/// match a stored command. The `is_error` field, when present, drives
+/// the `success` flag (`is_error: true` ⇒ `Some(false)`).
+fn parse_claude_tool_results(message: &serde_json::Value) -> Vec<ExecCommandCompletionHint> {
     let Some(content) = message.get("content").and_then(|v| v.as_array()) else {
         return Vec::new();
     };
     content
         .iter()
         .filter_map(|block| {
-            if block.get("type").and_then(|v| v.as_str()) == Some("tool_result") {
-                Some(ExecCommandCompletionHint {
-                    tool_call_id: block
-                        .get("tool_use_id")
-                        .and_then(|v| v.as_str())
-                        .map(|s| s.to_string()),
-                })
-            } else {
-                None
+            if block.get("type").and_then(|v| v.as_str()) != Some("tool_result") {
+                return None;
             }
+            let tool_call_id = block
+                .get("tool_use_id")
+                .and_then(|v| v.as_str())?
+                .to_string();
+            let success = block
+                .get("is_error")
+                .and_then(|v| v.as_bool())
+                .map(|is_error| !is_error);
+            Some(ExecCommandCompletionHint {
+                tool_call_id,
+                success,
+            })
         })
         .collect()
 }
@@ -494,9 +536,45 @@ mod tests {
         let hints = parse_claude_tool_results(&msg);
         let ids = hints
             .iter()
-            .map(|hint| hint.tool_call_id.as_deref())
+            .map(|hint| hint.tool_call_id.as_str())
             .collect::<Vec<_>>();
-        assert_eq!(ids, vec![Some("tu_1"), Some("tu_2")]);
+        assert_eq!(ids, vec!["tu_1", "tu_2"]);
+        // is_error absent ⇒ success is None
+        assert!(hints.iter().all(|hint| hint.success.is_none()));
+    }
+
+    #[test]
+    fn parse_claude_tool_results_propagates_is_error_into_success() {
+        let msg = json!({
+            "content": [
+                {"type": "tool_result", "tool_use_id": "tu_ok", "is_error": false, "content": "ok"},
+                {"type": "tool_result", "tool_use_id": "tu_err", "is_error": true, "content": "boom"},
+            ],
+        });
+        let hints = parse_claude_tool_results(&msg);
+        assert_eq!(hints.len(), 2);
+        assert_eq!(hints[0].tool_call_id, "tu_ok");
+        assert_eq!(hints[0].success, Some(true));
+        assert_eq!(hints[1].tool_call_id, "tu_err");
+        assert_eq!(hints[1].success, Some(false));
+    }
+
+    #[test]
+    fn parse_claude_tool_results_drops_blocks_without_tool_use_id() {
+        // A tool_result without a tool_use_id can't match any stored
+        // command. Surfacing it as a completion hint would risk a
+        // spurious match against a stored command whose own tool_call_id
+        // was absent — exactly the regression this PR is designed to
+        // prevent. The parser must drop these blocks at the boundary.
+        let msg = json!({
+            "content": [
+                {"type": "tool_result", "content": "no id here"},
+                {"type": "tool_result", "tool_use_id": "tu_real", "content": "fine"},
+            ],
+        });
+        let hints = parse_claude_tool_results(&msg);
+        assert_eq!(hints.len(), 1);
+        assert_eq!(hints[0].tool_call_id, "tu_real");
     }
 
     // ---- extract_exec_command_hint dispatch tests ------------------------
@@ -568,11 +646,39 @@ mod tests {
     #[test]
     fn extract_exec_command_completion_hints_handles_codex_item_completed() {
         let params = json!({
-            "item": {"id": "it_1", "type": "commandExecution"},
+            "item": {"id": "it_1", "type": "commandExecution", "status": "completed"},
         });
         let hints = extract_exec_command_completion_hints("item/completed", &params);
         assert_eq!(hints.len(), 1);
-        assert_eq!(hints[0].tool_call_id.as_deref(), Some("it_1"));
+        assert_eq!(hints[0].tool_call_id, "it_1");
+        assert_eq!(hints[0].success, Some(true));
+    }
+
+    #[test]
+    fn extract_exec_command_completion_hints_marks_failed_codex_item_unsuccessful() {
+        let params = json!({
+            "item": {"id": "it_2", "type": "commandExecution", "status": "failed"},
+        });
+        let hints = extract_exec_command_completion_hints("item/completed", &params);
+        assert_eq!(hints.len(), 1);
+        assert_eq!(hints[0].tool_call_id, "it_2");
+        assert_eq!(
+            hints[0].success,
+            Some(false),
+            "a failed item/completed must not be reported as a clean completion"
+        );
+    }
+
+    #[test]
+    fn extract_exec_command_completion_hints_drops_codex_item_completed_without_id() {
+        // Without an item id there is nothing to match against the stored
+        // command; emitting a hint here would spuriously mark unrelated
+        // commands as completed.
+        let params = json!({
+            "item": {"type": "commandExecution", "status": "completed"},
+        });
+        let hints = extract_exec_command_completion_hints("item/completed", &params);
+        assert!(hints.is_empty());
     }
 
     #[test]
@@ -586,9 +692,9 @@ mod tests {
         let hints = extract_exec_command_completion_hints("user/toolResult", &params);
         let ids = hints
             .iter()
-            .map(|hint| hint.tool_call_id.as_deref())
+            .map(|hint| hint.tool_call_id.as_str())
             .collect::<Vec<_>>();
-        assert_eq!(ids, vec![Some("tu_3"), Some("tu_4")]);
+        assert_eq!(ids, vec!["tu_3", "tu_4"]);
     }
 
     #[test]

--- a/runner/src/daemon/observability.rs
+++ b/runner/src/daemon/observability.rs
@@ -119,6 +119,15 @@ pub fn parse_codex_token_count(params: &serde_json::Value) -> Option<TokenUsage>
 pub struct ExecCommandHint {
     pub command: String,
     pub cwd: Option<String>,
+    pub tool_call_id: Option<String>,
+}
+
+/// Plain-data extract for a command-tool completion. Kept separate from
+/// [`ExecCommandHint`] because some protocols echo only the tool id on
+/// completion, not the command text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecCommandCompletionHint {
+    pub tool_call_id: Option<String>,
 }
 
 /// Single dispatch table for "what shell command did the agent just
@@ -128,8 +137,8 @@ pub struct ExecCommandHint {
 /// `assistant/message` (Bash tool_use blocks). Unit-testable in
 /// isolation; the supervisor calls this from `handle_bridge_event`
 /// without owning the routing logic itself, so a typo in either method
-/// name is caught by tests rather than by an unrenewable `last
-/// command:` field in production failures.
+/// name is caught by tests rather than by silently absent command-tool
+/// context in production failures.
 pub fn extract_exec_command_hint(
     method: &str,
     params: &serde_json::Value,
@@ -154,42 +163,107 @@ pub fn extract_exec_command_hint(
             Some(ExecCommandHint {
                 command: command.to_string(),
                 cwd,
+                tool_call_id: item
+                    .get("id")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string()),
             })
         }
-        "assistant/message" => parse_claude_bash_command(params).map(|cmd| ExecCommandHint {
-            command: cmd,
-            cwd: None,
-        }),
+        "assistant/message" => parse_claude_bash_tool_use(params),
         _ => None,
     }
 }
 
-/// Best-effort extractor for a Bash `tool_use` block in a Claude
-/// `assistant/message` Raw frame. Returns `Some(command)` if the message
-/// content array contains a `{"type":"tool_use","name":"Bash"}` block
-/// with a string `input.command`; `None` otherwise. Used to populate
-/// `last_exec_command` for failure-detail enrichment, in parallel with
-/// the codex `item/started` / `commandExecution` capture path.
+/// Extract command-tool completions from bridge Raw events. This lets the
+/// failure-detail builder say whether the last observed command had already
+/// completed before an agent/API failure occurred. Claude may echo multiple
+/// tool_result blocks in one message, so callers must consider every hint.
+pub fn extract_exec_command_completion_hints(
+    method: &str,
+    params: &serde_json::Value,
+) -> Vec<ExecCommandCompletionHint> {
+    match method {
+        "item/completed" => {
+            let Some(item) = params.get("item") else {
+                return Vec::new();
+            };
+            if item.get("type").and_then(|v| v.as_str()) != Some("commandExecution") {
+                return Vec::new();
+            }
+            vec![ExecCommandCompletionHint {
+                tool_call_id: item
+                    .get("id")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string()),
+            }]
+        }
+        "user/toolResult" => parse_claude_tool_results(params),
+        _ => Vec::new(),
+    }
+}
+
+/// Best-effort extractor for Bash `tool_use` blocks in a Claude
+/// `assistant/message` Raw frame. Returns the last valid Bash command if
+/// the message content array contains any `{"type":"tool_use","name":"Bash"}`
+/// block with a string `input.command`; `None` otherwise. Used to populate
+/// `last_exec_command` for failure-detail enrichment, in parallel with the
+/// codex `item/started` / `commandExecution` capture path.
 ///
 /// Other tool_use blocks (Read, Edit, Grep, …) are intentionally ignored
 /// — Bash is the call most likely to hang on network / sandbox issues
 /// and the only one whose `input.command` resembles a shell command we'd
 /// want to surface verbatim. Future tools can be added as new arms if
 /// they prove to be common stall sources.
-pub fn parse_claude_bash_command(message: &serde_json::Value) -> Option<String> {
+pub fn parse_claude_bash_tool_use(message: &serde_json::Value) -> Option<ExecCommandHint> {
     let content = message.get("content")?.as_array()?;
+    let mut last_bash: Option<ExecCommandHint> = None;
     for block in content {
         let is_tool_use = block.get("type").and_then(|v| v.as_str()) == Some("tool_use");
         let is_bash = block.get("name").and_then(|v| v.as_str()) == Some("Bash");
         if is_tool_use && is_bash {
-            let cmd = block.get("input")?.get("command")?.as_str()?.trim();
+            let Some(cmd) = block
+                .get("input")
+                .and_then(|input| input.get("command"))
+                .and_then(|command| command.as_str())
+                .map(str::trim)
+            else {
+                continue;
+            };
             if cmd.is_empty() {
-                return None;
+                continue;
             }
-            return Some(cmd.to_string());
+            last_bash = Some(ExecCommandHint {
+                command: cmd.to_string(),
+                cwd: None,
+                tool_call_id: block
+                    .get("id")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string()),
+            });
         }
     }
-    None
+    last_bash
+}
+
+pub fn parse_claude_tool_results(message: &serde_json::Value) -> Vec<ExecCommandCompletionHint> {
+    let Some(content) = message.get("content").and_then(|v| v.as_array()) else {
+        return Vec::new();
+    };
+    content
+        .iter()
+        .filter_map(|block| {
+            if block.get("type").and_then(|v| v.as_str()) == Some("tool_result") {
+                Some(ExecCommandCompletionHint {
+                    tool_call_id: block
+                        .get("tool_use_id")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string()),
+                })
+            } else {
+                None
+            }
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -324,7 +398,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_claude_bash_command_extracts_command() {
+    fn parse_claude_bash_tool_use_extracts_command_and_id() {
         let msg = json!({
             "id": "msg_1",
             "role": "assistant",
@@ -338,14 +412,42 @@ mod tests {
                 },
             ],
         });
-        assert_eq!(
-            parse_claude_bash_command(&msg),
-            Some("git fetch origin".to_string())
-        );
+        let hint = parse_claude_bash_tool_use(&msg).unwrap();
+        assert_eq!(hint.command, "git fetch origin");
+        assert_eq!(hint.tool_call_id.as_deref(), Some("tu_1"));
     }
 
     #[test]
-    fn parse_claude_bash_command_ignores_non_bash_tools() {
+    fn parse_claude_bash_tool_use_uses_last_bash_block() {
+        let msg = json!({
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "tu_1",
+                    "name": "Bash",
+                    "input": {"command": "git status"},
+                },
+                {
+                    "type": "tool_use",
+                    "id": "tu_read",
+                    "name": "Read",
+                    "input": {"file_path": "/tmp/foo"},
+                },
+                {
+                    "type": "tool_use",
+                    "id": "tu_2",
+                    "name": "Bash",
+                    "input": {"command": "npm test"},
+                },
+            ],
+        });
+        let hint = parse_claude_bash_tool_use(&msg).unwrap();
+        assert_eq!(hint.command, "npm test");
+        assert_eq!(hint.tool_call_id.as_deref(), Some("tu_2"));
+    }
+
+    #[test]
+    fn parse_claude_bash_tool_use_ignores_non_bash_tools() {
         // A Read tool_use should NOT populate last_exec_command — Read
         // hangs are far rarer than Bash and we want the extractor narrow
         // to avoid noise in the failure-detail string.
@@ -358,25 +460,43 @@ mod tests {
                 },
             ],
         });
-        assert!(parse_claude_bash_command(&msg).is_none());
+        assert!(parse_claude_bash_tool_use(&msg).is_none());
     }
 
     #[test]
-    fn parse_claude_bash_command_returns_none_when_no_tool_use() {
+    fn parse_claude_bash_tool_use_returns_none_when_no_tool_use() {
         let msg = json!({
             "content": [{"type": "text", "text": "just thinking"}],
         });
-        assert!(parse_claude_bash_command(&msg).is_none());
+        assert!(parse_claude_bash_tool_use(&msg).is_none());
     }
 
     #[test]
-    fn parse_claude_bash_command_returns_none_on_empty_command() {
+    fn parse_claude_bash_tool_use_returns_none_on_empty_command() {
         let msg = json!({
             "content": [
                 {"type": "tool_use", "name": "Bash", "input": {"command": "  "}},
             ],
         });
-        assert!(parse_claude_bash_command(&msg).is_none());
+        assert!(parse_claude_bash_tool_use(&msg).is_none());
+    }
+
+    #[test]
+    fn parse_claude_tool_results_extracts_all_tool_use_ids() {
+        let msg = json!({
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "done"},
+                {"type": "tool_result", "tool_use_id": "tu_1", "content": "ok"},
+                {"type": "tool_result", "tool_use_id": "tu_2", "content": "also ok"},
+            ],
+        });
+        let hints = parse_claude_tool_results(&msg);
+        let ids = hints
+            .iter()
+            .map(|hint| hint.tool_call_id.as_deref())
+            .collect::<Vec<_>>();
+        assert_eq!(ids, vec![Some("tu_1"), Some("tu_2")]);
     }
 
     // ---- extract_exec_command_hint dispatch tests ------------------------
@@ -384,8 +504,8 @@ mod tests {
     // These guard the supervisor's wiring against method-name typos. If
     // `handle_bridge_event` ever stops passing `"item/started"` /
     // `"assistant/message"` here, the production code silently degrades to
-    // "no last command" forever — these tests catch that at compile-fixed
-    // string level.
+    // "no command-tool context" forever — these tests catch that at
+    // compile-fixed string level.
 
     #[test]
     fn extract_exec_command_hint_handles_codex_item_started() {
@@ -400,6 +520,7 @@ mod tests {
         let hint = extract_exec_command_hint("item/started", &params).unwrap();
         assert_eq!(hint.command, "git fetch origin");
         assert_eq!(hint.cwd.as_deref(), Some("/tmp/x"));
+        assert!(hint.tool_call_id.is_none());
     }
 
     #[test]
@@ -430,6 +551,7 @@ mod tests {
             "content": [
                 {
                     "type": "tool_use",
+                    "id": "tu_2",
                     "name": "Bash",
                     "input": {"command": "npm install"},
                 },
@@ -440,6 +562,33 @@ mod tests {
         // Claude tool_use blocks don't carry cwd; the working dir is
         // implicit from the run's workspace_root.
         assert!(hint.cwd.is_none());
+        assert_eq!(hint.tool_call_id.as_deref(), Some("tu_2"));
+    }
+
+    #[test]
+    fn extract_exec_command_completion_hints_handles_codex_item_completed() {
+        let params = json!({
+            "item": {"id": "it_1", "type": "commandExecution"},
+        });
+        let hints = extract_exec_command_completion_hints("item/completed", &params);
+        assert_eq!(hints.len(), 1);
+        assert_eq!(hints[0].tool_call_id.as_deref(), Some("it_1"));
+    }
+
+    #[test]
+    fn extract_exec_command_completion_hints_handles_claude_tool_results() {
+        let params = json!({
+            "content": [
+                {"type": "tool_result", "tool_use_id": "tu_3", "content": "done"},
+                {"type": "tool_result", "tool_use_id": "tu_4", "content": "also done"},
+            ],
+        });
+        let hints = extract_exec_command_completion_hints("user/toolResult", &params);
+        let ids = hints
+            .iter()
+            .map(|hint| hint.tool_call_id.as_deref())
+            .collect::<Vec<_>>();
+        assert_eq!(ids, vec![Some("tu_3"), Some("tu_4")]);
     }
 
     #[test]

--- a/runner/src/daemon/state.rs
+++ b/runner/src/daemon/state.rs
@@ -46,10 +46,11 @@ pub struct ObservabilitySnapshot {
     pub tokens: Option<TokenUsage>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub turn_count: Option<u32>,
-    /// Last shell command the agent kicked off (for failure-detail enrichment).
-    /// Reset on rid change like the other per-run scalars; never serialised
-    /// onto the wire — only consumed locally to enrich `RunFailed.detail`
-    /// when the watchdog or stdout-close path fires.
+    /// Last shell command tool the agent kicked off (for failure-detail
+    /// enrichment), including whether a matching completion/result event was
+    /// later observed. Reset on rid change like the other per-run scalars;
+    /// never serialised onto the wire — only consumed locally to enrich
+    /// `RunFailed.detail` when the watchdog or stdout-close path fires.
     #[serde(skip)]
     pub last_exec_command: Option<ExecCommandSnapshot>,
 }
@@ -58,7 +59,9 @@ pub struct ObservabilitySnapshot {
 pub struct ExecCommandSnapshot {
     pub command: String,
     pub cwd: Option<String>,
+    pub tool_call_id: Option<String>,
     pub started_at: DateTime<Utc>,
+    pub completed_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Clone)]
@@ -282,6 +285,30 @@ impl StateHandle {
     /// item is a `commandExecution`.
     pub async fn note_exec_command(&self, snapshot: ExecCommandSnapshot) {
         self.inner.run_snapshot.lock().await.last_exec_command = Some(snapshot);
+        self.tick();
+    }
+
+    /// Mark the last observed command tool completed when the protocol gives
+    /// us a matching completion/result event. Matching by tool id avoids a
+    /// later result from an older command making the current command look done.
+    pub async fn note_exec_command_completed(
+        &self,
+        tool_call_id: Option<&str>,
+        completed_at: DateTime<Utc>,
+    ) {
+        let mut snap = self.inner.run_snapshot.lock().await;
+        let Some(cmd) = snap.last_exec_command.as_mut() else {
+            return;
+        };
+        let matches = match (cmd.tool_call_id.as_deref(), tool_call_id) {
+            (Some(stored), Some(done)) => stored == done,
+            (None, None) => true,
+            _ => false,
+        };
+        if matches {
+            cmd.completed_at = Some(completed_at);
+        }
+        drop(snap);
         self.tick();
     }
 
@@ -573,13 +600,16 @@ mod tests {
             .note_exec_command(ExecCommandSnapshot {
                 command: "git fetch origin".into(),
                 cwd: Some("/tmp/x".into()),
+                tool_call_id: Some("tool-1".into()),
                 started_at: Utc::now(),
+                completed_at: None,
             })
             .await;
         let snap = state.observability_snapshot().await;
         let cmd = snap.last_exec_command.expect("snapshot lost the command");
         assert_eq!(cmd.command, "git fetch origin");
         assert_eq!(cmd.cwd.as_deref(), Some("/tmp/x"));
+        assert_eq!(cmd.tool_call_id.as_deref(), Some("tool-1"));
 
         // Rid change wipes per-run scalars including the exec command, so
         // a stalled-on-foo failure detail can't bleed into a fresh run.
@@ -587,6 +617,36 @@ mod tests {
         state.set_current_run(Some(summary(rid_b, "running"))).await;
         let snap = state.observability_snapshot().await;
         assert!(snap.last_exec_command.is_none());
+    }
+
+    #[tokio::test]
+    async fn note_exec_command_completed_marks_matching_command_only() {
+        let state = empty_state();
+        state
+            .set_current_run(Some(summary(Uuid::new_v4(), "running")))
+            .await;
+        state
+            .note_exec_command(ExecCommandSnapshot {
+                command: "npm test".into(),
+                cwd: None,
+                tool_call_id: Some("tool-1".into()),
+                started_at: Utc::now(),
+                completed_at: None,
+            })
+            .await;
+
+        state
+            .note_exec_command_completed(Some("other-tool"), Utc::now())
+            .await;
+        let snap = state.observability_snapshot().await;
+        assert!(snap.last_exec_command.unwrap().completed_at.is_none());
+
+        let done_at = Utc::now();
+        state
+            .note_exec_command_completed(Some("tool-1"), done_at)
+            .await;
+        let snap = state.observability_snapshot().await;
+        assert_eq!(snap.last_exec_command.unwrap().completed_at, Some(done_at));
     }
 
     #[tokio::test]

--- a/runner/src/daemon/state.rs
+++ b/runner/src/daemon/state.rs
@@ -62,6 +62,12 @@ pub struct ExecCommandSnapshot {
     pub tool_call_id: Option<String>,
     pub started_at: DateTime<Utc>,
     pub completed_at: Option<DateTime<Utc>>,
+    /// `Some(true)` when the matching completion event reported a clean
+    /// terminal status, `Some(false)` for a non-success terminal (codex
+    /// `failed` status, Claude `is_error: true`). `None` when no
+    /// completion has been observed yet or the protocol frame didn't
+    /// surface an outcome.
+    pub completed_success: Option<bool>,
 }
 
 #[derive(Clone)]
@@ -289,24 +295,25 @@ impl StateHandle {
     }
 
     /// Mark the last observed command tool completed when the protocol gives
-    /// us a matching completion/result event. Matching by tool id avoids a
-    /// later result from an older command making the current command look done.
+    /// us a matching completion/result event. Matching requires both the
+    /// stored command and the completion hint to carry the same explicit
+    /// tool id — a stored command without an id is never marked completed
+    /// by a completion event, even one that also lacks an id. This avoids
+    /// the regression where a malformed `tool_result` (missing
+    /// `tool_use_id`) could mark an unrelated stored command as done.
     pub async fn note_exec_command_completed(
         &self,
-        tool_call_id: Option<&str>,
+        tool_call_id: &str,
+        success: Option<bool>,
         completed_at: DateTime<Utc>,
     ) {
         let mut snap = self.inner.run_snapshot.lock().await;
         let Some(cmd) = snap.last_exec_command.as_mut() else {
             return;
         };
-        let matches = match (cmd.tool_call_id.as_deref(), tool_call_id) {
-            (Some(stored), Some(done)) => stored == done,
-            (None, None) => true,
-            _ => false,
-        };
-        if matches {
+        if cmd.tool_call_id.as_deref() == Some(tool_call_id) {
             cmd.completed_at = Some(completed_at);
+            cmd.completed_success = success;
         }
         drop(snap);
         self.tick();
@@ -603,6 +610,7 @@ mod tests {
                 tool_call_id: Some("tool-1".into()),
                 started_at: Utc::now(),
                 completed_at: None,
+                completed_success: None,
             })
             .await;
         let snap = state.observability_snapshot().await;
@@ -632,21 +640,85 @@ mod tests {
                 tool_call_id: Some("tool-1".into()),
                 started_at: Utc::now(),
                 completed_at: None,
+                completed_success: None,
             })
             .await;
 
         state
-            .note_exec_command_completed(Some("other-tool"), Utc::now())
+            .note_exec_command_completed("other-tool", Some(true), Utc::now())
             .await;
         let snap = state.observability_snapshot().await;
-        assert!(snap.last_exec_command.unwrap().completed_at.is_none());
+        let cmd = snap.last_exec_command.unwrap();
+        assert!(cmd.completed_at.is_none());
+        assert!(cmd.completed_success.is_none());
 
         let done_at = Utc::now();
         state
-            .note_exec_command_completed(Some("tool-1"), done_at)
+            .note_exec_command_completed("tool-1", Some(true), done_at)
             .await;
         let snap = state.observability_snapshot().await;
-        assert_eq!(snap.last_exec_command.unwrap().completed_at, Some(done_at));
+        let cmd = snap.last_exec_command.unwrap();
+        assert_eq!(cmd.completed_at, Some(done_at));
+        assert_eq!(cmd.completed_success, Some(true));
+    }
+
+    #[tokio::test]
+    async fn note_exec_command_completed_does_not_match_when_stored_id_is_absent() {
+        // Regression guard: a stored command whose `tool_call_id` is
+        // `None` (e.g. codex `item/started` arrived without an `id`
+        // field) must never be marked completed by a completion event,
+        // even one that also lacks a tool id. The previous behaviour
+        // returned `true` on `(None, None)`, which let a malformed
+        // `tool_result` spuriously close out an unrelated command.
+        let state = empty_state();
+        state
+            .set_current_run(Some(summary(Uuid::new_v4(), "running")))
+            .await;
+        state
+            .note_exec_command(ExecCommandSnapshot {
+                command: "cat .pidash-workpad.md".into(),
+                cwd: None,
+                tool_call_id: None,
+                started_at: Utc::now(),
+                completed_at: None,
+                completed_success: None,
+            })
+            .await;
+
+        state
+            .note_exec_command_completed("tu_anything", Some(true), Utc::now())
+            .await;
+        let snap = state.observability_snapshot().await;
+        let cmd = snap.last_exec_command.unwrap();
+        assert!(
+            cmd.completed_at.is_none(),
+            "stored command without an id must not be marked completed by any incoming id"
+        );
+    }
+
+    #[tokio::test]
+    async fn note_exec_command_completed_captures_unsuccessful_outcome() {
+        let state = empty_state();
+        state
+            .set_current_run(Some(summary(Uuid::new_v4(), "running")))
+            .await;
+        state
+            .note_exec_command(ExecCommandSnapshot {
+                command: "npm test".into(),
+                cwd: None,
+                tool_call_id: Some("tool-x".into()),
+                started_at: Utc::now(),
+                completed_at: None,
+                completed_success: None,
+            })
+            .await;
+        state
+            .note_exec_command_completed("tool-x", Some(false), Utc::now())
+            .await;
+        let snap = state.observability_snapshot().await;
+        let cmd = snap.last_exec_command.unwrap();
+        assert!(cmd.completed_at.is_some());
+        assert_eq!(cmd.completed_success, Some(false));
     }
 
     #[tokio::test]

--- a/runner/src/daemon/supervisor.rs
+++ b/runner/src/daemon/supervisor.rs
@@ -1988,9 +1988,16 @@ fn format_exec_command_detail(
     if let Some(completed_at) = cmd.completed_at {
         let runtime = (completed_at - cmd.started_at).num_seconds().max(0);
         let since_completed = (now - completed_at).num_seconds().max(0);
+        // Distinguish a clean completion from a non-success terminal
+        // (codex `failed`, Claude `is_error: true`) so the failure
+        // detail does not call an errored command a "completion".
+        let verb = match cmd.completed_success {
+            Some(false) => "exited with error",
+            Some(true) | None => "completed",
+        };
         format!(
             "last observed command tool: `{}`{cwd} \
-             (completed {since_completed}s before failure; ran {runtime}s)",
+             ({verb} {since_completed}s before failure; ran {runtime}s)",
             cmd.command
         )
     } else {
@@ -2512,6 +2519,7 @@ impl AssignWorker {
                                 tool_call_id: hint.tool_call_id,
                                 started_at: Utc::now(),
                                 completed_at: None,
+                                completed_success: None,
                             })
                             .await;
                     }
@@ -2522,7 +2530,11 @@ impl AssignWorker {
                         params,
                     ) {
                         self.state
-                            .note_exec_command_completed(hint.tool_call_id.as_deref(), Utc::now())
+                            .note_exec_command_completed(
+                                &hint.tool_call_id,
+                                hint.success,
+                                Utc::now(),
+                            )
                             .await;
                     }
                 }
@@ -2794,6 +2806,7 @@ mod tests {
                 tool_call_id: Some("tool-1".into()),
                 started_at,
                 completed_at: Some(completed_at),
+                completed_success: Some(true),
             },
             now,
         );
@@ -2814,6 +2827,7 @@ mod tests {
                 tool_call_id: Some("tool-2".into()),
                 started_at,
                 completed_at: None,
+                completed_success: None,
             },
             now,
         );
@@ -2823,6 +2837,33 @@ mod tests {
             "last observed command tool start: `git fetch origin` in `/tmp/repo` \
              (started 69s ago; no completion event observed)"
         );
+    }
+
+    #[test]
+    fn format_exec_command_detail_distinguishes_errored_completion_from_clean_one() {
+        // A command whose completion event reported a non-success
+        // terminal status (codex `failed`, Claude `is_error: true`) must
+        // not be described as a clean "completion" — that wording reads
+        // like success, which can be just as misleading as the original
+        // "still running" bug this PR fixes.
+        let started_at = Utc.with_ymd_and_hms(2026, 5, 27, 9, 11, 0).unwrap();
+        let completed_at = Utc.with_ymd_and_hms(2026, 5, 27, 9, 11, 4).unwrap();
+        let now = Utc.with_ymd_and_hms(2026, 5, 27, 9, 12, 0).unwrap();
+        let detail = format_exec_command_detail(
+            &ExecCommandSnapshot {
+                command: "npm test".into(),
+                cwd: None,
+                tool_call_id: Some("tool-x".into()),
+                started_at,
+                completed_at: Some(completed_at),
+                completed_success: Some(false),
+            },
+            now,
+        );
+
+        assert!(detail.contains("exited with error 56s before failure"));
+        assert!(detail.contains("ran 4s"));
+        assert!(!detail.contains("completed 56s"));
     }
 
     /// Build the supervisor's ``hello_runners`` map from a list of

--- a/runner/src/daemon/supervisor.rs
+++ b/runner/src/daemon/supervisor.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -1976,6 +1976,33 @@ fn assistant_text_from_done_payload(payload: &serde_json::Value) -> Option<Strin
     None
 }
 
+fn format_exec_command_detail(
+    cmd: &crate::daemon::state::ExecCommandSnapshot,
+    now: DateTime<Utc>,
+) -> String {
+    let cwd = cmd
+        .cwd
+        .as_deref()
+        .map(|c| format!(" in `{c}`"))
+        .unwrap_or_default();
+    if let Some(completed_at) = cmd.completed_at {
+        let runtime = (completed_at - cmd.started_at).num_seconds().max(0);
+        let since_completed = (now - completed_at).num_seconds().max(0);
+        format!(
+            "last observed command tool: `{}`{cwd} \
+             (completed {since_completed}s before failure; ran {runtime}s)",
+            cmd.command
+        )
+    } else {
+        let elapsed = (now - cmd.started_at).num_seconds().max(0);
+        format!(
+            "last observed command tool start: `{}`{cwd} \
+             (started {elapsed}s ago; no completion event observed)",
+            cmd.command
+        )
+    }
+}
+
 /// Owns one `Assign`'s lifecycle. Spawned as a task from `RunnerLoop`, so the
 /// message loop stays live and can deliver Cancel / Decide frames to us via
 /// `self.cancel` and `self.approvals`.
@@ -2365,7 +2392,7 @@ impl AssignWorker {
     /// context might help the cloud / UI explain what went wrong:
     /// - the supervisor's own classifier message (e.g. `"no agent frames
     ///   for 5 minutes"`),
-    /// - the most recent shell command the agent kicked off,
+    /// - the most recent shell command tool the agent kicked off,
     /// - the last few lines of agent stderr.
     ///
     /// All inputs are optional and the assembly degrades gracefully when
@@ -2381,16 +2408,7 @@ impl AssignWorker {
 
         let mut parts: Vec<String> = vec![base.to_string()];
         if let Some(cmd) = last_cmd {
-            let elapsed = (Utc::now() - cmd.started_at).num_seconds().max(0);
-            let cwd = cmd
-                .cwd
-                .as_deref()
-                .map(|c| format!(" in `{c}`"))
-                .unwrap_or_default();
-            parts.push(format!(
-                "last command: `{}`{cwd} (started {elapsed}s ago)",
-                cmd.command
-            ));
+            parts.push(format_exec_command_detail(&cmd, Utc::now()));
         }
         // The stderr ring has already filtered codex tracing noise;
         // `stderr.dropped` is the running count of lines we rejected so
@@ -2481,7 +2499,7 @@ impl AssignWorker {
                     // in `extract_exec_command_hint` so it's
                     // unit-testable without a live bridge — a typo in
                     // either method name is caught by tests rather than
-                    // by silently absent `last command:` fields in
+                    // by silently absent command-tool context in
                     // production failure details.
                     if let Some(hint) = crate::daemon::observability::extract_exec_command_hint(
                         method.as_str(),
@@ -2491,8 +2509,20 @@ impl AssignWorker {
                             .note_exec_command(crate::daemon::state::ExecCommandSnapshot {
                                 command: hint.command,
                                 cwd: hint.cwd,
+                                tool_call_id: hint.tool_call_id,
                                 started_at: Utc::now(),
+                                completed_at: None,
                             })
+                            .await;
+                    }
+                }
+                "item/completed" | "user/toolResult" => {
+                    for hint in crate::daemon::observability::extract_exec_command_completion_hints(
+                        method.as_str(),
+                        params,
+                    ) {
+                        self.state
+                            .note_exec_command_completed(hint.tool_call_id.as_deref(), Utc::now())
                             .await;
                     }
                 }
@@ -2660,9 +2690,9 @@ impl AssignWorker {
                 // with `willRetry=false`) reach us with whatever bare
                 // string the bridge produced. Run them through the same
                 // enrichment helper the watchdog and stdout-close paths
-                // use so the user sees `last command:` and a stderr
-                // tail in the issue activity comment, not just the
-                // bridge's classifier text.
+                // use so the user sees command-tool context and a
+                // stderr tail in the issue activity comment, not just
+                // the bridge's classifier text.
                 let base = detail
                     .clone()
                     .unwrap_or_else(|| "agent reported failure".to_string());
@@ -2724,6 +2754,8 @@ mod tests {
         AgentSection, ApprovalPolicySection, ClaudeCodeSection, CodexSection, RunnerConfig,
         WorkspaceSection,
     };
+    use crate::daemon::state::ExecCommandSnapshot;
+    use chrono::TimeZone;
     use std::path::PathBuf;
     use tokio::sync::Notify;
 
@@ -2748,6 +2780,49 @@ mod tests {
             claude_code: ClaudeCodeSection::default(),
             approval_policy: ApprovalPolicySection::default(),
         }
+    }
+
+    #[test]
+    fn format_exec_command_detail_does_not_imply_completed_command_is_running() {
+        let started_at = Utc.with_ymd_and_hms(2026, 5, 27, 9, 11, 0).unwrap();
+        let completed_at = Utc.with_ymd_and_hms(2026, 5, 27, 9, 11, 4).unwrap();
+        let now = Utc.with_ymd_and_hms(2026, 5, 27, 9, 44, 0).unwrap();
+        let detail = format_exec_command_detail(
+            &ExecCommandSnapshot {
+                command: "cat .pidash-workpad.md".into(),
+                cwd: None,
+                tool_call_id: Some("tool-1".into()),
+                started_at,
+                completed_at: Some(completed_at),
+            },
+            now,
+        );
+
+        assert!(detail.contains("completed 1976s before failure"));
+        assert!(detail.contains("ran 4s"));
+        assert!(!detail.contains("no completion event observed"));
+    }
+
+    #[test]
+    fn format_exec_command_detail_says_when_completion_was_not_seen() {
+        let started_at = Utc.with_ymd_and_hms(2026, 5, 27, 9, 11, 0).unwrap();
+        let now = Utc.with_ymd_and_hms(2026, 5, 27, 9, 12, 9).unwrap();
+        let detail = format_exec_command_detail(
+            &ExecCommandSnapshot {
+                command: "git fetch origin".into(),
+                cwd: Some("/tmp/repo".into()),
+                tool_call_id: Some("tool-2".into()),
+                started_at,
+                completed_at: None,
+            },
+            now,
+        );
+
+        assert_eq!(
+            detail,
+            "last observed command tool start: `git fetch origin` in `/tmp/repo` \
+             (started 69s ago; no completion event observed)"
+        );
     }
 
     /// Build the supervisor's ``hello_runners`` map from a list of


### PR DESCRIPTION
## What changed

This updates runner failure diagnostics so the last observed command tool is not presented as though it necessarily hung.

- Track command tool IDs for Codex `commandExecution` items and Claude Bash `tool_use` blocks.
- Record matching Codex `item/completed` and Claude `user/toolResult` completions on the last command snapshot.
- Format failure details differently when the command completed versus when no completion event was observed.

## Why

Pi Dash previously attached the last command start to failure diagnostics without tracking whether that tool call had already completed. That made failures like Claude Code API socket closures look like a `cat` command was still running, even when the command may have completed earlier.

## Impact

Future run failures should produce clearer detail strings such as completed command timing, or explicitly say that no completion event was observed.

## Validation

- `cargo test -p pidash --lib`