### PR TITLE
Fix topbar issue body and comment search

### DIFF
--- a/apps/api/pi_dash/app/views/search/base.py
+++ b/apps/api/pi_dash/app/views/search/base.py
@@ -91,10 +91,10 @@ class GlobalSearchEndpoint(BaseAPIView):
             workspace__slug=slug,
         )
 
-        # include_comments=False — the top-bar picker expects
-        # title-scoped results; comment-text widening is reserved for
-        # IssueAdvancedSearchEndpoint (agent path).
-        issues = issue_search_queryset(issues, query, include_comments=False)
+        # Topbar issue search should surface issues by title, body, or
+        # comments. The UI only renders issue rows, so a comment match
+        # returns its parent issue here.
+        issues = issue_search_queryset(issues, query, include_comments=True)
 
         if workspace_search == "false" and project_id:
             issues = issues.filter(project_id=project_id)

--- a/apps/api/pi_dash/tests/contract/app/test_global_search.py
+++ b/apps/api/pi_dash/tests/contract/app/test_global_search.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+import pytest
+from rest_framework import status as http_status
+
+from pi_dash.db.models import Issue, IssueComment, ProjectMember
+
+
+def _search_url(slug):
+    return f"/api/workspaces/{slug}/search/"
+
+
+def _make_issue(project, user, *, name, description=""):
+    return Issue.objects.create(
+        name=name,
+        description_html=f"<p>{description}</p>" if description else "",
+        description_stripped=description,
+        project=project,
+        workspace=project.workspace,
+        created_by=user,
+    )
+
+
+@pytest.fixture
+def searchable_project(project, create_user):
+    ProjectMember.objects.get_or_create(
+        project=project,
+        member=create_user,
+        defaults={"role": 20, "is_active": True},
+    )
+    return project
+
+
+@pytest.mark.contract
+class TestGlobalSearchIssueMatches:
+    @pytest.mark.django_db
+    def test_issue_body_match_surfaces_issue(self, session_client, workspace, searchable_project, create_user):
+        issue = _make_issue(
+            searchable_project,
+            create_user,
+            name="unrelated title",
+            description="browser console has 38 same errors",
+        )
+
+        response = session_client.get(
+            _search_url(workspace.slug),
+            {"search": "38 same errors", "workspace_search": "true", "entities": "issue"},
+        )
+
+        assert response.status_code == http_status.HTTP_200_OK
+        ids = [str(result["id"]) for result in response.data["results"]["issue"]]
+        assert str(issue.id) in ids
+
+    @pytest.mark.django_db
+    def test_issue_comment_match_surfaces_parent_issue(
+        self, session_client, workspace, searchable_project, create_user
+    ):
+        issue = _make_issue(
+            searchable_project,
+            create_user,
+            name="unrelated title",
+            description="unrelated description",
+        )
+        IssueComment.objects.create(
+            issue=issue,
+            project=searchable_project,
+            workspace=searchable_project.workspace,
+            comment_html="<p>release blocker from upload retry loop</p>",
+            comment_stripped="release blocker from upload retry loop",
+            actor=create_user,
+        )
+
+        response = session_client.get(
+            _search_url(workspace.slug),
+            {"search": "upload retry loop", "workspace_search": "true", "entities": "issue"},
+        )
+
+        assert response.status_code == http_status.HTTP_200_OK
+        ids = [str(result["id"]) for result in response.data["results"]["issue"]]
+        assert str(issue.id) in ids

--- a/apps/web/core/components/navigation/top-nav-power-k.tsx
+++ b/apps/web/core/components/navigation/top-nav-power-k.tsx
@@ -14,6 +14,7 @@ import { cn } from "@pi-dash/utils";
 // power-k
 import type { TPowerKCommandConfig, TPowerKContext } from "@/components/power-k/core/types";
 import { ProjectsAppPowerKCommandsList } from "@/components/power-k/ui/modal/commands-list";
+import { powerKCommandFilter } from "@/components/power-k/ui/modal/filter";
 import { PowerKModalFooter } from "@/components/power-k/ui/modal/footer";
 import { useIssueDetail } from "@/hooks/store/use-issue-detail";
 import { usePowerK } from "@/hooks/store/use-power-k";
@@ -101,7 +102,7 @@ export const TopNavPowerK = observer(() => {
     return () => {
       setTopNavInputRef(null);
     };
-  }, [setTopNavInputRef]);
+  }, [inputRef, setTopNavInputRef]);
 
   const handleClear = () => {
     setSearchTerm("");
@@ -203,7 +204,7 @@ export const TopNavPowerK = observer(() => {
         return;
       }
     },
-    [searchTerm, activePage, context, shouldShowContextBasedActions, setActivePage, closePanel]
+    [searchTerm, activePage, context, shouldShowContextBasedActions, setActivePage, closePanel, isOpen, containerRef]
   );
 
   return (
@@ -220,8 +221,8 @@ export const TopNavPowerK = observer(() => {
               "bg-layer-1": isOpen,
             }
           )}
-          onClick={() => inputRef.current?.focus()}
-          role="button"
+          onMouseDown={() => inputRef.current?.focus()}
+          role="presentation"
         >
           <SearchIcon className="mr-2 size-3.5 shrink-0 text-placeholder" />
           <input
@@ -256,11 +257,7 @@ export const TopNavPowerK = observer(() => {
       >
         {isOpen && (
           <Command
-            filter={(i18nValue: string, search: string) => {
-              if (i18nValue === "no-results") return 1;
-              if (i18nValue.toLowerCase().includes(search.toLowerCase())) return 1;
-              return 0;
-            }}
+            filter={powerKCommandFilter}
             shouldFilter={searchTerm.length > 0}
             className="flex h-full w-full flex-col"
           >

--- a/apps/web/core/components/power-k/ui/modal/command-item.tsx
+++ b/apps/web/core/components/power-k/ui/modal/command-item.tsx
@@ -19,6 +19,7 @@ type Props = {
   isDisabled?: boolean;
   isSelected?: boolean;
   keySequence?: string;
+  keywords?: string[];
   label: string | React.ReactNode;
   onSelect: () => void;
   shortcut?: string;
@@ -26,10 +27,27 @@ type Props = {
 };
 
 export function PowerKModalCommandItem(props: Props) {
-  const { icon: Icon, iconNode, isDisabled, isSelected, keySequence, label, onSelect, shortcut, value } = props;
+  const {
+    icon: Icon,
+    iconNode,
+    isDisabled,
+    isSelected,
+    keySequence,
+    keywords,
+    label,
+    onSelect,
+    shortcut,
+    value,
+  } = props;
 
   return (
-    <Command.Item value={value} onSelect={onSelect} className="focus:outline-none" disabled={isDisabled}>
+    <Command.Item
+      value={value}
+      keywords={keywords}
+      onSelect={onSelect}
+      className="focus:outline-none"
+      disabled={isDisabled}
+    >
       <div
         className={cn("flex items-center gap-2 text-secondary", {
           "opacity-70": isDisabled,

--- a/apps/web/core/components/power-k/ui/modal/filter.ts
+++ b/apps/web/core/components/power-k/ui/modal/filter.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+export const powerKCommandFilter = (value: string, search: string, keywords?: string[]) => {
+  if (value === "no-results") return 1;
+
+  const normalizedSearch = search.trim().toLowerCase();
+  if (value.toLowerCase().includes(normalizedSearch)) return 1;
+  if (keywords?.some((keyword) => keyword.toLowerCase().includes(normalizedSearch))) return 1;
+
+  return 0;
+};

--- a/apps/web/core/components/power-k/ui/modal/search-menu.tsx
+++ b/apps/web/core/components/power-k/ui/modal/search-menu.tsx
@@ -37,6 +37,7 @@ export function PowerKModalSearchMenu(props: Props) {
   const [resultsCount, setResultsCount] = useState(0);
   const [isSearching, setIsSearching] = useState(false);
   const [results, setResults] = useState<IWorkspaceSearchResults>(WORKSPACE_DEFAULT_SEARCH_RESULT);
+  const [resultsSearchTerm, setResultsSearchTerm] = useState("");
   const debouncedSearchTerm = useDebounce(searchTerm, 500);
   // navigation
   const { workspaceSlug, projectId } = useParams();
@@ -48,27 +49,36 @@ export function PowerKModalSearchMenu(props: Props) {
     setIsSearching(true);
 
     if (debouncedSearchTerm) {
+      setResults(WORKSPACE_DEFAULT_SEARCH_RESULT);
+      setResultsCount(0);
+      setResultsSearchTerm("");
       workspaceService
         .searchWorkspace(workspaceSlug.toString(), {
           ...(projectId ? { project_id: projectId.toString() } : {}),
           search: debouncedSearchTerm,
           workspace_search: !projectId ? true : isWorkspaceLevel,
         })
-        .then((results) => {
-          setResults(results);
-          const count = Object.keys(results.results).reduce(
-            (accumulator, key) => results.results[key as keyof typeof results.results]?.length + accumulator,
+        .then((searchResults) => {
+          setResults(searchResults);
+          const count = Object.keys(searchResults.results).reduce(
+            (accumulator, key) =>
+              searchResults.results[key as keyof typeof searchResults.results]?.length + accumulator,
             0
           );
           setResultsCount(count);
+          setResultsSearchTerm(debouncedSearchTerm);
+          return searchResults;
         })
         .catch(() => {
           setResults(WORKSPACE_DEFAULT_SEARCH_RESULT);
           setResultsCount(0);
+          setResultsSearchTerm("");
         })
         .finally(() => setIsSearching(false));
     } else {
       setResults(WORKSPACE_DEFAULT_SEARCH_RESULT);
+      setResultsCount(0);
+      setResultsSearchTerm("");
       setIsSearching(false);
     }
   }, [debouncedSearchTerm, isWorkspaceLevel, projectId, workspaceSlug, activePage]);
@@ -109,7 +119,14 @@ export function PowerKModalSearchMenu(props: Props) {
         />
       )}
 
-      {searchTerm.trim() !== "" && <PowerKModalSearchResults closePalette={handleClosePalette} results={results} />}
+      {searchTerm.trim() !== "" && (
+        <PowerKModalSearchResults
+          closePalette={handleClosePalette}
+          matchedSearchTerm={resultsSearchTerm}
+          results={results}
+          searchTerm={searchTerm}
+        />
+      )}
     </>
   );
 }

--- a/apps/web/core/components/power-k/ui/modal/search-results.tsx
+++ b/apps/web/core/components/power-k/ui/modal/search-results.tsx
@@ -17,16 +17,20 @@ import { POWER_K_SEARCH_RESULTS_GROUPS_MAP } from "./search-results-map";
 
 type Props = {
   closePalette: () => void;
+  matchedSearchTerm: string;
   results: IWorkspaceSearchResults;
+  searchTerm: string;
 };
 
 export const PowerKModalSearchResults = observer(function PowerKModalSearchResults(props: Props) {
-  const { closePalette, results } = props;
+  const { closePalette, matchedSearchTerm, results, searchTerm } = props;
   // router
   const router = useAppRouter();
   const { projectId: routerProjectId } = useParams();
   // derived values
   const projectId = routerProjectId?.toString();
+  const resultSearchTerm = matchedSearchTerm.trim();
+  const shouldTrustServerResults = resultSearchTerm !== "" && resultSearchTerm === searchTerm.trim();
 
   return (
     <>
@@ -55,6 +59,7 @@ export const PowerKModalSearchResults = observer(function PowerKModalSearchResul
                   key={item.id}
                   label={currentSection.itemName(item)}
                   icon={currentSection.icon}
+                  keywords={shouldTrustServerResults ? [resultSearchTerm] : undefined}
                   onSelect={() => {
                     closePalette();
                     router.push(currentSection.path(item, projectId));

--- a/apps/web/core/components/power-k/ui/modal/wrapper.tsx
+++ b/apps/web/core/components/power-k/ui/modal/wrapper.tsx
@@ -13,6 +13,7 @@ import { usePowerK } from "@/hooks/store/use-power-k";
 // local imports
 import type { TPowerKCommandConfig, TPowerKContext } from "../../core/types";
 import type { TPowerKCommandsListProps } from "./commands-list";
+import { powerKCommandFilter } from "./filter";
 import { PowerKModalFooter } from "./footer";
 import { PowerKModalHeader } from "./header";
 
@@ -145,11 +146,7 @@ export const ProjectsAppPowerKModalWrapper = observer(function ProjectsAppPowerK
             >
               <Dialog.Panel className="divide-opacity-10 relative flex w-full max-w-2xl transform flex-col items-center justify-center divide-y divide-subtle-1 rounded-lg bg-surface-1 shadow-raised-200 transition-all">
                 <Command
-                  filter={(i18nValue: string, search: string) => {
-                    if (i18nValue === "no-results") return 1;
-                    if (i18nValue.toLowerCase().includes(search.toLowerCase())) return 1;
-                    return 0;
-                  }}
+                  filter={powerKCommandFilter}
                   shouldFilter={searchTerm.length > 0}
                   onKeyDown={handleKeyDown}
                   className="w-full"

--- a/apps/web/tests/power-k/filter.test.ts
+++ b/apps/web/tests/power-k/filter.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { powerKCommandFilter } from "@/components/power-k/ui/modal/filter";
+
+describe("powerKCommandFilter", () => {
+  it("keeps server-matched search results when the query only matches keywords", () => {
+    expect(powerKCommandFilter("issue-de4163f5-front end error-PIDASH-1", "38 same errors", ["38 same errors"])).toBe(
+      1
+    );
+  });
+
+  it("keeps server-matched search results when the query has surrounding whitespace", () => {
+    expect(powerKCommandFilter("issue-de4163f5-front end error-PIDASH-1", " 38 same errors ", ["38 same errors"])).toBe(
+      1
+    );
+  });
+
+  it("still filters ordinary command values", () => {
+    expect(powerKCommandFilter("open-project", "project")).toBe(1);
+    expect(powerKCommandFilter("open-project", "38 same errors")).toBe(0);
+  });
+
+  it("always keeps the no-results command", () => {
+    expect(powerKCommandFilter("no-results", "anything")).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- keep topbar issue results visible when the server matched issue body/comment text instead of only visible title text
- include issue comments in the topbar global issue search backend path
- add frontend filter coverage and backend contract coverage for body/comment matches

## Testing
- pnpm --filter web test tests/power-k/filter.test.ts
- pnpm exec oxfmt --check apps/web/core/components/navigation/top-nav-power-k.tsx apps/web/core/components/power-k/ui/modal/command-item.tsx apps/web/core/components/power-k/ui/modal/filter.ts apps/web/core/components/power-k/ui/modal/search-menu.tsx apps/web/core/components/power-k/ui/modal/search-results.tsx apps/web/core/components/power-k/ui/modal/wrapper.tsx apps/web/tests/power-k/filter.test.ts
- pnpm exec oxlint apps/web/core/components/navigation/top-nav-power-k.tsx apps/web/core/components/power-k/ui/modal/command-item.tsx apps/web/core/components/power-k/ui/modal/filter.ts apps/web/core/components/power-k/ui/modal/search-menu.tsx apps/web/core/components/power-k/ui/modal/search-results.tsx apps/web/core/components/power-k/ui/modal/wrapper.tsx apps/web/tests/power-k/filter.test.ts
- docker run --rm --network private-pi-dash_cloud_dev -v /home/rich/dev/airepublic/pi-dash/s3/pi-dash/apps/api:/code -w /code -e DJANGO_SETTINGS_MODULE=pi_dash.settings.test -e DATABASE_URL=postgresql://pi_dash:pi_dash@pi-dash-db:5432/pi_dash -e REDIS_URL=redis://pi-dash-redis:6379/ -e SECRET_KEY=test pi-dash-api sh -lc "pip install -q -r requirements/test.txt && python -m pytest pi_dash/tests/contract/app/test_global_search.py"
- docker run --rm -v /home/rich/dev/airepublic/pi-dash/s3/pi-dash/apps/api:/code -w /code pi-dash-api sh -lc "pip install -q ruff==0.9.7 && ruff format --check pi_dash/app/views/search/base.py pi_dash/tests/contract/app/test_global_search.py && ruff check pi_dash/app/views/search/base.py pi_dash/tests/contract/app/test_global_search.py"