### PR TITLE
fix(runner): self-heal missing launchd plist in `pidash restart`

### DIFF
--- a/runner/src/service/launchd.rs
+++ b/runner/src/service/launchd.rs
@@ -569,6 +569,15 @@ fn ensure_plist_present(plist: &Path) -> Result<()> {
 ///
 /// We only rewrite when missing (not unconditionally on every restart) so
 /// operators hand-editing the plist for debugging don't get clobbered.
+///
+/// Gated to `target_os = "macos"` (not the module's broader `macos || test`
+/// gate) because the only call site is also `cfg(target_os = "macos")`. The
+/// module's `test` arm exists so the path/exit-status parsers are unit-
+/// testable on Linux CI runners; this self-heal does macOS-specific I/O
+/// (`write_unit` renders the launchd plist) and has no Linux test path of
+/// its own, so compiling it on Linux would just produce a dead-code warning
+/// under `-D dead-code`.
+#[cfg(target_os = "macos")]
 pub(crate) async fn rewrite_unit_if_missing(paths: &Paths) -> Result<bool> {
     let plist = plist_path()?;
     if plist.exists() {

--- a/runner/src/service/launchd.rs
+++ b/runner/src/service/launchd.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 use tokio::process::Command;
 
@@ -149,6 +149,18 @@ pub async fn start() -> Result<()> {
     let domain = format!("gui/{uid}");
     let target = format!("{domain}/{LABEL}");
     let plist = plist_path()?;
+
+    // Precondition: the plist must exist on disk before we ask launchctl
+    // to bootstrap it. macOS reports a missing plist as the same opaque
+    // `Bootstrap failed: 5: Input/output error` that we elsewhere treat
+    // as "raced an in-flight teardown" — without this check we pass the
+    // cryptic EIO straight through to the operator. `pidash update` only
+    // swaps the binary and never rewrites the plist, so an operator who
+    // ran `pidash update` then `pidash restart` against a machine whose
+    // plist had been removed (manual cleanup, an older `pidash uninstall`,
+    // or never written for the current install location) would see the
+    // EIO without any hint that the fix is `pidash install`.
+    ensure_plist_present(&plist)?;
 
     // Snapshot the pre-action PID so `wait_for_running` can tell a fresh
     // daemon from the one we're about to kick. None = no daemon before.
@@ -539,6 +551,24 @@ pub async fn status() -> Result<String> {
     Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
 }
 
+/// Verify the LaunchAgent plist exists before we hand its path to
+/// `launchctl bootstrap`. Pulled out as a pure function so the
+/// missing-plist error message is unit-testable without spawning
+/// launchctl. The hint deliberately names `pidash install` (the
+/// command that writes the plist) and contrasts it with
+/// `pidash update` (the command that does NOT) so operators who
+/// hit this after an update know the difference.
+fn ensure_plist_present(plist: &Path) -> Result<()> {
+    if plist.exists() {
+        return Ok(());
+    }
+    anyhow::bail!(
+        "launchd plist missing at {}. Run `pidash install` to (re)write it; \
+         `pidash update` only swaps the binary and does not touch the plist.",
+        plist.display()
+    )
+}
+
 fn plist_path() -> Result<PathBuf> {
     let home = std::env::var_os("HOME")
         .map(PathBuf::from)
@@ -852,6 +882,40 @@ mod tests {
             cfg.to_lowercase().contains("config") || cfg.to_lowercase().contains("non-zero"),
             "high exit codes should suggest config/credential errors; got: {cfg}"
         );
+    }
+
+    #[test]
+    fn ensure_plist_present_errors_with_install_hint_when_missing() {
+        // Use a path that's guaranteed not to exist. The error must point
+        // the operator at `pidash install` (the command that writes the
+        // plist) and include the missing path so they can confirm what
+        // they're looking for. This replaces the cryptic
+        // `Bootstrap failed: 5: Input/output error` that launchctl
+        // returns for a missing plist.
+        let missing = std::env::temp_dir().join("pidash-ensure-plist-missing-DNE.plist");
+        let _ = std::fs::remove_file(&missing);
+        let err = ensure_plist_present(&missing).expect_err("missing plist must error");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("pidash install"),
+            "missing-plist error must point at `pidash install`; got: {msg}"
+        );
+        assert!(
+            msg.contains(&missing.display().to_string()),
+            "missing-plist error must include the path; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn ensure_plist_present_ok_when_file_exists() {
+        // tempdir-free: just write into the OS temp dir under a unique
+        // name and clean up. The function only checks `exists()` so we
+        // don't care about the file's contents.
+        let present = std::env::temp_dir().join("pidash-ensure-plist-present-OK.plist");
+        std::fs::write(&present, b"x").unwrap();
+        let result = ensure_plist_present(&present);
+        let _ = std::fs::remove_file(&present);
+        assert!(result.is_ok(), "existing plist must pass; got: {result:?}");
     }
 
     #[test]

--- a/runner/src/service/launchd.rs
+++ b/runner/src/service/launchd.rs
@@ -150,16 +150,14 @@ pub async fn start() -> Result<()> {
     let target = format!("{domain}/{LABEL}");
     let plist = plist_path()?;
 
-    // Precondition: the plist must exist on disk before we ask launchctl
-    // to bootstrap it. macOS reports a missing plist as the same opaque
-    // `Bootstrap failed: 5: Input/output error` that we elsewhere treat
-    // as "raced an in-flight teardown" — without this check we pass the
-    // cryptic EIO straight through to the operator. `pidash update` only
-    // swaps the binary and never rewrites the plist, so an operator who
-    // ran `pidash update` then `pidash restart` against a machine whose
-    // plist had been removed (manual cleanup, an older `pidash uninstall`,
-    // or never written for the current install location) would see the
-    // EIO without any hint that the fix is `pidash install`.
+    // Precondition: the plist must exist before we hand its path to
+    // launchctl. macOS reports "plist not found" as the opaque
+    // `Bootstrap failed: 5: Input/output error` — indistinguishable
+    // from the teardown-race EIO without out-of-band knowledge — so
+    // surface it here with an actionable hint. `pidash restart` rewrites
+    // the plist via `reload::restart_and_verify_with_progress` before
+    // reaching this point; this bail only fires for direct `pidash start`
+    // callers on a plist-less machine.
     ensure_plist_present(&plist)?;
 
     // Snapshot the pre-action PID so `wait_for_running` can tell a fresh
@@ -551,13 +549,7 @@ pub async fn status() -> Result<String> {
     Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
 }
 
-/// Verify the LaunchAgent plist exists before we hand its path to
-/// `launchctl bootstrap`. Pulled out as a pure function so the
-/// missing-plist error message is unit-testable without spawning
-/// launchctl. The hint deliberately names `pidash install` (the
-/// command that writes the plist) and contrasts it with
-/// `pidash update` (the command that does NOT) so operators who
-/// hit this after an update know the difference.
+/// Pure path-existence check, extracted so the error message is unit-testable.
 fn ensure_plist_present(plist: &Path) -> Result<()> {
     if plist.exists() {
         return Ok(());
@@ -566,7 +558,24 @@ fn ensure_plist_present(plist: &Path) -> Result<()> {
         "launchd plist missing at {}. Run `pidash install` to (re)write it; \
          `pidash update` only swaps the binary and does not touch the plist.",
         plist.display()
-    )
+    );
+}
+
+/// Self-heal entry point used by `reload::restart_and_verify_with_progress`:
+/// returns `Ok(true)` when the plist was missing and got rewritten, `Ok(false)`
+/// when it was already present. Lets `pidash restart` after `pidash update` on
+/// a plist-less machine recover transparently instead of bailing with the
+/// `ensure_plist_present` error the operator would have to act on by hand.
+///
+/// We only rewrite when missing (not unconditionally on every restart) so
+/// operators hand-editing the plist for debugging don't get clobbered.
+pub(crate) async fn rewrite_unit_if_missing(paths: &Paths) -> Result<bool> {
+    let plist = plist_path()?;
+    if plist.exists() {
+        return Ok(false);
+    }
+    write_unit(paths).await?;
+    Ok(true)
 }
 
 fn plist_path() -> Result<PathBuf> {
@@ -886,14 +895,13 @@ mod tests {
 
     #[test]
     fn ensure_plist_present_errors_with_install_hint_when_missing() {
-        // Use a path that's guaranteed not to exist. The error must point
-        // the operator at `pidash install` (the command that writes the
-        // plist) and include the missing path so they can confirm what
-        // they're looking for. This replaces the cryptic
-        // `Bootstrap failed: 5: Input/output error` that launchctl
-        // returns for a missing plist.
-        let missing = std::env::temp_dir().join("pidash-ensure-plist-missing-DNE.plist");
-        let _ = std::fs::remove_file(&missing);
+        // The error must point the operator at `pidash install` (the
+        // command that writes the plist) and include the missing path,
+        // replacing the cryptic `Bootstrap failed: 5: Input/output error`
+        // launchctl returns for a missing plist. Use a tempdir-scoped
+        // path so parallel test invocations can't collide.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let missing = dir.path().join("so.pidash.daemon.plist");
         let err = ensure_plist_present(&missing).expect_err("missing plist must error");
         let msg = format!("{err}");
         assert!(
@@ -908,14 +916,13 @@ mod tests {
 
     #[test]
     fn ensure_plist_present_ok_when_file_exists() {
-        // tempdir-free: just write into the OS temp dir under a unique
-        // name and clean up. The function only checks `exists()` so we
-        // don't care about the file's contents.
-        let present = std::env::temp_dir().join("pidash-ensure-plist-present-OK.plist");
+        // The function only checks `exists()` so the contents don't
+        // matter. tempdir-scoped so parallel runs can't race on the
+        // same path.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let present = dir.path().join("so.pidash.daemon.plist");
         std::fs::write(&present, b"x").unwrap();
-        let result = ensure_plist_present(&present);
-        let _ = std::fs::remove_file(&present);
-        assert!(result.is_ok(), "existing plist must pass; got: {result:?}");
+        assert!(ensure_plist_present(&present).is_ok());
     }
 
     #[test]

--- a/runner/src/service/reload.rs
+++ b/runner/src/service/reload.rs
@@ -63,6 +63,27 @@ where
 {
     let svc = crate::service::detect();
 
+    // Self-heal: rewrite the service unit if it's gone (manual cleanup, an
+    // older `pidash uninstall`, or never written for the current install
+    // location). Without this, `pidash restart` after `pidash update` on a
+    // unit-less machine hard-fails — `pidash update` only swaps the binary
+    // and doesn't touch the unit, and operators should not need to know
+    // that `pidash install` is the magic recovery command.
+    //
+    // macOS-only today: the reported case is launchctl bootstrap returning
+    // EIO for a missing plist. systemd surfaces the same kind of failure
+    // with a clearer "Unit not found" message and Windows uses schtasks
+    // which has its own recovery path — extend per backend when we hit
+    // them. `launchd::start` keeps its precondition check as a last-line-
+    // of-defense for direct `pidash start` callers that don't pass through
+    // this self-heal.
+    #[cfg(target_os = "macos")]
+    match crate::service::launchd::rewrite_unit_if_missing(paths).await {
+        Ok(true) => progress("rewrote missing launchd plist".into()),
+        Ok(false) => {}
+        Err(e) => tracing::warn!("pre-restart launchd unit check failed: {e:#}"),
+    }
+
     progress("starting runner service".into());
     // `enable_and_start` is idempotent *and* on systemd uses `restart`, so
     // this covers both "first start" and "reload after config change."


### PR DESCRIPTION
## Real-world problem
On a dev machine where `~/Library/LaunchAgents/so.pidash.daemon.plist` had been removed, running `pidash update` followed by `pidash restart` failed with:

```
restarting daemon...
starting runner service
Error: daemon restart did not complete cleanly: failed to start runner service
service manager rejected start/restart: launchctl bootstrap failed (exit status: 5): Bootstrap failed: 5: Input/output error
Try re-running the command as root for richer errors.
```

Reproduced exactly by running `launchctl bootstrap gui/501 <missing-plist-path>`: macOS reports a missing plist with the opaque `Bootstrap failed: 5: Input/output error` — indistinguishable from the teardown-race EIO without out-of-band knowledge.

`pidash update` only swaps the binary (by design) and never touches the plist. `pidash restart` calls `restart_and_verify_with_progress` → `enable_and_start` → `launchctl bootstrap` directly, so a unit-less machine had no recovery path other than the operator knowing to run `pidash install` themselves.

## Fix
**Make `pidash restart` self-heal** when the LaunchAgent plist is missing.

`reload::restart_and_verify_with_progress` now calls a new
`launchd::rewrite_unit_if_missing(paths)` before `enable_and_start`. When the plist exists it's a no-op; when it's missing the function writes it (same code path as `pidash install`) and emits a progress message. `launchctl bootstrap` then succeeds and the daemon comes up.

Scope is intentionally narrow:
- **macOS only** today (`#[cfg(target_os = "macos")]`). The reported bug is launchctl's opaque EIO. systemd surfaces the same shape as a clearer "Unit not found" message and Windows uses schtasks which has its own recovery path. Extend per backend when we hit them.
- **Only rewrites when missing**, never unconditionally. Operators hand-editing the plist for debugging don't get clobbered on every restart.
- **`launchd::start` keeps its precondition bail** (`ensure_plist_present`) as a last-line-of-defense for direct `pidash start` callers that don't go through `reload::*`.

## Repro before the fix
```
$ rm -f ~/Library/LaunchAgents/so.pidash.daemon.plist
$ pidash restart
restarting daemon...
starting runner service
Error: daemon restart did not complete cleanly: failed to start runner service
service manager rejected start/restart: launchctl bootstrap failed (exit status: 5): Bootstrap failed: 5: Input/output error
```

## After the fix (verified on the originally reporting machine)
```
$ rm -f ~/Library/LaunchAgents/so.pidash.daemon.plist
$ pidash restart
restarting daemon...
installed launchd agent at /Users/.../Library/LaunchAgents/so.pidash.daemon.plist
rewrote missing launchd plist
starting runner service
waiting up to 5s for daemon IPC
…  (daemon starts; the EIO is gone)
```
The plist is rewritten, `launchctl bootstrap` succeeds, and the daemon is launched. Any post-bootstrap failure (e.g. config errors) now surfaces via the existing IPC-wait diagnosis path — i.e. an actionable error pointing at the daemon's stderr log — rather than the opaque service-manager EIO.

## Test plan
- [x] `cargo test -p pidash --lib service::launchd::` — 22 tests pass:
  - `ensure_plist_present_errors_with_install_hint_when_missing` — error names `pidash install` + the missing path
  - `ensure_plist_present_ok_when_file_exists` — no-op when present
  - Both tests use `tempfile::tempdir()` so parallel cargo-test invocations can't collide on shared `/tmp` paths.
- [x] Manual: with the plist removed, `pidash restart` prints `rewrote missing launchd plist`, launchctl bootstrap succeeds, daemon is launched (the originally reporting machine).
- [x] Manual: with the plist present, restart does NOT print `rewrote missing launchd plist` (no-op path verified by code inspection — `rewrite_unit_if_missing` returns `Ok(false)` and the `match` arm has no body).

## Out of scope / follow-up questions
- **Why was the plist missing in the first place on the reporter's machine?** Candidates: an older `pidash uninstall`/`remove` that removed it, an external cleanup tool, or a teardown bug somewhere we haven't found. Worth a separate investigation; this PR is the diagnostic safety net regardless.
- **systemd and Windows self-heal**: not addressed here. systemd's "Unit not found" is already clearer; extend when needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)