### PR TITLE
PDASHOSS01-15 guide user to install codex and claude if missing in dev machine

### DIFF
--- a/runner/src/cli/auth/login.rs
+++ b/runner/src/cli/auth/login.rs
@@ -123,7 +123,7 @@ async fn login_and_bind_workspace(args: &Args, paths: &Paths) -> Result<LoginOut
 
     if !args.no_browser {
         let with_code = format!("{}?code={}", start.verification_uri, start.user_code);
-        let _ = try_open_browser(&with_code);
+        let _ = crate::util::browser::open(&with_code);
     }
 
     let token = poll_for_token(&client, &cloud_url, &start).await?;
@@ -249,27 +249,6 @@ fn print_user_code_block(start: &StartResponse) {
     println!();
     print!("Waiting for browser approval...");
     let _ = std::io::stdout().flush();
-}
-
-fn try_open_browser(url: &str) -> Result<()> {
-    let (program, arg_prefix): (&str, Option<&str>) = if cfg!(target_os = "macos") {
-        ("open", None)
-    } else if cfg!(target_os = "windows") {
-        ("cmd", Some("/C start"))
-    } else {
-        ("xdg-open", None)
-    };
-    let mut cmd = std::process::Command::new(program);
-    if let Some(prefix) = arg_prefix {
-        for arg in prefix.split_whitespace() {
-            cmd.arg(arg);
-        }
-    }
-    cmd.arg(url);
-    cmd.stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null());
-    cmd.spawn().context("opening browser")?;
-    Ok(())
 }
 
 async fn poll_for_token(

--- a/runner/src/cli/runner.rs
+++ b/runner/src/cli/runner.rs
@@ -278,10 +278,13 @@ pub async fn add(args: AddArgs, paths: &Paths) -> Result<RunnerConfig> {
 }
 
 /// Best-effort post-add nudge: when the agent CLI the new runner will
-/// drive isn't installed, print a notice and open its official install
-/// page in the operator's browser. Always a no-op on success and never
-/// returns an error — the runner is already added by the time this runs,
-/// so installation guidance must not block or fail the `add`.
+/// drive isn't installed, print a notice and (only when interactive) open
+/// its official install page in the operator's browser. Always a no-op on
+/// success and never returns an error — the runner is already added by the
+/// time this runs, so installation guidance must not block or fail the
+/// `add`. The browser is gated on a TTY because `runner add` is fully
+/// scriptable, and a CI/scripted caller has no operator to see the page;
+/// the notice (with the URL) is still printed so it lands in logs.
 async fn guide_agent_install_if_missing(kind: AgentKind, binary: &str) {
     if agent_binary_installed(binary).await {
         return;
@@ -289,12 +292,16 @@ async fn guide_agent_install_if_missing(kind: AgentKind, binary: &str) {
     let url = kind.install_url();
     println!(
         "\nThe `{binary}` CLI for the selected agent ({}) isn't installed on this host.\n\
-         Opening its installation page in your browser: {url}\n\
          (The runner was still added — install `{binary}`, then `pidash doctor` re-checks it.)",
         kind.label(),
     );
-    if let Err(err) = crate::util::browser::open(url) {
-        println!("(Couldn't open a browser automatically: {err:#}. Visit {url} to install.)");
+    if std::io::stdout().is_terminal() && std::io::stdin().is_terminal() {
+        println!("Opening its installation page in your browser: {url}");
+        if let Err(err) = crate::util::browser::open(url) {
+            println!("(Couldn't open a browser automatically: {err:#}. Visit {url} to install.)");
+        }
+    } else {
+        println!("Install page: {url}");
     }
 }
 

--- a/runner/src/cli/runner.rs
+++ b/runner/src/cli/runner.rs
@@ -11,6 +11,7 @@ use anyhow::{Context, Result};
 use clap::{Args as ClapArgs, Subcommand};
 use std::io::IsTerminal;
 use std::path::PathBuf;
+use std::process::Stdio;
 
 use crate::cli::runner_ops;
 use crate::cloud::http::{CreateRunnerRequest, SharedHttpTransport, create_runner};
@@ -20,6 +21,7 @@ use crate::config::schema::{AgentKind, MAX_RUNNERS_PER_DAEMON, RunnerConfig};
 use crate::util::confirm::maybe_confirm;
 use crate::util::paths::Paths;
 use crate::util::runner_name;
+use crate::util::shell::login_shell_command;
 
 #[derive(Debug, ClapArgs)]
 pub struct RunnerArgs {
@@ -260,7 +262,51 @@ pub async fn add(args: AddArgs, paths: &Paths) -> Result<RunnerConfig> {
             }
         }
     }
+
+    // The runner is fully persisted by this point, so this guidance is
+    // purely advisory and never fails the add (issue PDASHOSS01-15): if
+    // the selected agent's CLI isn't installed, point the operator at
+    // its install page so they can fix it before starting runs.
+    let kind = applied.runner.agent.kind;
+    let agent_binary = match kind {
+        AgentKind::Codex => applied.runner.codex.binary.as_str(),
+        AgentKind::ClaudeCode => applied.runner.claude_code.binary.as_str(),
+    };
+    guide_agent_install_if_missing(kind, agent_binary).await;
+
     Ok(applied.runner)
+}
+
+/// Best-effort post-add nudge: when the agent CLI the new runner will
+/// drive isn't installed, print a notice and open its official install
+/// page in the operator's browser. Always a no-op on success and never
+/// returns an error — the runner is already added by the time this runs,
+/// so installation guidance must not block or fail the `add`.
+async fn guide_agent_install_if_missing(kind: AgentKind, binary: &str) {
+    if agent_binary_installed(binary).await {
+        return;
+    }
+    let url = kind.install_url();
+    println!(
+        "\nThe `{binary}` CLI for the selected agent ({}) isn't installed on this host.\n\
+         Opening its installation page in your browser: {url}\n\
+         (The runner was still added — install `{binary}`, then `pidash doctor` re-checks it.)",
+        kind.label(),
+    );
+    if let Err(err) = crate::util::browser::open(url) {
+        println!("(Couldn't open a browser automatically: {err:#}. Visit {url} to install.)");
+    }
+}
+
+/// True when `<binary> --version` succeeds through the same login-shell
+/// wrapper the daemon uses to spawn agents, so the probe reflects what
+/// the daemon will actually see at spawn time rather than the caller's
+/// interactive `PATH`. Mirrors `doctor::check_version`'s probe; any
+/// spawn/exit failure is treated as "not installed".
+async fn agent_binary_installed(binary: &str) -> bool {
+    let mut cmd = login_shell_command(binary, &["--version"], None);
+    cmd.stdout(Stdio::null()).stderr(Stdio::null());
+    matches!(cmd.output().await, Ok(out) if out.status.success())
 }
 
 async fn ensure_cli_token(
@@ -576,5 +622,26 @@ async fn try_ipc_remove_local(paths: &Paths, runner_name: &str) -> Result<()> {
             );
             Ok(())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A binary that cannot possibly exist resolves to "not installed"
+    /// rather than panicking or hanging — the guidance path that opens
+    /// the install page depends on this returning `false`.
+    #[tokio::test]
+    async fn agent_binary_installed_false_for_missing_binary() {
+        assert!(!agent_binary_installed("pidash-nonexistent-agent-xyz").await);
+    }
+
+    /// A binary that is always present on the host (`true`, a POSIX
+    /// builtin/exe that exits 0 and ignores `--version`) resolves to
+    /// "installed", proving the probe recognises a working binary.
+    #[tokio::test]
+    async fn agent_binary_installed_true_for_present_binary() {
+        assert!(agent_binary_installed("true").await);
     }
 }

--- a/runner/src/config/schema.rs
+++ b/runner/src/config/schema.rs
@@ -222,6 +222,26 @@ impl AgentKind {
             AgentKind::ClaudeCode => Duration::from_secs(15 * 60),
         }
     }
+
+    /// Human-facing name for this agent, used in operator-facing CLI
+    /// messages (`"Codex"`, `"Claude Code"`).
+    pub fn label(self) -> &'static str {
+        match self {
+            AgentKind::Codex => "Codex",
+            AgentKind::ClaudeCode => "Claude Code",
+        }
+    }
+
+    /// Official installation page for this agent's CLI. `pidash runner
+    /// add` opens this in the operator's browser when the selected
+    /// agent's binary isn't installed on the host. URLs mirror the
+    /// prerequisite links in the runner README.
+    pub fn install_url(self) -> &'static str {
+        match self {
+            AgentKind::Codex => "https://github.com/openai/codex",
+            AgentKind::ClaudeCode => "https://docs.anthropic.com/en/docs/claude-code",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -537,6 +557,25 @@ mod tests {
     fn validate_accepts_single_runner() {
         let cfg = config_with(vec![runner("main", "/work/main")]);
         cfg.validate().unwrap();
+    }
+
+    #[test]
+    fn agent_kind_install_url_and_label_per_agent() {
+        assert_eq!(AgentKind::Codex.label(), "Codex");
+        assert_eq!(
+            AgentKind::Codex.install_url(),
+            "https://github.com/openai/codex"
+        );
+        assert_eq!(AgentKind::ClaudeCode.label(), "Claude Code");
+        assert_eq!(
+            AgentKind::ClaudeCode.install_url(),
+            "https://docs.anthropic.com/en/docs/claude-code"
+        );
+        // The two agents must not collapse onto the same install page.
+        assert_ne!(
+            AgentKind::Codex.install_url(),
+            AgentKind::ClaudeCode.install_url()
+        );
     }
 
     #[test]

--- a/runner/src/util/browser.rs
+++ b/runner/src/util/browser.rs
@@ -1,0 +1,37 @@
+//! Best-effort "open this URL in the operator's default browser" helper.
+//!
+//! Used as a convenience by interactive CLI flows — `pidash auth login`
+//! (open the device-code verification page) and `pidash runner add`
+//! (open an agent's install page when its CLI is missing). Opening a
+//! browser is never load-bearing: callers treat a failure as a no-op and
+//! fall back to printing the URL for the operator to open by hand.
+
+use anyhow::{Context, Result};
+
+/// Spawn the platform's "open this URL" helper for `url`.
+///
+/// Fire-and-forget: we spawn the helper with its stdio nulled and return
+/// as soon as it launches; we don't wait for the browser to actually
+/// render anything. Returns `Err` only when the helper process itself
+/// can't be spawned (e.g. `xdg-open` absent on a headless Linux box), so
+/// callers can print a "visit this URL manually" fallback.
+pub fn open(url: &str) -> Result<()> {
+    let (program, arg_prefix): (&str, Option<&str>) = if cfg!(target_os = "macos") {
+        ("open", None)
+    } else if cfg!(target_os = "windows") {
+        ("cmd", Some("/C start"))
+    } else {
+        ("xdg-open", None)
+    };
+    let mut cmd = std::process::Command::new(program);
+    if let Some(prefix) = arg_prefix {
+        for arg in prefix.split_whitespace() {
+            cmd.arg(arg);
+        }
+    }
+    cmd.arg(url);
+    cmd.stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    cmd.spawn().context("opening browser")?;
+    Ok(())
+}

--- a/runner/src/util/mod.rs
+++ b/runner/src/util/mod.rs
@@ -1,4 +1,5 @@
 pub mod backoff;
+pub mod browser;
 pub mod confirm;
 pub mod hostname;
 pub mod logging;


### PR DESCRIPTION
## What

`pidash runner add --agent <codex|claude-code>` previously persisted a runner without checking whether the selected agent's CLI was installed on the dev machine — the operator only found out later (via `pidash doctor` or a failed run). This wires in install guidance.

When the selected agent's binary is missing, `runner add` now:
- prints a notice naming the missing CLI and the agent, and
- opens that agent's **official installation page** in the default browser.

The runner is fully persisted *before* this guidance runs, so it is purely advisory — it never blocks or fails the `add` (per the issue requirement).

## How

- **`AgentKind::label()` / `install_url()`** (`config/schema.rs`) — Codex → `github.com/openai/codex`, Claude Code → `docs.anthropic.com/en/docs/claude-code`, mirroring the prerequisite links in the runner README.
- **Binary probe** (`cli/runner.rs::agent_binary_installed`) — runs `<binary> --version` through the same login-shell wrapper the daemon uses to spawn agents, so the check reflects what the daemon will actually see at spawn time rather than the caller's interactive `PATH`. Mirrors `doctor::check_version`. Any spawn/exit failure ⇒ "not installed".
- **`util::browser::open`** — extracted the cross-platform browser-open helper that previously lived privately in `cli/auth/login.rs::try_open_browser`, and reused it from both the auth-login flow and the new guidance.

## Tests

- `AgentKind` URL/label mapping (incl. the two agents not collapsing onto one URL).
- `agent_binary_installed` returns `false` for a bogus binary and `true` for a present one.
- Full runner suite green: `cargo test --all-targets --locked`, `cargo clippy --all-targets --locked -- -D warnings`.

Closes PDASHOSS01-15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
