### PR TITLE
release(runner): bump pidash to 0.1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1382,7 +1382,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pidash"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "axoupdater",

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pidash"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 rust-version = "1.93"
 description = "Pi Dash local runner: connects a dev machine to the Pi Dash cloud and drives Codex for assigned tasks."


### PR DESCRIPTION
## Summary

- Bump `runner/Cargo.toml` from `0.1.7` → `0.1.8`. Cargo.lock updated to match.
- Ships the `pidash issue search` subcommand that landed in #180.

## Why

PR #180 added the Rust source for `pidash issue search` and the agent prompt fragment that documents it, but no runner binary containing the subcommand has been published yet. Tagging this version bump triggers `.github/workflows/release.yml` (cargo-dist) to build artifacts for every target and upload them as a GitHub release.

## Post-merge sequence

1. Merge this PR.
2. Push `pidash-v0.1.8` tag (or let the release automation cut it from this version bump if that's how the repo's workflow is wired).
3. Bump cloud advisory `LATEST_RUNNER_VERSION=0.1.8` in prod SSM so `auto_update=true` runners pick up the new binary on next heartbeat.

Operators on older binaries continue to work — PR #180 added a graceful-fallback clause to the agent prompt that tells the agent to silently skip `pidash issue search` if it returns clap's "unrecognized subcommand" error. So the upgrade is non-breaking; this release just unlocks the new feature.

## Test plan

- [ ] `cargo build -p pidash` succeeds locally (verified)
- [ ] `cargo test` green (CI)
- [ ] Release workflow `plan` step recognizes the new version
- [ ] After tag push: confirm new binary artifacts appear on the GitHub release page
- [ ] After cloud advisory bump: confirm one auto-update runner swaps to 0.1.8 and `pidash issue search "..."` returns a valid JSON envelope