### PR TITLE
docs: point skill install at npx @pi-dash/skill-installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Pi Dash does not ship an AI agent — you bring your own. Ensure your chosen age
 [`pi-dash-skill`](https://github.com/The-AI-Republic/pi-dash-skill) packages a portable agent skill so Claude Code or Codex can create, list, move, and inspect Pi Dash issues directly from a coding session via the `pidash` CLI.
 
 ```bash
-npx @pi-dash/skill-installer           # installs to Claude Code, Codex, or both
+npx @airepublic/pidash-skill-installer           # installs to Claude Code, Codex, or both
 ```
 
 The installer prompts for a target (default: all) and fetches the skill from GitHub on demand — no clone required. Pass `--all`, `--claude-code`, or `--codex` to skip the prompt.

--- a/README.md
+++ b/README.md
@@ -176,12 +176,12 @@ Pi Dash does not ship an AI agent — you bring your own. Ensure your chosen age
 [`pi-dash-skill`](https://github.com/The-AI-Republic/pi-dash-skill) packages a portable agent skill so Claude Code or Codex can create, list, move, and inspect Pi Dash issues directly from a coding session via the `pidash` CLI.
 
 ```bash
-git clone https://github.com/The-AI-Republic/pi-dash-skill.git
-cd pi-dash-skill
-node install.mjs           # installs to Claude Code, Codex, or both
+npx @pi-dash/skill-installer           # installs to Claude Code, Codex, or both
 ```
 
-Codex users can also install without cloning by asking `$skill-installer` from inside a Codex session. See the [pi-dash-skill README](https://github.com/The-AI-Republic/pi-dash-skill#readme) for env-var overrides (`CLAUDE_HOME` / `CODEX_HOME`), non-interactive flags, and the full set of install paths.
+The installer prompts for a target (default: all) and fetches the skill from GitHub on demand — no clone required. Pass `--all`, `--claude-code`, or `--codex` to skip the prompt.
+
+Codex users can also install via the built-in `$skill-installer` from inside a Codex session. See the [pi-dash-skill README](https://github.com/The-AI-Republic/pi-dash-skill#readme) for env-var overrides (`CLAUDE_HOME` / `CODEX_HOME`), the clone-based install path, and other alternatives.
 
 ## ⚙️ Built with
 


### PR DESCRIPTION
## Summary
- Swap the `git clone && cd && node install.mjs` snippet in the Pi Dash skill section for `npx @pi-dash/skill-installer`. Same end result, one command.
- Pairs with [pi-dash-skill#4](https://github.com/The-AI-Republic/pi-dash-skill/pull/4) which adds the npm package metadata.

## ⚠️ Do not merge until the npm package is published

This PR points users at `npx @pi-dash/skill-installer`. That URL will 404 until:
1. pi-dash-skill PR #4 is merged.
2. The `@pi-dash` scope is claimed on npmjs.org and `@pi-dash/skill-installer@0.1.0` is published.

Hold this PR (or set `auto-merge`) until both are done. If the eventual published name differs (e.g. `@airepublic/...` or unscoped), update the snippet here before merging.

## Test plan
- [x] README renders cleanly (one snippet swapped, surrounding prose adjusted)
- [ ] After publish: `npx @pi-dash/skill-installer --help` works from a clean machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)