### PR TITLE
Rewrite first-run product tour around Pi Dash, not Plane

### DIFF
--- a/apps/web/ce/components/onboarding/tour/root.tsx
+++ b/apps/web/ce/components/onboarding/tour/root.tsx
@@ -49,7 +49,7 @@ const TOUR_STEPS: {
     key: "runners",
     title: "Connect a Pi Dash Runner",
     description:
-      "Install the Pi Dash Runner on your dev machine to plug in Claude Code, Codex, or other coding agents. The runner picks up work items you dispatch and executes them in the background.",
+      "Install the Pi Dash Runner on your dev machine to plug in Claude Code or Codex. The runner picks up work items you dispatch and executes them in the background.",
     image: CyclesTour,
     prevStep: "work-items",
     nextStep: "chat",

--- a/apps/web/ce/components/onboarding/tour/root.tsx
+++ b/apps/web/ce/components/onboarding/tour/root.tsx
@@ -10,6 +10,8 @@ import { observer } from "mobx-react";
 import { Button } from "@pi-dash/propel/button";
 import { CloseIcon, PiSymbol } from "@pi-dash/propel/icons";
 // assets
+// TODO(onboarding): replace these reused Plane-era screenshots with Pi Dash-native captures
+// (runner CLI, runner chat, workpad) once design provides them.
 import CyclesTour from "@/app/assets/onboarding/cycles.webp?url";
 import IssuesTour from "@/app/assets/onboarding/issues.webp?url";
 import ModulesTour from "@/app/assets/onboarding/modules.webp?url";
@@ -25,7 +27,7 @@ export type TOnboardingTourProps = {
   onComplete: () => void;
 };
 
-export type TTourSteps = "welcome" | "work-items" | "cycles" | "modules" | "views" | "pages";
+export type TTourSteps = "welcome" | "work-items" | "runners" | "chat" | "workpads" | "pages";
 
 const TOUR_STEPS: {
   key: TTourSteps;
@@ -37,44 +39,46 @@ const TOUR_STEPS: {
 }[] = [
   {
     key: "work-items",
-    title: "Plan with work items",
+    title: "Plan work your agents can run",
     description:
-      "The work item is the building block of the Pi Dash. Most concepts in Pi Dash are either associated with work items and their properties.",
+      "Work items are the unit of work in Pi Dash. Describe what needs to happen, attach context, and hand it to a coding agent — or keep it for your team.",
     image: IssuesTour,
-    nextStep: "cycles",
+    nextStep: "runners",
   },
   {
-    key: "cycles",
-    title: "Move with cycles",
+    key: "runners",
+    title: "Connect a Pi Dash Runner",
     description:
-      "Cycles help you and your team to progress faster, similar to the sprints commonly used in agile development.",
+      "Install the Pi Dash Runner on your dev machine to plug in Claude Code, Codex, or other coding agents. The runner picks up work items you dispatch and executes them in the background.",
     image: CyclesTour,
     prevStep: "work-items",
-    nextStep: "modules",
+    nextStep: "chat",
   },
   {
-    key: "modules",
-    title: "Break into modules",
-    description: "Modules break your big thing into Projects or Features, to help you organize better.",
-    image: ModulesTour,
-    prevStep: "cycles",
-    nextStep: "views",
-  },
-  {
-    key: "views",
-    title: "Views",
+    key: "chat",
+    title: "Steer agents from Runner Chat",
     description:
-      "Create custom filters to display only the work items that matter to you. Save and share your filters in just a few clicks.",
+      "Talk to your agents while they work. Answer questions, redirect mid-task, or review what they are doing — all in a live chat tied to each runner session.",
+    image: ModulesTour,
+    prevStep: "runners",
+    nextStep: "workpads",
+  },
+  {
+    key: "workpads",
+    title: "Collaborate in the workpad",
+    description:
+      "Every work item has a workpad — a shared Markdown space where you and your agent build context together. Plans, decisions, and handoff notes stay with the issue.",
     image: ViewsTour,
-    prevStep: "modules",
+    prevStep: "chat",
     nextStep: "pages",
   },
   {
     key: "pages",
     title: "Document with pages",
-    description: "Use Pages to quickly jot down work items when you're in a meeting or starting a day.",
+    description:
+      "Use Pages for specs, runbooks, and notes your team and your agents can reference. A good place to capture context that spans multiple work items.",
     image: PagesTour,
-    prevStep: "views",
+    prevStep: "workpads",
   },
 ];
 
@@ -102,8 +106,8 @@ export const TourRoot = observer(function TourRoot(props: TOnboardingTourProps) 
                 Welcome to Pi Dash, {currentUser?.first_name} {currentUser?.last_name}
               </h3>
               <p className="mt-3 text-13 text-secondary">
-                We{"'"}re glad that you decided to try out Pi Dash. You can now manage your projects with ease. Get
-                started by creating a project.
+                Pi Dash is where you plan work and dispatch it to AI coding agents. Define what needs to be done,
+                connect a runner, and watch your agents execute it — with you in the loop the whole way.
               </p>
               <div className="flex h-full items-end">
                 <div className="mt-12 flex items-center gap-6">

--- a/apps/web/ce/components/onboarding/tour/sidebar.tsx
+++ b/apps/web/ce/components/onboarding/tour/sidebar.tsx
@@ -5,7 +5,7 @@
  */
 
 // pi dash imports
-import { CycleIcon, ModuleIcon, PageIcon, ViewsIcon, WorkItemsIcon } from "@pi-dash/propel/icons";
+import { AiIcon, CommentFillIcon, PageIcon, StickyNoteIcon, WorkItemsIcon } from "@pi-dash/propel/icons";
 import type { ISvgIcons } from "@pi-dash/propel/icons";
 // types
 import type { TTourSteps } from "./root";
@@ -21,19 +21,19 @@ const sidebarOptions: {
     Icon: WorkItemsIcon,
   },
   {
-    key: "cycles",
-    label: "Cycles",
-    Icon: CycleIcon,
+    key: "runners",
+    label: "Runners",
+    Icon: AiIcon,
   },
   {
-    key: "modules",
-    label: "Modules",
-    Icon: ModuleIcon,
+    key: "chat",
+    label: "Runner chat",
+    Icon: CommentFillIcon,
   },
   {
-    key: "views",
-    label: "Views",
-    Icon: ViewsIcon,
+    key: "workpads",
+    label: "Workpads",
+    Icon: StickyNoteIcon,
   },
   {
     key: "pages",
@@ -57,17 +57,17 @@ export function TourSidebar({ step, setStep }: Props) {
       </h3>
       <div className="mt-8 space-y-5">
         {sidebarOptions.map((option) => (
-          <h5
+          <button
             key={option.key}
-            className={`flex cursor-pointer items-center gap-2 border-l-[3px] py-0.5 pr-2 pl-3 text-13 font-medium capitalize ${
+            type="button"
+            className={`flex w-full cursor-pointer items-center gap-2 border-l-[3px] py-0.5 pr-2 pl-3 text-left text-13 font-medium capitalize ${
               step === option.key ? "border-accent-strong text-accent-primary" : "border-transparent text-secondary"
             }`}
             onClick={() => setStep(option.key)}
-            role="button"
           >
             <option.Icon className="h-4 w-4" aria-hidden="true" />
             {option.label}
-          </h5>
+          </button>
         ))}
       </div>
     </div>

--- a/apps/web/ce/components/onboarding/tour/sidebar.tsx
+++ b/apps/web/ce/components/onboarding/tour/sidebar.tsx
@@ -60,6 +60,7 @@ export function TourSidebar({ step, setStep }: Props) {
           <button
             key={option.key}
             type="button"
+            aria-current={step === option.key ? "step" : undefined}
             className={`flex w-full cursor-pointer items-center gap-2 border-l-[3px] py-0.5 pr-2 pl-3 text-left text-13 font-medium capitalize ${
               step === option.key ? "border-accent-strong text-accent-primary" : "border-transparent text-secondary"
             }`}


### PR DESCRIPTION
## Summary

- The post-signup "Get more out of Pi Dash" tour was still pitching Plane's stock concepts (Work items → Cycles → Modules → Views → Pages) verbatim. It said nothing about runners, runner chat, or workpads — i.e., the things that actually distinguish Pi Dash from upstream Plane. New users were getting the wrong mental model on day one.
- This rewrites the 5-step tour to: **Work items** (reframed as agent-dispatchable units) → **Runners** → **Runner chat** → **Workpads** → **Pages**. Welcome screen copy is refreshed to lead with the agent-dispatch story. Sidebar icons updated (`AiIcon`, `CommentFillIcon`, `StickyNoteIcon`).
- Tour images are reused from the existing webp assets with a `TODO(onboarding)` comment — proper Pi Dash screenshots (runner CLI, runner chat, workpad) are a follow-up for design.
- Also fixes the pre-existing a11y warnings in `sidebar.tsx`: the `<h5 role="button">` pattern is now a real `<button>`. The lint-staged hook was already flagging these and they were blocking the commit.

## Test plan

- [ ] `pnpm dev` (web app), sign up a fresh user, confirm the welcome screen body copy is the new agent-centric text
- [ ] Click "Take a Product Tour" → step through Work items → Runners → Runner chat → Workpads → Pages; back/next nav works in both directions
- [ ] Sidebar shows the five new labels with correct icons; clicking each jumps to the right step; active step highlights
- [ ] Final step shows "Create your first project" CTA; clicking it marks tour completed and opens the project create modal
- [ ] Reload — tour does not re-appear (`is_tour_completed` persisted)
- [ ] No type or lint regressions: `pnpm turbo run check:types --filter=web`, `pnpm exec oxlint --deny-warnings apps/web/ce/components/onboarding/tour/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)