### PR TITLE
feat(api): include project name and description in issue prompt

### DIFF
--- a/apps/api/pi_dash/prompting/context.py
+++ b/apps/api/pi_dash/prompting/context.py
@@ -164,7 +164,7 @@ def build_context(issue: Issue, run: AgentRun) -> Dict[str, Any]:
             "id": str(project.id),
             "identifier": project.identifier,
             "name": project.name,
-            "description": getattr(project, "description", "") or "",
+            "description": project.description or "",
         },
         "repo": {
             "url": (getattr(project, "repo_url", "") or None),

--- a/apps/api/pi_dash/prompting/context.py
+++ b/apps/api/pi_dash/prompting/context.py
@@ -164,6 +164,7 @@ def build_context(issue: Issue, run: AgentRun) -> Dict[str, Any]:
             "id": str(project.id),
             "identifier": project.identifier,
             "name": project.name,
+            "description": getattr(project, "description", "") or "",
         },
         "repo": {
             "url": (getattr(project, "repo_url", "") or None),

--- a/apps/api/pi_dash/prompting/fragments/01_intro.md
+++ b/apps/api/pi_dash/prompting/fragments/01_intro.md
@@ -14,7 +14,6 @@ Project: {{ project.name }} ({{ project.identifier }})
 {% if project.description %}
 {{ project.description }}
 {% endif %}
-
 Issue Description:
 {% if issue.description %}
 {{ issue.description }}

--- a/apps/api/pi_dash/prompting/fragments/01_intro.md
+++ b/apps/api/pi_dash/prompting/fragments/01_intro.md
@@ -10,7 +10,12 @@ Issue context:
 - URL: {{ issue.url }}
 {% if issue.target_date %}- Target date: {{ issue.target_date }}{% endif %}
 
-Description:
+Project: {{ project.name }} ({{ project.identifier }})
+{% if project.description %}
+{{ project.description }}
+{% endif %}
+
+Issue Description:
 {% if issue.description %}
 {{ issue.description }}
 {% else %}

--- a/apps/api/pi_dash/prompting/seed.py
+++ b/apps/api/pi_dash/prompting/seed.py
@@ -36,7 +36,7 @@ You are reviewing the work product of a previous implementation pass.
 "Review" can mean different things depending on what was produced.
 
 Issue: {{ issue.title }}
-Description: {{ issue.description }}
+Issue Description: {{ issue.description }}
 Recent activity:
 {{ comments_section }}
 Latest implementation run output (read this carefully —

--- a/apps/api/pi_dash/tests/unit/prompting/test_context.py
+++ b/apps/api/pi_dash/tests/unit/prompting/test_context.py
@@ -151,6 +151,46 @@ def test_context_parent_work_branch_empty_surfaces_as_none(
 
 
 @pytest.mark.unit
+def test_context_includes_project_description_when_set(
+    workspace, create_user
+):
+    project = Project.objects.create(
+        name="Documented Project",
+        identifier="DP",
+        workspace=workspace,
+        created_by=create_user,
+        description="Core backend services. Prefer additive migrations.",
+    )
+    project_state = State.objects.create(
+        name="Todo", project=project, group="unstarted"
+    )
+    issue = Issue.objects.create(
+        name="Fix a thing",
+        workspace=workspace,
+        project=project,
+        state=project_state,
+        created_by=create_user,
+    )
+    run = AgentRun.objects.create(
+        owner=create_user, workspace=workspace, prompt="", work_item=issue
+    )
+    ctx = build_context(issue, run)
+    assert (
+        ctx["project"]["description"]
+        == "Core backend services. Prefer additive migrations."
+    )
+
+
+@pytest.mark.unit
+def test_context_project_description_defaults_to_empty_string(issue, run):
+    # The `project` fixture above doesn't set `description`, so the model's
+    # TextField(blank=True) default applies — must surface as "" (never None)
+    # so the template's `{% if project.description %}` guard behaves.
+    ctx = build_context(issue, run)
+    assert ctx["project"]["description"] == ""
+
+
+@pytest.mark.unit
 def test_context_empty_base_branch_surfaces_as_none(workspace, create_user):
     # A project with no base_branch set — empty strings must flow through as
     # ``None`` so the prompt template takes the "auto-detect remote default"

--- a/apps/api/pi_dash/tests/unit/prompting/test_fragments.py
+++ b/apps/api/pi_dash/tests/unit/prompting/test_fragments.py
@@ -113,7 +113,14 @@ def test_fragments_directory_exists_on_disk():
     assert FRAGMENTS_DIR.is_dir(), f"fragments dir missing: {FRAGMENTS_DIR}"
 
 
-def _ctx_from_db(*, parent_branch=None, work_branch=None, base_branch="trunk", has_parent=False):
+def _ctx_from_db(
+    *,
+    parent_branch=None,
+    work_branch=None,
+    base_branch="trunk",
+    has_parent=False,
+    project_description="",
+):
     """Build the Jinja context for these fragment tests via the production
     ``prompting.context.build_context``.
 
@@ -166,6 +173,7 @@ def _ctx_from_db(*, parent_branch=None, work_branch=None, base_branch="trunk", h
         workspace=workspace,
         created_by=owner,
         base_branch=base_branch,
+        description=project_description,
     )
     State.objects.create(
         name="Todo", project=project, workspace=workspace, group="unstarted", default=True
@@ -239,3 +247,36 @@ def test_assemble_renders_existing_work_branch_skips_base_resolution():
     # repo.work_branch path → checkout existing branch directly, no BASE= resolution.
     assert "git checkout feat/pinned" in body
     assert "BASE=" not in body
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_assemble_renders_project_header_and_description_when_set():
+    body = render(
+        assemble(),
+        _ctx_from_db(project_description="Core backend services."),
+    )
+    # The project header always renders.
+    assert "Project: Test Project (TP)" in body
+    # When description is set, it renders verbatim on its own line,
+    # framed by blank lines between the Project header and Issue Description.
+    assert "\nCore backend services.\n" in body
+    assert (
+        "Project: Test Project (TP)\n\nCore backend services.\n\nIssue Description:"
+        in body
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_assemble_renders_project_header_without_description_has_no_extra_blank_line():
+    # Whitespace regression guard: with description empty, the conditional
+    # block must not leave a double-blank-line gap between the Project header
+    # and the Issue Description heading. renderer.py uses trim_blocks=False,
+    # so the structure of fragments/01_intro.md around the {% if %} block is
+    # what enforces single-blank-line spacing here.
+    body = render(assemble(), _ctx_from_db(project_description=""))
+    assert "Project: Test Project (TP)" in body
+    assert "Project: Test Project (TP)\n\nIssue Description:" in body
+    # Triple-newline would mean a double blank line — that's the regression.
+    assert "Project: Test Project (TP)\n\n\nIssue Description:" not in body


### PR DESCRIPTION
## Summary
- Surface the parent project's **name**, **identifier**, and **description** in the default issue prompt so agents see the project's purpose and conventions alongside the issue itself. Previously only issue/repo/comments were rendered — the `Project.description` column was unused at prompt time.
- Add `description` to the `project` dict in `prompting/context.py` (empty string when unset, so the template can guard with `{% if project.description %}`).
- Render a new `Project:` block in `fragments/01_intro.md` right after Issue context; rename the issue's `Description:` heading to `Issue Description:` to disambiguate.

## Rendered output (example)

Before:
```
Issue context:
- Identifier: ENG-142
- Title: Fix flaky webhook retry
  ...

Description:
Webhook retries occasionally fire twice when the upstream returns 502.
```

After:
```
Issue context:
- Identifier: ENG-142
- Title: Fix flaky webhook retry
  ...

Project: Engineering (ENG)
Core backend services for the Pi Dash platform — Django API, Celery
workers, runner protocol. Prefer additive migrations and back out via
feature flag rather than column drops.

Issue Description:
Webhook retries occasionally fire twice when the upstream returns 502.
```

Projects without a description render just `Project: <name> (<identifier>)` and nothing extra — no empty block.

## Operator note
The runtime default prompt is stored in a `PromptTemplate` DB row that is seeded from these fragments at migrate time (`prompting/seed.py`). Existing workspaces won't see the new project block until someone runs the `reseed_default_template` management command (or edits the workspace's template row directly).

## Test plan
- [ ] Backend unit: `cd apps/api && python run_tests.py -u` (no existing tests assert the `project` dict shape, so this is a smoke check).
- [ ] Manually run `reseed_default_template` against a local workspace and verify the next issue run's prompt renders the new `Project:` block.
- [ ] Confirm projects with no `description` render only the `Project: <name> (<identifier>)` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)