### PR TITLE
Improve issue detail first paint

### DIFF
--- a/apps/api/pi_dash/app/serializers/issue.py
+++ b/apps/api/pi_dash/app/serializers/issue.py
@@ -5,7 +5,7 @@
 # Django imports
 from django.utils import timezone
 from django.core.validators import URLValidator
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import IntegrityError
 
 # Third Party imports
@@ -61,6 +61,11 @@ _LOCKED_COMMENT_FIELDS = {"comment_html", "comment_json", "comment_stripped"}
 def _issue_is_actively_synced(issue) -> bool:
     if issue is None or issue.external_source != "github":
         return False
+
+    annotated_is_synced = getattr(issue, "is_synced", None)
+    if annotated_is_synced is not None:
+        return bool(annotated_is_synced)
+
     from pi_dash.db.models import GithubIssueSync
 
     return GithubIssueSync.objects.filter(issue=issue).exists()
@@ -1065,7 +1070,11 @@ class IssueDetailSerializer(IssueSerializer):
         never been moved to In Progress). See
         ``.ai_design/issue_ticking_system/design.md`` §8.1.
         """
-        ticker = getattr(obj, "agent_ticker", None)
+        try:
+            ticker = obj.agent_ticker
+        except ObjectDoesNotExist:
+            return None
+
         if ticker is None:
             return None
         return {

--- a/apps/api/pi_dash/app/views/issue/base.py
+++ b/apps/api/pi_dash/app/views/issue/base.py
@@ -1211,6 +1211,34 @@ class IssueDetailIdentifierEndpoint(BaseAPIView):
             raise ValueError("Invalid integer string")
         return int(s)
 
+    def is_lite_request(self, request):
+        return request.GET.get("lite", "").lower() in ("1", "true", "yes")
+
+    def serialize_lite_issue(self, issue):
+        if issue.external_source == "github":
+            from pi_dash.db.models import GithubIssueSync
+
+            is_synced = GithubIssueSync.objects.filter(issue=issue).exists()
+        else:
+            is_synced = False
+
+        return {
+            "id": issue.id,
+            "sequence_id": issue.sequence_id,
+            "name": issue.name,
+            "description_html": issue.description_html,
+            "sort_order": issue.sort_order,
+            "project_id": issue.project_id,
+            "created_at": issue.created_at,
+            "updated_at": issue.updated_at,
+            "created_by": issue.created_by_id,
+            "updated_by": issue.updated_by_id,
+            "is_draft": issue.is_draft,
+            "is_intake": issue.is_intake,
+            "is_synced": is_synced,
+            "archived_at": issue.archived_at,
+        }
+
     def get(self, request, slug, project_identifier, issue_identifier):
         # Check if the issue identifier is a valid integer
         try:
@@ -1236,139 +1264,171 @@ class IssueDetailIdentifierEndpoint(BaseAPIView):
                 status=status.HTTP_403_FORBIDDEN,
             )
 
-        # Fetch the issue
-        issue = (
-            Issue.objects.filter(project_id=project.id)
-            .filter(workspace__slug=slug)
-            .select_related("workspace", "project", "state", "parent", "agent_ticker")
-            .prefetch_related("assignees", "labels", "issue_module__module")
-            .annotate(
-                cycle_id=Subquery(
-                    CycleIssue.objects.filter(issue=OuterRef("id"), deleted_at__isnull=True).values("cycle_id")[:1]
+        if self.is_lite_request(request):
+            issue = (
+                Issue.objects.filter(project_id=project.id)
+                .filter(workspace__slug=slug)
+                .filter(sequence_id=issue_identifier)
+                .only(
+                    "id",
+                    "sequence_id",
+                    "name",
+                    "description_html",
+                    "sort_order",
+                    "project_id",
+                    "workspace_id",
+                    "created_at",
+                    "updated_at",
+                    "created_by_id",
+                    "updated_by_id",
+                    "is_draft",
+                    "archived_at",
+                    "external_source",
                 )
-            )
-            .annotate(
-                link_count=Coalesce(
-                    Subquery(
-                        IssueLink.objects.filter(issue=OuterRef("id"))
-                        .order_by()
-                        .values("issue")
-                        .annotate(count=Count("id"))
-                        .values("count"),
-                        output_field=IntegerField(),
-                    ),
-                    0,
-                )
-            )
-            .annotate(
-                attachment_count=Coalesce(
-                    Subquery(
-                        FileAsset.objects.filter(
-                            issue_id=OuterRef("id"),
-                            entity_type=FileAsset.EntityTypeContext.ISSUE_ATTACHMENT,
+                .annotate(
+                    is_intake=Exists(
+                        IntakeIssue.objects.filter(
+                            issue=OuterRef("id"),
+                            status__in=[-2, 0],
+                            workspace__slug=slug,
+                            project_id=project.id,
                         )
-                        .order_by()
-                        .values("issue_id")
-                        .annotate(count=Count("id"))
-                        .values("count"),
-                        output_field=IntegerField(),
-                    ),
-                    0,
-                )
-            )
-            .annotate(
-                sub_issues_count=Coalesce(
-                    Subquery(
-                        Issue.issue_objects.filter(parent=OuterRef("id"))
-                        .order_by()
-                        .values("parent")
-                        .annotate(count=Count("id"))
-                        .values("count"),
-                        output_field=IntegerField(),
-                    ),
-                    0,
-                )
-            )
-            .filter(sequence_id=issue_identifier)
-            # Keep multi-value properties as correlated subqueries; joining them
-            # into this single-issue query inflates planner cost enough to trip
-            # PostgreSQL JIT and add seconds of compile time.
-            .annotate(
-                label_ids=Coalesce(
-                    Subquery(
-                        IssueLabel.objects.filter(issue_id=OuterRef("id"), deleted_at__isnull=True)
-                        .order_by()
-                        .values("issue_id")
-                        .annotate(arr=ArrayAgg("label_id", distinct=True))
-                        .values("arr"),
-                        output_field=ArrayField(UUIDField()),
-                    ),
-                    Value([], output_field=ArrayField(UUIDField())),
-                ),
-                assignee_ids=Coalesce(
-                    Subquery(
-                        IssueAssignee.objects.filter(
-                            issue_id=OuterRef("id"),
-                            assignee__member_project__is_active=True,
-                            deleted_at__isnull=True,
-                        )
-                        .order_by()
-                        .values("issue_id")
-                        .annotate(arr=ArrayAgg("assignee_id", distinct=True))
-                        .values("arr"),
-                        output_field=ArrayField(UUIDField()),
-                    ),
-                    Value([], output_field=ArrayField(UUIDField())),
-                ),
-                module_ids=Coalesce(
-                    Subquery(
-                        ModuleIssue.objects.filter(
-                            issue_id=OuterRef("id"),
-                            module__archived_at__isnull=True,
-                            deleted_at__isnull=True,
-                        )
-                        .order_by()
-                        .values("issue_id")
-                        .annotate(arr=ArrayAgg("module_id", distinct=True))
-                        .values("arr"),
-                        output_field=ArrayField(UUIDField()),
-                    ),
-                    Value([], output_field=ArrayField(UUIDField())),
-                ),
-            )
-            .prefetch_related(
-                Prefetch(
-                    "issue_reactions",
-                    queryset=IssueReaction.objects.select_related("issue", "actor"),
-                )
-            )
-            .prefetch_related(
-                Prefetch(
-                    "issue_link",
-                    queryset=IssueLink.objects.select_related("created_by"),
-                )
-            )
-            .annotate(
-                is_subscribed=Exists(
-                    IssueSubscriber.objects.filter(
-                        workspace__slug=slug,
-                        project_id=project.id,
-                        issue_id=OuterRef("id"),
-                        subscriber=request.user,
                     )
                 )
-            )
-            .annotate(
-                is_intake=Exists(
-                    IntakeIssue.objects.filter(
-                        issue=OuterRef("id"),
-                        status__in=[-2, 0],
-                        workspace__slug=slug,
-                        project_id=project.id,
+            ).first()
+        else:
+            issue = (
+                Issue.objects.filter(project_id=project.id)
+                .filter(workspace__slug=slug)
+                .select_related("workspace", "project", "state", "parent", "agent_ticker")
+                .prefetch_related("assignees", "labels", "issue_module__module")
+                .annotate(
+                    cycle_id=Subquery(
+                        CycleIssue.objects.filter(issue=OuterRef("id"), deleted_at__isnull=True).values("cycle_id")[:1]
                     )
                 )
-            )
-        ).first()
+                .annotate(
+                    link_count=Coalesce(
+                        Subquery(
+                            IssueLink.objects.filter(issue=OuterRef("id"))
+                            .order_by()
+                            .values("issue")
+                            .annotate(count=Count("id"))
+                            .values("count"),
+                            output_field=IntegerField(),
+                        ),
+                        0,
+                    )
+                )
+                .annotate(
+                    attachment_count=Coalesce(
+                        Subquery(
+                            FileAsset.objects.filter(
+                                issue_id=OuterRef("id"),
+                                entity_type=FileAsset.EntityTypeContext.ISSUE_ATTACHMENT,
+                            )
+                            .order_by()
+                            .values("issue_id")
+                            .annotate(count=Count("id"))
+                            .values("count"),
+                            output_field=IntegerField(),
+                        ),
+                        0,
+                    )
+                )
+                .annotate(
+                    sub_issues_count=Coalesce(
+                        Subquery(
+                            Issue.issue_objects.filter(parent=OuterRef("id"))
+                            .order_by()
+                            .values("parent")
+                            .annotate(count=Count("id"))
+                            .values("count"),
+                            output_field=IntegerField(),
+                        ),
+                        0,
+                    )
+                )
+                .filter(sequence_id=issue_identifier)
+                # Keep multi-value properties as correlated subqueries; joining them
+                # into this single-issue query inflates planner cost enough to trip
+                # PostgreSQL JIT and add seconds of compile time.
+                .annotate(
+                    label_ids=Coalesce(
+                        Subquery(
+                            IssueLabel.objects.filter(issue_id=OuterRef("id"), deleted_at__isnull=True)
+                            .order_by()
+                            .values("issue_id")
+                            .annotate(arr=ArrayAgg("label_id", distinct=True))
+                            .values("arr"),
+                            output_field=ArrayField(UUIDField()),
+                        ),
+                        Value([], output_field=ArrayField(UUIDField())),
+                    ),
+                    assignee_ids=Coalesce(
+                        Subquery(
+                            IssueAssignee.objects.filter(
+                                issue_id=OuterRef("id"),
+                                assignee__member_project__is_active=True,
+                                deleted_at__isnull=True,
+                            )
+                            .order_by()
+                            .values("issue_id")
+                            .annotate(arr=ArrayAgg("assignee_id", distinct=True))
+                            .values("arr"),
+                            output_field=ArrayField(UUIDField()),
+                        ),
+                        Value([], output_field=ArrayField(UUIDField())),
+                    ),
+                    module_ids=Coalesce(
+                        Subquery(
+                            ModuleIssue.objects.filter(
+                                issue_id=OuterRef("id"),
+                                module__archived_at__isnull=True,
+                                deleted_at__isnull=True,
+                            )
+                            .order_by()
+                            .values("issue_id")
+                            .annotate(arr=ArrayAgg("module_id", distinct=True))
+                            .values("arr"),
+                            output_field=ArrayField(UUIDField()),
+                        ),
+                        Value([], output_field=ArrayField(UUIDField())),
+                    ),
+                )
+                .prefetch_related(
+                    Prefetch(
+                        "issue_reactions",
+                        queryset=IssueReaction.objects.select_related("issue", "actor"),
+                    )
+                )
+                .prefetch_related(
+                    Prefetch(
+                        "issue_link",
+                        queryset=IssueLink.objects.select_related("created_by"),
+                    )
+                )
+                .annotate(
+                    is_subscribed=Exists(
+                        IssueSubscriber.objects.filter(
+                            workspace__slug=slug,
+                            project_id=project.id,
+                            issue_id=OuterRef("id"),
+                            subscriber=request.user,
+                        )
+                    )
+                )
+                .annotate(
+                    is_intake=Exists(
+                        IntakeIssue.objects.filter(
+                            issue=OuterRef("id"),
+                            status__in=[-2, 0],
+                            workspace__slug=slug,
+                            project_id=project.id,
+                        )
+                    )
+                )
+            ).first()
 
         # Check if the issue exists
         if not issue:
@@ -1391,7 +1451,7 @@ class IssueDetailIdentifierEndpoint(BaseAPIView):
                 is_active=True,
             ).exists()
             and not project.guest_view_all_features
-            and not issue.created_by == request.user
+            and issue.created_by_id != request.user.id
         ):
             return Response(
                 {"error": "You are not allowed to view this issue"},
@@ -1405,6 +1465,9 @@ class IssueDetailIdentifierEndpoint(BaseAPIView):
             user_id=str(request.user.id),
             project_id=str(project.id),
         )
+
+        if self.is_lite_request(request):
+            return Response(self.serialize_lite_issue(issue), status=status.HTTP_200_OK)
 
         # Serialize the issue
         serializer = IssueDetailSerializer(issue, expand=self.expand)

--- a/apps/api/pi_dash/app/views/issue/base.py
+++ b/apps/api/pi_dash/app/views/issue/base.py
@@ -1281,7 +1281,6 @@ class IssueDetailIdentifierEndpoint(BaseAPIView):
                     "is_draft",
                     "archived_at",
                     "external_source",
-                    "type_id",
                 )
                 .annotate(
                     is_epic=Coalesce(
@@ -1318,35 +1317,47 @@ class IssueDetailIdentifierEndpoint(BaseAPIView):
                     )
                 )
                 .annotate(
-                    link_count=Subquery(
-                        IssueLink.objects.filter(issue=OuterRef("id"))
-                        .order_by()
-                        .values("issue")
-                        .annotate(count=Count("id"))
-                        .values("count"),
+                    link_count=Coalesce(
+                        Subquery(
+                            IssueLink.objects.filter(issue=OuterRef("id"))
+                            .order_by()
+                            .values("issue")
+                            .annotate(count=Count("id"))
+                            .values("count"),
+                            output_field=IntegerField(),
+                        ),
+                        Value(0),
                         output_field=IntegerField(),
                     )
                 )
                 .annotate(
-                    attachment_count=Subquery(
-                        FileAsset.objects.filter(
-                            issue_id=OuterRef("id"),
-                            entity_type=FileAsset.EntityTypeContext.ISSUE_ATTACHMENT,
-                        )
-                        .order_by()
-                        .values("issue_id")
-                        .annotate(count=Count("id"))
-                        .values("count"),
+                    attachment_count=Coalesce(
+                        Subquery(
+                            FileAsset.objects.filter(
+                                issue_id=OuterRef("id"),
+                                entity_type=FileAsset.EntityTypeContext.ISSUE_ATTACHMENT,
+                            )
+                            .order_by()
+                            .values("issue_id")
+                            .annotate(count=Count("id"))
+                            .values("count"),
+                            output_field=IntegerField(),
+                        ),
+                        Value(0),
                         output_field=IntegerField(),
                     )
                 )
                 .annotate(
-                    sub_issues_count=Subquery(
-                        Issue.issue_objects.filter(parent=OuterRef("id"))
-                        .order_by()
-                        .values("parent")
-                        .annotate(count=Count("id"))
-                        .values("count"),
+                    sub_issues_count=Coalesce(
+                        Subquery(
+                            Issue.issue_objects.filter(parent=OuterRef("id"))
+                            .order_by()
+                            .values("parent")
+                            .annotate(count=Count("id"))
+                            .values("count"),
+                            output_field=IntegerField(),
+                        ),
+                        Value(0),
                         output_field=IntegerField(),
                     )
                 )

--- a/apps/api/pi_dash/app/views/issue/base.py
+++ b/apps/api/pi_dash/app/views/issue/base.py
@@ -15,6 +15,7 @@ from django.db.models import (
     Exists,
     F,
     Func,
+    IntegerField,
     OuterRef,
     Prefetch,
     Q,
@@ -1239,61 +1240,98 @@ class IssueDetailIdentifierEndpoint(BaseAPIView):
         issue = (
             Issue.objects.filter(project_id=project.id)
             .filter(workspace__slug=slug)
-            .select_related("workspace", "project", "state", "parent")
+            .select_related("workspace", "project", "state", "parent", "agent_ticker")
             .prefetch_related("assignees", "labels", "issue_module__module")
-            .annotate(cycle_id=Subquery(CycleIssue.objects.filter(issue=OuterRef("id")).values("cycle_id")[:1]))
             .annotate(
-                link_count=IssueLink.objects.filter(issue=OuterRef("id"))
-                .order_by()
-                .annotate(count=Func(F("id"), function="Count"))
-                .values("count")
-            )
-            .annotate(
-                attachment_count=FileAsset.objects.filter(
-                    issue_id=OuterRef("id"),
-                    entity_type=FileAsset.EntityTypeContext.ISSUE_ATTACHMENT,
+                cycle_id=Subquery(
+                    CycleIssue.objects.filter(issue=OuterRef("id"), deleted_at__isnull=True).values("cycle_id")[:1]
                 )
-                .order_by()
-                .annotate(count=Func(F("id"), function="Count"))
-                .values("count")
             )
             .annotate(
-                sub_issues_count=Issue.issue_objects.filter(parent=OuterRef("id"))
-                .order_by()
-                .annotate(count=Func(F("id"), function="Count"))
-                .values("count")
+                link_count=Coalesce(
+                    Subquery(
+                        IssueLink.objects.filter(issue=OuterRef("id"))
+                        .order_by()
+                        .values("issue")
+                        .annotate(count=Count("id"))
+                        .values("count"),
+                        output_field=IntegerField(),
+                    ),
+                    0,
+                )
+            )
+            .annotate(
+                attachment_count=Coalesce(
+                    Subquery(
+                        FileAsset.objects.filter(
+                            issue_id=OuterRef("id"),
+                            entity_type=FileAsset.EntityTypeContext.ISSUE_ATTACHMENT,
+                        )
+                        .order_by()
+                        .values("issue_id")
+                        .annotate(count=Count("id"))
+                        .values("count"),
+                        output_field=IntegerField(),
+                    ),
+                    0,
+                )
+            )
+            .annotate(
+                sub_issues_count=Coalesce(
+                    Subquery(
+                        Issue.issue_objects.filter(parent=OuterRef("id"))
+                        .order_by()
+                        .values("parent")
+                        .annotate(count=Count("id"))
+                        .values("count"),
+                        output_field=IntegerField(),
+                    ),
+                    0,
+                )
             )
             .filter(sequence_id=issue_identifier)
+            # Keep multi-value properties as correlated subqueries; joining them
+            # into this single-issue query inflates planner cost enough to trip
+            # PostgreSQL JIT and add seconds of compile time.
             .annotate(
                 label_ids=Coalesce(
-                    ArrayAgg(
-                        "labels__id",
-                        distinct=True,
-                        filter=Q(~Q(labels__id__isnull=True) & Q(label_issue__deleted_at__isnull=True)),
+                    Subquery(
+                        IssueLabel.objects.filter(issue_id=OuterRef("id"), deleted_at__isnull=True)
+                        .order_by()
+                        .values("issue_id")
+                        .annotate(arr=ArrayAgg("label_id", distinct=True))
+                        .values("arr"),
+                        output_field=ArrayField(UUIDField()),
                     ),
                     Value([], output_field=ArrayField(UUIDField())),
                 ),
                 assignee_ids=Coalesce(
-                    ArrayAgg(
-                        "assignees__id",
-                        distinct=True,
-                        filter=Q(
-                            ~Q(assignees__id__isnull=True)
-                            & Q(assignees__member_project__is_active=True)
-                            & Q(issue_assignee__deleted_at__isnull=True)
-                        ),
+                    Subquery(
+                        IssueAssignee.objects.filter(
+                            issue_id=OuterRef("id"),
+                            assignee__member_project__is_active=True,
+                            deleted_at__isnull=True,
+                        )
+                        .order_by()
+                        .values("issue_id")
+                        .annotate(arr=ArrayAgg("assignee_id", distinct=True))
+                        .values("arr"),
+                        output_field=ArrayField(UUIDField()),
                     ),
                     Value([], output_field=ArrayField(UUIDField())),
                 ),
                 module_ids=Coalesce(
-                    ArrayAgg(
-                        "issue_module__module_id",
-                        distinct=True,
-                        filter=Q(
-                            ~Q(issue_module__module_id__isnull=True)
-                            & Q(issue_module__module__archived_at__isnull=True)
-                            & Q(issue_module__deleted_at__isnull=True)
-                        ),
+                    Subquery(
+                        ModuleIssue.objects.filter(
+                            issue_id=OuterRef("id"),
+                            module__archived_at__isnull=True,
+                            deleted_at__isnull=True,
+                        )
+                        .order_by()
+                        .values("issue_id")
+                        .annotate(arr=ArrayAgg("module_id", distinct=True))
+                        .values("arr"),
+                        output_field=ArrayField(UUIDField()),
                     ),
                     Value([], output_field=ArrayField(UUIDField())),
                 ),
@@ -1315,7 +1353,7 @@ class IssueDetailIdentifierEndpoint(BaseAPIView):
                     IssueSubscriber.objects.filter(
                         workspace__slug=slug,
                         project_id=project.id,
-                        issue__sequence_id=issue_identifier,
+                        issue_id=OuterRef("id"),
                         subscriber=request.user,
                     )
                 )

--- a/apps/api/pi_dash/app/views/issue/base.py
+++ b/apps/api/pi_dash/app/views/issue/base.py
@@ -11,6 +11,7 @@ from django.contrib.postgres.aggregates import ArrayAgg
 from django.contrib.postgres.fields import ArrayField
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db.models import (
+    BooleanField,
     Count,
     Exists,
     F,
@@ -41,6 +42,7 @@ from pi_dash.app.serializers import (
     IssueSerializer,
     ProjectUserPropertySerializer,
 )
+from pi_dash.app.serializers.issue import _issue_is_actively_synced
 from pi_dash.bgtasks.issue_activities_task import issue_activity
 from pi_dash.bgtasks.issue_description_version_task import issue_description_version_task
 from pi_dash.bgtasks.recent_visited_task import recent_visited_task
@@ -51,6 +53,7 @@ from pi_dash.db.models import (
     IntakeIssue,
     Issue,
     IssueAssignee,
+    GithubIssueSync,
     IssueLabel,
     IssueLink,
     IssueReaction,
@@ -1215,13 +1218,6 @@ class IssueDetailIdentifierEndpoint(BaseAPIView):
         return request.GET.get("lite", "").lower() in ("1", "true", "yes")
 
     def serialize_lite_issue(self, issue):
-        if issue.external_source == "github":
-            from pi_dash.db.models import GithubIssueSync
-
-            is_synced = GithubIssueSync.objects.filter(issue=issue).exists()
-        else:
-            is_synced = False
-
         return {
             "id": issue.id,
             "sequence_id": issue.sequence_id,
@@ -1234,8 +1230,9 @@ class IssueDetailIdentifierEndpoint(BaseAPIView):
             "created_by": issue.created_by_id,
             "updated_by": issue.updated_by_id,
             "is_draft": issue.is_draft,
+            "is_epic": bool(getattr(issue, "is_epic", False)),
             "is_intake": issue.is_intake,
-            "is_synced": is_synced,
+            "is_synced": _issue_is_actively_synced(issue),
             "archived_at": issue.archived_at,
         }
 
@@ -1284,14 +1281,27 @@ class IssueDetailIdentifierEndpoint(BaseAPIView):
                     "is_draft",
                     "archived_at",
                     "external_source",
+                    "type_id",
                 )
                 .annotate(
+                    is_epic=Coalesce(
+                        F("type__is_epic"),
+                        Value(False),
+                        output_field=BooleanField(),
+                    ),
                     is_intake=Exists(
                         IntakeIssue.objects.filter(
                             issue=OuterRef("id"),
                             status__in=[-2, 0],
                             workspace__slug=slug,
                             project_id=project.id,
+                        )
+                    )
+                )
+                .annotate(
+                    is_synced=Exists(
+                        GithubIssueSync.objects.filter(
+                            issue=OuterRef("id"),
                         )
                     )
                 )
@@ -1304,49 +1314,40 @@ class IssueDetailIdentifierEndpoint(BaseAPIView):
                 .prefetch_related("assignees", "labels", "issue_module__module")
                 .annotate(
                     cycle_id=Subquery(
-                        CycleIssue.objects.filter(issue=OuterRef("id"), deleted_at__isnull=True).values("cycle_id")[:1]
+                        CycleIssue.objects.filter(issue=OuterRef("id")).values("cycle_id")[:1]
                     )
                 )
                 .annotate(
-                    link_count=Coalesce(
-                        Subquery(
-                            IssueLink.objects.filter(issue=OuterRef("id"))
-                            .order_by()
-                            .values("issue")
-                            .annotate(count=Count("id"))
-                            .values("count"),
-                            output_field=IntegerField(),
-                        ),
-                        0,
+                    link_count=Subquery(
+                        IssueLink.objects.filter(issue=OuterRef("id"))
+                        .order_by()
+                        .values("issue")
+                        .annotate(count=Count("id"))
+                        .values("count"),
+                        output_field=IntegerField(),
                     )
                 )
                 .annotate(
-                    attachment_count=Coalesce(
-                        Subquery(
-                            FileAsset.objects.filter(
-                                issue_id=OuterRef("id"),
-                                entity_type=FileAsset.EntityTypeContext.ISSUE_ATTACHMENT,
-                            )
-                            .order_by()
-                            .values("issue_id")
-                            .annotate(count=Count("id"))
-                            .values("count"),
-                            output_field=IntegerField(),
-                        ),
-                        0,
+                    attachment_count=Subquery(
+                        FileAsset.objects.filter(
+                            issue_id=OuterRef("id"),
+                            entity_type=FileAsset.EntityTypeContext.ISSUE_ATTACHMENT,
+                        )
+                        .order_by()
+                        .values("issue_id")
+                        .annotate(count=Count("id"))
+                        .values("count"),
+                        output_field=IntegerField(),
                     )
                 )
                 .annotate(
-                    sub_issues_count=Coalesce(
-                        Subquery(
-                            Issue.issue_objects.filter(parent=OuterRef("id"))
-                            .order_by()
-                            .values("parent")
-                            .annotate(count=Count("id"))
-                            .values("count"),
-                            output_field=IntegerField(),
-                        ),
-                        0,
+                    sub_issues_count=Subquery(
+                        Issue.issue_objects.filter(parent=OuterRef("id"))
+                        .order_by()
+                        .values("parent")
+                        .annotate(count=Count("id"))
+                        .values("count"),
+                        output_field=IntegerField(),
                     )
                 )
                 .filter(sequence_id=issue_identifier)

--- a/apps/web/app/(all)/[workspaceSlug]/(projects)/browse/[workItem]/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/(projects)/browse/[workItem]/page.tsx
@@ -41,6 +41,7 @@ export const IssueDetailsPage = observer(function IssueDetailsPage({ params }: R
   // store hooks
   const { t } = useTranslation();
   const {
+    fetchIssue,
     fetchIssueWithIdentifier,
     issue: { getIssueById },
   } = useIssueDetail();
@@ -52,7 +53,7 @@ export const IssueDetailsPage = observer(function IssueDetailsPage({ params }: R
   // fetching issue details
   const { data, isLoading, error } = useSWR<TIssue, Error>(
     `ISSUE_DETAIL_${workspaceSlug}_${projectIdentifier}_${sequence_id}`,
-    () => fetchIssueWithIdentifier(workspaceSlug.toString(), projectIdentifier, sequence_id)
+    () => fetchIssueWithIdentifier(workspaceSlug.toString(), projectIdentifier, sequence_id, { lite: true })
   );
 
   // derived values
@@ -90,6 +91,14 @@ export const IssueDetailsPage = observer(function IssueDetailsPage({ params }: R
       router.push(`/${workspaceSlug}/projects/${data.project_id}/intake/?currentTab=open&inboxIssueId=${data?.id}`);
     }
   }, [workspaceSlug, data, router]);
+
+  useEffect(() => {
+    if (!workspaceSlug || !projectId || !issueId || data?.is_intake) return;
+
+    void fetchIssue(workspaceSlug.toString(), projectId.toString(), issueId.toString(), {
+      skipActivityAndComments: true,
+    }).catch(() => undefined);
+  }, [workspaceSlug, projectId, issueId, data?.is_intake, fetchIssue]);
 
   if (error && !isLoading) {
     return (

--- a/apps/web/app/(all)/[workspaceSlug]/(projects)/browse/[workItem]/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/(projects)/browse/[workItem]/page.tsx
@@ -46,6 +46,7 @@ export const IssueDetailsPage = observer(function IssueDetailsPage({ params }: R
     fetchIssueWithIdentifier,
     issue: { getIssueById },
   } = useIssueDetail();
+  const { fetchIssue: fetchEpic } = useIssueDetail(EIssueServiceType.EPICS);
   const { getProjectById, getProjectByIdentifier } = useProject();
   const { toggleIssueDetailSidebar, issueDetailSidebarCollapsed } = useAppTheme();
 
@@ -78,10 +79,15 @@ export const IssueDetailsPage = observer(function IssueDetailsPage({ params }: R
   } = useSWR<TIssue, Error>(
     shouldHydrateIssue ? `ISSUE_DETAIL_HYDRATE_${workspaceSlug}_${projectId}_${issueId}` : null,
     () =>
-      fetchIssue(workspaceSlug.toString(), projectId.toString(), issueId?.toString() ?? "", {
-        preserveSubscription: true,
-        skipActivityAndComments: true,
-      }),
+      (liteIssue?.is_epic ? fetchEpic : fetchIssue)(
+        workspaceSlug.toString(),
+        projectId.toString(),
+        issueId?.toString() ?? "",
+        {
+          preserveSubscription: true,
+          skipActivityAndComments: true,
+        }
+      ),
     { revalidateOnFocus: false }
   );
   const isMetadataHydrating = shouldHydrateIssue && isHydratingIssue && !hydratedIssue;
@@ -113,7 +119,7 @@ export const IssueDetailsPage = observer(function IssueDetailsPage({ params }: R
         `/${workspaceSlug}/projects/${liteIssue.project_id}/intake/?currentTab=open&inboxIssueId=${liteIssue?.id}`
       );
     }
-  }, [workspaceSlug, liteIssue, router]);
+  }, [workspaceSlug, liteIssue?.id, liteIssue?.is_intake, liteIssue?.project_id, router]);
 
   if ((error && !isLoading) || hydrationError) {
     return (
@@ -122,7 +128,7 @@ export const IssueDetailsPage = observer(function IssueDetailsPage({ params }: R
         title={t("issue.empty_state.issue_detail.title")}
         description={t("issue.empty_state.issue_detail.description")}
         primaryButton={{
-          text: hydrationError ? "Retry" : t("issue.empty_state.issue_detail.primary_button.text"),
+          text: hydrationError ? t("common.retry") : t("issue.empty_state.issue_detail.primary_button.text"),
           onClick: () => {
             if (hydrationError) void retryIssueHydration();
             else router.push(`/${workspaceSlug}/workspace-views/all-issues/`);

--- a/apps/web/app/(all)/[workspaceSlug]/(projects)/browse/[workItem]/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/(projects)/browse/[workItem]/page.tsx
@@ -24,6 +24,7 @@ import { useAppTheme } from "@/hooks/store/use-app-theme";
 import { useIssueDetail } from "@/hooks/store/use-issue-detail";
 import { useProject } from "@/hooks/store/use-project";
 import { useAppRouter } from "@/hooks/use-app-router";
+import type { TIssueLite } from "@/store/issue/issue-details/issue.store";
 // layouts
 import { ProjectAuthWrapper } from "@/layouts/auth-layout/project-wrapper";
 // pi dash web imports
@@ -51,19 +52,39 @@ export const IssueDetailsPage = observer(function IssueDetailsPage({ params }: R
   const [projectIdentifier, sequence_id] = workItem.split("-");
 
   // fetching issue details
-  const { data, isLoading, error } = useSWR<TIssue, Error>(
-    `ISSUE_DETAIL_${workspaceSlug}_${projectIdentifier}_${sequence_id}`,
-    () => fetchIssueWithIdentifier(workspaceSlug.toString(), projectIdentifier, sequence_id, { lite: true })
+  const {
+    data: liteIssue,
+    isLoading,
+    error,
+  } = useSWR<TIssueLite, Error>(`ISSUE_DETAIL_${workspaceSlug}_${projectIdentifier}_${sequence_id}`, () =>
+    fetchIssueWithIdentifier(workspaceSlug.toString(), projectIdentifier, sequence_id, { lite: true })
   );
 
   // derived values
   const projectDetails = getProjectByIdentifier(projectIdentifier);
-  const issueId = data?.id;
-  const projectId = data?.project_id ?? projectDetails?.id ?? "";
+  const issueId = liteIssue?.id;
+  const projectId = liteIssue?.project_id ?? projectDetails?.id ?? "";
   const issue = getIssueById(issueId?.toString() || "") || undefined;
   const project = (issue?.project_id && getProjectById(issue?.project_id)) || undefined;
   const issueLoader = !issue || isLoading;
   const pageTitle = project && issue ? `${project?.identifier}-${issue?.sequence_id} ${issue?.name}` : undefined;
+  const shouldHydrateIssue = !!workspaceSlug && !!projectId && !!issueId && !liteIssue?.is_intake;
+
+  const {
+    data: hydratedIssue,
+    isLoading: isHydratingIssue,
+    error: hydrationError,
+    mutate: retryIssueHydration,
+  } = useSWR<TIssue, Error>(
+    shouldHydrateIssue ? `ISSUE_DETAIL_HYDRATE_${workspaceSlug}_${projectId}_${issueId}` : null,
+    () =>
+      fetchIssue(workspaceSlug.toString(), projectId.toString(), issueId?.toString() ?? "", {
+        preserveSubscription: true,
+        skipActivityAndComments: true,
+      }),
+    { revalidateOnFocus: false }
+  );
+  const isMetadataHydrating = shouldHydrateIssue && isHydratingIssue && !hydratedIssue;
 
   useWorkItemProperties(
     projectId,
@@ -87,28 +108,25 @@ export const IssueDetailsPage = observer(function IssueDetailsPage({ params }: R
   }, [issueDetailSidebarCollapsed, toggleIssueDetailSidebar]);
 
   useEffect(() => {
-    if (data?.is_intake) {
-      router.push(`/${workspaceSlug}/projects/${data.project_id}/intake/?currentTab=open&inboxIssueId=${data?.id}`);
+    if (liteIssue?.is_intake) {
+      router.push(
+        `/${workspaceSlug}/projects/${liteIssue.project_id}/intake/?currentTab=open&inboxIssueId=${liteIssue?.id}`
+      );
     }
-  }, [workspaceSlug, data, router]);
+  }, [workspaceSlug, liteIssue, router]);
 
-  useEffect(() => {
-    if (!workspaceSlug || !projectId || !issueId || data?.is_intake) return;
-
-    void fetchIssue(workspaceSlug.toString(), projectId.toString(), issueId.toString(), {
-      skipActivityAndComments: true,
-    }).catch(() => undefined);
-  }, [workspaceSlug, projectId, issueId, data?.is_intake, fetchIssue]);
-
-  if (error && !isLoading) {
+  if ((error && !isLoading) || hydrationError) {
     return (
       <EmptyState
         image={resolvedTheme === "dark" ? emptyIssueDark : emptyIssueLight}
         title={t("issue.empty_state.issue_detail.title")}
         description={t("issue.empty_state.issue_detail.description")}
         primaryButton={{
-          text: t("issue.empty_state.issue_detail.primary_button.text"),
-          onClick: () => router.push(`/${workspaceSlug}/workspace-views/all-issues/`),
+          text: hydrationError ? "Retry" : t("issue.empty_state.issue_detail.primary_button.text"),
+          onClick: () => {
+            if (hydrationError) void retryIssueHydration();
+            else router.push(`/${workspaceSlug}/workspace-views/all-issues/`);
+          },
         }}
       />
     );
@@ -143,6 +161,7 @@ export const IssueDetailsPage = observer(function IssueDetailsPage({ params }: R
             projectId={projectId.toString()}
             issueId={issueId.toString()}
             issue={issue}
+            isMetadataHydrating={isMetadataHydrating}
           />
         </ProjectAuthWrapper>
       )}

--- a/apps/web/ce/components/browse/workItem-detail.tsx
+++ b/apps/web/ce/components/browse/workItem-detail.tsx
@@ -13,10 +13,11 @@ export type TWorkItemDetailRoot = {
   projectId: string;
   issueId: string;
   issue: TIssue | undefined;
+  isMetadataHydrating?: boolean;
 };
 
 export const WorkItemDetailRoot = observer(function WorkItemDetailRoot(props: TWorkItemDetailRoot) {
-  const { workspaceSlug, projectId, issueId, issue } = props;
+  const { workspaceSlug, projectId, issueId, issue, isMetadataHydrating = false } = props;
 
   return (
     <IssueDetailRoot
@@ -24,6 +25,7 @@ export const WorkItemDetailRoot = observer(function WorkItemDetailRoot(props: TW
       projectId={projectId.toString()}
       issueId={issueId.toString()}
       is_archived={!!issue?.archived_at}
+      isMetadataHydrating={isMetadataHydrating}
     />
   );
 });

--- a/apps/web/core/components/issues/issue-detail/main-content.tsx
+++ b/apps/web/core/components/issues/issue-detail/main-content.tsx
@@ -47,10 +47,19 @@ type Props = {
   issueOperations: TIssueOperations;
   isEditable: boolean;
   isArchived: boolean;
+  isMetadataHydrating?: boolean;
 };
 
 export const IssueMainContent = observer(function IssueMainContent(props: Props) {
-  const { workspaceSlug, projectId, issueId, issueOperations, isEditable, isArchived } = props;
+  const {
+    workspaceSlug,
+    projectId,
+    issueId,
+    issueOperations,
+    isEditable,
+    isArchived,
+    isMetadataHydrating = false,
+  } = props;
   // refs
   const editorRef = useRef<EditorRefApi>(null);
   // states
@@ -170,7 +179,7 @@ export const IssueMainContent = observer(function IssueMainContent(props: Props)
               projectId={projectId}
               issueId={issueId}
               currentUser={currentUser}
-              disabled={isArchived}
+              disabled={isArchived || isMetadataHydrating}
             />
           )}
           {isEditable && (
@@ -201,7 +210,7 @@ export const IssueMainContent = observer(function IssueMainContent(props: Props)
         workspaceSlug={workspaceSlug}
         projectId={projectId}
         issueId={issueId}
-        disabled={!isEditable || isArchived}
+        disabled={!isEditable || isArchived || isMetadataHydrating}
         renderWidgetModals={!isPeekModeActive}
         issueServiceType={EIssueServiceType.ISSUES}
       />
@@ -220,7 +229,7 @@ export const IssueMainContent = observer(function IssueMainContent(props: Props)
             projectId={projectId}
             issueId={issueId}
             issueOperations={issueOperations}
-            disabled={!isEditable || isArchived}
+            disabled={!isEditable || isArchived || isMetadataHydrating}
           />
         </div>
       )}

--- a/apps/web/core/components/issues/issue-detail/root.tsx
+++ b/apps/web/core/components/issues/issue-detail/root.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from "@pi-dash/i18n";
 import { TOAST_TYPE, setPromiseToast, setToast } from "@pi-dash/propel/toast";
 import type { TIssue } from "@pi-dash/types";
 import { EIssuesStoreType } from "@pi-dash/types";
+import { Loader } from "@pi-dash/ui";
 // assets
 import emptyIssue from "@/app/assets/empty-state/issue.svg?url";
 // components
@@ -56,11 +57,12 @@ export type TIssueDetailRoot = {
   projectId: string;
   issueId: string;
   is_archived?: boolean;
+  isMetadataHydrating?: boolean;
 };
 
 export const IssueDetailRoot = observer(function IssueDetailRoot(props: TIssueDetailRoot) {
   const { t } = useTranslation();
-  const { workspaceSlug, projectId, issueId, is_archived = false } = props;
+  const { workspaceSlug, projectId, issueId, is_archived = false, isMetadataHydrating = false } = props;
   // router
   const router = useAppRouter();
   // hooks
@@ -84,16 +86,16 @@ export const IssueDetailRoot = observer(function IssueDetailRoot(props: TIssueDe
 
   const issueOperations: TIssueOperations = useMemo(
     () => ({
-      fetch: async (workspaceSlug: string, projectId: string, issueId: string) => {
+      fetch: async (opWorkspaceSlug: string, opProjectId: string, opIssueId: string) => {
         try {
-          await fetchIssue(workspaceSlug, projectId, issueId);
+          await fetchIssue(opWorkspaceSlug, opProjectId, opIssueId);
         } catch (error) {
           console.error("Error fetching the parent issue:", error);
         }
       },
-      update: async (workspaceSlug: string, projectId: string, issueId: string, data: Partial<TIssue>) => {
+      update: async (opWorkspaceSlug: string, opProjectId: string, opIssueId: string, data: Partial<TIssue>) => {
         try {
-          await updateIssue(workspaceSlug, projectId, issueId, data);
+          await updateIssue(opWorkspaceSlug, opProjectId, opIssueId, data);
         } catch (error) {
           console.log("Error in updating issue:", error);
           setToast({
@@ -103,10 +105,10 @@ export const IssueDetailRoot = observer(function IssueDetailRoot(props: TIssueDe
           });
         }
       },
-      remove: async (workspaceSlug: string, projectId: string, issueId: string) => {
+      remove: async (opWorkspaceSlug: string, opProjectId: string, opIssueId: string) => {
         try {
-          if (is_archived) await removeArchivedIssue(workspaceSlug, projectId, issueId);
-          else await removeIssue(workspaceSlug, projectId, issueId);
+          if (is_archived) await removeArchivedIssue(opWorkspaceSlug, opProjectId, opIssueId);
+          else await removeIssue(opWorkspaceSlug, opProjectId, opIssueId);
           setToast({
             title: t("common.success"),
             type: TOAST_TYPE.SUCCESS,
@@ -121,16 +123,16 @@ export const IssueDetailRoot = observer(function IssueDetailRoot(props: TIssueDe
           });
         }
       },
-      archive: async (workspaceSlug: string, projectId: string, issueId: string) => {
+      archive: async (opWorkspaceSlug: string, opProjectId: string, opIssueId: string) => {
         try {
-          await archiveIssue(workspaceSlug, projectId, issueId);
+          await archiveIssue(opWorkspaceSlug, opProjectId, opIssueId);
         } catch (error) {
           console.log("Error in archiving issue:", error);
         }
       },
-      addCycleToIssue: async (workspaceSlug: string, projectId: string, cycleId: string, issueId: string) => {
+      addCycleToIssue: async (opWorkspaceSlug: string, opProjectId: string, cycleId: string, opIssueId: string) => {
         try {
-          await addCycleToIssue(workspaceSlug, projectId, cycleId, issueId);
+          await addCycleToIssue(opWorkspaceSlug, opProjectId, cycleId, opIssueId);
         } catch (_error) {
           setToast({
             type: TOAST_TYPE.ERROR,
@@ -139,9 +141,9 @@ export const IssueDetailRoot = observer(function IssueDetailRoot(props: TIssueDe
           });
         }
       },
-      addIssueToCycle: async (workspaceSlug: string, projectId: string, cycleId: string, issueIds: string[]) => {
+      addIssueToCycle: async (opWorkspaceSlug: string, opProjectId: string, cycleId: string, issueIds: string[]) => {
         try {
-          await addIssueToCycle(workspaceSlug, projectId, cycleId, issueIds);
+          await addIssueToCycle(opWorkspaceSlug, opProjectId, cycleId, issueIds);
         } catch (_error) {
           setToast({
             type: TOAST_TYPE.ERROR,
@@ -150,9 +152,14 @@ export const IssueDetailRoot = observer(function IssueDetailRoot(props: TIssueDe
           });
         }
       },
-      removeIssueFromCycle: async (workspaceSlug: string, projectId: string, cycleId: string, issueId: string) => {
+      removeIssueFromCycle: async (
+        opWorkspaceSlug: string,
+        opProjectId: string,
+        cycleId: string,
+        opIssueId: string
+      ) => {
         try {
-          const removeFromCyclePromise = removeIssueFromCycle(workspaceSlug, projectId, cycleId, issueId);
+          const removeFromCyclePromise = removeIssueFromCycle(opWorkspaceSlug, opProjectId, cycleId, opIssueId);
           setPromiseToast(removeFromCyclePromise, {
             loading: t("issue.remove.cycle.loading"),
             success: {
@@ -169,9 +176,14 @@ export const IssueDetailRoot = observer(function IssueDetailRoot(props: TIssueDe
           console.log("Error in removing issue from cycle:", error);
         }
       },
-      removeIssueFromModule: async (workspaceSlug: string, projectId: string, moduleId: string, issueId: string) => {
+      removeIssueFromModule: async (
+        opWorkspaceSlug: string,
+        opProjectId: string,
+        moduleId: string,
+        opIssueId: string
+      ) => {
         try {
-          const removeFromModulePromise = removeIssueFromModule(workspaceSlug, projectId, moduleId, issueId);
+          const removeFromModulePromise = removeIssueFromModule(opWorkspaceSlug, opProjectId, moduleId, opIssueId);
           setPromiseToast(removeFromModulePromise, {
             loading: t("issue.remove.module.loading"),
             success: {
@@ -189,13 +201,19 @@ export const IssueDetailRoot = observer(function IssueDetailRoot(props: TIssueDe
         }
       },
       changeModulesInIssue: async (
-        workspaceSlug: string,
-        projectId: string,
-        issueId: string,
+        opWorkspaceSlug: string,
+        opProjectId: string,
+        opIssueId: string,
         addModuleIds: string[],
         removeModuleIds: string[]
       ) => {
-        const promise = await changeModulesInIssue(workspaceSlug, projectId, issueId, addModuleIds, removeModuleIds);
+        const promise = await changeModulesInIssue(
+          opWorkspaceSlug,
+          opProjectId,
+          opIssueId,
+          addModuleIds,
+          removeModuleIds
+        );
         return promise;
       },
     }),
@@ -224,6 +242,7 @@ export const IssueDetailRoot = observer(function IssueDetailRoot(props: TIssueDe
     workspaceSlug,
     projectId
   );
+  const isMetadataEditable = !is_archived && isEditable && !isMetadataHydrating;
 
   return (
     <>
@@ -247,19 +266,30 @@ export const IssueDetailRoot = observer(function IssueDetailRoot(props: TIssueDe
               issueOperations={issueOperations}
               isEditable={isEditable}
               isArchived={is_archived}
+              isMetadataHydrating={isMetadataHydrating}
             />
           </div>
           <div
             className="fixed right-0 z-[5] h-full w-full min-w-[300px] border-l border-subtle bg-surface-1 sm:w-1/2 md:relative md:w-1/4 lg:min-w-80 xl:min-w-96"
             style={issueDetailSidebarCollapsed ? { right: `-${window?.innerWidth || 0}px` } : {}}
           >
-            <IssueDetailsSidebar
-              workspaceSlug={workspaceSlug}
-              projectId={projectId}
-              issueId={issueId}
-              issueOperations={issueOperations}
-              isEditable={!is_archived && isEditable}
-            />
+            {isMetadataHydrating ? (
+              <Loader className="h-full w-full space-y-3 p-6">
+                <Loader.Item height="30px" />
+                <Loader.Item height="30px" />
+                <Loader.Item height="30px" />
+                <Loader.Item height="30px" />
+                <Loader.Item height="30px" />
+              </Loader>
+            ) : (
+              <IssueDetailsSidebar
+                workspaceSlug={workspaceSlug}
+                projectId={projectId}
+                issueId={issueId}
+                issueOperations={issueOperations}
+                isEditable={isMetadataEditable}
+              />
+            )}
           </div>
         </div>
       )}

--- a/apps/web/core/store/issue/issue-details/issue.store.ts
+++ b/apps/web/core/store/issue/issue-details/issue.store.ts
@@ -14,9 +14,22 @@ import { IssueArchiveService, WorkspaceDraftService, IssueService } from "@/serv
 // types
 import type { IIssueDetail } from "./root.store";
 
+export type TFetchIssueOptions = {
+  skipActivityAndComments?: boolean;
+};
+
+export type TFetchIssueWithIdentifierOptions = {
+  lite?: boolean;
+};
+
 export interface IIssueStoreActions {
   // actions
-  fetchIssue: (workspaceSlug: string, projectId: string, issueId: string) => Promise<TIssue>;
+  fetchIssue: (
+    workspaceSlug: string,
+    projectId: string,
+    issueId: string,
+    options?: TFetchIssueOptions
+  ) => Promise<TIssue>;
   updateIssue: (workspaceSlug: string, projectId: string, issueId: string, data: Partial<TIssue>) => Promise<void>;
   removeIssue: (workspaceSlug: string, projectId: string, issueId: string) => Promise<void>;
   archiveIssue: (workspaceSlug: string, projectId: string, issueId: string) => Promise<void>;
@@ -31,7 +44,12 @@ export interface IIssueStoreActions {
     removeModuleIds: string[]
   ) => Promise<void>;
   removeIssueFromModule: (workspaceSlug: string, projectId: string, moduleId: string, issueId: string) => Promise<void>;
-  fetchIssueWithIdentifier: (workspaceSlug: string, project_identifier: string, sequence_id: string) => Promise<TIssue>;
+  fetchIssueWithIdentifier: (
+    workspaceSlug: string,
+    project_identifier: string,
+    sequence_id: string,
+    options?: TFetchIssueWithIdentifierOptions
+  ) => Promise<TIssue>;
 }
 
 export interface IIssueStore extends IIssueStoreActions {
@@ -84,7 +102,7 @@ export class IssueStore implements IIssueStore {
   });
 
   // actions
-  fetchIssue = async (workspaceSlug: string, projectId: string, issueId: string) => {
+  fetchIssue = async (workspaceSlug: string, projectId: string, issueId: string, options: TFetchIssueOptions = {}) => {
     const query = {
       expand: "issue_reactions,issue_attachments,issue_link,parent",
     };
@@ -120,11 +138,13 @@ export class IssueStore implements IIssueStore {
 
     this.rootIssueDetailStore.addSubscription(issueId, issue.is_subscribed);
 
-    // fetch issue activity
-    this.rootIssueDetailStore.activity.fetchActivities(workspaceSlug, projectId, issueId);
+    if (!options.skipActivityAndComments) {
+      // fetch issue activity
+      this.rootIssueDetailStore.activity.fetchActivities(workspaceSlug, projectId, issueId);
 
-    // fetch issue comments
-    this.rootIssueDetailStore.comment.fetchComments(workspaceSlug, projectId, issueId);
+      // fetch issue comments
+      this.rootIssueDetailStore.comment.fetchComments(workspaceSlug, projectId, issueId);
+    }
 
     // fetch sub issues
     this.rootIssueDetailStore.subIssues.fetchSubIssues(workspaceSlug, projectId, issueId);
@@ -178,10 +198,14 @@ export class IssueStore implements IIssueStore {
       state__group: issue?.state__group,
     };
 
-    this.rootIssueDetailStore.rootIssueStore.issues.addIssue([issuePayload]);
+    const compactIssuePayload = Object.fromEntries(
+      Object.entries(issuePayload).filter(([, value]) => value !== undefined)
+    ) as TIssue;
+
+    this.rootIssueDetailStore.rootIssueStore.issues.addIssue([compactIssuePayload]);
     this.fetchingIssueDetails = undefined;
 
-    return issuePayload;
+    return compactIssuePayload;
   };
 
   updateIssue = async (workspaceSlug: string, projectId: string, issueId: string, data: Partial<TIssue>) => {
@@ -275,10 +299,17 @@ export class IssueStore implements IIssueStore {
     return currentModule;
   };
 
-  fetchIssueWithIdentifier = async (workspaceSlug: string, project_identifier: string, sequence_id: string) => {
-    const query = {
-      expand: "issue_reactions,issue_attachments,issue_link,parent",
-    };
+  fetchIssueWithIdentifier = async (
+    workspaceSlug: string,
+    project_identifier: string,
+    sequence_id: string,
+    options: TFetchIssueWithIdentifierOptions = {}
+  ) => {
+    const query = options.lite
+      ? { lite: true }
+      : {
+          expand: "issue_reactions,issue_attachments,issue_link,parent",
+        };
     const issue = await this.issueService.retrieveWithIdentifier(workspaceSlug, project_identifier, sequence_id, query);
     const issueIdentifier = `${project_identifier}-${sequence_id}`;
     const issueId = issue?.id;
@@ -292,6 +323,21 @@ export class IssueStore implements IIssueStore {
     const issuePayload = this.addIssueToStore(issue);
     this.rootIssueDetailStore.rootIssueStore.issues.addIssue([issuePayload]);
 
+    // add identifiers to map
+    rootWorkItemDetailStore.rootIssueStore.issues.addIssueIdentifier(issueIdentifier, issueId);
+
+    if (issue.is_subscribed !== undefined) rootWorkItemDetailStore.addSubscription(issueId, issue.is_subscribed);
+
+    // start the visible activity/comment stream as soon as the core issue is known
+    rootWorkItemDetailStore.activity.fetchActivities(workspaceSlug, projectId, issueId);
+    rootWorkItemDetailStore.comment.fetchComments(workspaceSlug, projectId, issueId);
+
+    // fetching states
+    // TODO: check if this function is required
+    rootWorkItemDetailStore.rootIssueStore.rootStore.state.fetchProjectStates(workspaceSlug, projectId);
+
+    if (options.lite) return issue;
+
     // handle parent issue if exists
     if (issue?.parent && issue?.parent?.id && issue?.parent?.project_id) {
       this.issueService
@@ -299,42 +345,16 @@ export class IssueStore implements IIssueStore {
         .then((res) => this.rootIssueDetailStore.rootIssueStore.issues.addIssue([res]));
     }
 
-    // add identifiers to map
-    rootWorkItemDetailStore.rootIssueStore.issues.addIssueIdentifier(issueIdentifier, issueId);
-
     // add related data
     if (issue.issue_reactions) rootWorkItemDetailStore.addReactions(issue.id, issue.issue_reactions);
     if (issue.issue_link) rootWorkItemDetailStore.addLinks(issue.id, issue.issue_link);
     if (issue.issue_attachments) rootWorkItemDetailStore.addAttachments(issue.id, issue.issue_attachments);
-    rootWorkItemDetailStore.addSubscription(issue.id, issue.is_subscribed);
-
-    // fetch related data
-    // issue reactions
-    if (issue.issue_reactions) rootWorkItemDetailStore.addReactions(issueId, issue.issue_reactions);
-
-    // fetch issue links
-    if (issue.issue_link) rootWorkItemDetailStore.addLinks(issueId, issue.issue_link);
-
-    // fetch issue attachments
-    if (issue.issue_attachments) rootWorkItemDetailStore.addAttachments(issueId, issue.issue_attachments);
-
-    rootWorkItemDetailStore.addSubscription(issueId, issue.is_subscribed);
-
-    // fetch issue activity
-    rootWorkItemDetailStore.activity.fetchActivities(workspaceSlug, projectId, issueId);
-
-    // fetch issue comments
-    rootWorkItemDetailStore.comment.fetchComments(workspaceSlug, projectId, issueId);
 
     // fetch sub issues
     rootWorkItemDetailStore.subIssues.fetchSubIssues(workspaceSlug, projectId, issueId);
 
     // fetch issue relations
     rootWorkItemDetailStore.relation.fetchRelations(workspaceSlug, projectId, issueId);
-
-    // fetching states
-    // TODO: check if this function is required
-    rootWorkItemDetailStore.rootIssueStore.rootStore.state.fetchProjectStates(workspaceSlug, projectId);
 
     return issue;
   };

--- a/apps/web/core/store/issue/issue-details/issue.store.ts
+++ b/apps/web/core/store/issue/issue-details/issue.store.ts
@@ -15,11 +15,47 @@ import { IssueArchiveService, WorkspaceDraftService, IssueService } from "@/serv
 import type { IIssueDetail } from "./root.store";
 
 export type TFetchIssueOptions = {
+  preserveSubscription?: boolean;
   skipActivityAndComments?: boolean;
 };
 
 export type TFetchIssueWithIdentifierOptions = {
   lite?: boolean;
+};
+
+export type TIssueLite = Pick<
+  TIssue,
+  | "id"
+  | "sequence_id"
+  | "name"
+  | "sort_order"
+  | "project_id"
+  | "created_at"
+  | "updated_at"
+  | "created_by"
+  | "updated_by"
+  | "is_draft"
+  | "is_epic"
+  | "archived_at"
+  | "is_intake"
+  | "is_synced"
+> & {
+  description_html: string;
+};
+
+export type TFetchIssueWithIdentifier = {
+  (
+    workspaceSlug: string,
+    project_identifier: string,
+    sequence_id: string,
+    options: { lite: true }
+  ): Promise<TIssueLite>;
+  (
+    workspaceSlug: string,
+    project_identifier: string,
+    sequence_id: string,
+    options?: TFetchIssueWithIdentifierOptions
+  ): Promise<TIssue>;
 };
 
 export interface IIssueStoreActions {
@@ -44,12 +80,7 @@ export interface IIssueStoreActions {
     removeModuleIds: string[]
   ) => Promise<void>;
   removeIssueFromModule: (workspaceSlug: string, projectId: string, moduleId: string, issueId: string) => Promise<void>;
-  fetchIssueWithIdentifier: (
-    workspaceSlug: string,
-    project_identifier: string,
-    sequence_id: string,
-    options?: TFetchIssueWithIdentifierOptions
-  ) => Promise<TIssue>;
+  fetchIssueWithIdentifier: TFetchIssueWithIdentifier;
 }
 
 export interface IIssueStore extends IIssueStoreActions {
@@ -112,9 +143,7 @@ export class IssueStore implements IIssueStore {
 
     if (!issue) throw new Error("Work item not found");
 
-    const issuePayload = this.addIssueToStore(issue);
-
-    this.rootIssueDetailStore.rootIssueStore.issues.addIssue([issuePayload]);
+    this.addIssueToStore(issue);
 
     // store handlers from issue detail
     // parent
@@ -136,7 +165,12 @@ export class IssueStore implements IIssueStore {
     // fetch issue attachments
     if (issue.issue_attachments) this.rootIssueDetailStore.addAttachments(issueId, issue.issue_attachments);
 
-    this.rootIssueDetailStore.addSubscription(issueId, issue.is_subscribed);
+    if (
+      !options.preserveSubscription ||
+      this.rootIssueDetailStore.subscription.getSubscriptionByIssueId(issueId) === undefined
+    ) {
+      this.rootIssueDetailStore.addSubscription(issueId, issue.is_subscribed);
+    }
 
     if (!options.skipActivityAndComments) {
       // fetch issue activity
@@ -299,12 +333,12 @@ export class IssueStore implements IIssueStore {
     return currentModule;
   };
 
-  fetchIssueWithIdentifier = async (
+  fetchIssueWithIdentifier = (async (
     workspaceSlug: string,
     project_identifier: string,
     sequence_id: string,
     options: TFetchIssueWithIdentifierOptions = {}
-  ) => {
+  ): Promise<TIssue | TIssueLite> => {
     const query = options.lite
       ? { lite: true }
       : {
@@ -320,23 +354,21 @@ export class IssueStore implements IIssueStore {
 
     if (!issue || !projectId || !issueId) throw new Error("Issue not found");
 
-    const issuePayload = this.addIssueToStore(issue);
-    this.rootIssueDetailStore.rootIssueStore.issues.addIssue([issuePayload]);
+    this.addIssueToStore(issue);
 
     // add identifiers to map
     rootWorkItemDetailStore.rootIssueStore.issues.addIssueIdentifier(issueIdentifier, issueId);
 
     if (issue.is_subscribed !== undefined) rootWorkItemDetailStore.addSubscription(issueId, issue.is_subscribed);
 
-    // start the visible activity/comment stream as soon as the core issue is known
-    rootWorkItemDetailStore.activity.fetchActivities(workspaceSlug, projectId, issueId);
-    rootWorkItemDetailStore.comment.fetchComments(workspaceSlug, projectId, issueId);
-
-    // fetching states
-    // TODO: check if this function is required
-    rootWorkItemDetailStore.rootIssueStore.rootStore.state.fetchProjectStates(workspaceSlug, projectId);
-
-    if (options.lite) return issue;
+    if (options.lite) {
+      if (!issue.is_intake) {
+        // start the visible activity/comment stream as soon as the core issue is known
+        rootWorkItemDetailStore.activity.fetchActivities(workspaceSlug, projectId, issueId);
+        rootWorkItemDetailStore.comment.fetchComments(workspaceSlug, projectId, issueId);
+      }
+      return issue as TIssueLite;
+    }
 
     // handle parent issue if exists
     if (issue?.parent && issue?.parent?.id && issue?.parent?.project_id) {
@@ -356,6 +388,16 @@ export class IssueStore implements IIssueStore {
     // fetch issue relations
     rootWorkItemDetailStore.relation.fetchRelations(workspaceSlug, projectId, issueId);
 
+    // fetch issue activity
+    rootWorkItemDetailStore.activity.fetchActivities(workspaceSlug, projectId, issueId);
+
+    // fetch issue comments
+    rootWorkItemDetailStore.comment.fetchComments(workspaceSlug, projectId, issueId);
+
+    // fetching states
+    // TODO: check if this function is required
+    rootWorkItemDetailStore.rootIssueStore.rootStore.state.fetchProjectStates(workspaceSlug, projectId);
+
     return issue;
-  };
+  }) as TFetchIssueWithIdentifier;
 }

--- a/apps/web/core/store/issue/issue-details/root.store.ts
+++ b/apps/web/core/store/issue/issue-details/root.store.ts
@@ -32,7 +32,12 @@ import type { IIssueCommentStore, IIssueCommentStoreActions, TCommentLoader } fr
 import { IssueCommentReactionStore } from "./comment_reaction.store";
 import type { IIssueCommentReactionStore, IIssueCommentReactionStoreActions } from "./comment_reaction.store";
 import { IssueStore } from "./issue.store";
-import type { IIssueStore, IIssueStoreActions } from "./issue.store";
+import type {
+  IIssueStore,
+  IIssueStoreActions,
+  TFetchIssueOptions,
+  TFetchIssueWithIdentifierOptions,
+} from "./issue.store";
 import { IssueLinkStore } from "./link.store";
 import type { IIssueLinkStore, IIssueLinkStoreActions } from "./link.store";
 import { IssueReactionStore } from "./reaction.store";
@@ -259,8 +264,8 @@ export abstract class IssueDetail implements IIssueDetail {
     this.openWidgets = state;
     if (this.lastWidgetAction) this.lastWidgetAction = null;
   };
-  setLastWidgetAction = (action: TWorkItemWidgets) => {
-    this.openWidgets = [action];
+  setLastWidgetAction = (widget: TWorkItemWidgets) => {
+    this.openWidgets = [widget];
   };
   toggleOpenWidget = (state: TWorkItemWidgets) => {
     if (this.openWidgets && this.openWidgets.includes(state))
@@ -270,10 +275,14 @@ export abstract class IssueDetail implements IIssueDetail {
   setIssueLinkData = (issueLinkData: TIssueLink | null) => (this.issueLinkData = issueLinkData);
 
   // issue
-  fetchIssue = async (workspaceSlug: string, projectId: string, issueId: string) =>
-    this.issue.fetchIssue(workspaceSlug, projectId, issueId);
-  fetchIssueWithIdentifier = async (workspaceSlug: string, projectIdentifier: string, sequenceId: string) =>
-    this.issue.fetchIssueWithIdentifier(workspaceSlug, projectIdentifier, sequenceId);
+  fetchIssue = async (workspaceSlug: string, projectId: string, issueId: string, options?: TFetchIssueOptions) =>
+    this.issue.fetchIssue(workspaceSlug, projectId, issueId, options);
+  fetchIssueWithIdentifier = async (
+    workspaceSlug: string,
+    projectIdentifier: string,
+    sequenceId: string,
+    options?: TFetchIssueWithIdentifierOptions
+  ) => this.issue.fetchIssueWithIdentifier(workspaceSlug, projectIdentifier, sequenceId, options);
   updateIssue = async (workspaceSlug: string, projectId: string, issueId: string, data: Partial<TIssue>) =>
     this.issue.updateIssue(workspaceSlug, projectId, issueId, data);
   removeIssue = async (workspaceSlug: string, projectId: string, issueId: string) =>

--- a/apps/web/core/store/issue/issue-details/root.store.ts
+++ b/apps/web/core/store/issue/issue-details/root.store.ts
@@ -4,7 +4,7 @@
  * See the LICENSE file for details.
  */
 
-import { action, computed, makeObservable, observable } from "mobx";
+import { action as mobxAction, computed, makeObservable, observable } from "mobx";
 // types
 import type {
   TIssue,
@@ -36,6 +36,7 @@ import type {
   IIssueStore,
   IIssueStoreActions,
   TFetchIssueOptions,
+  TFetchIssueWithIdentifier,
   TFetchIssueWithIdentifierOptions,
 } from "./issue.store";
 import { IssueLinkStore } from "./link.store";
@@ -194,21 +195,21 @@ export abstract class IssueDetail implements IIssueDetail {
       isAnyModalOpen: computed,
       isPeekOpen: computed,
       // action
-      setPeekIssue: action,
-      setIssueLinkData: action,
-      toggleCreateIssueModal: action,
-      toggleIssueLinkModal: action,
-      toggleParentIssueModal: action,
-      toggleDeleteIssueModal: action,
-      toggleArchiveIssueModal: action,
-      toggleRelationModal: action,
-      toggleSubIssuesModal: action,
-      toggleDeleteAttachmentModal: action,
-      setOpenWidgets: action,
-      setLastWidgetAction: action,
-      toggleOpenWidget: action,
-      setRelationKey: action,
-      setIssueCrudOperationState: action,
+      setPeekIssue: mobxAction,
+      setIssueLinkData: mobxAction,
+      toggleCreateIssueModal: mobxAction,
+      toggleIssueLinkModal: mobxAction,
+      toggleParentIssueModal: mobxAction,
+      toggleDeleteIssueModal: mobxAction,
+      toggleArchiveIssueModal: mobxAction,
+      toggleRelationModal: mobxAction,
+      toggleSubIssuesModal: mobxAction,
+      toggleDeleteAttachmentModal: mobxAction,
+      setOpenWidgets: mobxAction,
+      setLastWidgetAction: mobxAction,
+      toggleOpenWidget: mobxAction,
+      setRelationKey: mobxAction,
+      setIssueCrudOperationState: mobxAction,
     });
 
     // store
@@ -264,8 +265,8 @@ export abstract class IssueDetail implements IIssueDetail {
     this.openWidgets = state;
     if (this.lastWidgetAction) this.lastWidgetAction = null;
   };
-  setLastWidgetAction = (widget: TWorkItemWidgets) => {
-    this.openWidgets = [widget];
+  setLastWidgetAction = (action: TWorkItemWidgets) => {
+    this.openWidgets = [action];
   };
   toggleOpenWidget = (state: TWorkItemWidgets) => {
     if (this.openWidgets && this.openWidgets.includes(state))
@@ -277,12 +278,18 @@ export abstract class IssueDetail implements IIssueDetail {
   // issue
   fetchIssue = async (workspaceSlug: string, projectId: string, issueId: string, options?: TFetchIssueOptions) =>
     this.issue.fetchIssue(workspaceSlug, projectId, issueId, options);
-  fetchIssueWithIdentifier = async (
+  fetchIssueWithIdentifier = ((
     workspaceSlug: string,
     projectIdentifier: string,
     sequenceId: string,
     options?: TFetchIssueWithIdentifierOptions
-  ) => this.issue.fetchIssueWithIdentifier(workspaceSlug, projectIdentifier, sequenceId, options);
+  ) =>
+    this.issue.fetchIssueWithIdentifier(
+      workspaceSlug,
+      projectIdentifier,
+      sequenceId,
+      options
+    )) as TFetchIssueWithIdentifier;
   updateIssue = async (workspaceSlug: string, projectId: string, issueId: string, data: Partial<TIssue>) =>
     this.issue.updateIssue(workspaceSlug, projectId, issueId, data);
   removeIssue = async (workspaceSlug: string, projectId: string, issueId: string) =>

--- a/packages/i18n/src/locales/en/translations.ts
+++ b/packages/i18n/src/locales/en/translations.ts
@@ -524,6 +524,7 @@ export default {
     filters: "Filters",
     display: "Display",
     load_more: "Load more",
+    retry: "Retry",
     activity: "Activity",
     analytics: "Analytics",
     dates: "Dates",


### PR DESCRIPTION
## Summary
- avoid PostgreSQL JIT-heavy joins in issue key lookup by using correlated subqueries
- add a lightweight `lite=true` issue identifier response for the browse page
- render core issue content first, then hydrate comments/activity and sidebar metadata asynchronously

## Verification
- `ruff check pi_dash/app/views/issue/base.py`
- `python3 -m py_compile apps/api/pi_dash/app/views/issue/base.py`
- `pnpm --filter web exec oxlint "app/(all)/[workspaceSlug]/(projects)/browse/[workItem]/page.tsx" core/store/issue/issue-details/issue.store.ts core/store/issue/issue-details/root.store.ts`
- `pnpm --filter web exec oxfmt --check "app/(all)/[workspaceSlug]/(projects)/browse/[workItem]/page.tsx" core/store/issue/issue-details/issue.store.ts core/store/issue/issue-details/root.store.ts`
- `git diff --check`

## Note
- Full `pnpm --filter web check:types` currently fails on existing workspace type drift unrelated to this change, including scheduler exports, state group type drift, and agent status generated types.