### PR TITLE
feat(issues): add pod selector to issue modal + guard reassignment

### DIFF
--- a/apps/api/pi_dash/app/serializers/issue.py
+++ b/apps/api/pi_dash/app/serializers/issue.py
@@ -122,8 +122,13 @@ class IssueCreateSerializer(BaseSerializer):
     # (like state_id / parent_id) so the web client routes it the same way as
     # every other FK. The bare ``assigned_pod`` model field is removed from the
     # auto-generated set below so this is the single read/write key.
+    # ``all_objects`` (not the default manager, which hides soft-deleted pods)
+    # so a tombstoned pod id still resolves and validate() can return the
+    # friendly "pod has been deleted" message instead of DRF's generic
+    # "object does not exist". Cross-project / deleted pods are rejected in
+    # validate(), not here.
     assigned_pod_id = serializers.PrimaryKeyRelatedField(
-        source="assigned_pod", queryset=Pod.objects.all(), required=False, allow_null=True
+        source="assigned_pod", queryset=Pod.all_objects.all(), required=False, allow_null=True
     )
     label_ids = serializers.ListField(
         child=serializers.PrimaryKeyRelatedField(queryset=Label.objects.all()),
@@ -200,36 +205,36 @@ class IssueCreateSerializer(BaseSerializer):
         # the same workspace would be a cross-project routing escape hatch
         # — a Project P issue could end up assigned to Project Q's pod and
         # dispatch would happily route P's runs to Q's runners.
-        if "assigned_pod" in attrs and attrs["assigned_pod"] is not None:
-            pod = attrs["assigned_pod"]
-            project_id = self.context.get("project_id")
-            if project_id is None and self.instance is not None:
-                project_id = self.instance.project_id
-            # ``project`` may also be present in attrs on issue create.
-            if project_id is None and "project" in attrs and attrs["project"] is not None:
-                proj = attrs["project"]
-                project_id = getattr(proj, "id", proj)
-            if project_id is not None and str(pod.project_id) != str(project_id):
-                raise serializers.ValidationError(
-                    {"assigned_pod_id": "pod is in a different project"}
-                )
-            if pod.deleted_at is not None:
-                raise serializers.ValidationError(
-                    {"assigned_pod_id": "pod has been deleted"}
-                )
-            # Block mid-flight reassignment. Once a run is queued/executing its
-            # pod FK is immutable, so re-pointing the issue would silently take
-            # effect only on the *next* dispatch — confusing and unsafe. Only
-            # reject when the pod actually changes; re-sending the current pod
+        if "assigned_pod" in attrs:
+            pod = attrs["assigned_pod"]  # may be None when clearing the pod
+            if pod is not None:
+                project_id = self.context.get("project_id")
+                if project_id is None and self.instance is not None:
+                    project_id = self.instance.project_id
+                # ``project`` may also be present in attrs on issue create.
+                if project_id is None and "project" in attrs and attrs["project"] is not None:
+                    proj = attrs["project"]
+                    project_id = getattr(proj, "id", proj)
+                if project_id is not None and str(pod.project_id) != str(project_id):
+                    raise serializers.ValidationError(
+                        {"assigned_pod_id": "pod is in a different project"}
+                    )
+                if pod.deleted_at is not None:
+                    raise serializers.ValidationError(
+                        {"assigned_pod_id": "pod has been deleted"}
+                    )
+            # Block mid-flight *reassignment* — changing OR clearing the pod once
+            # a run is active. The run's pod FK is immutable, so a change would
+            # silently take effect only on the *next* dispatch (and clearing to
+            # null would re-route the next run to the project default). Initial
+            # assignment (no prior pod) is allowed; re-sending the current pod
             # (the web form re-PATCHes the full editable set on blur) is a no-op.
-            if (
-                self.instance is not None
-                and str(pod.id) != str(self.instance.assigned_pod_id)
-                and self.instance.has_active_run
-            ):
-                raise serializers.ValidationError(
-                    {"assigned_pod_id": "cannot reassign pod while the issue has an active run"}
-                )
+            if self.instance is not None and self.instance.assigned_pod_id is not None:
+                new_pod_id = pod.id if pod is not None else None
+                if str(new_pod_id) != str(self.instance.assigned_pod_id) and self.instance.has_active_run:
+                    raise serializers.ValidationError(
+                        {"assigned_pod_id": "cannot reassign pod while the issue has an active run"}
+                    )
 
         # Validate description content for security
         if "description_html" in attrs and attrs["description_html"]:

--- a/apps/api/pi_dash/app/serializers/issue.py
+++ b/apps/api/pi_dash/app/serializers/issue.py
@@ -43,6 +43,7 @@ from pi_dash.db.models import (
     ProjectMember,
     EstimatePoint,
 )
+from pi_dash.runner.models import Pod
 from pi_dash.utils.content_validator import (
     validate_html_content,
     validate_binary_data,
@@ -117,6 +118,13 @@ class IssueCreateSerializer(BaseSerializer):
     parent_id = serializers.PrimaryKeyRelatedField(
         source="parent", queryset=Issue.objects.all(), required=False, allow_null=True
     )
+    # Pod this issue's runs dispatch to. Exposed under the ``*_id`` convention
+    # (like state_id / parent_id) so the web client routes it the same way as
+    # every other FK. The bare ``assigned_pod`` model field is removed from the
+    # auto-generated set below so this is the single read/write key.
+    assigned_pod_id = serializers.PrimaryKeyRelatedField(
+        source="assigned_pod", queryset=Pod.objects.all(), required=False, allow_null=True
+    )
     label_ids = serializers.ListField(
         child=serializers.PrimaryKeyRelatedField(queryset=Label.objects.all()),
         write_only=True,
@@ -134,8 +142,9 @@ class IssueCreateSerializer(BaseSerializer):
         model = Issue
         # Exclude the agent workpad — it's read/written via the dedicated
         # workpad endpoint and would bloat every web-tier issue payload if
-        # included here.
-        exclude = ["workpad"]
+        # included here. ``assigned_pod`` is excluded too because it's surfaced
+        # explicitly as ``assigned_pod_id`` above (the *_id FK convention).
+        exclude = ["workpad", "assigned_pod"]
         read_only_fields = [
             "workspace",
             "project",
@@ -202,11 +211,24 @@ class IssueCreateSerializer(BaseSerializer):
                 project_id = getattr(proj, "id", proj)
             if project_id is not None and str(pod.project_id) != str(project_id):
                 raise serializers.ValidationError(
-                    {"assigned_pod": "pod is in a different project"}
+                    {"assigned_pod_id": "pod is in a different project"}
                 )
             if pod.deleted_at is not None:
                 raise serializers.ValidationError(
-                    {"assigned_pod": "pod has been deleted"}
+                    {"assigned_pod_id": "pod has been deleted"}
+                )
+            # Block mid-flight reassignment. Once a run is queued/executing its
+            # pod FK is immutable, so re-pointing the issue would silently take
+            # effect only on the *next* dispatch — confusing and unsafe. Only
+            # reject when the pod actually changes; re-sending the current pod
+            # (the web form re-PATCHes the full editable set on blur) is a no-op.
+            if (
+                self.instance is not None
+                and str(pod.id) != str(self.instance.assigned_pod_id)
+                and self.instance.has_active_run
+            ):
+                raise serializers.ValidationError(
+                    {"assigned_pod_id": "cannot reassign pod while the issue has an active run"}
                 )
 
         # Validate description content for security
@@ -866,6 +888,10 @@ class IssueIntakeSerializer(DynamicBaseSerializer):
 class IssueSerializer(DynamicBaseSerializer):
     # ids
     cycle_id = serializers.PrimaryKeyRelatedField(read_only=True)
+    # FK id only (PK-only optimization — no extra query). Lets the UI show and
+    # round-trip the issue's current pod. Reassignment while a run is active is
+    # rejected server-side in IssueCreateSerializer.validate.
+    assigned_pod_id = serializers.PrimaryKeyRelatedField(source="assigned_pod", read_only=True)
     module_ids = serializers.ListField(child=serializers.UUIDField(), required=False)
 
     # Many to many
@@ -897,6 +923,7 @@ class IssueSerializer(DynamicBaseSerializer):
             "project_id",
             "parent_id",
             "cycle_id",
+            "assigned_pod_id",
             "module_ids",
             "label_ids",
             "assignee_ids",

--- a/apps/api/pi_dash/db/models/issue.py
+++ b/apps/api/pi_dash/db/models/issue.py
@@ -197,6 +197,25 @@ class Issue(ProjectBaseModel):
 
     issue_objects = IssueManager()
 
+    @property
+    def has_active_run(self) -> bool:
+        """True when this issue has a non-terminal (active) AgentRun.
+
+        Used to block pod reassignment mid-flight: once a run is queued or
+        executing, that run's pod FK is immutable, so changing
+        ``assigned_pod`` would silently desync the issue from its live run
+        (the change would only take effect on the *next* dispatch). Reuses
+        the canonical ``NON_TERMINAL_STATUSES`` set rather than redefining
+        "active" here. Lazy imports mirror ``save()`` to avoid an app-load
+        cycle with the runner app.
+        """
+        from pi_dash.runner.models import AgentRun
+        from pi_dash.runner.services.matcher import NON_TERMINAL_STATUSES
+
+        return AgentRun.objects.filter(
+            work_item=self, status__in=NON_TERMINAL_STATUSES
+        ).exists()
+
     class Meta:
         verbose_name = "Issue"
         verbose_name_plural = "Issues"

--- a/apps/api/pi_dash/tests/unit/runner/test_issue_assigned_pod.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_issue_assigned_pod.py
@@ -79,7 +79,7 @@ def test_issue_create_serializer_rejects_cross_project_pod(
             "name": "An issue",
             "project": str(project.id),
             "state": str(state.id),
-            "assigned_pod": str(other_pod.id),
+            "assigned_pod_id": str(other_pod.id),
         },
         context={
             "project_id": str(project.id),
@@ -88,7 +88,7 @@ def test_issue_create_serializer_rejects_cross_project_pod(
     )
     valid = serializer.is_valid()
     assert not valid, serializer.errors
-    err = serializer.errors.get("assigned_pod") or serializer.errors
+    err = serializer.errors.get("assigned_pod_id") or serializer.errors
     assert any("different project" in str(e) for e in err)
 
 
@@ -118,7 +118,7 @@ def test_issue_create_serializer_accepts_same_project_pod(
                 "name": "An issue",
                 "project": str(project.id),
                 "state": str(state.id),
-                "assigned_pod": str(same_pod.id),
+                "assigned_pod_id": str(same_pod.id),
             },
             context={
                 "project_id": str(project.id),

--- a/apps/api/pi_dash/tests/unit/runner/test_issue_pod.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_issue_pod.py
@@ -18,7 +18,7 @@ from pi_dash.db.models import (
     WorkspaceMember,
 )
 from pi_dash.db.models.issue import Issue
-from pi_dash.runner.models import Pod
+from pi_dash.runner.models import AgentRun, AgentRunStatus, Pod
 
 
 @pytest.fixture
@@ -100,7 +100,7 @@ def test_create_serializer_rejects_pod_in_other_project(
     serializer = IssueCreateSerializer(
         data={
             "name": "Bad",
-            "assigned_pod": str(other_pod.id),
+            "assigned_pod_id": str(other_pod.id),
         },
         context={
             "project_id": project.id,
@@ -108,7 +108,7 @@ def test_create_serializer_rejects_pod_in_other_project(
         },
     )
     assert serializer.is_valid() is False
-    assert "assigned_pod" in serializer.errors
+    assert "assigned_pod_id" in serializer.errors
 
 
 @pytest.mark.unit
@@ -129,14 +129,132 @@ def test_create_serializer_rejects_soft_deleted_pod(
     extra.save(update_fields=["deleted_at"])
 
     serializer = IssueCreateSerializer(
-        data={"name": "Bad2", "assigned_pod": str(extra.id)},
+        data={"name": "Bad2", "assigned_pod_id": str(extra.id)},
         context={
             "project_id": project.id,
             "workspace_id": project.workspace_id,
         },
     )
     assert serializer.is_valid() is False
-    assert "assigned_pod" in serializer.errors
+    assert "assigned_pod_id" in serializer.errors
+
+
+@pytest.mark.unit
+def test_create_serializer_accepts_assigned_pod_id(
+    db, create_user, project, state
+):
+    """The write key is ``assigned_pod_id`` (the *_id FK convention)."""
+    from pi_dash.app.serializers.issue import IssueCreateSerializer
+
+    custom = Pod.objects.create(
+        workspace=project.workspace,
+        project=project,
+        name=f"{project.identifier}_custom",
+        created_by=create_user,
+    )
+    serializer = IssueCreateSerializer(
+        data={"name": "Pinned", "assigned_pod_id": str(custom.id)},
+        context={
+            "project_id": project.id,
+            "workspace_id": project.workspace_id,
+        },
+    )
+    assert serializer.is_valid(), serializer.errors
+    # source="assigned_pod" maps the *_id key onto the model field.
+    assert serializer.validated_data["assigned_pod"] == custom
+
+
+def _make_active_run(user, issue):
+    """Seed a non-terminal (active) run occupying the issue's run slot."""
+    return AgentRun.objects.create(
+        owner=user,
+        created_by=user,
+        workspace=issue.workspace,
+        pod=issue.assigned_pod,
+        work_item=issue,
+        prompt="x",
+        status=AgentRunStatus.RUNNING,
+    )
+
+
+@pytest.mark.unit
+def test_reassign_pod_allowed_without_active_run(
+    db, create_user, project, state
+):
+    from pi_dash.app.serializers.issue import IssueCreateSerializer
+
+    issue = Issue.objects.create(
+        name="Repoint",
+        project=project,
+        workspace=project.workspace,
+        created_by=create_user,
+    )
+    target = Pod.objects.create(
+        workspace=project.workspace,
+        project=project,
+        name=f"{project.identifier}_target",
+        created_by=create_user,
+    )
+    serializer = IssueCreateSerializer(
+        instance=issue,
+        data={"assigned_pod_id": str(target.id)},
+        partial=True,
+        context={"project_id": project.id, "workspace_id": project.workspace_id},
+    )
+    assert serializer.is_valid(), serializer.errors
+
+
+@pytest.mark.unit
+def test_reassign_pod_blocked_with_active_run(
+    db, create_user, project, state
+):
+    from pi_dash.app.serializers.issue import IssueCreateSerializer
+
+    issue = Issue.objects.create(
+        name="Running",
+        project=project,
+        workspace=project.workspace,
+        created_by=create_user,
+    )
+    _make_active_run(create_user, issue)
+    target = Pod.objects.create(
+        workspace=project.workspace,
+        project=project,
+        name=f"{project.identifier}_target",
+        created_by=create_user,
+    )
+    serializer = IssueCreateSerializer(
+        instance=issue,
+        data={"assigned_pod_id": str(target.id)},
+        partial=True,
+        context={"project_id": project.id, "workspace_id": project.workspace_id},
+    )
+    assert serializer.is_valid() is False
+    assert "assigned_pod_id" in serializer.errors
+
+
+@pytest.mark.unit
+def test_resend_same_pod_allowed_with_active_run(
+    db, create_user, project, state
+):
+    """Re-PATCHing the *current* pod is a no-op even mid-flight (the web form
+    re-sends the full editable set on blur)."""
+    from pi_dash.app.serializers.issue import IssueCreateSerializer
+
+    issue = Issue.objects.create(
+        name="RunningNoop",
+        project=project,
+        workspace=project.workspace,
+        created_by=create_user,
+    )
+    _make_active_run(create_user, issue)
+    serializer = IssueCreateSerializer(
+        instance=issue,
+        data={"assigned_pod_id": str(issue.assigned_pod_id)},
+        partial=True,
+        context={"project_id": project.id, "workspace_id": project.workspace_id},
+    )
+    assert serializer.is_valid(), serializer.errors
 
 
 @pytest.mark.unit

--- a/apps/api/pi_dash/tests/unit/runner/test_issue_pod.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_issue_pod.py
@@ -136,7 +136,9 @@ def test_create_serializer_rejects_soft_deleted_pod(
         },
     )
     assert serializer.is_valid() is False
-    assert "assigned_pod_id" in serializer.errors
+    # The field uses Pod.all_objects so the tombstone resolves and validate()
+    # returns the friendly message (not DRF's generic "object does not exist").
+    assert "deleted" in str(serializer.errors["assigned_pod_id"]).lower()
 
 
 @pytest.mark.unit
@@ -251,6 +253,99 @@ def test_resend_same_pod_allowed_with_active_run(
     serializer = IssueCreateSerializer(
         instance=issue,
         data={"assigned_pod_id": str(issue.assigned_pod_id)},
+        partial=True,
+        context={"project_id": project.id, "workspace_id": project.workspace_id},
+    )
+    assert serializer.is_valid(), serializer.errors
+
+
+@pytest.mark.unit
+def test_first_pod_assignment_allowed_with_active_run(
+    db, create_user, project, state
+):
+    """Setting a pod on an issue that currently has NO pod is an initial
+    assignment, not a reassignment — allowed even with an active run.
+
+    Reachable because soft-deleting a pod nulls assigned_pod on its issues
+    (runner/views/pods.py) while a run may still be live.
+    """
+    from pi_dash.app.serializers.issue import IssueCreateSerializer
+
+    issue = Issue.objects.create(
+        name="NoPod",
+        project=project,
+        workspace=project.workspace,
+        created_by=create_user,
+    )
+    run_pod = issue.assigned_pod  # auto-resolved default
+    # Null the issue's pod (simulating the pod-soft-delete cleanup path).
+    issue.assigned_pod = None
+    issue.save(update_fields=["assigned_pod"])
+    AgentRun.objects.create(
+        owner=create_user,
+        created_by=create_user,
+        workspace=issue.workspace,
+        pod=run_pod,
+        work_item=issue,
+        prompt="x",
+        status=AgentRunStatus.RUNNING,
+    )
+    target = Pod.objects.create(
+        workspace=project.workspace,
+        project=project,
+        name=f"{project.identifier}_first",
+        created_by=create_user,
+    )
+    serializer = IssueCreateSerializer(
+        instance=issue,
+        data={"assigned_pod_id": str(target.id)},
+        partial=True,
+        context={"project_id": project.id, "workspace_id": project.workspace_id},
+    )
+    assert serializer.is_valid(), serializer.errors
+
+
+@pytest.mark.unit
+def test_clearing_pod_blocked_with_active_run(
+    db, create_user, project, state
+):
+    """Clearing the pod (assigned_pod_id=null) is a reassignment too — the
+    next dispatch would re-route to the project default — so it's blocked
+    while a run is active."""
+    from pi_dash.app.serializers.issue import IssueCreateSerializer
+
+    issue = Issue.objects.create(
+        name="ClearBusy",
+        project=project,
+        workspace=project.workspace,
+        created_by=create_user,
+    )
+    _make_active_run(create_user, issue)
+    serializer = IssueCreateSerializer(
+        instance=issue,
+        data={"assigned_pod_id": None},
+        partial=True,
+        context={"project_id": project.id, "workspace_id": project.workspace_id},
+    )
+    assert serializer.is_valid() is False
+    assert "assigned_pod_id" in serializer.errors
+
+
+@pytest.mark.unit
+def test_clearing_pod_allowed_without_active_run(
+    db, create_user, project, state
+):
+    from pi_dash.app.serializers.issue import IssueCreateSerializer
+
+    issue = Issue.objects.create(
+        name="ClearIdle",
+        project=project,
+        workspace=project.workspace,
+        created_by=create_user,
+    )
+    serializer = IssueCreateSerializer(
+        instance=issue,
+        data={"assigned_pod_id": None},
         partial=True,
         context={"project_id": project.id, "workspace_id": project.workspace_id},
     )

--- a/apps/web/core/components/dropdowns/pod/base.tsx
+++ b/apps/web/core/components/dropdowns/pod/base.tsx
@@ -1,0 +1,207 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useRef, useState } from "react";
+import { usePopper } from "react-popper";
+import { Combobox } from "@headlessui/react";
+import { Check, Container } from "lucide-react";
+// pi dash imports
+import { useTranslation } from "@pi-dash/i18n";
+import { SearchIcon, ChevronDownIcon } from "@pi-dash/propel/icons";
+import type { IPod } from "@pi-dash/types";
+import { ComboDropDown, Spinner } from "@pi-dash/ui";
+import { cn } from "@pi-dash/utils";
+// components
+import { DropdownButton } from "@/components/dropdowns/buttons";
+import { BUTTON_VARIANTS_WITH_TEXT } from "@/components/dropdowns/constants";
+import type { TDropdownProps } from "@/components/dropdowns/types";
+// hooks
+import { useDropdown } from "@/hooks/use-dropdown";
+
+export type TPodDropdownBaseProps = TDropdownProps & {
+  dropdownArrow?: boolean;
+  dropdownArrowClassName?: string;
+  isInitializing?: boolean;
+  onChange: (val: string) => void;
+  onClose?: () => void;
+  onDropdownOpen?: () => void;
+  pods: IPod[];
+  renderByDefault?: boolean;
+  value: string | undefined | null;
+};
+
+export function PodDropdownBase(props: TPodDropdownBaseProps) {
+  const {
+    buttonClassName,
+    buttonContainerClassName,
+    buttonVariant,
+    className = "",
+    disabled = false,
+    dropdownArrow = false,
+    dropdownArrowClassName = "",
+    hideIcon = false,
+    isInitializing = false,
+    onChange,
+    onClose,
+    onDropdownOpen,
+    placement,
+    pods,
+    renderByDefault = true,
+    showTooltip = false,
+    tabIndex,
+    value,
+  } = props;
+  // refs
+  const dropdownRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  // popper-js refs
+  const [referenceElement, setReferenceElement] = useState<HTMLButtonElement | null>(null);
+  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
+  // states
+  const [query, setQuery] = useState("");
+  const [isOpen, setIsOpen] = useState(false);
+  // i18n
+  const { t } = useTranslation();
+  // popper-js init
+  const { styles, attributes } = usePopper(referenceElement, popperElement, {
+    placement: placement ?? "bottom-start",
+    modifiers: [{ name: "preventOverflow", options: { padding: 12 } }],
+  });
+  // dropdown init
+  const { handleClose, handleKeyDown, handleOnClick, searchInputKeyDown } = useDropdown({
+    dropdownRef,
+    inputRef,
+    isOpen,
+    onClose,
+    onOpen: onDropdownOpen,
+    query,
+    setIsOpen,
+    setQuery,
+  });
+
+  // derived values
+  const selectedPod = value ? pods.find((pod) => pod.id === value) : undefined;
+  const filteredPods = query === "" ? pods : pods.filter((pod) => pod.name.toLowerCase().includes(query.toLowerCase()));
+
+  const dropdownOnChange = (val: string) => {
+    onChange(val);
+    handleClose();
+  };
+
+  const comboButton = (
+    <button
+      tabIndex={tabIndex}
+      ref={setReferenceElement}
+      type="button"
+      className={cn(
+        "clickable block h-full max-w-full outline-none",
+        {
+          "cursor-not-allowed text-secondary": disabled,
+          "cursor-pointer": !disabled,
+        },
+        buttonContainerClassName
+      )}
+      onClick={handleOnClick}
+      disabled={disabled}
+    >
+      <DropdownButton
+        className={buttonClassName}
+        isActive={isOpen}
+        tooltipHeading={t("pod")}
+        tooltipContent={selectedPod?.name ?? t("pod")}
+        showTooltip={showTooltip}
+        variant={buttonVariant}
+        renderToolTipByDefault={renderByDefault}
+      >
+        {isInitializing ? (
+          <Spinner className="h-3.5 w-3.5" />
+        ) : (
+          <>
+            {!hideIcon && <Container className="size-3.5 flex-shrink-0" />}
+            {BUTTON_VARIANTS_WITH_TEXT.includes(buttonVariant) && (
+              <span className="flex-grow truncate text-left">{selectedPod?.name ?? t("pod")}</span>
+            )}
+            {dropdownArrow && (
+              <ChevronDownIcon className={cn("h-2.5 w-2.5 flex-shrink-0", dropdownArrowClassName)} aria-hidden="true" />
+            )}
+          </>
+        )}
+      </DropdownButton>
+    </button>
+  );
+
+  return (
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions -- keyboard handling lives on the headless Combobox; matches sibling dropdowns (e.g. state).
+    <ComboDropDown
+      as="div"
+      ref={dropdownRef}
+      className={cn("h-full", className)}
+      value={value}
+      onChange={dropdownOnChange}
+      disabled={disabled}
+      onKeyDown={handleKeyDown}
+      button={comboButton}
+      renderByDefault={renderByDefault}
+    >
+      {isOpen && (
+        <Combobox.Options className="fixed z-10" static>
+          <div
+            className="my-1 w-48 rounded-sm border-[0.5px] border-strong bg-surface-1 px-2 py-2.5 text-11 shadow-raised-200 focus:outline-none"
+            ref={setPopperElement}
+            style={styles.popper}
+            {...attributes.popper}
+          >
+            <div className="flex items-center gap-1.5 rounded-sm border border-subtle bg-surface-2 px-2">
+              <SearchIcon className="h-3.5 w-3.5 text-placeholder" strokeWidth={1.5} />
+              <Combobox.Input
+                as="input"
+                ref={inputRef}
+                className="w-full bg-transparent py-1 text-11 text-secondary placeholder:text-placeholder focus:outline-none"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder={t("common.search.label")}
+                onKeyDown={searchInputKeyDown}
+              />
+            </div>
+            <div className="mt-2 max-h-48 space-y-1 overflow-y-scroll">
+              {filteredPods.length > 0 ? (
+                filteredPods.map((pod) => (
+                  <Combobox.Option
+                    key={pod.id}
+                    value={pod.id}
+                    className={({ active, selected }) =>
+                      cn(
+                        "flex w-full cursor-pointer items-center justify-between gap-2 truncate rounded-sm px-1 py-1.5 select-none",
+                        { "bg-surface-2": active, "text-primary": selected, "text-secondary": !selected }
+                      )
+                    }
+                  >
+                    {({ selected }) => (
+                      <>
+                        <div className="flex items-center gap-2 truncate">
+                          <Container className="size-3.5 flex-shrink-0" />
+                          <span className="flex-grow truncate">{pod.name}</span>
+                          {pod.is_default && (
+                            <span className="flex-shrink-0 rounded-sm bg-surface-2 px-1 py-0.5 text-9 text-tertiary uppercase">
+                              {t("pod_default_badge")}
+                            </span>
+                          )}
+                        </div>
+                        {selected && <Check className="size-3.5 flex-shrink-0" />}
+                      </>
+                    )}
+                  </Combobox.Option>
+                ))
+              ) : (
+                <p className="px-1.5 py-1 text-placeholder italic">{t("no_matching_results")}</p>
+              )}
+            </div>
+          </div>
+        </Combobox.Options>
+      )}
+    </ComboDropDown>
+  );
+}

--- a/apps/web/core/components/dropdowns/pod/dropdown.tsx
+++ b/apps/web/core/components/dropdowns/pod/dropdown.tsx
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useEffect, useRef } from "react";
+import useSWR from "swr";
+// pi dash imports
+import { PodService } from "@pi-dash/services";
+import type { IPod } from "@pi-dash/types";
+// local imports
+import type { TPodDropdownBaseProps } from "./base";
+import { PodDropdownBase } from "./base";
+
+const podService = new PodService();
+
+type TPodDropdownProps = Omit<TPodDropdownBaseProps, "pods" | "isInitializing"> & {
+  projectId: string | undefined;
+  /** When true (work-item creation), pre-select the project's default pod so
+   * every new issue is pinned to a concrete pod rather than left to the
+   * server-side fallback. */
+  isForWorkItemCreation?: boolean;
+};
+
+export function PodDropdown(props: TPodDropdownProps) {
+  const { projectId, isForWorkItemCreation, value, onChange } = props;
+  // Pods are project-scoped; key the cache by project so switching the issue's
+  // project refetches the right list.
+  const { data: pods, isLoading } = useSWR<IPod[]>(
+    projectId ? ["issue-pods", projectId] : null,
+    projectId ? () => podService.list(undefined, projectId) : null
+  );
+  // Pre-select the default pod exactly once on create, only while the field is
+  // still empty (never clobber a user's explicit pick or an existing issue).
+  const didPreselect = useRef(false);
+  useEffect(() => {
+    if (!isForWorkItemCreation || didPreselect.current || value || !pods?.length) return;
+    const defaultPod = pods.find((pod) => pod.is_default) ?? pods[0];
+    if (defaultPod) {
+      didPreselect.current = true;
+      onChange(defaultPod.id);
+    }
+  }, [isForWorkItemCreation, value, pods, onChange]);
+
+  return <PodDropdownBase {...props} pods={pods ?? []} isInitializing={isLoading} />;
+}

--- a/apps/web/core/components/dropdowns/pod/dropdown.tsx
+++ b/apps/web/core/components/dropdowns/pod/dropdown.tsx
@@ -4,7 +4,7 @@
  * See the LICENSE file for details.
  */
 
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import useSWR from "swr";
 // pi dash imports
 import { PodService } from "@pi-dash/services";
@@ -31,16 +31,16 @@ export function PodDropdown(props: TPodDropdownProps) {
     projectId ? ["issue-pods", projectId] : null,
     projectId ? () => podService.list(undefined, projectId) : null
   );
-  // Pre-select the default pod exactly once on create, only while the field is
-  // still empty (never clobber a user's explicit pick or an existing issue).
-  const didPreselect = useRef(false);
+  // Pre-select the project's default pod on create whenever the field is empty
+  // and pods are loaded. Gating on `value` (not a once-only ref) means a
+  // project switch or "create more" reset — which clears assigned_pod_id back
+  // to null — re-defaults to the NEW project's pod instead of leaving it blank
+  // or stranding the previous project's pod. The dropdown has no clear action,
+  // so `value` only goes null via those resets, never by user intent → no loop.
   useEffect(() => {
-    if (!isForWorkItemCreation || didPreselect.current || value || !pods?.length) return;
+    if (!isForWorkItemCreation || value || !pods?.length) return;
     const defaultPod = pods.find((pod) => pod.is_default) ?? pods[0];
-    if (defaultPod) {
-      didPreselect.current = true;
-      onChange(defaultPod.id);
-    }
+    if (defaultPod) onChange(defaultPod.id);
   }, [isForWorkItemCreation, value, pods, onChange]);
 
   return <PodDropdownBase {...props} pods={pods ?? []} isInitializing={isLoading} />;

--- a/apps/web/core/components/issues/issue-modal/components/default-properties.tsx
+++ b/apps/web/core/components/issues/issue-modal/components/default-properties.tsx
@@ -22,6 +22,7 @@ import { DateDropdown } from "@/components/dropdowns/date";
 import { EstimateDropdown } from "@/components/dropdowns/estimate";
 import { MemberDropdown } from "@/components/dropdowns/member/dropdown";
 import { ModuleDropdown } from "@/components/dropdowns/module/dropdown";
+import { PodDropdown } from "@/components/dropdowns/pod/dropdown";
 import { PriorityDropdown } from "@/components/dropdowns/priority";
 import { StateDropdown } from "@/components/dropdowns/state/dropdown";
 import { ParentIssuesListModal } from "@/components/issues/parent-issues-list-modal";
@@ -101,6 +102,24 @@ export const IssueDefaultProperties = observer(function IssueDefaultProperties(p
               projectId={projectId ?? undefined}
               buttonVariant="border-with-text"
               tabIndex={getIndex("state_id")}
+              isForWorkItemCreation={!id}
+            />
+          </div>
+        )}
+      />
+      <Controller
+        control={control}
+        name="assigned_pod_id"
+        render={({ field: { value, onChange } }) => (
+          <div className="h-7">
+            <PodDropdown
+              value={value}
+              onChange={(podId) => {
+                onChange(podId);
+                handleFormChange();
+              }}
+              projectId={projectId ?? undefined}
+              buttonVariant="border-with-text"
               isForWorkItemCreation={!id}
             />
           </div>

--- a/packages/constants/src/issue/modal.ts
+++ b/packages/constants/src/issue/modal.ts
@@ -20,6 +20,7 @@ export const DEFAULT_WORK_ITEM_FORM_VALUES: Partial<TIssue> = {
   label_ids: [],
   cycle_id: null,
   module_ids: null,
+  assigned_pod_id: null,
   start_date: null,
   target_date: null,
   git_work_branch: "",

--- a/packages/i18n/src/locales/cs/translations.ts
+++ b/packages/i18n/src/locales/cs/translations.ts
@@ -5,6 +5,8 @@
  */
 
 export default {
+  pod: "Pod",
+  pod_default_badge: "Default",
   sidebar: {
     projects: "Projekty",
     pages: "Stránky",

--- a/packages/i18n/src/locales/de/translations.ts
+++ b/packages/i18n/src/locales/de/translations.ts
@@ -5,6 +5,8 @@
  */
 
 export default {
+  pod: "Pod",
+  pod_default_badge: "Default",
   sidebar: {
     projects: "Projekte",
     pages: "Seiten",

--- a/packages/i18n/src/locales/en/translations.ts
+++ b/packages/i18n/src/locales/en/translations.ts
@@ -5,6 +5,8 @@
  */
 
 export default {
+  pod: "Pod",
+  pod_default_badge: "Default",
   submit: "Submit",
   cancel: "Cancel",
   loading: "Loading",

--- a/packages/i18n/src/locales/es/translations.ts
+++ b/packages/i18n/src/locales/es/translations.ts
@@ -5,6 +5,8 @@
  */
 
 export default {
+  pod: "Pod",
+  pod_default_badge: "Default",
   sidebar: {
     projects: "Proyectos",
     pages: "Páginas",

--- a/packages/i18n/src/locales/fr/translations.ts
+++ b/packages/i18n/src/locales/fr/translations.ts
@@ -5,6 +5,8 @@
  */
 
 export default {
+  pod: "Pod",
+  pod_default_badge: "Default",
   sidebar: {
     projects: "Projets",
     pages: "Pages",

--- a/packages/i18n/src/locales/id/translations.ts
+++ b/packages/i18n/src/locales/id/translations.ts
@@ -5,6 +5,8 @@
  */
 
 export default {
+  pod: "Pod",
+  pod_default_badge: "Default",
   sidebar: {
     projects: "Projek",
     pages: "Halaman",

--- a/packages/i18n/src/locales/it/translations.ts
+++ b/packages/i18n/src/locales/it/translations.ts
@@ -5,6 +5,8 @@
  */
 
 export default {
+  pod: "Pod",
+  pod_default_badge: "Default",
   sidebar: {
     projects: "Progetti",
     pages: "Pagine",

--- a/packages/i18n/src/locales/ja/translations.ts
+++ b/packages/i18n/src/locales/ja/translations.ts
@@ -5,6 +5,8 @@
  */
 
 export default {
+  pod: "Pod",
+  pod_default_badge: "Default",
   sidebar: {
     projects: "プロジェクト",
     pages: "ページ",

--- a/packages/i18n/src/locales/ko/translations.ts
+++ b/packages/i18n/src/locales/ko/translations.ts
@@ -5,6 +5,8 @@
  */
 
 export default {
+  pod: "Pod",
+  pod_default_badge: "Default",
   sidebar: {
     projects: "프로젝트",
     pages: "페이지",

--- a/packages/i18n/src/locales/pl/translations.ts
+++ b/packages/i18n/src/locales/pl/translations.ts
@@ -5,6 +5,8 @@
  */
 
 export default {
+  pod: "Pod",
+  pod_default_badge: "Default",
   sidebar: {
     projects: "Projekty",
     pages: "Strony",

--- a/packages/i18n/src/locales/pt-BR/translations.ts
+++ b/packages/i18n/src/locales/pt-BR/translations.ts
@@ -5,6 +5,8 @@
  */
 
 export default {
+  pod: "Pod",
+  pod_default_badge: "Default",
   sidebar: {
     projects: "Projetos",
     pages: "Páginas",

--- a/packages/i18n/src/locales/ro/translations.ts
+++ b/packages/i18n/src/locales/ro/translations.ts
@@ -5,6 +5,8 @@
  */
 
 export default {
+  pod: "Pod",
+  pod_default_badge: "Default",
   sidebar: {
     projects: "Proiecte",
     pages: "Documentație",

--- a/packages/i18n/src/locales/ru/translations.ts
+++ b/packages/i18n/src/locales/ru/translations.ts
@@ -5,6 +5,8 @@
  */
 
 export default {
+  pod: "Pod",
+  pod_default_badge: "Default",
   sidebar: {
     projects: "Проекты",
     pages: "Страницы",

--- a/packages/i18n/src/locales/sk/translations.ts
+++ b/packages/i18n/src/locales/sk/translations.ts
@@ -5,6 +5,8 @@
  */
 
 export default {
+  pod: "Pod",
+  pod_default_badge: "Default",
   sidebar: {
     projects: "Projekty",
     pages: "Stránky",

--- a/packages/i18n/src/locales/tr-TR/translations.ts
+++ b/packages/i18n/src/locales/tr-TR/translations.ts
@@ -5,6 +5,8 @@
  */
 
 export default {
+  pod: "Pod",
+  pod_default_badge: "Default",
   sidebar: {
     projects: "Projeler",
     pages: "Sayfalar",

--- a/packages/i18n/src/locales/ua/translations.ts
+++ b/packages/i18n/src/locales/ua/translations.ts
@@ -5,6 +5,8 @@
  */
 
 export default {
+  pod: "Pod",
+  pod_default_badge: "Default",
   sidebar: {
     projects: "Проєкти",
     pages: "Сторінки",

--- a/packages/i18n/src/locales/vi-VN/translations.ts
+++ b/packages/i18n/src/locales/vi-VN/translations.ts
@@ -5,6 +5,8 @@
  */
 
 export default {
+  pod: "Pod",
+  pod_default_badge: "Default",
   sidebar: {
     projects: "Dự án",
     pages: "Trang",

--- a/packages/i18n/src/locales/zh-CN/translations.ts
+++ b/packages/i18n/src/locales/zh-CN/translations.ts
@@ -5,6 +5,8 @@
  */
 
 export default {
+  pod: "Pod",
+  pod_default_badge: "Default",
   sidebar: {
     projects: "项目",
     pages: "页面",

--- a/packages/i18n/src/locales/zh-TW/translations.ts
+++ b/packages/i18n/src/locales/zh-TW/translations.ts
@@ -5,6 +5,8 @@
  */
 
 export default {
+  pod: "Pod",
+  pod_default_badge: "Default",
   sidebar: {
     projects: "專案",
     pages: "頁面",

--- a/packages/services/src/runner/pod.service.ts
+++ b/packages/services/src/runner/pod.service.ts
@@ -18,8 +18,17 @@ export class PodService extends APIService {
     super(BASE_URL || API_BASE_URL);
   }
 
-  async list(workspaceId: string): Promise<IPod[]> {
-    return this.get("/api/runners/pods/", { params: { workspace: workspaceId } })
+  /**
+   * List pods. Pods are project-scoped, so pass ``projectId`` to fetch the
+   * pods for a single project (the server's ``project`` filter wins over
+   * ``workspace``). The ``workspaceId``-only form is kept for the workspace
+   * runners views.
+   */
+  async list(workspaceId?: string, projectId?: string): Promise<IPod[]> {
+    const params: Record<string, string> = {};
+    if (projectId) params.project = projectId;
+    if (workspaceId) params.workspace = workspaceId;
+    return this.get("/api/runners/pods/", { params })
       .then((r) => r?.data)
       .catch((e) => {
         throw e?.response?.data;

--- a/packages/types/src/issues/issue.ts
+++ b/packages/types/src/issues/issue.ts
@@ -65,6 +65,11 @@ export type TBaseIssue = {
   module_ids: string[] | null;
   type_id: string | null;
 
+  // Pod (runner queue) this issue's agent runs dispatch to. Null falls back to
+  // the project's default pod, resolved server-side. Reassignment is rejected
+  // by the backend once the issue has an active run.
+  assigned_pod_id?: string | null;
+
   created_at: string;
   updated_at: string;
   start_date: string | null;


### PR DESCRIPTION
## What & why

Today an issue's pod is chosen entirely by the backend — `IssueCreateSerializer` accepts a pod, but the web UI has no field for it, so every issue created from the UI silently lands on the project's **default pod**. This adds a pod selector to the create/edit issue modal so users can route an issue's agent runs to a specific pod.

## Changes

### Backend (`apps/api`)
- Expose the pod as **`assigned_pod_id`** on `IssueCreateSerializer` (write) and `IssueSerializer` (read), matching the `*_id` FK convention (`state_id`/`parent_id`/`cycle_id`). Removes the bare `assigned_pod` write key.
- **Reassignment guard:** new `Issue.has_active_run` helper + a check in `validate()` that rejects changing `assigned_pod_id` once the issue has a non-terminal `AgentRun`. Re-sending the current pod stays a no-op (the web form re-PATCHes on blur).

### Frontend (`apps/web`, `packages`)
- New **`PodDropdown`** (`dropdowns/pod/`) mirroring the state dropdown: fetches project-scoped pods via `PodService`, badges the default, and **pre-selects the project's default pod on create**.
- Wired into the issue modal next to the state selector (create + edit).
- `assigned_pod_id` added to `TBaseIssue` and the form defaults; `PodService.list` gains an optional project filter; `pod`/`pod_default_badge` i18n keys added to all locales.

## Behavior decisions
- **Scope:** selector shows in both create and edit.
- **Mid-flight reassignment:** blocked server-side once a run is active.
- **Default:** new issues are pinned to the project's default pod explicitly (they no longer follow the project default if it later changes).

## Reassignment notes
- **Issue → different pod:** allowed pre-flight, blocked once a run is active.
- **Runner → different pod:** unsupported by design (a runner is bound to one pod at enrollment; moving requires re-enrollment).

## Testing
- Backend: full runner suite green (**285 passed**), incl. new tests for create-with-`assigned_pod_id`, reassign allowed without an active run, reassign blocked with an active run, and same-pod no-op.
- Frontend: changed files type-clean; i18n package typechecks; pod/runner web tests pass (9); oxfmt/oxlint clean.
- ⚠️ Manual UI click-through not yet done — the dropdown is wired end-to-end but hasn't been visually verified in a running app.

## Out of scope
- Per-pod capability tags / project-level routing rules (deferred).
- Moving runners between pods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)