### PR TITLE
[codex] Add agent comment attribution

### DIFF
--- a/apps/api/pi_dash/api/serializers/issue.py
+++ b/apps/api/pi_dash/api/serializers/issue.py
@@ -713,6 +713,9 @@ class IssueCommentCreateSerializer(BaseSerializer):
             "access",
             "external_source",
             "external_id",
+            "speaker_type",
+            "speaker_label",
+            "speaker_agent_run_id",
         ]
         read_only_fields = [
             "id",

--- a/apps/api/pi_dash/db/migrations/0144_issuecomment_speaker_metadata.py
+++ b/apps/api/pi_dash/db/migrations/0144_issuecomment_speaker_metadata.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("db", "0143_issue_comment_fts_idx"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="issuecomment",
+            name="speaker_type",
+            field=models.CharField(
+                choices=[
+                    ("human", "Human"),
+                    ("agent", "Agent"),
+                    ("system", "System"),
+                    ("integration", "Integration"),
+                ],
+                default="human",
+                max_length=32,
+            ),
+        ),
+        migrations.AddField(
+            model_name="issuecomment",
+            name="speaker_label",
+            field=models.CharField(blank=True, default="", max_length=128),
+        ),
+        migrations.AddField(
+            model_name="issuecomment",
+            name="speaker_agent_run_id",
+            field=models.UUIDField(blank=True, null=True),
+        ),
+    ]

--- a/apps/api/pi_dash/db/models/issue.py
+++ b/apps/api/pi_dash/db/models/issue.py
@@ -517,6 +517,12 @@ class IssueActivity(ProjectBaseModel):
 
 
 class IssueComment(ChangeTrackerMixin, ProjectBaseModel):
+    class SpeakerType(models.TextChoices):
+        HUMAN = "human", "Human"
+        AGENT = "agent", "Agent"
+        SYSTEM = "system", "System"
+        INTEGRATION = "integration", "Integration"
+
     comment_stripped = models.TextField(verbose_name="Comment", blank=True)
     comment_json = models.JSONField(blank=True, default=dict)
     comment_html = models.TextField(blank=True, default="<p></p>")
@@ -539,6 +545,15 @@ class IssueComment(ChangeTrackerMixin, ProjectBaseModel):
     )
     external_source = models.CharField(max_length=255, null=True, blank=True)
     external_id = models.CharField(max_length=255, blank=True, null=True)
+    # Conversation attribution. ``actor`` remains the authenticated principal
+    # for audit; these fields say whose message this is in the issue thread.
+    speaker_type = models.CharField(
+        max_length=32,
+        choices=SpeakerType.choices,
+        default=SpeakerType.HUMAN,
+    )
+    speaker_label = models.CharField(max_length=128, blank=True, default="")
+    speaker_agent_run_id = models.UUIDField(null=True, blank=True)
     edited_at = models.DateTimeField(null=True, blank=True)
     parent = models.ForeignKey(
         "self", on_delete=models.CASCADE, null=True, blank=True, related_name="parent_issue_comment"

--- a/apps/api/pi_dash/prompting/context.py
+++ b/apps/api/pi_dash/prompting/context.py
@@ -40,24 +40,44 @@ def _absolute_issue_url(issue: Issue) -> str:
     return f"/{ws}/projects/{issue.project_id}/issues/{issue.id}" if ws else ""
 
 
-def _comment_author_label(actor) -> str:
-    """Render an audience-friendly author label for a comment.
-
-    Bot comments are flattened to a single ``Pi Dash Agent`` label so the
-    agent reading its own prior posts immediately recognizes them as
-    self-authored. Humans get display name → email → username, falling
-    back to "Unknown user" rather than leaking ``None``.
-    """
+def _actor_label(actor) -> str:
     if actor is None:
         return "Unknown"
-    if getattr(actor, "is_bot", False):
-        return "Pi Dash Agent"
     return (
         getattr(actor, "display_name", None)
         or getattr(actor, "email", None)
         or getattr(actor, "username", None)
         or "Unknown user"
     )
+
+
+def _comment_author_label(comment) -> str:
+    """Render an audience-friendly speaker label for a comment.
+
+    Bot comments are flattened to a single ``Pi Dash Agent`` label so the
+    agent reading its own prior posts immediately recognizes them as
+    self-authored. Explicit speaker metadata wins over the authenticated
+    actor because agent CLI comments may be submitted with a human token.
+    """
+    actor = comment.actor
+    speaker_type = getattr(comment, "speaker_type", None) or "human"
+    speaker_label = (getattr(comment, "speaker_label", None) or "").strip()
+    actor_label = _actor_label(actor)
+
+    if speaker_type == "agent":
+        label = speaker_label or "AI Agent"
+        if actor is not None and not getattr(actor, "is_bot", False):
+            return f"AI agent: {label} (submitted by {actor_label})"
+        return f"AI agent: {label}"
+    if speaker_type == "system":
+        return f"System: {speaker_label or 'Pi Dash'}"
+    if speaker_type == "integration":
+        return f"Integration: {speaker_label or actor_label}"
+    if actor is None:
+        return "Unknown"
+    if getattr(actor, "is_bot", False):
+        return "AI agent: Pi Dash Agent"
+    return f"Human: {actor_label}"
 
 
 def _comments_section(issue: Issue) -> str:
@@ -83,11 +103,15 @@ def _comments_section(issue: Issue) -> str:
         if not body:
             continue
         index += 1
-        author = _comment_author_label(comment.actor)
+        author = _comment_author_label(comment)
         timestamp = (
             comment.created_at.isoformat() if comment.created_at else "unknown time"
         )
-        parts.append(f"### Comment {index} — {author} at {timestamp}\n\n{body}")
+        run_id = getattr(comment, "speaker_agent_run_id", None)
+        run_line = f"\nAgent run: {run_id}" if run_id else ""
+        parts.append(
+            f"### Comment {index} — {author} at {timestamp}{run_line}\n\n{body}"
+        )
     if not parts:
         return "(no comments on this issue yet)"
     return "\n\n".join(parts)

--- a/apps/api/pi_dash/prompting/fragments/03_pidash_cli.md
+++ b/apps/api/pi_dash/prompting/fragments/03_pidash_cli.md
@@ -30,8 +30,8 @@ On success every command prints a single JSON document to stdout and exits `0`. 
 
 Comments are the human ↔ agent conversation channel. Use them to ask clarifying questions, post blocker notices, share PR links, and announce completion. **Comments are not for tracking your own progress — that's what the workpad is for.**
 
-- `pidash comment list <identifier>` — list comments on the issue. Each entry has `id` (UUID), `comment_html`, `comment_stripped`, `actor_detail`, and timestamps. Read these in chronological order to pick up any human replies since your last run.
-- `pidash comment add <identifier> --body-file <path>` — post a new comment from a file. `--body <markdown>` works for one-liners. Prefer `--body-file` for anything multi-line — shell quoting of markdown is error-prone.
+- `pidash comment list <identifier>` — list comments on the issue. Each entry has `id` (UUID), `comment_html`, `comment_stripped`, `actor_detail`, `speaker_type`, `speaker_label`, `speaker_agent_run_id`, and timestamps. Read these in chronological order to pick up any human replies since your last run.
+- `pidash comment add <identifier> --body-file <path> --as-agent "<agent name>" --agent-run-id "{{ run.id }}"` — post a new comment from a file and mark it as spoken by this AI agent run. `--body <markdown>` works for one-liners. Prefer `--body-file` for anything multi-line — shell quoting of markdown is error-prone. When you post any issue comment during this run, always include `--as-agent` and `--agent-run-id`; use your actual runtime name if you know it (`Codex`, `Claude Code`, etc.), otherwise use `AI Agent`.
 - `pidash comment update <identifier> <comment-id> --body-file <path>` — edit a comment you own. Both the issue identifier and the comment UUID are required. Rarely needed — prefer posting a fresh comment for new information.
 
 #### Workpad
@@ -66,7 +66,7 @@ pidash workpad update --body-file ./.pidash-workpad.md
 Post a blocker and move the issue to "Blocked":
 
 ```sh
-pidash comment add {{ issue.identifier }} --body-file ./.pidash-blocked.md
+pidash comment add {{ issue.identifier }} --body-file ./.pidash-blocked.md --as-agent "AI Agent" --agent-run-id "{{ run.id }}"
 pidash issue patch {{ issue.identifier }} --state "Blocked"
 ```
 

--- a/apps/api/pi_dash/tests/unit/prompting/test_composer.py
+++ b/apps/api/pi_dash/tests/unit/prompting/test_composer.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from pi_dash.db.models import Issue, Project, State
+from pi_dash.db.models import Issue, IssueComment, Project, State
 from pi_dash.prompting.composer import (
     PromptTemplateNotFound,
     build_first_turn,
@@ -94,6 +94,29 @@ def test_build_first_turn_uses_default_template(seeded_default, issue, run):
     assert "Pi Dash issue" in rendered
     assert issue.name in rendered
     assert "TP-" in rendered  # project identifier-based issue identifier
+
+
+@pytest.mark.unit
+def test_build_first_turn_serializes_comment_speaker_metadata(
+    seeded_default, issue, run, create_user
+):
+    IssueComment.objects.create(
+        workspace=issue.workspace,
+        project=issue.project,
+        issue=issue,
+        actor=create_user,
+        created_by=create_user,
+        comment_html="<p>I will post the PR link next.</p>",
+        speaker_type=IssueComment.SpeakerType.AGENT,
+        speaker_label="Codex",
+        speaker_agent_run_id=run.id,
+    )
+
+    rendered = build_first_turn(issue, run)
+
+    assert f"AI agent: Codex (submitted by {create_user.display_name})" in rendered
+    assert f"Agent run: {run.id}" in rendered
+    assert "I will post the PR link next." in rendered
 
 
 # ---------------------------------------------------------------------------

--- a/apps/space/components/issues/peek-overview/comment/comment-detail-card.tsx
+++ b/apps/space/components/issues/peek-overview/comment/comment-detail-card.tsx
@@ -64,6 +64,7 @@ export const CommentCard = observer(function CommentCard(props: Props) {
     editorRef.current?.setEditorValue(formData.comment_html);
     showEditorRef.current?.setEditorValue(formData.comment_html);
   };
+  const agentSpeakerLabel = comment.speaker_type === "agent" ? comment.speaker_label?.trim() || "AI Agent" : undefined;
 
   return (
     <div className="relative flex items-start space-x-3">
@@ -152,6 +153,11 @@ export const CommentCard = observer(function CommentCard(props: Props) {
             </div>
           </form>
           <div className={`${isEditing ? "hidden" : ""}`}>
+            {agentSpeakerLabel ? (
+              <div className="px-3 pt-1 text-12 text-primary">
+                <span className="font-medium">{agentSpeakerLabel}:</span>
+              </div>
+            ) : null}
             <LiteTextEditor
               editable={false}
               anchor={anchor}

--- a/apps/web/core/components/comments/card/display.tsx
+++ b/apps/web/core/components/comments/card/display.tsx
@@ -67,6 +67,7 @@ export const CommentCardDisplay = observer(function CommentCardDisplay(props: TC
     ? comment?.actor_detail?.first_name + `Bot`
     : (userDetails?.display_name ?? comment?.actor_detail?.display_name);
   const avatarUrl = userDetails?.avatar_url ?? comment?.actor_detail?.avatar_url;
+  const agentSpeakerLabel = comment.speaker_type === "agent" ? comment.speaker_label?.trim() || "AI Agent" : undefined;
 
   const userReactions = activityOperations.userReactions(comment.id);
 
@@ -160,6 +161,11 @@ export const CommentCardDisplay = observer(function CommentCardDisplay(props: TC
         />
       ) : (
         <>
+          {agentSpeakerLabel ? (
+            <div className="px-3 pt-1 text-body-sm-regular text-primary">
+              <span className="font-medium">{agentSpeakerLabel}:</span>
+            </div>
+          ) : null}
           <LiteTextEditor
             editable={false}
             ref={readOnlyEditorRef}

--- a/docs/wiki/17-cli-reference.md
+++ b/docs/wiki/17-cli-reference.md
@@ -340,13 +340,15 @@ pidash comment list ENG-42
 Post a new comment.
 
 ```
-pidash comment add ENG-42 (--body <BODY> | --body-file <PATH>)
+pidash comment add ENG-42 (--body <BODY> | --body-file <PATH>) [--as-agent <NAME>] [--agent-run-id <UUID>]
 ```
 
-| Flag                 | Purpose                                |
-| -------------------- | -------------------------------------- |
-| `--body <B>`         | Comment body (plain text or markdown). |
-| `--body-file <PATH>` | Read body from file.                   |
+| Flag                    | Purpose                                                                 |
+| ----------------------- | ----------------------------------------------------------------------- |
+| `--body <B>`            | Comment body (plain text or markdown).                                  |
+| `--body-file <PATH>`    | Read body from file.                                                    |
+| `--as-agent <NAME>`     | Mark the comment as spoken by an AI agent with this display name.       |
+| `--agent-run-id <UUID>` | Record the Pi Dash agent run UUID that produced the agent-spoken reply. |
 
 ### `pidash comment update <IDENTIFIER> <COMMENT_UUID>`
 

--- a/packages/types/src/issues/activity/issue_comment.ts
+++ b/packages/types/src/issues/activity/issue_comment.ts
@@ -44,6 +44,9 @@ export type TIssueComment = {
   comment_json: JSONContent;
   external_id: string | undefined;
   external_source: string | undefined;
+  speaker_type?: "human" | "agent" | "system" | "integration";
+  speaker_label?: string;
+  speaker_agent_run_id?: string;
   access: EIssueCommentAccessSpecifier;
 };
 
@@ -138,6 +141,9 @@ export type TIssuePublicComment = {
     reaction: string;
   }[];
   comment_stripped: string;
+  speaker_type?: "human" | "agent" | "system" | "integration";
+  speaker_label?: string;
+  speaker_agent_run_id?: string;
   created_at: Date;
   created_by: string;
   id: string;

--- a/runner/src/cli/comment.rs
+++ b/runner/src/cli/comment.rs
@@ -7,9 +7,9 @@
 use std::path::{Path, PathBuf};
 
 use clap::{Args, Subcommand};
-use serde_json::{Map, Value, json};
+use serde_json::{Map, Value};
 
-use crate::api_client::{ApiClient, CliEnv, CliError, EXIT_UNKNOWN, report_error};
+use crate::api_client::{ApiClient, CliEnv, CliError, EXIT_INVALID, EXIT_UNKNOWN, report_error};
 
 use super::resolve::resolve_issue;
 
@@ -30,6 +30,16 @@ pub struct CommentBodyArgs {
     body_file: Option<PathBuf>,
 }
 
+#[derive(Debug, Args)]
+pub struct CommentSpeakerArgs {
+    /// Mark the comment as spoken by an AI agent with this display name.
+    #[arg(long = "as-agent", value_name = "NAME")]
+    as_agent: Option<String>,
+    /// Pi Dash agent run UUID that produced this comment.
+    #[arg(long = "agent-run-id", value_name = "UUID")]
+    agent_run_id: Option<String>,
+}
+
 #[derive(Debug, Subcommand)]
 pub enum CommentCommand {
     /// List comments on a work item.
@@ -43,6 +53,8 @@ pub enum CommentCommand {
         identifier: String,
         #[command(flatten)]
         comment_body: CommentBodyArgs,
+        #[command(flatten)]
+        speaker: CommentSpeakerArgs,
     },
     /// Edit an existing comment owned by this user. Requires the issue
     /// identifier because the REST URL is project-scoped.
@@ -71,7 +83,8 @@ pub async fn run(args: CommentArgs, paths: &crate::util::paths::Paths) -> i32 {
         CommentCommand::Add {
             identifier,
             comment_body,
-        } => cmd_add(&client, &identifier, comment_body).await,
+            speaker,
+        } => cmd_add(&client, &identifier, comment_body, speaker).await,
         CommentCommand::Update {
             identifier,
             comment_id,
@@ -102,6 +115,7 @@ async fn cmd_add(
     client: &ApiClient,
     identifier: &str,
     comment_body: CommentBodyArgs,
+    speaker: CommentSpeakerArgs,
 ) -> Result<(), CliError> {
     let body = load_comment_body(comment_body)?;
     let issue = resolve_issue(client, identifier).await?;
@@ -109,12 +123,49 @@ async fn cmd_add(
         "workspaces/{}/projects/{}/work-items/{}/comments/",
         client.env.workspace_slug, issue.project_id, issue.id
     );
-    let resp = client.post(&path, &json!({"comment_html": body})).await?;
+    let mut payload: Map<String, Value> = Map::new();
+    payload.insert("comment_html".into(), Value::String(body));
+    add_speaker_metadata(&mut payload, speaker)?;
+    let resp = client.post(&path, &Value::Object(payload)).await?;
     println!(
         "{}",
         serde_json::to_string(&resp).expect("serialize JSON value")
     );
     Ok(())
+}
+
+fn add_speaker_metadata(
+    payload: &mut Map<String, Value>,
+    speaker: CommentSpeakerArgs,
+) -> Result<(), CliError> {
+    let as_agent = speaker.as_agent.and_then(non_empty);
+    let agent_run_id = speaker.agent_run_id.and_then(non_empty);
+    match (as_agent, agent_run_id) {
+        (Some(label), agent_run_id) => {
+            payload.insert("speaker_type".into(), Value::String("agent".into()));
+            payload.insert("speaker_label".into(), Value::String(label));
+            if let Some(run_id) = agent_run_id {
+                payload.insert("speaker_agent_run_id".into(), Value::String(run_id));
+            }
+        }
+        (None, Some(_)) => {
+            return Err(CliError::new(
+                EXIT_INVALID,
+                "--agent-run-id requires --as-agent so Pi Dash can mark the comment speaker",
+            ));
+        }
+        (None, None) => {}
+    }
+    Ok(())
+}
+
+fn non_empty(value: String) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
 }
 
 async fn cmd_update(
@@ -161,7 +212,9 @@ fn display_path(path: &Path) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{CommentBodyArgs, load_comment_body};
+    use serde_json::{Map, Value};
+
+    use super::{CommentBodyArgs, CommentSpeakerArgs, add_speaker_metadata, load_comment_body};
 
     #[test]
     fn load_comment_body_prefers_inline_body() {
@@ -185,5 +238,50 @@ mod tests {
         })
         .expect("file body");
         assert_eq!(body, "from file\n");
+    }
+
+    #[test]
+    fn add_speaker_metadata_marks_agent_comment() {
+        let mut payload = Map::new();
+        add_speaker_metadata(
+            &mut payload,
+            CommentSpeakerArgs {
+                as_agent: Some("Codex".into()),
+                agent_run_id: Some("11111111-1111-1111-1111-111111111111".into()),
+            },
+        )
+        .expect("speaker metadata");
+
+        assert_eq!(
+            payload.get("speaker_type"),
+            Some(&Value::String("agent".into()))
+        );
+        assert_eq!(
+            payload.get("speaker_label"),
+            Some(&Value::String("Codex".into()))
+        );
+        assert_eq!(
+            payload.get("speaker_agent_run_id"),
+            Some(&Value::String(
+                "11111111-1111-1111-1111-111111111111".into()
+            ))
+        );
+    }
+
+    #[test]
+    fn add_speaker_metadata_rejects_agent_run_without_agent_label() {
+        let mut payload = Map::new();
+        let err = add_speaker_metadata(
+            &mut payload,
+            CommentSpeakerArgs {
+                as_agent: None,
+                agent_run_id: Some("11111111-1111-1111-1111-111111111111".into()),
+            },
+        )
+        .expect_err("run id without agent label should fail");
+
+        assert_eq!(err.exit_code, crate::api_client::EXIT_INVALID);
+        assert!(err.message.contains("--agent-run-id requires --as-agent"));
+        assert!(payload.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Adds first-class issue-comment speaker metadata so Pi Dash can distinguish the authenticated audit actor from the conversation speaker. The CLI can now mark agent-authored comments with `--as-agent` and `--agent-run-id`, prompts serialize agent/human/system speakers clearly, and the web UI shows an agent label prefix such as `Claude Code:` before agent comments.

## Changes

- Add `speaker_type`, `speaker_label`, and `speaker_agent_run_id` to `IssueComment` with a migration.
- Accept speaker metadata through the comment creation serializer and `pidash comment add`.
- Render comment speaker attribution in agent prompts and add regression coverage.
- Update agent prompt/CLI docs to instruct agents to use the new flags.
- Show agent comment prefixes in the main web and space comment UIs.

## Validation

- `cargo test cli::comment --lib`
- `pnpm --filter @pi-dash/types check:types`
- `python3 -m py_compile apps/api/pi_dash/prompting/context.py apps/api/pi_dash/db/models/issue.py apps/api/pi_dash/api/serializers/issue.py apps/api/pi_dash/tests/unit/prompting/test_composer.py`
- `pnpm exec oxfmt --check apps/web/core/components/comments/card/display.tsx apps/space/components/issues/peek-overview/comment/comment-detail-card.tsx packages/types/src/issues/activity/issue_comment.ts`
- `git diff --cached --check` before commit

## Notes

- `pytest apps/api/pi_dash/tests/unit/prompting/test_composer.py -q` could not collect in this environment because `celery` is missing.
- `pnpm --filter web check:types` and `pnpm --filter space check:types` still fail on existing unrelated baseline errors around `TStateGroups` including `review`, GitHub sync nullability, and scheduler typing; the new `speaker_*` property errors were resolved after rebuilding `@pi-dash/types`.
- Local unstaged runner formatting files and `.pidash/` were intentionally not included in this PR.