### PR TITLE
Improve Codex runner failure diagnostics

### DIFF
--- a/runner/src/agent/mod.rs
+++ b/runner/src/agent/mod.rs
@@ -118,8 +118,12 @@ pub type StderrRing = Arc<Mutex<StderrBuffer>>;
 /// Returns `None` to mean "drop this line entirely."
 pub fn sanitize_stderr_line(line: &str) -> Option<String> {
     let stripped = strip_ansi_codes(line);
-    let trimmed = stripped.trim_end();
+    let without_telemetry = strip_codex_telemetry_suffix(&stripped);
+    let trimmed = without_telemetry.trim_end();
     if trimmed.is_empty() {
+        return None;
+    }
+    if is_codex_transcript_wrapper(trimmed) {
         return None;
     }
     if is_noisy_tracing(trimmed) {
@@ -151,6 +155,26 @@ fn strip_ansi_codes(s: &str) -> String {
         }
     }
     out
+}
+
+/// Codex sometimes mirrors app telemetry key/value fields onto stderr
+/// after a tool output snippet, e.g. `mcp_server=... event.timestamp=...`.
+/// That suffix buries the useful line in failure details. Strip it when it
+/// trails real content, or let the caller drop the now-empty line.
+fn strip_codex_telemetry_suffix(s: &str) -> &str {
+    if let Some(idx) = s.find("mcp_server=") {
+        let before = &s[..idx];
+        if idx == 0 || before.chars().last().is_some_and(char::is_whitespace) {
+            return before;
+        }
+    }
+    s
+}
+
+/// Drop Codex transcript wrapper lines that describe token accounting or
+/// output framing rather than the underlying failure.
+fn is_codex_transcript_wrapper(line: &str) -> bool {
+    line.starts_with("Original token count:") || line == "Output:" || line.starts_with("Wall time:")
 }
 
 /// True for lines that match `tracing-subscriber`'s default text
@@ -523,6 +547,42 @@ mod tests {
         let gh = "gh: error: HTTP 401: Bad credentials";
         assert!(sanitize_stderr_line(panic).is_some());
         assert!(sanitize_stderr_line(gh).is_some());
+    }
+
+    #[test]
+    fn sanitize_drops_codex_transcript_wrappers() {
+        for line in [
+            "Original token count: 85",
+            "Output:",
+            "Wall time: 0.0000 seconds",
+        ] {
+            assert_eq!(sanitize_stderr_line(line), None, "should drop {line}");
+        }
+        assert_eq!(
+            sanitize_stderr_line("Process exited with code 1"),
+            Some("Process exited with code 1".into())
+        );
+    }
+
+    #[test]
+    fn sanitize_strips_codex_telemetry_suffix() {
+        let noisy = "gh: error: HTTP 401 mcp_server= mcp_server_origin= event.timestamp=2026-05-29T05:25:42.074Z conversation.id=abc";
+        assert_eq!(
+            sanitize_stderr_line(noisy),
+            Some("gh: error: HTTP 401".into())
+        );
+        assert_eq!(
+            sanitize_stderr_line(
+                " mcp_server= mcp_server_origin= event.timestamp=2026-05-29T05:25:42.074Z"
+            ),
+            None
+        );
+        assert_eq!(
+            sanitize_stderr_line(
+                "mcp_server= mcp_server_origin= event.timestamp=2026-05-29T05:25:42.074Z"
+            ),
+            None
+        );
     }
 
     #[test]

--- a/runner/src/codex/bridge.rs
+++ b/runner/src/codex/bridge.rs
@@ -87,6 +87,7 @@ impl Bridge {
             seq: 0,
             pending_command: None,
             pending_command_approval_id: None,
+            unpaired_waiting_on_approval: false,
         })
     }
 
@@ -122,8 +123,9 @@ impl Bridge {
             &ThreadStartParams {
                 cwd: cwd.to_string_lossy().to_string(),
                 model: self.model_default.clone(),
-                sandbox_policy: "workspace-write".into(),
-                approval_policy: "on-request".into(),
+                // Match Claude Code's MVP `bypassPermissions` posture.
+                sandbox_policy: "danger-full-access".into(),
+                approval_policy: "never".into(),
             },
         )?;
         self.server.send_raw(&line).await?;
@@ -227,6 +229,12 @@ pub struct BridgeCursor {
     /// sent more than once for the same item) doesn't open duplicate
     /// approval rows.
     pending_command_approval_id: Option<String>,
+    /// A `waitingOnApproval` status frame that arrived before its command.
+    ///
+    /// Codex can emit `waitingOnApproval` before the matching
+    /// `item/started` command frame. Keep this unpaired signal so the command
+    /// frame can still synthesize the approval request instead of deadlocking.
+    unpaired_waiting_on_approval: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -238,6 +246,34 @@ struct PendingCommand {
 }
 
 impl BridgeCursor {
+    fn synthesize_pending_command_approval(&mut self) -> Option<BridgeEvent> {
+        let pending = self.pending_command.clone()?;
+        if self.pending_command_approval_id.is_some() {
+            return None;
+        }
+
+        let approval_id = Uuid::new_v4().to_string();
+        self.pending_command_approval_id = Some(approval_id.clone());
+        let reason = Some(format!(
+            "codex requesting approval to run: {}",
+            pending.command
+        ));
+        let payload = serde_json::json!({
+            "command": pending.command,
+            "cwd": pending.cwd,
+            "item_id": pending.item_id,
+            "synthesized": true,
+            "raw": pending.raw,
+        });
+        Some(BridgeEvent::ApprovalRequest {
+            run_id: self.run_id,
+            approval_id,
+            kind: ApprovalKind::CommandExecution,
+            payload,
+            reason,
+        })
+    }
+
     /// Translate one inbound Codex frame into daemon-level events.
     pub fn translate(&mut self, frame: Incoming) -> Vec<BridgeEvent> {
         self.seq = self.seq.saturating_add(1);
@@ -370,7 +406,9 @@ impl BridgeCursor {
                         .and_then(|f| f.as_array())
                         .map(|arr| arr.iter().any(|v| v.as_str() == Some("waitingOnApproval")))
                         .unwrap_or(false);
-                    if waiting && let Some(pending) = self.pending_command.clone() {
+                    if !waiting {
+                        self.unpaired_waiting_on_approval = false;
+                    } else if self.pending_command.is_some() {
                         // We've already emitted an ApprovalRequest for this
                         // pending command. Re-emitting here would re-send a
                         // ClientMsg::ApprovalRequest to the cloud and append
@@ -385,30 +423,11 @@ impl BridgeCursor {
                                 params,
                             }];
                         }
-                        let approval_id = Uuid::new_v4().to_string();
-                        self.pending_command_approval_id = Some(approval_id.clone());
-                        let reason = Some(format!(
-                            "codex requesting approval to run: {}",
-                            pending.command
-                        ));
-                        // Synthesise a payload that downstream consumers
-                        // (cloud-side ApprovalRequest serializer, TUI
-                        // approval card) can render the same way as a real
-                        // codex-fired approval.
-                        let payload = serde_json::json!({
-                            "command": pending.command,
-                            "cwd": pending.cwd,
-                            "item_id": pending.item_id,
-                            "synthesized": true,
-                            "raw": pending.raw,
-                        });
-                        return vec![BridgeEvent::ApprovalRequest {
-                            run_id: self.run_id,
-                            approval_id,
-                            kind: ApprovalKind::CommandExecution,
-                            payload,
-                            reason,
-                        }];
+                        if let Some(ev) = self.synthesize_pending_command_approval() {
+                            return vec![ev];
+                        }
+                    } else {
+                        self.unpaired_waiting_on_approval = true;
                     }
                     vec![BridgeEvent::Raw {
                         run_id: self.run_id,
@@ -418,6 +437,7 @@ impl BridgeCursor {
                 } else if method == "item/started" {
                     // Cache the most recent in-progress commandExecution so
                     // a later `waitingOnApproval` flag can refer to it.
+                    let mut synthesize_now = false;
                     if let Some(item) = params.get("item")
                         && item.get("type").and_then(|v| v.as_str()) == Some("commandExecution")
                         && item.get("status").and_then(|v| v.as_str()) == Some("inProgress")
@@ -446,12 +466,18 @@ impl BridgeCursor {
                         // is no longer relevant; allow a fresh approval id next
                         // time codex reports waiting.
                         self.pending_command_approval_id = None;
+                        synthesize_now = self.unpaired_waiting_on_approval;
+                        self.unpaired_waiting_on_approval = false;
                     }
-                    vec![BridgeEvent::Raw {
+                    let mut events = vec![BridgeEvent::Raw {
                         run_id: self.run_id,
                         method,
                         params,
-                    }]
+                    }];
+                    if synthesize_now && let Some(ev) = self.synthesize_pending_command_approval() {
+                        events.push(ev);
+                    }
+                    events
                 } else if method == "item/completed" {
                     // The cached command finished; drop the tracking so a
                     // late waitingOnApproval doesn't re-open it.
@@ -470,6 +496,7 @@ impl BridgeCursor {
                         if same {
                             self.pending_command = None;
                             self.pending_command_approval_id = None;
+                            self.unpaired_waiting_on_approval = false;
                         }
                     }
                     vec![BridgeEvent::Raw {
@@ -503,6 +530,7 @@ mod translate_tests {
             seq: 0,
             pending_command: None,
             pending_command_approval_id: None,
+            unpaired_waiting_on_approval: false,
         }
     }
 
@@ -698,6 +726,70 @@ mod translate_tests {
             json!({"status": {"activeFlags": ["waitingOnApproval"]}}),
         ));
         assert!(matches!(evs.as_slice(), [BridgeEvent::Raw { .. }]));
+        assert!(c.unpaired_waiting_on_approval);
+    }
+
+    #[test]
+    fn waiting_on_approval_before_item_started_synthesizes_when_command_arrives() {
+        let mut c = cursor();
+        let first = c.translate(notif(
+            "thread/status/changed",
+            json!({"status": {"activeFlags": ["waitingOnApproval"]}}),
+        ));
+        assert!(matches!(first.as_slice(), [BridgeEvent::Raw { .. }]));
+
+        let evs = c.translate(notif(
+            "item/started",
+            json!({
+                "item": {
+                    "id": "it_1",
+                    "type": "commandExecution",
+                    "status": "inProgress",
+                    "command": "pidash workspace me",
+                    "cwd": "/work",
+                    "processId": null,
+                    "source": "agent"
+                }
+            }),
+        ));
+        match evs.as_slice() {
+            [
+                BridgeEvent::Raw { .. },
+                BridgeEvent::ApprovalRequest {
+                    kind,
+                    payload,
+                    reason,
+                    ..
+                },
+            ] => {
+                assert!(matches!(kind, ApprovalKind::CommandExecution));
+                assert_eq!(
+                    payload.get("command").and_then(|v| v.as_str()),
+                    Some("pidash workspace me")
+                );
+                assert_eq!(
+                    payload.get("synthesized").and_then(|v| v.as_bool()),
+                    Some(true)
+                );
+                assert!(
+                    reason
+                        .as_deref()
+                        .unwrap_or("")
+                        .contains("pidash workspace me")
+                );
+            }
+            other => panic!("expected Raw + ApprovalRequest, got {other:?}"),
+        }
+        assert!(c.pending_command_approval_id.is_some());
+
+        let duplicate = c.translate(notif(
+            "thread/status/changed",
+            json!({"status": {"activeFlags": ["waitingOnApproval"]}}),
+        ));
+        assert!(
+            matches!(duplicate.as_slice(), [BridgeEvent::Raw { .. }]),
+            "duplicate waitingOnApproval must not re-emit ApprovalRequest, got {duplicate:?}"
+        );
     }
 
     #[test]

--- a/runner/src/daemon/supervisor.rs
+++ b/runner/src/daemon/supervisor.rs
@@ -2000,18 +2000,155 @@ fn format_exec_command_detail(
             Some(true) | None => "completed",
         };
         format!(
-            "last observed command tool: `{}`{cwd} \
+            "command context: last observed command tool `{}`{cwd} \
              ({verb} {since_completed}s before failure; ran {runtime}s)",
             cmd.command
         )
     } else {
         let elapsed = (now - cmd.started_at).num_seconds().max(0);
         format!(
-            "last observed command tool start: `{}`{cwd} \
-             (started {elapsed}s ago; no completion event observed)",
+            "command context: last command frame `{}`{cwd} \
+             (started {elapsed}s ago; no completion frame observed)",
             cmd.command
         )
     }
+}
+
+fn diagnostic_signal_from_stderr(lines: &[String]) -> Option<String> {
+    lines
+        .iter()
+        .rev()
+        .find_map(|line| diagnostic_signal_from_stderr_line(line))
+}
+
+fn diagnostic_signal_from_stderr_line(line: &str) -> Option<String> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed)
+        && let Some(message) = json_error_message(&value)
+    {
+        return Some(format!("stderr JSON error: {message}"));
+    }
+
+    let lower = trimmed.to_ascii_lowercase();
+    let looks_relevant = lower.contains("error")
+        || lower.contains("failed")
+        || lower.contains("failure")
+        || lower.contains("denied")
+        || lower.contains("timed out")
+        || lower.contains("timeout")
+        || lower.contains("panic")
+        || lower.contains("exit code")
+        || lower.contains("not logged in")
+        || lower.contains("unauthorized")
+        || lower.contains("forbidden");
+    if looks_relevant {
+        Some(format!("stderr: {trimmed}"))
+    } else {
+        None
+    }
+}
+
+fn json_error_message(value: &serde_json::Value) -> Option<String> {
+    for key in ["error", "detail", "message"] {
+        let Some(v) = value.get(key) else {
+            continue;
+        };
+        if let Some(s) = v.as_str()
+            && !s.trim().is_empty()
+        {
+            return Some(s.trim().to_string());
+        }
+        if let Some(s) = v.get("message").and_then(|m| m.as_str())
+            && !s.trim().is_empty()
+        {
+            return Some(s.trim().to_string());
+        }
+    }
+    None
+}
+
+fn core_error_summary(base: &str, diagnostic_signal: Option<&str>) -> String {
+    let Some(signal) = diagnostic_signal else {
+        return base.to_string();
+    };
+    signal
+        .strip_prefix("stderr JSON error: ")
+        .or_else(|| signal.strip_prefix("stderr: "))
+        .unwrap_or(signal)
+        .to_string()
+}
+
+fn assemble_failure_detail(
+    base: &str,
+    last_cmd: Option<&crate::daemon::state::ExecCommandSnapshot>,
+    stderr: &crate::agent::StderrSnapshot,
+    now: DateTime<Utc>,
+) -> String {
+    const DETAIL_BYTES_CAP: usize = 4096;
+    const STDERR_TAIL_LINES: usize = 10;
+
+    let diagnostic_signal = diagnostic_signal_from_stderr(&stderr.lines);
+    let core = core_error_summary(base, diagnostic_signal.as_deref());
+
+    let mut trace: Vec<String> = vec![format!("- watchdog: {base}")];
+    if let Some(signal) = diagnostic_signal {
+        trace.push(format!("- diagnostic signal: {signal}"));
+    }
+    if let Some(cmd) = last_cmd {
+        trace.push(format!("- {}", format_exec_command_detail(cmd, now)));
+    }
+    // The stderr ring has already filtered codex tracing noise;
+    // `stderr.dropped` is the running count of lines we rejected so
+    // the user has an honest signal of how much was suppressed.
+    // Emit the section if either we have content to show OR a
+    // non-zero dropped count (the latter alone tells the operator
+    // "the agent was emitting noise but no signal").
+    if !stderr.lines.is_empty() || stderr.dropped > 0 {
+        let shown = stderr.lines.len().min(STDERR_TAIL_LINES);
+        let suffix = if stderr.dropped > 0 {
+            format!(
+                " (plus {} low-signal line(s) filtered from agent stderr)",
+                stderr.dropped
+            )
+        } else {
+            String::new()
+        };
+        if shown > 0 {
+            let tail = stderr
+                .lines
+                .iter()
+                .rev()
+                .take(STDERR_TAIL_LINES)
+                .rev()
+                .map(|line| format!("  {line}"))
+                .collect::<Vec<_>>()
+                .join("\n");
+            trace.push(format!(
+                "- stderr context ({shown} line(s){suffix}):\n{tail}"
+            ));
+        } else {
+            // Filter dropped everything — surface that fact alone
+            // rather than emitting an empty stderr block.
+            trace.push(format!("- stderr context: empty after filtering{suffix}"));
+        }
+    }
+
+    let mut joined = format!("Core error: {core}\n\nError trace:\n{}", trace.join("\n"));
+    if joined.len() > DETAIL_BYTES_CAP {
+        // Truncate on a char boundary, leaving a sentinel so consumers
+        // can tell the body was clipped.
+        let mut end = DETAIL_BYTES_CAP;
+        while !joined.is_char_boundary(end) && end > 0 {
+            end -= 1;
+        }
+        joined.truncate(end);
+        joined.push('…');
+    }
+    joined
 }
 
 /// Owns one `Assign`'s lifecycle. Spawned as a task from `RunnerLoop`, so the
@@ -2412,7 +2549,7 @@ impl AssignWorker {
                     }
                 } => {
                     let mins = stall_timeout.as_secs() / 60;
-                    let base = format!("no agent frames for {mins} minutes");
+                    let base = format!("agent stalled for {mins} minutes without new agent events");
                     let detail = self.build_failure_detail(&base, bridge).await;
                     run_events.flush_before_lifecycle(&self.out).await;
                     let metadata = self.run_metadata().await;
@@ -2438,71 +2575,20 @@ impl AssignWorker {
 
     /// Build a `RunFailed.detail` string that includes whatever local
     /// context might help the cloud / UI explain what went wrong:
-    /// - the supervisor's own classifier message (e.g. `"no agent frames
-    ///   for 5 minutes"`),
-    /// - the most recent shell command tool the agent kicked off,
-    /// - the last few lines of agent stderr.
+    /// - the supervisor's own classifier message,
+    /// - the strongest diagnostic signal we can infer from stderr,
+    /// - the most recent shell command tool the agent kicked off as context,
+    /// - the last few filtered lines of agent stderr.
     ///
     /// All inputs are optional and the assembly degrades gracefully when
-    /// they're missing — for a healthy code-edit task the result is just
-    /// the base string. The total payload is bounded so a runaway stderr
-    /// dump can't balloon a `RunFailed` body.
+    /// they're missing. The first line is the best root-cause summary we
+    /// have; supporting context is listed under `Error trace:`. The total
+    /// payload is bounded so a runaway stderr dump can't balloon a
+    /// `RunFailed` body.
     async fn build_failure_detail(&self, base: &str, bridge: &AgentBridge) -> String {
-        const DETAIL_BYTES_CAP: usize = 4096;
-        const STDERR_TAIL_LINES: usize = 10;
-
         let last_cmd = self.state.observability_snapshot().await.last_exec_command;
         let stderr = bridge.recent_stderr().await;
-
-        let mut parts: Vec<String> = vec![base.to_string()];
-        if let Some(cmd) = last_cmd {
-            parts.push(format_exec_command_detail(&cmd, Utc::now()));
-        }
-        // The stderr ring has already filtered codex tracing noise;
-        // `stderr.dropped` is the running count of lines we rejected so
-        // the user has an honest signal of how much was suppressed.
-        // Emit the section if either we have content to show OR a
-        // non-zero dropped count (the latter alone tells the operator
-        // "the agent was emitting noise but no signal").
-        if !stderr.lines.is_empty() || stderr.dropped > 0 {
-            let shown = stderr.lines.len().min(STDERR_TAIL_LINES);
-            let tail = stderr
-                .lines
-                .iter()
-                .rev()
-                .take(STDERR_TAIL_LINES)
-                .rev()
-                .cloned()
-                .collect::<Vec<_>>()
-                .join("\n  ");
-            let suffix = if stderr.dropped > 0 {
-                format!(
-                    " (plus {} noise line(s) filtered from codex tracing)",
-                    stderr.dropped
-                )
-            } else {
-                String::new()
-            };
-            if shown > 0 {
-                parts.push(format!("stderr tail ({shown} line(s){suffix}):\n  {tail}"));
-            } else {
-                // Filter dropped everything — surface that fact alone
-                // rather than emitting an empty stderr block.
-                parts.push(format!("stderr: empty after filtering{suffix}"));
-            }
-        }
-        let mut joined = parts.join("; ");
-        if joined.len() > DETAIL_BYTES_CAP {
-            // Truncate on a char boundary, leaving a sentinel so consumers
-            // can tell the body was clipped.
-            let mut end = DETAIL_BYTES_CAP;
-            while !joined.is_char_boundary(end) && end > 0 {
-                end -= 1;
-            }
-            joined.truncate(end);
-            joined.push('…');
-        }
-        joined
+        assemble_failure_detail(base, last_cmd.as_ref(), &stderr, Utc::now())
     }
 
     async fn handle_bridge_event(
@@ -2881,8 +2967,8 @@ mod tests {
 
         assert_eq!(
             detail,
-            "last observed command tool start: `git fetch origin` in `/tmp/repo` \
-             (started 69s ago; no completion event observed)"
+            "command context: last command frame `git fetch origin` in `/tmp/repo` \
+             (started 69s ago; no completion frame observed)"
         );
     }
 
@@ -2911,6 +2997,88 @@ mod tests {
         assert!(detail.contains("exited with error 56s before failure"));
         assert!(detail.contains("ran 4s"));
         assert!(!detail.contains("completed 56s"));
+    }
+
+    #[test]
+    fn diagnostic_signal_prefers_json_error_messages() {
+        let lines = vec![
+            "pidash 0.1.10".to_string(),
+            "Process exited with code 1".to_string(),
+            r#"{"error":"GET https://pidash.airepublic.com/api/v1/users/me/: error sending request"}"#.to_string(),
+        ];
+        let signal = diagnostic_signal_from_stderr(&lines).unwrap();
+        assert_eq!(
+            signal,
+            "stderr JSON error: GET https://pidash.airepublic.com/api/v1/users/me/: error sending request"
+        );
+    }
+
+    #[test]
+    fn diagnostic_signal_keeps_non_json_errors() {
+        let lines = vec![
+            "pidash 0.1.10".to_string(),
+            "gh: error: HTTP 401: Bad credentials".to_string(),
+        ];
+        let signal = diagnostic_signal_from_stderr(&lines).unwrap();
+        assert_eq!(signal, "stderr: gh: error: HTTP 401: Bad credentials");
+    }
+
+    #[test]
+    fn assemble_failure_detail_puts_core_error_first_and_trace_second() {
+        let started_at = Utc.with_ymd_and_hms(2026, 5, 29, 5, 25, 53).unwrap();
+        let now = Utc.with_ymd_and_hms(2026, 5, 29, 5, 30, 57).unwrap();
+        let cmd = ExecCommandSnapshot {
+            command: "pidash workspace me".into(),
+            cwd: Some("/work".into()),
+            tool_call_id: Some("call-1".into()),
+            started_at,
+            completed_at: None,
+            completed_success: None,
+        };
+        let stderr = crate::agent::StderrSnapshot {
+            lines: vec![
+                "pidash 0.1.10".into(),
+                "Process exited with code 1".into(),
+                r#"{"error":"GET https://pidash.airepublic.com/api/v1/users/me/: error sending request"}"#.into(),
+            ],
+            dropped: 42,
+        };
+
+        let detail = assemble_failure_detail(
+            "agent stalled for 5 minutes without new agent events",
+            Some(&cmd),
+            &stderr,
+            now,
+        );
+
+        let mut lines = detail.lines();
+        assert_eq!(
+            lines.next(),
+            Some(
+                "Core error: GET https://pidash.airepublic.com/api/v1/users/me/: error sending request"
+            )
+        );
+        assert!(detail.contains("\n\nError trace:\n"));
+        assert!(
+            detail.contains("- watchdog: agent stalled for 5 minutes without new agent events")
+        );
+        assert!(detail.contains("- diagnostic signal: stderr JSON error: GET https://pidash.airepublic.com/api/v1/users/me/: error sending request"));
+        assert!(
+            detail
+                .contains("- command context: last command frame `pidash workspace me` in `/work`")
+        );
+        assert!(detail.contains(
+            "- stderr context (3 line(s) (plus 42 low-signal line(s) filtered from agent stderr))"
+        ));
+    }
+
+    #[test]
+    fn assemble_failure_detail_uses_watchdog_when_no_better_signal_exists() {
+        let stderr = crate::agent::StderrSnapshot::default();
+        let detail = assemble_failure_detail("agent stdout closed", None, &stderr, Utc::now());
+
+        assert!(detail.starts_with("Core error: agent stdout closed\n\nError trace:\n"));
+        assert!(detail.contains("- watchdog: agent stdout closed"));
     }
 
     /// Build the supervisor's ``hello_runners`` map from a list of

--- a/runner/src/daemon/supervisor.rs
+++ b/runner/src/daemon/supervisor.rs
@@ -2014,14 +2014,34 @@ fn format_exec_command_detail(
     }
 }
 
-fn diagnostic_signal_from_stderr(lines: &[String]) -> Option<String> {
-    lines
-        .iter()
-        .rev()
-        .find_map(|line| diagnostic_signal_from_stderr_line(line))
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum DiagnosticSignalPriority {
+    ExitStatus,
+    TextError,
+    JsonError,
 }
 
-fn diagnostic_signal_from_stderr_line(line: &str) -> Option<String> {
+fn diagnostic_signal_from_stderr(lines: &[String]) -> Option<String> {
+    let mut best: Option<(DiagnosticSignalPriority, String)> = None;
+    for line in lines.iter().rev() {
+        let Some((priority, signal)) = diagnostic_signal_from_stderr_line(line) else {
+            continue;
+        };
+        if priority == DiagnosticSignalPriority::JsonError {
+            return Some(signal);
+        }
+        if best
+            .as_ref()
+            .map(|(best_priority, _)| priority > *best_priority)
+            .unwrap_or(true)
+        {
+            best = Some((priority, signal));
+        }
+    }
+    best.map(|(_, signal)| signal)
+}
+
+fn diagnostic_signal_from_stderr_line(line: &str) -> Option<(DiagnosticSignalPriority, String)> {
     let trimmed = line.trim();
     if trimmed.is_empty() {
         return None;
@@ -2030,10 +2050,17 @@ fn diagnostic_signal_from_stderr_line(line: &str) -> Option<String> {
     if let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed)
         && let Some(message) = json_error_message(&value)
     {
-        return Some(format!("stderr JSON error: {message}"));
+        return Some((
+            DiagnosticSignalPriority::JsonError,
+            format!("stderr JSON error: {message}"),
+        ));
     }
 
     let lower = trimmed.to_ascii_lowercase();
+    let has_exit_code = lower.contains("exit code");
+    let generic_exit_status = lower.starts_with("process exited with code")
+        || lower.starts_with("exited with code")
+        || lower.starts_with("exit code ");
     let looks_relevant = lower.contains("error")
         || lower.contains("failed")
         || lower.contains("failure")
@@ -2041,12 +2068,18 @@ fn diagnostic_signal_from_stderr_line(line: &str) -> Option<String> {
         || lower.contains("timed out")
         || lower.contains("timeout")
         || lower.contains("panic")
-        || lower.contains("exit code")
+        || has_exit_code
+        || generic_exit_status
         || lower.contains("not logged in")
         || lower.contains("unauthorized")
         || lower.contains("forbidden");
     if looks_relevant {
-        Some(format!("stderr: {trimmed}"))
+        let priority = if generic_exit_status {
+            DiagnosticSignalPriority::ExitStatus
+        } else {
+            DiagnosticSignalPriority::TextError
+        };
+        Some((priority, format!("stderr: {trimmed}")))
     } else {
         None
     }
@@ -3021,6 +3054,20 @@ mod tests {
         ];
         let signal = diagnostic_signal_from_stderr(&lines).unwrap();
         assert_eq!(signal, "stderr: gh: error: HTTP 401: Bad credentials");
+    }
+
+    #[test]
+    fn diagnostic_signal_prefers_substantive_error_over_exit_status() {
+        let lines = vec![
+            "gh: error: HTTP 401: Bad credentials".to_string(),
+            "Process exited with code 1".to_string(),
+        ];
+        let signal = diagnostic_signal_from_stderr(&lines).unwrap();
+        assert_eq!(signal, "stderr: gh: error: HTTP 401: Bad credentials");
+
+        let fallback = diagnostic_signal_from_stderr(&["Process exited with code 1".to_string()])
+            .expect("exit status should remain useful as a fallback");
+        assert_eq!(fallback, "stderr: Process exited with code 1");
     }
 
     #[test]

--- a/runner/tests/codex_bridge_fake.rs
+++ b/runner/tests/codex_bridge_fake.rs
@@ -42,7 +42,11 @@ fn fake_codex_script() -> &'static str {
         # initialized notification (no response expected)
         read _
         # thread/start
-        read _
+        read thread
+        case "$thread" in
+          *'"sandboxPolicy":"danger-full-access"'*'"approvalPolicy":"never"'*) ;;
+          *) printf '%s\n' '{"jsonrpc":"2.0","id":2,"error":{"code":-32600,"message":"expected bypassed codex thread/start policy"}}'; exit 0;;
+        esac
         printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"threadId":"th_fake_001"}}'
         # turn/start
         read _
@@ -66,6 +70,7 @@ async fn warm_bridge_reuses_initialized_thread_across_turns() {
         case "$initialized" in *'"method":"initialized"'*) ;; *) exit 1;; esac
         read thread
         case "$thread" in *'"method":"thread/start"'*) ;; *) printf '%s\n' '{"jsonrpc":"2.0","id":2,"error":{"code":-32600,"message":"expected thread/start"}}'; exit 0;; esac
+        case "$thread" in *'"sandboxPolicy":"danger-full-access"'*'"approvalPolicy":"never"'*) ;; *) printf '%s\n' '{"jsonrpc":"2.0","id":2,"error":{"code":-32600,"message":"expected bypassed codex thread/start policy"}}'; exit 0;; esac
         printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"threadId":"th_chat"}}'
         read turn1
         case "$turn1" in *'"method":"turn/start"'*) ;; *) printf '%s\n' '{"jsonrpc":"2.0","id":3,"error":{"code":-32600,"message":"expected first turn/start"}}'; exit 0;; esac


### PR DESCRIPTION
## Summary
- run Codex app-server turns with `danger-full-access` and `never` approval policy to match Claude's MVP bypass posture
- preserve out-of-order `waitingOnApproval` signals so a later command frame can still synthesize an approval request
- rewrite runner failure details so the first line is the core error and supporting watchdog/command/stderr context appears under `Error trace:`
- filter Codex transcript wrapper and telemetry noise while preserving real stderr errors

## Validation
- `cargo test -p pidash agent::tests --lib`
- `cargo test -p pidash daemon::supervisor::tests --lib`
- `cargo test -p pidash codex::bridge::translate_tests --lib`
- `cargo test -p pidash --test codex_bridge_fake`
- `git diff --check -- runner/src/agent/mod.rs runner/src/daemon/supervisor.rs runner/src/codex/bridge.rs runner/tests/codex_bridge_fake.rs`
