### PR TITLE
PDASHOSS01-19 add reminder of deleting runner won't delete ai agent itself

### DIFF
--- a/apps/web/app/(all)/[workspaceSlug]/runners/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/page.tsx
@@ -301,9 +301,7 @@ const RunnersListPage = observer(function RunnersListPage() {
         title={t("Delete runner?")}
         content={`${t(
           "The runner row is removed and the daemon is forced offline. Historic runs are preserved with a null runner reference."
-        )} ${t(
-          "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it."
-        )}`}
+        )} ${t("Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine.")}`}
         primaryButtonText={{ default: t("Delete"), loading: t("Delete") }}
       />
       <AlertModalCore

--- a/apps/web/app/(all)/[workspaceSlug]/runners/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/page.tsx
@@ -299,9 +299,11 @@ const RunnersListPage = observer(function RunnersListPage() {
         handleSubmit={confirmDeleteRunner}
         isSubmitting={deleting}
         title={t("Delete runner?")}
-        content={t(
+        content={`${t(
           "The runner row is removed and the daemon is forced offline. Historic runs are preserved with a null runner reference."
-        )}
+        )} ${t(
+          "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it."
+        )}`}
         primaryButtonText={{ default: t("Delete"), loading: t("Delete") }}
       />
       <AlertModalCore

--- a/packages/i18n/src/locales/cs/translations.ts
+++ b/packages/i18n/src/locales/cs/translations.ts
@@ -438,6 +438,7 @@ export default {
   "Current password": "Aktuální heslo",
   "Current timezone setting.": "Aktuální nastavení časového pásma.",
   "Current version": "Aktuální verze",
+  Cursor: "",
   Custom: "Vlastní",
   "Custom theme": "Vlastní motiv",
   "Customize for this workspace": "Přizpůsobit pro tento pracovní prostor",
@@ -488,6 +489,8 @@ export default {
   "Delete this workspace": "Smazat tento pracovní prostor",
   "Delete work item": "Smazat pracovní položku",
   Deleting: "Mazání",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
+    "",
   Descending: "Sestupně",
   Description: "Popis",
   "Description (optional)": "Popis (volitelný)",
@@ -893,10 +896,10 @@ export default {
   "Manage your AI Agent connectivities": "Spravovat připojení vašeho AI Agenta",
   Manifest: "Manifest",
   Manual: "Manuální",
-  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
-    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Manually or through automation, you can archive work items that are completed or cancelled. Find them here once archived.":
     "Ručně nebo pomocí automatizace můžete archivovat dokončené nebo zrušené pracovní položky. Po archivaci je najdete zde.",
+  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
+    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Map your project goals to Modules and track easily.": "Mapujte cíle svého projektu na moduly a snadno je sledujte.",
   "Mark all as read": "Označit vše jako přečtené",
   "Mark as duplicate": "Označit jako duplicitní",

--- a/packages/i18n/src/locales/cs/translations.ts
+++ b/packages/i18n/src/locales/cs/translations.ts
@@ -489,8 +489,7 @@ export default {
   "Delete this workspace": "Smazat tento pracovní prostor",
   "Delete work item": "Smazat pracovní položku",
   Deleting: "Mazání",
-  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
-    "",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine.": "",
   Descending: "Sestupně",
   Description: "Popis",
   "Description (optional)": "Popis (volitelný)",

--- a/packages/i18n/src/locales/de/translations.ts
+++ b/packages/i18n/src/locales/de/translations.ts
@@ -443,6 +443,7 @@ export default {
   "Current password": "Aktuelles Passwort",
   "Current timezone setting.": "Aktuelle Zeitzoneneinstellung.",
   "Current version": "Aktuelle Version",
+  Cursor: "",
   Custom: "Benutzerdefiniert",
   "Custom theme": "Benutzerdefiniertes Design",
   "Customize for this workspace": "Für diesen Arbeitsbereich anpassen",
@@ -493,6 +494,8 @@ export default {
   "Delete this workspace": "Diesen Arbeitsbereich löschen",
   "Delete work item": "Arbeitselement löschen",
   Deleting: "Löschen",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
+    "",
   Descending: "Absteigend",
   Description: "Beschreibung",
   "Description (optional)": "Beschreibung (optional)",
@@ -907,10 +910,10 @@ export default {
   "Manage your AI Agent connectivities": "AI Agent-Verbindungen verwalten",
   Manifest: "Manifest",
   Manual: "Handbuch",
-  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
-    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Manually or through automation, you can archive work items that are completed or cancelled. Find them here once archived.":
     "Manuell oder per Automatisierung können Sie abgeschlossene oder stornierte Arbeitselemente archivieren. Finden Sie sie hier, sobald sie archiviert sind.",
+  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
+    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Map your project goals to Modules and track easily.":
     "Ordnen Sie Ihre Projektziele Modulen zu und verfolgen Sie sie einfach.",
   "Mark all as read": "Alle als gelesen markieren",

--- a/packages/i18n/src/locales/de/translations.ts
+++ b/packages/i18n/src/locales/de/translations.ts
@@ -494,8 +494,7 @@ export default {
   "Delete this workspace": "Diesen Arbeitsbereich löschen",
   "Delete work item": "Arbeitselement löschen",
   Deleting: "Löschen",
-  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
-    "",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine.": "",
   Descending: "Absteigend",
   Description: "Beschreibung",
   "Description (optional)": "Beschreibung (optional)",

--- a/packages/i18n/src/locales/en/translations.ts
+++ b/packages/i18n/src/locales/en/translations.ts
@@ -482,6 +482,8 @@ export default {
   "Delete this workspace": "Delete this workspace",
   "Delete work item": "Delete work item",
   Deleting: "Deleting",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
+    "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.",
   Descending: "Descending",
   Description: "Description",
   "Description (optional)": "Description (optional)",
@@ -883,10 +885,10 @@ export default {
   "Manage your AI Agent connectivities": "Manage your AI Agent connectivities",
   Manifest: "Manifest",
   Manual: "Manual",
-  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
-    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Manually or through automation, you can archive work items that are completed or cancelled. Find them here once archived.":
     "Manually or through automation, you can archive work items that are completed or cancelled. Find them here once archived.",
+  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
+    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Map your project goals to Modules and track easily.": "Map your project goals to Modules and track easily.",
   "Mark all as read": "Mark all as read",
   "Mark as duplicate": "Mark as duplicate",

--- a/packages/i18n/src/locales/en/translations.ts
+++ b/packages/i18n/src/locales/en/translations.ts
@@ -482,8 +482,8 @@ export default {
   "Delete this workspace": "Delete this workspace",
   "Delete work item": "Delete work item",
   Deleting: "Deleting",
-  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
-    "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine.":
+    "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine.",
   Descending: "Descending",
   Description: "Description",
   "Description (optional)": "Description (optional)",

--- a/packages/i18n/src/locales/es/translations.ts
+++ b/packages/i18n/src/locales/es/translations.ts
@@ -438,6 +438,7 @@ export default {
   "Current password": "Contraseña actual",
   "Current timezone setting.": "Configuración de zona horaria actual",
   "Current version": "Versión actual",
+  Cursor: "",
   Custom: "Personalizado",
   "Custom theme": "Tema personalizado",
   "Customize for this workspace": "Personalizar para este espacio de trabajo",
@@ -489,6 +490,8 @@ export default {
   "Delete this workspace": "Eliminar este espacio de trabajo",
   "Delete work item": "Eliminar elemento de trabajo",
   Deleting: "Eliminando",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
+    "",
   Descending: "Descendente",
   Description: "Descripción",
   "Description (optional)": "Descripción (opcional)",
@@ -900,10 +903,10 @@ export default {
   "Manage your AI Agent connectivities": "Gestionar las conexiones de tu AI Agent",
   Manifest: "Manifiesto",
   Manual: "Manual",
-  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
-    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Manually or through automation, you can archive work items that are completed or cancelled. Find them here once archived.":
     "De forma manual o mediante automatización, puedes archivar elementos de trabajo que estén completados o cancelados. Encuéntralos aquí una vez archivados.",
+  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
+    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Map your project goals to Modules and track easily.":
     "Asigna los objetivos de tu proyecto a Modules y haz un seguimiento fácilmente.",
   "Mark all as read": "Marcar todo como leído",

--- a/packages/i18n/src/locales/es/translations.ts
+++ b/packages/i18n/src/locales/es/translations.ts
@@ -490,8 +490,7 @@ export default {
   "Delete this workspace": "Eliminar este espacio de trabajo",
   "Delete work item": "Eliminar elemento de trabajo",
   Deleting: "Eliminando",
-  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
-    "",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine.": "",
   Descending: "Descendente",
   Description: "Descripción",
   "Description (optional)": "Descripción (opcional)",

--- a/packages/i18n/src/locales/fr/translations.ts
+++ b/packages/i18n/src/locales/fr/translations.ts
@@ -496,8 +496,7 @@ export default {
   "Delete this workspace": "Supprimer cet espace de travail",
   "Delete work item": "Supprimer le work item",
   Deleting: "Suppression",
-  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
-    "",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine.": "",
   Descending: "Décroissant",
   Description: "Description",
   "Description (optional)": "Description (facultatif)",

--- a/packages/i18n/src/locales/fr/translations.ts
+++ b/packages/i18n/src/locales/fr/translations.ts
@@ -444,6 +444,7 @@ export default {
   "Current password": "Mot de passe actuel",
   "Current timezone setting.": "Paramètre de fuseau horaire actuel.",
   "Current version": "Version actuelle",
+  Cursor: "",
   Custom: "Personnalisé",
   "Custom theme": "Thème personnalisé",
   "Customize for this workspace": "Personnaliser pour cet espace de travail",
@@ -495,6 +496,8 @@ export default {
   "Delete this workspace": "Supprimer cet espace de travail",
   "Delete work item": "Supprimer le work item",
   Deleting: "Suppression",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
+    "",
   Descending: "Décroissant",
   Description: "Description",
   "Description (optional)": "Description (facultatif)",
@@ -905,10 +908,10 @@ export default {
   "Manage your AI Agent connectivities": "Gérer les connectivités de votre agent IA",
   Manifest: "Manifeste",
   Manual: "Manuel",
-  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
-    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Manually or through automation, you can archive work items that are completed or cancelled. Find them here once archived.":
     "Manuellement ou via l'automatisation, vous pouvez archiver les éléments de travail terminés ou annulés. Retrouvez-les ici une fois archivés.",
+  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
+    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Map your project goals to Modules and track easily.":
     "Associez les objectifs de votre projet aux Modules et suivez-les facilement.",
   "Mark all as read": "Tout marquer comme lu",

--- a/packages/i18n/src/locales/id/translations.ts
+++ b/packages/i18n/src/locales/id/translations.ts
@@ -432,6 +432,7 @@ export default {
   "Current password": "Kata sandi saat ini",
   "Current timezone setting.": "Pengaturan zona waktu saat ini.",
   "Current version": "Versi saat ini",
+  Cursor: "",
   Custom: "Kustom",
   "Custom theme": "Tema kustom",
   "Customize for this workspace": "Sesuaikan untuk ruang kerja ini",
@@ -482,6 +483,8 @@ export default {
   "Delete this workspace": "Hapus ruang kerja ini",
   "Delete work item": "Hapus item pekerjaan",
   Deleting: "Menghapus",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
+    "",
   Descending: "Menurun",
   Description: "Deskripsi",
   "Description (optional)": "Deskripsi (opsional)",
@@ -887,10 +890,10 @@ export default {
   "Manage your AI Agent connectivities": "Kelola konektivitas AI Agent Anda",
   Manifest: "Manifest",
   Manual: "Manual",
-  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
-    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Manually or through automation, you can archive work items that are completed or cancelled. Find them here once archived.":
     "Secara manual atau melalui otomatisasi, Anda dapat mengarsipkan item pekerjaan yang telah selesai atau dibatalkan. Temukan di sini setelah diarsipkan.",
+  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
+    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Map your project goals to Modules and track easily.": "Petakan tujuan proyek Anda ke Modul dan lacak dengan mudah.",
   "Mark all as read": "Tandai semua sudah dibaca",
   "Mark as duplicate": "Tandai sebagai duplikat",

--- a/packages/i18n/src/locales/id/translations.ts
+++ b/packages/i18n/src/locales/id/translations.ts
@@ -483,8 +483,7 @@ export default {
   "Delete this workspace": "Hapus ruang kerja ini",
   "Delete work item": "Hapus item pekerjaan",
   Deleting: "Menghapus",
-  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
-    "",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine.": "",
   Descending: "Menurun",
   Description: "Deskripsi",
   "Description (optional)": "Deskripsi (opsional)",

--- a/packages/i18n/src/locales/it/translations.ts
+++ b/packages/i18n/src/locales/it/translations.ts
@@ -438,6 +438,7 @@ export default {
   "Current password": "Password corrente",
   "Current timezone setting.": "Impostazione del fuso orario corrente.",
   "Current version": "Versione corrente",
+  Cursor: "",
   Custom: "Personalizzato",
   "Custom theme": "Tema personalizzato",
   "Customize for this workspace": "Personalizza per questo spazio di lavoro",
@@ -489,6 +490,8 @@ export default {
   "Delete this workspace": "Elimina questo spazio di lavoro",
   "Delete work item": "Elimina elemento di lavoro",
   Deleting: "Eliminazione",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
+    "",
   Descending: "Discendente",
   Description: "Descrizione",
   "Description (optional)": "Descrizione (opzionale)",
@@ -896,10 +899,10 @@ export default {
   "Manage your AI Agent connectivities": "Gestisci le connettività del tuo AI Agent",
   Manifest: "Manifesto",
   Manual: "Manuale",
-  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
-    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Manually or through automation, you can archive work items that are completed or cancelled. Find them here once archived.":
     "Manualmente o tramite automazione, puoi archiviare gli elementi di lavoro completati o annullati. Trovateli qui una volta archiviati.",
+  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
+    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Map your project goals to Modules and track easily.":
     "Mappa i tuoi obiettivi di progetto sui Moduli e monitorali facilmente.",
   "Mark all as read": "Segna tutti come letti",

--- a/packages/i18n/src/locales/it/translations.ts
+++ b/packages/i18n/src/locales/it/translations.ts
@@ -490,8 +490,7 @@ export default {
   "Delete this workspace": "Elimina questo spazio di lavoro",
   "Delete work item": "Elimina elemento di lavoro",
   Deleting: "Eliminazione",
-  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
-    "",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine.": "",
   Descending: "Discendente",
   Description: "Descrizione",
   "Description (optional)": "Descrizione (opzionale)",

--- a/packages/i18n/src/locales/ja/translations.ts
+++ b/packages/i18n/src/locales/ja/translations.ts
@@ -436,6 +436,7 @@ export default {
   "Current password": "現在のパスワード",
   "Current timezone setting.": "現在のタイムゾーン設定。",
   "Current version": "現在のバージョン",
+  Cursor: "",
   Custom: "カスタム",
   "Custom theme": "カスタムテーマ",
   "Customize for this workspace": "このワークスペース用にカスタマイズ",
@@ -486,6 +487,8 @@ export default {
   "Delete this workspace": "このワークスペースを削除",
   "Delete work item": "作業項目を削除",
   Deleting: "削除中",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
+    "",
   Descending: "降順",
   Description: "説明",
   "Description (optional)": "説明（任意）",
@@ -893,10 +896,10 @@ export default {
   "Manage your AI Agent connectivities": "AIエージェントの接続を管理",
   Manifest: "マニフェスト",
   Manual: "手動",
-  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
-    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Manually or through automation, you can archive work items that are completed or cancelled. Find them here once archived.":
     "手動または自動化により、完了またはキャンセルされた作業項目をアーカイブできます。アーカイブ後はこちらで確認できます。",
+  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
+    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Map your project goals to Modules and track easily.":
     "プロジェクトの目標をモジュールにマッピングして、簡単に追跡できます。",
   "Mark all as read": "すべて既読にする",

--- a/packages/i18n/src/locales/ja/translations.ts
+++ b/packages/i18n/src/locales/ja/translations.ts
@@ -487,8 +487,7 @@ export default {
   "Delete this workspace": "このワークスペースを削除",
   "Delete work item": "作業項目を削除",
   Deleting: "削除中",
-  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
-    "",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine.": "",
   Descending: "降順",
   Description: "説明",
   "Description (optional)": "説明（任意）",

--- a/packages/i18n/src/locales/ko/translations.ts
+++ b/packages/i18n/src/locales/ko/translations.ts
@@ -482,8 +482,7 @@ export default {
   "Delete this workspace": "이 워크스페이스 삭제",
   "Delete work item": "작업 항목 삭제",
   Deleting: "삭제 중",
-  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
-    "",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine.": "",
   Descending: "내림차순",
   Description: "설명",
   "Description (optional)": "설명 (선택 사항)",

--- a/packages/i18n/src/locales/ko/translations.ts
+++ b/packages/i18n/src/locales/ko/translations.ts
@@ -431,6 +431,7 @@ export default {
   "Current password": "현재 비밀번호",
   "Current timezone setting.": "현재 시간대 설정.",
   "Current version": "현재 버전",
+  Cursor: "",
   Custom: "사용자 정의",
   "Custom theme": "사용자 정의 테마",
   "Customize for this workspace": "이 워크스페이스에 맞게 사용자 지정",
@@ -481,6 +482,8 @@ export default {
   "Delete this workspace": "이 워크스페이스 삭제",
   "Delete work item": "작업 항목 삭제",
   Deleting: "삭제 중",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
+    "",
   Descending: "내림차순",
   Description: "설명",
   "Description (optional)": "설명 (선택 사항)",
@@ -879,10 +882,10 @@ export default {
   "Manage your AI Agent connectivities": "AI 에이전트 연결 관리",
   Manifest: "매니페스트",
   Manual: "수동",
-  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
-    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Manually or through automation, you can archive work items that are completed or cancelled. Find them here once archived.":
     "수동 또는 자동화를 통해 완료되거나 취소된 작업 항목을 보관할 수 있습니다. 보관된 후에는 여기에서 찾을 수 있습니다.",
+  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
+    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Map your project goals to Modules and track easily.": "프로젝트 목표를 모듈에 매핑하고 쉽게 추적하세요.",
   "Mark all as read": "모두 읽음으로 표시",
   "Mark as duplicate": "중복으로 표시",

--- a/packages/i18n/src/locales/pl/translations.ts
+++ b/packages/i18n/src/locales/pl/translations.ts
@@ -488,8 +488,7 @@ export default {
   "Delete this workspace": "Usuń ten obszar roboczy",
   "Delete work item": "Usuń element pracy",
   Deleting: "Usuwanie",
-  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
-    "",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine.": "",
   Descending: "Malejąco",
   Description: "Opis",
   "Description (optional)": "Opis (opcjonalny)",

--- a/packages/i18n/src/locales/pl/translations.ts
+++ b/packages/i18n/src/locales/pl/translations.ts
@@ -437,6 +437,7 @@ export default {
   "Current password": "Aktualne hasło",
   "Current timezone setting.": "Bieżące ustawienie strefy czasowej.",
   "Current version": "Aktualna wersja",
+  Cursor: "",
   Custom: "Niestandardowy",
   "Custom theme": "Motyw niestandardowy",
   "Customize for this workspace": "Dostosuj dla tego obszaru roboczego",
@@ -487,6 +488,8 @@ export default {
   "Delete this workspace": "Usuń ten obszar roboczy",
   "Delete work item": "Usuń element pracy",
   Deleting: "Usuwanie",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
+    "",
   Descending: "Malejąco",
   Description: "Opis",
   "Description (optional)": "Opis (opcjonalny)",
@@ -896,10 +899,10 @@ export default {
   "Manage your AI Agent connectivities": "Zarządzaj połączeniami swojego agenta AI",
   Manifest: "Manifest",
   Manual: "Ręcznie",
-  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
-    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Manually or through automation, you can archive work items that are completed or cancelled. Find them here once archived.":
     "Ręcznie lub automatycznie możesz archiwizować elementy pracy, które są ukończone lub anulowane. Znajdziesz je tutaj po zarchiwizowaniu.",
+  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
+    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Map your project goals to Modules and track easily.": "Przypisz cele projektu do modułów i łatwo śledź postępy.",
   "Mark all as read": "Oznacz wszystkie jako przeczytane",
   "Mark as duplicate": "Oznacz jako duplikat",

--- a/packages/i18n/src/locales/pt-BR/translations.ts
+++ b/packages/i18n/src/locales/pt-BR/translations.ts
@@ -487,8 +487,7 @@ export default {
   "Delete this workspace": "Excluir este workspace",
   "Delete work item": "Excluir item de trabalho",
   Deleting: "Excluindo",
-  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
-    "",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine.": "",
   Descending: "Decrescente",
   Description: "Descrição",
   "Description (optional)": "Descrição (opcional)",

--- a/packages/i18n/src/locales/pt-BR/translations.ts
+++ b/packages/i18n/src/locales/pt-BR/translations.ts
@@ -435,6 +435,7 @@ export default {
   "Current password": "Senha atual",
   "Current timezone setting.": "Configuração de fuso horário atual.",
   "Current version": "Versão atual",
+  Cursor: "",
   Custom: "Personalizado",
   "Custom theme": "Tema personalizado",
   "Customize for this workspace": "Personalizar para este espaço de trabalho",
@@ -486,6 +487,8 @@ export default {
   "Delete this workspace": "Excluir este workspace",
   "Delete work item": "Excluir item de trabalho",
   Deleting: "Excluindo",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
+    "",
   Descending: "Decrescente",
   Description: "Descrição",
   "Description (optional)": "Descrição (opcional)",
@@ -891,10 +894,10 @@ export default {
   "Manage your AI Agent connectivities": "Gerenciar as conectividades do seu AI Agent",
   Manifest: "Manifesto",
   Manual: "Manual",
-  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
-    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Manually or through automation, you can archive work items that are completed or cancelled. Find them here once archived.":
     "Manualmente ou por automação, você pode arquivar itens de trabalho que foram concluídos ou cancelados. Encontre-os aqui depois de arquivados.",
+  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
+    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Map your project goals to Modules and track easily.":
     "Mapeie suas metas de projeto para Módulos e acompanhe facilmente.",
   "Mark all as read": "Marcar todos como lidos",

--- a/packages/i18n/src/locales/ro/translations.ts
+++ b/packages/i18n/src/locales/ro/translations.ts
@@ -443,6 +443,7 @@ export default {
   "Current password": "Parola curentă",
   "Current timezone setting.": "Setarea fusului orar curent.",
   "Current version": "Versiunea curentă",
+  Cursor: "",
   Custom: "Personalizat",
   "Custom theme": "Temă personalizată",
   "Customize for this workspace": "Personalizează pentru acest spațiu de lucru",
@@ -494,6 +495,8 @@ export default {
   "Delete this workspace": "Șterge acest spațiu de lucru",
   "Delete work item": "Șterge elementul de lucru",
   Deleting: "Se șterge",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
+    "",
   Descending: "Descrescător",
   Description: "Descriere",
   "Description (optional)": "Descriere (opțional)",
@@ -907,10 +910,10 @@ export default {
   "Manage your AI Agent connectivities": "Gestionează conexiunile agentului tău AI",
   Manifest: "Manifest",
   Manual: "Manual",
-  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
-    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Manually or through automation, you can archive work items that are completed or cancelled. Find them here once archived.":
     "Manual sau prin automatizare, puteți arhiva elemente de lucru care sunt finalizate sau anulate. Găsiți-le aici odată arhivate.",
+  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
+    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Map your project goals to Modules and track easily.":
     "Asociați obiectivele proiectului dvs. cu Module și urmăriți-le ușor.",
   "Mark all as read": "Marchează totul ca citit",

--- a/packages/i18n/src/locales/ro/translations.ts
+++ b/packages/i18n/src/locales/ro/translations.ts
@@ -495,8 +495,7 @@ export default {
   "Delete this workspace": "Șterge acest spațiu de lucru",
   "Delete work item": "Șterge elementul de lucru",
   Deleting: "Se șterge",
-  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
-    "",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine.": "",
   Descending: "Descrescător",
   Description: "Descriere",
   "Description (optional)": "Descriere (opțional)",

--- a/packages/i18n/src/locales/ru/translations.ts
+++ b/packages/i18n/src/locales/ru/translations.ts
@@ -494,8 +494,7 @@ export default {
   "Delete this workspace": "Удалить эту рабочую область",
   "Delete work item": "Удалить элемент работы",
   Deleting: "Удаление",
-  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
-    "",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine.": "",
   Descending: "По убыванию",
   Description: "Описание",
   "Description (optional)": "Описание (необязательно)",

--- a/packages/i18n/src/locales/ru/translations.ts
+++ b/packages/i18n/src/locales/ru/translations.ts
@@ -443,6 +443,7 @@ export default {
   "Current password": "Текущий пароль",
   "Current timezone setting.": "Текущая настройка часового пояса.",
   "Current version": "Текущая версия",
+  Cursor: "",
   Custom: "Пользовательский",
   "Custom theme": "Пользовательская тема",
   "Customize for this workspace": "Настроить для этой рабочей области",
@@ -493,6 +494,8 @@ export default {
   "Delete this workspace": "Удалить эту рабочую область",
   "Delete work item": "Удалить элемент работы",
   Deleting: "Удаление",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
+    "",
   Descending: "По убыванию",
   Description: "Описание",
   "Description (optional)": "Описание (необязательно)",
@@ -900,10 +903,10 @@ export default {
   "Manage your AI Agent connectivities": "Управление подключениями вашего AI Agent",
   Manifest: "Манифест",
   Manual: "Руководство",
-  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
-    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Manually or through automation, you can archive work items that are completed or cancelled. Find them here once archived.":
     "Вручную или с помощью автоматизации вы можете архивировать завершенные или отмененные рабочие элементы. Найдите их здесь после архивации.",
+  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
+    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Map your project goals to Modules and track easily.":
     "Сопоставьте цели вашего проекта с модулями и легко отслеживайте их.",
   "Mark all as read": "Отметить все как прочитанное",

--- a/packages/i18n/src/locales/sk/translations.ts
+++ b/packages/i18n/src/locales/sk/translations.ts
@@ -490,8 +490,7 @@ export default {
   "Delete this workspace": "Odstrániť tento pracovný priestor",
   "Delete work item": "Odstrániť pracovnú položku",
   Deleting: "Odstraňuje sa",
-  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
-    "",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine.": "",
   Descending: "Zostupne",
   Description: "Popis",
   "Description (optional)": "Popis (voliteľný)",

--- a/packages/i18n/src/locales/sk/translations.ts
+++ b/packages/i18n/src/locales/sk/translations.ts
@@ -439,6 +439,7 @@ export default {
   "Current password": "Aktuálne heslo",
   "Current timezone setting.": "Nastavenie aktuálneho časového pásma.",
   "Current version": "Aktuálna verzia",
+  Cursor: "",
   Custom: "Vlastné",
   "Custom theme": "Vlastná téma",
   "Customize for this workspace": "Prispôsobiť pre tento pracovný priestor",
@@ -489,6 +490,8 @@ export default {
   "Delete this workspace": "Odstrániť tento pracovný priestor",
   "Delete work item": "Odstrániť pracovnú položku",
   Deleting: "Odstraňuje sa",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
+    "",
   Descending: "Zostupne",
   Description: "Popis",
   "Description (optional)": "Popis (voliteľný)",
@@ -894,10 +897,10 @@ export default {
   "Manage your AI Agent connectivities": "Spravovať pripojenia vášho AI agenta",
   Manifest: "Manifest",
   Manual: "Manuálny",
-  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
-    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Manually or through automation, you can archive work items that are completed or cancelled. Find them here once archived.":
     "Manuálne alebo prostredníctvom automatizácie môžete archivovať pracovné položky, ktoré sú dokončené alebo zrušené. Po archivácii ich nájdete tu.",
+  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
+    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Map your project goals to Modules and track easily.":
     "Mapujte ciele svojho projektu na moduly a jednoducho ich sledujte.",
   "Mark all as read": "Označiť všetky ako prečítané",

--- a/packages/i18n/src/locales/tr-TR/translations.ts
+++ b/packages/i18n/src/locales/tr-TR/translations.ts
@@ -435,6 +435,7 @@ export default {
   "Current password": "Mevcut şifre",
   "Current timezone setting.": "Mevcut saat dilimi ayarı.",
   "Current version": "Mevcut sürüm",
+  Cursor: "",
   Custom: "Özel",
   "Custom theme": "Özel tema",
   "Customize for this workspace": "Bu çalışma alanı için özelleştir",
@@ -485,6 +486,8 @@ export default {
   "Delete this workspace": "Bu çalışma alanını sil",
   "Delete work item": "İş öğesini sil",
   Deleting: "Siliniyor",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
+    "",
   Descending: "Azalan",
   Description: "Açıklama",
   "Description (optional)": "Açıklama (isteğe bağlı)",
@@ -890,10 +893,10 @@ export default {
   "Manage your AI Agent connectivities": "AI Ajan bağlantılarınızı yönetin",
   Manifest: "Manifest",
   Manual: "Manuel",
-  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
-    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Manually or through automation, you can archive work items that are completed or cancelled. Find them here once archived.":
     "Manuel olarak veya otomasyon yoluyla, tamamlanmış veya iptal edilmiş iş öğelerini arşivleyebilirsiniz. Arşivlendikten sonra onları burada bulun.",
+  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
+    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Map your project goals to Modules and track easily.":
     "Proje hedeflerinizi Modüllerle eşleyin ve kolayca takip edin.",
   "Mark all as read": "Tümünü okundu olarak işaretle",

--- a/packages/i18n/src/locales/tr-TR/translations.ts
+++ b/packages/i18n/src/locales/tr-TR/translations.ts
@@ -486,8 +486,7 @@ export default {
   "Delete this workspace": "Bu çalışma alanını sil",
   "Delete work item": "İş öğesini sil",
   Deleting: "Siliniyor",
-  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
-    "",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine.": "",
   Descending: "Azalan",
   Description: "Açıklama",
   "Description (optional)": "Açıklama (isteğe bağlı)",

--- a/packages/i18n/src/locales/ua/translations.ts
+++ b/packages/i18n/src/locales/ua/translations.ts
@@ -438,6 +438,7 @@ export default {
   "Current password": "Поточний пароль",
   "Current timezone setting.": "Поточне налаштування часового поясу.",
   "Current version": "Поточна версія",
+  Cursor: "",
   Custom: "Користувацький",
   "Custom theme": "Користувацька тема",
   "Customize for this workspace": "Налаштувати для цього робочого простору",
@@ -488,6 +489,8 @@ export default {
   "Delete this workspace": "Видалити цю робочу область",
   "Delete work item": "Видалити робочий елемент",
   Deleting: "Видалення",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
+    "",
   Descending: "За спаданням",
   Description: "Опис",
   "Description (optional)": "Опис (необов'язково)",
@@ -894,10 +897,10 @@ export default {
   "Manage your AI Agent connectivities": "Керуйте підключеннями вашого AI Agent",
   Manifest: "Маніфест",
   Manual: "Посібник",
-  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
-    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Manually or through automation, you can archive work items that are completed or cancelled. Find them here once archived.":
     "Вручну або за допомогою автоматизації ви можете архівувати робочі елементи, які завершені або скасовані. Знайдіть їх тут після архівування.",
+  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
+    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Map your project goals to Modules and track easily.":
     "Зіставте цілі вашого проекту з модулями та легко відстежуйте.",
   "Mark all as read": "Позначити всі як прочитані",

--- a/packages/i18n/src/locales/ua/translations.ts
+++ b/packages/i18n/src/locales/ua/translations.ts
@@ -489,8 +489,7 @@ export default {
   "Delete this workspace": "Видалити цю робочу область",
   "Delete work item": "Видалити робочий елемент",
   Deleting: "Видалення",
-  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
-    "",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine.": "",
   Descending: "За спаданням",
   Description: "Опис",
   "Description (optional)": "Опис (необов'язково)",

--- a/packages/i18n/src/locales/vi-VN/translations.ts
+++ b/packages/i18n/src/locales/vi-VN/translations.ts
@@ -433,6 +433,7 @@ export default {
   "Current password": "Mật khẩu hiện tại",
   "Current timezone setting.": "Cài đặt múi giờ hiện tại.",
   "Current version": "Phiên bản hiện tại",
+  Cursor: "",
   Custom: "Tùy chỉnh",
   "Custom theme": "Chủ đề tùy chỉnh",
   "Customize for this workspace": "Tùy chỉnh cho không gian làm việc này",
@@ -483,6 +484,8 @@ export default {
   "Delete this workspace": "Xóa không gian làm việc này",
   "Delete work item": "Xóa mục công việc",
   Deleting: "Đang xóa",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
+    "",
   Descending: "Giảm dần",
   Description: "Mô tả",
   "Description (optional)": "Mô tả (không bắt buộc)",
@@ -887,10 +890,10 @@ export default {
   "Manage your AI Agent connectivities": "Quản lý kết nối của AI Agent của bạn",
   Manifest: "Tệp kê khai",
   Manual: "Hướng dẫn",
-  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
-    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Manually or through automation, you can archive work items that are completed or cancelled. Find them here once archived.":
     "Bạn có thể lưu trữ các mục công việc đã hoàn thành hoặc bị hủy theo cách thủ công hoặc thông qua tự động hóa. Tìm chúng ở đây sau khi đã lưu trữ.",
+  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
+    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Map your project goals to Modules and track easily.":
     "Ánh xạ mục tiêu dự án của bạn vào Modules và theo dõi dễ dàng.",
   "Mark all as read": "Đánh dấu tất cả là đã đọc",

--- a/packages/i18n/src/locales/vi-VN/translations.ts
+++ b/packages/i18n/src/locales/vi-VN/translations.ts
@@ -484,8 +484,7 @@ export default {
   "Delete this workspace": "Xóa không gian làm việc này",
   "Delete work item": "Xóa mục công việc",
   Deleting: "Đang xóa",
-  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
-    "",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine.": "",
   Descending: "Giảm dần",
   Description: "Mô tả",
   "Description (optional)": "Mô tả (không bắt buộc)",

--- a/packages/i18n/src/locales/zh-CN/translations.ts
+++ b/packages/i18n/src/locales/zh-CN/translations.ts
@@ -422,6 +422,7 @@ export default {
   "Current password": "当前密码",
   "Current timezone setting.": "当前时区设置。",
   "Current version": "当前版本",
+  Cursor: "",
   Custom: "自定义",
   "Custom theme": "自定义主题",
   "Customize for this workspace": "为此工作区自定义",
@@ -472,6 +473,8 @@ export default {
   "Delete this workspace": "删除此工作区",
   "Delete work item": "删除工作项",
   Deleting: "正在删除",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
+    "",
   Descending: "降序",
   Description: "描述",
   "Description (optional)": "描述（可选）",
@@ -865,10 +868,10 @@ export default {
   "Manage your AI Agent connectivities": "管理您的 AI 代理连接",
   Manifest: "清单",
   Manual: "手动",
-  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
-    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Manually or through automation, you can archive work items that are completed or cancelled. Find them here once archived.":
     "您可以通过手动或自动方式归档已完成或已取消的工作项。归档后，可在此处找到它们。",
+  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
+    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Map your project goals to Modules and track easily.": "将您的项目目标映射到模块，并轻松跟踪。",
   "Mark all as read": "全部标记为已读",
   "Mark as duplicate": "标记为重复",

--- a/packages/i18n/src/locales/zh-CN/translations.ts
+++ b/packages/i18n/src/locales/zh-CN/translations.ts
@@ -473,8 +473,7 @@ export default {
   "Delete this workspace": "删除此工作区",
   "Delete work item": "删除工作项",
   Deleting: "正在删除",
-  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
-    "",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine.": "",
   Descending: "降序",
   Description: "描述",
   "Description (optional)": "描述（可选）",

--- a/packages/i18n/src/locales/zh-TW/translations.ts
+++ b/packages/i18n/src/locales/zh-TW/translations.ts
@@ -471,8 +471,7 @@ export default {
   "Delete this workspace": "刪除此工作區",
   "Delete work item": "刪除工作項目",
   Deleting: "正在刪除",
-  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
-    "",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine.": "",
   Descending: "降序",
   Description: "描述",
   "Description (optional)": "描述（選填）",

--- a/packages/i18n/src/locales/zh-TW/translations.ts
+++ b/packages/i18n/src/locales/zh-TW/translations.ts
@@ -420,6 +420,7 @@ export default {
   "Current password": "目前密碼",
   "Current timezone setting.": "目前的時區設定。",
   "Current version": "目前版本",
+  Cursor: "",
   Custom: "自訂",
   "Custom theme": "自訂主題",
   "Customize for this workspace": "為此工作區自訂",
@@ -470,6 +471,8 @@ export default {
   "Delete this workspace": "刪除此工作區",
   "Delete work item": "刪除工作項目",
   Deleting: "正在刪除",
+  "Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.":
+    "",
   Descending: "降序",
   Description: "描述",
   "Description (optional)": "描述（選填）",
@@ -864,10 +867,10 @@ export default {
   "Manage your AI Agent connectivities": "管理您的 AI 代理連線",
   Manifest: "資訊清單",
   Manual: "手動",
-  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
-    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Manually or through automation, you can archive work items that are completed or cancelled. Find them here once archived.":
     "您可以手動或透過自動化方式，將已完成或已取消的工作項目封存。封存後，請在此處尋找。",
+  "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
+    "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Map your project goals to Modules and track easily.": "將您的專案目標對應到模組，輕鬆追蹤。",
   "Mark all as read": "全部標為已讀",
   "Mark as duplicate": "標記為重複",


### PR DESCRIPTION
## Summary

The delete-runner confirmation modal previously only explained that the runner row is removed and historic runs are preserved. Users had no indication that deleting a runner in the cloud does **not** uninstall the AI agent (e.g. Codex or Claude) installed on their dev machine.

This adds a reminder sentence to the delete-runner confirmation:

> Deleting a runner does not uninstall the AI agent (such as Codex or Claude) on your dev machine — remove it there separately if you no longer need it.

The `IRunner` payload carries no reliable per-runner `agent_kind`, so the copy names Codex/Claude as examples rather than detecting the specific agent.

## Changes

- `apps/web/app/(all)/[workspaceSlug]/runners/page.tsx` — append the new translatable sentence to the delete modal `content`.
- `packages/i18n/src/locales/**` — synced the new key via `pnpm i18n:sync` (English source; non-English placeholders fall back to English until translated).

## Validation

- `@pi-dash/i18n` `check:lint` and `check:types` pass.
- `oxlint` + `oxfmt --check` clean on the changed web file.
- Remaining `web check:types` errors are pre-existing on `main` (stale `packages/types/dist`) and unrelated to this change.

Resolves PDASHOSS01-19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
