### PR TITLE
PDASHOSS01-16 currently the issue comment button shows common.comment

### DIFF
--- a/apps/web/core/components/editor/lite-text/editor.tsx
+++ b/apps/web/core/components/editor/lite-text/editor.tsx
@@ -87,7 +87,7 @@ export const LiteTextEditor = React.forwardRef(function LiteTextEditor(
     disabledExtensions: additionalDisabledExtensions = [],
     editorClassName = "",
     showPlaceholderOnEmpty = true,
-    submitButtonText = "common.comment",
+    submitButtonText = "Comment",
     extraToolbarActions,
     ...rest
   } = props;

--- a/apps/web/core/components/editor/lite-text/toolbar.tsx
+++ b/apps/web/core/components/editor/lite-text/toolbar.tsx
@@ -73,7 +73,7 @@ export function IssueCommentToolbar(props: Props) {
     showAccessSpecifier,
     showSubmitButton,
     editorRef,
-    submitButtonText = "common.comment",
+    submitButtonText = "Comment",
     extraToolbarActions,
   } = props;
   // State to manage active states of toolbar items

--- a/packages/i18n/src/locales/en/translations.ts
+++ b/packages/i18n/src/locales/en/translations.ts
@@ -307,6 +307,7 @@ export default {
   Color: "Color",
   "Coming soon": "Coming soon",
   "Command Prompt": "Command Prompt",
+  Comment: "Comment",
   "Comment & Run": "Comment & Run",
   "Comment created successfully": "Comment created successfully",
   "Comment creation failed. Please try again later.": "Comment creation failed. Please try again later.",


### PR DESCRIPTION
## Summary

The comment submit button rendered the literal string `common.comment` instead of "Comment".

`submitButtonText` defaulted to the legacy dot-notation i18n key `"common.comment"` and is passed through `t(submitButtonText)`. After the move to source-English i18n keys (#200), that key no longer resolves, and `t()` returns the raw key as a last resort — so `common.comment` leaked to the UI.

## Changes

- `apps/web/core/components/editor/lite-text/editor.tsx` — default `submitButtonText` `"common.comment"` → `"Comment"`
- `apps/web/core/components/editor/lite-text/toolbar.tsx` — same default updated
- `packages/i18n/src/locales/en/translations.ts` — add the source-English `"Comment"` key (only compound `"Comment …"` keys existed)

## Validation

- `rg "common.comment"` → no matches remain
- oxlint on changed files → 0 warnings, 0 errors
- `@pi-dash/i18n` typecheck passes

Fixes PDASHOSS01-16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
