### PR TITLE
PDASHOSS01-18 some UI components does't recognize the theme

### DIFF
--- a/apps/web/app/(all)/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/schedulers/layout.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/schedulers/layout.tsx
@@ -65,7 +65,7 @@ function SchedulerTabLink({ to, active, icon, children }: SchedulerTabLinkProps)
       className={cn(
         "inline-flex items-center gap-1.5 border-b-2 px-3 py-2 text-13 font-medium transition-colors",
         active
-          ? "border-primary text-primary"
+          ? "border-accent-strong text-primary"
           : "border-transparent text-secondary hover:border-subtle hover:text-primary"
       )}
     >

--- a/apps/web/app/(all)/[workspaceSlug]/prompts/[promptId]/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/prompts/[promptId]/page.tsx
@@ -124,7 +124,9 @@ const PromptDetailPage = observer(function PromptDetailPage() {
     }
   }
 
-  const pageTitle = record.is_global_default ? t("Prompt template (Pi Dash default)") : t("Prompt template (workspace override)");
+  const pageTitle = record.is_global_default
+    ? t("Prompt template (Pi Dash default)")
+    : t("Prompt template (workspace override)");
 
   return (
     <div className="flex flex-col gap-4 p-6">
@@ -141,8 +143,12 @@ const PromptDetailPage = observer(function PromptDetailPage() {
           </div>
           <p className="mt-1 text-13 text-secondary">
             {record.is_global_default
-              ? t("This is the built-in Pi Dash default. Workspace admins cannot edit it here — customize for your workspace to override.")
-              : t("Your workspace's override of the Pi Dash default. Edits bump the version and apply to the next agent run for this workspace.")}
+              ? t(
+                  "This is the built-in Pi Dash default. Workspace admins cannot edit it here — customize for your workspace to override."
+                )
+              : t(
+                  "Your workspace's override of the Pi Dash default. Edits bump the version and apply to the next agent run for this workspace."
+                )}
           </p>
         </div>
         <Link to={`/${slug}/prompts`} className="text-13 text-secondary hover:text-primary">
@@ -171,7 +177,7 @@ const PromptDetailPage = observer(function PromptDetailPage() {
             }}
             readOnly={!canEdit}
             spellCheck={false}
-            className="bg-layer-base font-mono focus:border-primary min-h-[60vh] w-full resize-y rounded-md border border-subtle p-3 text-11 leading-5 text-primary focus:outline-none"
+            className="font-mono min-h-[60vh] w-full resize-y rounded-md border border-subtle bg-layer-1 p-3 text-11 leading-5 text-primary focus:border-accent-strong focus:outline-none"
           />
         </section>
 
@@ -196,7 +202,7 @@ const PromptDetailPage = observer(function PromptDetailPage() {
               </Button>
             </div>
             {previewError && (
-              <div className="border-destructive text-destructive rounded border bg-layer-1 p-2 text-11">
+              <div className="rounded border border-danger-subtle bg-layer-1 p-2 text-11 text-danger-primary">
                 {previewError}
               </div>
             )}
@@ -211,7 +217,11 @@ const PromptDetailPage = observer(function PromptDetailPage() {
           // when role changes mid-session.
           <section className="flex flex-col gap-2">
             <h2 className="text-13 font-medium text-primary">{t("Template body (Jinja + Markdown)")}</h2>
-            <p className="text-13 text-secondary">{t("Previewing the rendered prompt is a workspace-admin action. Ask your workspace admin if you need to see it rendered against a specific issue.")}</p>
+            <p className="text-13 text-secondary">
+              {t(
+                "Previewing the rendered prompt is a workspace-admin action. Ask your workspace admin if you need to see it rendered against a specific issue."
+              )}
+            </p>
           </section>
         )}
       </div>

--- a/apps/web/app/(all)/[workspaceSlug]/runners/chat/[runnerId]/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/chat/[runnerId]/page.tsx
@@ -273,7 +273,7 @@ const RunnerChatPage = observer(function RunnerChatPage() {
               <div key={message.id} className={`flex ${message.role === "user" ? "justify-end" : "justify-start"}`}>
                 <div
                   className={`max-w-[72%] rounded-md px-3 py-2 text-13 ${
-                    message.role === "user" ? "bg-brand-accent text-white" : "bg-layer-1 text-primary"
+                    message.role === "user" ? "bg-accent-primary text-on-color" : "bg-layer-1 text-primary"
                   }`}
                 >
                   <div className="whitespace-pre-wrap">{message.content || message.status}</div>
@@ -291,7 +291,7 @@ const RunnerChatPage = observer(function RunnerChatPage() {
               .map((event) => (
                 <div
                   key={event.seq}
-                  className="bg-layer-0 rounded border border-subtle px-3 py-2 text-11 text-secondary"
+                  className="rounded border border-subtle bg-surface-1 px-3 py-2 text-11 text-secondary"
                 >
                   <span className="font-mono">{event.kind}</span>
                 </div>
@@ -313,7 +313,7 @@ const RunnerChatPage = observer(function RunnerChatPage() {
               }
             }}
             disabled={!!reason || sending}
-            className="bg-layer-0 focus:border-brand-accent min-h-20 flex-1 resize-none rounded-md border border-subtle px-3 py-2 text-13 outline-none"
+            className="min-h-20 flex-1 resize-none rounded-md border border-subtle bg-surface-1 px-3 py-2 text-13 outline-none focus:border-accent-strong"
           />
           {session?.active_message_id || session?.active_turn_id ? (
             <Button onClick={stop} variant="tertiary-danger">

--- a/apps/web/app/(all)/[workspaceSlug]/runners/detail/[runnerId]/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/detail/[runnerId]/page.tsx
@@ -63,7 +63,9 @@ const RunnerDetailPage = observer(function RunnerDetailPage() {
       </div>
 
       {error && !runner ? (
-        <div className="text-destructive rounded-md border border-subtle p-4 text-13">{t("Failed to load runner")}</div>
+        <div className="rounded-md border border-subtle p-4 text-13 text-danger-primary">
+          {t("Failed to load runner")}
+        </div>
       ) : isLoading || !runner ? (
         <div className="rounded-md border border-subtle p-4 text-13 text-secondary">{t("Loading…")}</div>
       ) : (

--- a/apps/web/app/(all)/[workspaceSlug]/runners/layout.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/layout.tsx
@@ -57,7 +57,7 @@ const RunnersLayout = observer(function RunnersLayout() {
   return (
     <WorkspaceShell>
       <div className="flex h-full w-full overflow-hidden">
-        <aside className="bg-layer-0 w-[280px] shrink-0 border-r border-subtle">
+        <aside className="w-[280px] shrink-0 border-r border-subtle bg-surface-1">
           <div className="flex h-12 items-center border-b border-subtle px-4 text-14 font-semibold text-primary">
             {t("AI Agents")}
           </div>

--- a/apps/web/app/(all)/[workspaceSlug]/runners/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/page.tsx
@@ -154,7 +154,7 @@ const RunnersListPage = observer(function RunnersListPage() {
           )}
         </div>
         {podsError ? (
-          <div className="text-destructive text-12">{t("Failed to load pods")}</div>
+          <div className="text-12 text-danger-primary">{t("Failed to load pods")}</div>
         ) : (
           <div className="flex flex-wrap gap-2">
             {(pods ?? []).map((p) => {
@@ -168,8 +168,8 @@ const RunnersListPage = observer(function RunnersListPage() {
                   onClick={() => setSelectedPodId(isSelected ? null : p.id)}
                   className={`rounded-md border px-3 py-2 text-left text-12 transition-colors ${
                     isSelected
-                      ? "border-custom-primary-100 bg-custom-primary-100/10 ring-custom-primary-100 ring-1"
-                      : "hover:border-primary border-subtle bg-layer-1"
+                      ? "border-accent-strong bg-accent-primary/10 ring-1 ring-accent-strong"
+                      : "border-subtle bg-layer-1 hover:border-strong"
                   }`}
                 >
                   <div className="flex items-center gap-2">
@@ -188,7 +188,7 @@ const RunnersListPage = observer(function RunnersListPage() {
               type="button"
               onClick={() => setCreatePodOpen(true)}
               disabled={!workspaceSlug}
-              className="hover:border-primary flex items-center gap-1.5 rounded-md border border-dashed border-subtle bg-transparent px-3 py-2 text-12 text-secondary hover:text-primary disabled:cursor-not-allowed disabled:opacity-50"
+              className="flex items-center gap-1.5 rounded-md border border-dashed border-subtle bg-transparent px-3 py-2 text-12 text-secondary hover:border-strong hover:text-primary disabled:cursor-not-allowed disabled:opacity-50"
             >
               <Plus className="size-3.5" />
               <span className="font-medium">{t("Create new pod")}</span>
@@ -207,7 +207,7 @@ const RunnersListPage = observer(function RunnersListPage() {
               <button
                 type="button"
                 onClick={() => setSelectedPodId(null)}
-                className="text-custom-primary-100 underline-offset-2 hover:underline"
+                className="text-accent-primary underline-offset-2 hover:underline"
               >
                 {t("Clear filter")}
               </button>

--- a/apps/web/app/(all)/auth/device/page.tsx
+++ b/apps/web/app/(all)/auth/device/page.tsx
@@ -81,36 +81,36 @@ function DeviceAuthPage() {
   }
 
   return (
-    <div className="bg-custom-background-100 flex min-h-[80vh] items-center justify-center p-8">
-      <div className="border-custom-border-200 bg-custom-background-90 shadow-sm w-full max-w-md rounded-lg border p-8">
-        <h1 className="text-xl text-custom-text-100 mb-2 font-semibold">Authorize Pi Dash CLI</h1>
-        <p className="text-sm text-custom-text-300 mb-6">
+    <div className="flex min-h-[80vh] items-center justify-center bg-canvas p-8">
+      <div className="w-full max-w-md rounded-lg border border-subtle bg-surface-1 p-8 shadow-raised-200">
+        <h1 className="text-xl mb-2 font-semibold text-primary">Authorize Pi Dash CLI</h1>
+        <p className="text-sm mb-6 text-tertiary">
           Enter the code shown on your terminal to grant this device access to your account.
         </p>
 
         {status === "approved" && approvedFor ? (
           <div className="space-y-3">
-            <div className="border-green-500/30 bg-green-500/10 text-sm text-green-700 dark:text-green-300 rounded-md border p-3">
+            <div className="text-sm rounded-md border border-success-subtle bg-success-subtle p-3 text-success-primary">
               <strong>Approved.</strong> Your CLI should pick up the token within a few seconds.
             </div>
-            <dl className="text-sm text-custom-text-200 space-y-1">
+            <dl className="text-sm space-y-1 text-secondary">
               <div className="flex justify-between">
-                <dt className="text-custom-text-400">Account</dt>
+                <dt className="text-placeholder">Account</dt>
                 <dd>{approvedFor.email}</dd>
               </div>
               {approvedFor.workspace && (
                 <div className="flex justify-between">
-                  <dt className="text-custom-text-400">Workspace</dt>
+                  <dt className="text-placeholder">Workspace</dt>
                   <dd>{approvedFor.workspace}</dd>
                 </div>
               )}
             </dl>
-            <p className="text-xs text-custom-text-400 pt-2">You can close this tab.</p>
+            <p className="text-xs pt-2 text-placeholder">You can close this tab.</p>
           </div>
         ) : (
           <form onSubmit={onSubmit} className="space-y-4">
             <label className="block">
-              <span className="text-xs text-custom-text-400 mb-1 block font-medium tracking-wide uppercase">
+              <span className="text-xs mb-1 block font-medium tracking-wide text-placeholder uppercase">
                 Device code
               </span>
               <input
@@ -126,13 +126,13 @@ function DeviceAuthPage() {
                 value={code}
                 onChange={(e) => setCode(formatUserCode(e.target.value))}
                 placeholder="XXXX-YYYY"
-                className="border-custom-border-200 bg-custom-background-100 font-mono text-lg tracking-widest text-custom-text-100 focus:border-custom-primary-100 w-full rounded-md border px-3 py-2 uppercase focus:outline-none"
+                className="font-mono text-lg tracking-widest w-full rounded-md border border-subtle bg-canvas px-3 py-2 text-primary uppercase focus:border-accent-strong focus:outline-none"
                 maxLength={9}
               />
             </label>
 
             {status === "error" && errorMessage && (
-              <div className="border-red-500/30 bg-red-500/10 text-sm text-red-600 dark:text-red-300 rounded-md border p-3">
+              <div className="text-sm rounded-md border border-danger-subtle bg-danger-subtle p-3 text-danger-primary">
                 {errorMessage}
               </div>
             )}
@@ -140,14 +140,14 @@ function DeviceAuthPage() {
             <button
               type="submit"
               disabled={!submittable}
-              className="bg-custom-primary-100 text-sm hover:bg-custom-primary-200 w-full rounded-md px-4 py-2 font-medium text-white transition disabled:cursor-not-allowed disabled:opacity-50"
+              className="text-sm w-full rounded-md bg-accent-primary px-4 py-2 font-medium text-on-color transition hover:bg-accent-primary-hover disabled:cursor-not-allowed disabled:opacity-50"
             >
               {status === "submitting" ? "Approving…" : "Approve"}
             </button>
           </form>
         )}
 
-        <p className="text-xs text-custom-text-400 mt-6">
+        <p className="text-xs mt-6 text-placeholder">
           Only approve a code that you started by running <code className="font-mono">pidash auth login</code> on a
           device you control.
         </p>

--- a/apps/web/core/components/project/scheduler-bindings/binding-schedule-fields.tsx
+++ b/apps/web/core/components/project/scheduler-bindings/binding-schedule-fields.tsx
@@ -74,12 +74,14 @@ export function BindingScheduleFields<T extends FieldValues>({
                 {...field}
                 type="datetime-local"
                 id={`field-${String(dtstartName)}`}
-                className="bg-layer-0 focus:ring-accent-primary rounded-md border border-subtle px-3 py-2 text-13 text-primary focus:ring-1 focus:outline-none"
+                className="rounded-md border border-subtle bg-surface-1 px-3 py-2 text-13 text-primary focus:ring-1 focus:ring-accent-strong focus:outline-none"
               />
             )}
           />
-          <p className="text-12 text-secondary">{t("First firing of this binding. The recurrence rule expands from here.")}</p>
-          {dtstartErr && <span className="text-red-500 text-12">{String(dtstartErr.message ?? "")}</span>}
+          <p className="text-12 text-secondary">
+            {t("First firing of this binding. The recurrence rule expands from here.")}
+          </p>
+          {dtstartErr && <span className="text-12 text-danger-primary">{String(dtstartErr.message ?? "")}</span>}
         </div>
         <div className="flex flex-col gap-1">
           <label htmlFor={`field-${String(tzidName)}`} className="text-13 font-medium text-primary">
@@ -90,7 +92,9 @@ export function BindingScheduleFields<T extends FieldValues>({
             name={tzidName}
             render={({ field }) => <TzidSelect id={`field-${String(tzidName)}`} {...field} />}
           />
-          <p className="text-12 text-secondary">{t("Stored with the binding. Future PRs honour it for wall-clock-aware DST semantics.")}</p>
+          <p className="text-12 text-secondary">
+            {t("Stored with the binding. Future PRs honour it for wall-clock-aware DST semantics.")}
+          </p>
         </div>
       </div>
 
@@ -112,9 +116,10 @@ export function BindingScheduleFields<T extends FieldValues>({
           )}
         />
         <p className="text-12 text-secondary">
-          {t("RFC 5545 RRULE — e.g. ``FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR``. Leave blank to fire only once at the start.")} — <span className="text-primary">{humanRule}</span>
+          {t("RFC 5545 RRULE — e.g. ``FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR``. Leave blank to fire only once at the start.")}{" "}
+          — <span className="text-primary">{humanRule}</span>
         </p>
-        {rruleErr && <span className="text-red-500 text-12">{String(rruleErr.message ?? "")}</span>}
+        {rruleErr && <span className="text-12 text-danger-primary">{String(rruleErr.message ?? "")}</span>}
       </div>
 
       <div className="flex flex-col gap-1">
@@ -133,7 +138,11 @@ export function BindingScheduleFields<T extends FieldValues>({
             />
           )}
         />
-        <p className="text-12 text-secondary">{t("Appended to the scheduler's base prompt at run time. Use it to give project-specific framing the workspace prompt shouldn't carry.")}</p>
+        <p className="text-12 text-secondary">
+          {t(
+            "Appended to the scheduler's base prompt at run time. Use it to give project-specific framing the workspace prompt shouldn't carry."
+          )}
+        </p>
       </div>
 
       <Controller
@@ -142,9 +151,7 @@ export function BindingScheduleFields<T extends FieldValues>({
         render={({ field }) => (
           <div className="flex items-center justify-between gap-4">
             <div className="flex flex-col">
-              <span className="text-13 font-medium text-primary">
-                {t("Enabled")}
-              </span>
+              <span className="text-13 font-medium text-primary">{t("Enabled")}</span>
               <span className="text-12 text-secondary">{t("Disabled installs do not fire until re-enabled.")}</span>
             </div>
             <ToggleSwitch value={field.value} onChange={field.onChange} />
@@ -188,7 +195,7 @@ function TzidSelect({ id, value, onChange, onBlur, name }: TzidSelectProps) {
       value={value}
       onChange={(e) => onChange(e.target.value)}
       onBlur={onBlur}
-      className="bg-layer-0 focus:ring-accent-primary rounded-md border border-subtle px-3 py-2 text-13 text-primary focus:ring-1 focus:outline-none"
+      className="rounded-md border border-subtle bg-surface-1 px-3 py-2 text-13 text-primary focus:ring-1 focus:ring-accent-strong focus:outline-none"
     >
       {zones.map((z) => (
         <option key={z} value={z}>

--- a/apps/web/core/components/project/scheduler-bindings/calendar/month-view.tsx
+++ b/apps/web/core/components/project/scheduler-bindings/calendar/month-view.tsx
@@ -83,7 +83,7 @@ function DayCell({ date, isInMonth, isCurrentDay, blocks, now, onSelectOccurrenc
     <div
       className={cn(
         "flex min-h-[6rem] flex-col gap-0.5 border-r border-b border-subtle p-1.5",
-        !isInMonth && "bg-layer-0/50"
+        !isInMonth && "bg-layer-1/50"
       )}
     >
       <div className="flex items-center justify-between">

--- a/apps/web/core/components/project/scheduler-bindings/calendar/week-view.tsx
+++ b/apps/web/core/components/project/scheduler-bindings/calendar/week-view.tsx
@@ -172,8 +172,8 @@ function CurrentTimeLine() {
   }, []);
   const top = ((now.getHours() * 60 + now.getMinutes()) / 60) * HOUR_HEIGHT;
   return (
-    <div className="border-red-500 pointer-events-none absolute right-0 left-0 z-10 border-t-2" style={{ top }}>
-      <div className="bg-red-500 absolute -top-1.5 -left-1 size-3 rounded-full" />
+    <div className="pointer-events-none absolute right-0 left-0 z-10 border-t-2 border-danger-strong" style={{ top }}>
+      <div className="absolute -top-1.5 -left-1 size-3 rounded-full bg-danger-primary" />
     </div>
   );
 }

--- a/apps/web/core/components/project/scheduler-bindings/install-binding-modal.tsx
+++ b/apps/web/core/components/project/scheduler-bindings/install-binding-modal.tsx
@@ -126,10 +126,12 @@ export const InstallSchedulerBindingModal = observer(function InstallSchedulerBi
     return (
       <ModalCore isOpen={isOpen} handleClose={onClose} position={EModalPosition.CENTER} width={EModalWidth.XL}>
         <div className="flex flex-col gap-4 p-5">
-          <div className="text-18 font-medium text-primary">
-            {t("No schedulers available")}
-          </div>
-          <p className="text-13 text-secondary">{t("Either every workspace scheduler is already installed on this project, or your workspace admin hasn't enabled any. Visit Workspace → Schedulers to manage the catalog.")}</p>
+          <div className="text-18 font-medium text-primary">{t("No schedulers available")}</div>
+          <p className="text-13 text-secondary">
+            {t(
+              "Either every workspace scheduler is already installed on this project, or your workspace admin hasn't enabled any. Visit Workspace → Schedulers to manage the catalog."
+            )}
+          </p>
           <div className="flex justify-end">
             <Button variant="secondary" onClick={onClose}>
               {t("Cancel")}
@@ -157,7 +159,7 @@ export const InstallSchedulerBindingModal = observer(function InstallSchedulerBi
               <select
                 {...field}
                 id="binding-scheduler"
-                className="bg-layer-0 focus:ring-accent-primary rounded-md border border-subtle px-3 py-2 text-13 text-primary focus:ring-1 focus:outline-none"
+                className="rounded-md border border-subtle bg-surface-1 px-3 py-2 text-13 text-primary focus:ring-1 focus:ring-accent-strong focus:outline-none"
               >
                 {installable.map((s) => (
                   <option key={s.id} value={s.id}>
@@ -167,8 +169,10 @@ export const InstallSchedulerBindingModal = observer(function InstallSchedulerBi
               </select>
             )}
           />
-          <p className="text-12 text-secondary">{t("Pick from your workspace's enabled schedulers. Already-installed ones aren't listed.")}</p>
-          {errors.scheduler && <span className="text-red-500 text-12">{errors.scheduler.message}</span>}
+          <p className="text-12 text-secondary">
+            {t("Pick from your workspace's enabled schedulers. Already-installed ones aren't listed.")}
+          </p>
+          {errors.scheduler && <span className="text-12 text-danger-primary">{errors.scheduler.message}</span>}
         </div>
 
         <BindingScheduleFields
@@ -188,9 +192,7 @@ export const InstallSchedulerBindingModal = observer(function InstallSchedulerBi
             {t("Cancel")}
           </Button>
           <Button type="submit" loading={isSubmitting} disabled={isSubmitting}>
-            {isSubmitting
-              ? t("Installing…")
-              : t("Install")}
+            {isSubmitting ? t("Installing…") : t("Install")}
           </Button>
         </div>
       </form>

--- a/apps/web/core/components/runners/create-pod-modal.tsx
+++ b/apps/web/core/components/runners/create-pod-modal.tsx
@@ -84,7 +84,9 @@ export const CreatePodModal = observer(function CreatePodModal(props: Props) {
       <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-5 p-5">
         <div>
           <div className="text-18 font-medium text-primary">{t("Create new pod")}</div>
-          <p className="mt-1 text-13 text-secondary">{t("Pods group runners under a project. Pick a project, then give the pod a name.")}</p>
+          <p className="mt-1 text-13 text-secondary">
+            {t("Pods group runners under a project. Pick a project, then give the pod a name.")}
+          </p>
         </div>
 
         <div className="flex flex-col gap-1">
@@ -98,9 +100,7 @@ export const CreatePodModal = observer(function CreatePodModal(props: Props) {
             render={({ field }) => (
               <CustomSelect
                 value={field.value}
-                label={
-                  projects?.find((p) => p.id === field.value)?.name ?? t("Select a project")
-                }
+                label={projects?.find((p) => p.id === field.value)?.name ?? t("Select a project")}
                 onChange={field.onChange}
                 buttonClassName="border border-subtle"
                 input
@@ -118,11 +118,11 @@ export const CreatePodModal = observer(function CreatePodModal(props: Props) {
               </CustomSelect>
             )}
           />
-          <p className="text-12 text-secondary">{t("The project this pod belongs to. The name will be prefixed with the project identifier.")}</p>
-          {errors.projectId && <span className="text-red-500 text-12">{errors.projectId.message}</span>}
-          {projectsError && (
-            <span className="text-red-500 text-12">{t("Could not load projects.")}</span>
-          )}
+          <p className="text-12 text-secondary">
+            {t("The project this pod belongs to. The name will be prefixed with the project identifier.")}
+          </p>
+          {errors.projectId && <span className="text-12 text-danger-primary">{errors.projectId.message}</span>}
+          {projectsError && <span className="text-12 text-danger-primary">{t("Could not load projects.")}</span>}
         </div>
 
         <div className="flex flex-col gap-1">
@@ -135,12 +135,12 @@ export const CreatePodModal = observer(function CreatePodModal(props: Props) {
             rules={{
               validate: (v) => v.trim().length > 0 || t("Name is required."),
             }}
-            render={({ field }) => (
-              <Input {...field} id="create-pod-name" placeholder={t("beefy")} />
-            )}
+            render={({ field }) => <Input {...field} id="create-pod-name" placeholder={t("beefy")} />}
           />
-          <p className="text-12 text-secondary">{t("Letters, digits, dashes, and underscores. The project prefix is added automatically.")}</p>
-          {errors.name && <span className="text-red-500 text-12">{errors.name.message}</span>}
+          <p className="text-12 text-secondary">
+            {t("Letters, digits, dashes, and underscores. The project prefix is added automatically.")}
+          </p>
+          {errors.name && <span className="text-12 text-danger-primary">{errors.name.message}</span>}
         </div>
 
         <div className="flex flex-col gap-1">

--- a/apps/web/core/components/runners/runner-agent-status-panel.tsx
+++ b/apps/web/core/components/runners/runner-agent-status-panel.tsx
@@ -115,7 +115,7 @@ export function RunnerAgentStatusPanel({ runner, liveState }: RunnerAgentStatusP
   const modelLabel = liveState?.llm_model?.trim() || "—";
 
   return (
-    <div className="border-custom-border-200 space-y-3 rounded border p-4">
+    <div className="space-y-3 rounded border border-subtle p-4">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <h3 className="text-sm font-medium">Agent</h3>
@@ -123,36 +123,36 @@ export function RunnerAgentStatusPanel({ runner, liveState }: RunnerAgentStatusP
             {BADGE_LABEL[activityBadge]}
           </Badge>
         </div>
-        <span className="text-xs text-custom-text-300">{runner.name}</span>
+        <span className="text-xs text-tertiary">{runner.name}</span>
       </div>
 
       <dl className="text-xs grid grid-cols-2 gap-x-4 gap-y-2">
-        <dt className="text-custom-text-300">Last activity</dt>
+        <dt className="text-tertiary">Last activity</dt>
         <dd className="font-mono" title={liveState?.last_event_summary ?? undefined}>
           {lastEventLabel}
         </dd>
 
-        <dt className="text-custom-text-300">Last event</dt>
+        <dt className="text-tertiary">Last event</dt>
         <dd className="font-mono truncate">{liveState?.last_event_kind ?? "—"}</dd>
 
-        <dt className="text-custom-text-300">Agent PID</dt>
+        <dt className="text-tertiary">Agent PID</dt>
         <dd className="font-mono">{liveState?.agent_pid ?? "—"}</dd>
 
-        <dt className="text-custom-text-300">Subprocess alive</dt>
+        <dt className="text-tertiary">Subprocess alive</dt>
         <dd>{formatBoolish(liveState?.agent_subprocess_alive ?? null)}</dd>
 
-        <dt className="text-custom-text-300">Approvals</dt>
+        <dt className="text-tertiary">Approvals</dt>
         <dd>{liveState?.approvals_pending ?? 0}</dd>
 
-        <dt className="text-custom-text-300">Tokens</dt>
+        <dt className="text-tertiary">Tokens</dt>
         <dd className="font-mono">{tokensLabel}</dd>
 
-        <dt className="text-custom-text-300">Model</dt>
+        <dt className="text-tertiary">Model</dt>
         <dd className="font-mono truncate" title={modelLabel === "—" ? undefined : modelLabel}>
           {modelLabel}
         </dd>
 
-        <dt className="text-custom-text-300">Turn</dt>
+        <dt className="text-tertiary">Turn</dt>
         <dd className="font-mono">{liveState?.turn_count != null ? liveState.turn_count : "—"}</dd>
       </dl>
     </div>

--- a/apps/web/core/components/runners/runner-cli-command.tsx
+++ b/apps/web/core/components/runners/runner-cli-command.tsx
@@ -119,7 +119,7 @@ export function RunnerCliCommand(props: Props) {
   };
 
   return (
-    <div className="border-custom-primary-100/40 bg-custom-primary-100/10 rounded border p-3 text-13 text-primary">
+    <div className="rounded border border-accent-strong/40 bg-accent-primary/10 p-3 text-13 text-primary">
       <p className="text-secondary">{t("Run this on the machine that will host the runner:")}</p>
       <div className="mt-3 flex flex-wrap items-center gap-2">
         <span className="text-12 text-secondary">{t("Shell")}</span>
@@ -131,7 +131,7 @@ export function RunnerCliCommand(props: Props) {
               aria-pressed={shell === option}
               onClick={() => setShell(option)}
               className={`border-r border-subtle px-2 py-1 text-12 last:border-r-0 ${
-                shell === option ? "bg-custom-primary-100 text-white" : "text-secondary hover:text-primary"
+                shell === option ? "bg-accent-primary text-on-color" : "text-secondary hover:text-primary"
               }`}
             >
               {shellLabel(option)}
@@ -143,7 +143,9 @@ export function RunnerCliCommand(props: Props) {
         {command}
       </pre>
       {isUsingBrowserOrigin && (
-        <p className="mt-2 text-12 text-secondary">{t("Using the current browser origin as the cloud URL because VITE_API_BASE_URL is not configured.")}</p>
+        <p className="mt-2 text-12 text-secondary">
+          {t("Using the current browser origin as the cloud URL because VITE_API_BASE_URL is not configured.")}
+        </p>
       )}
       <div className="mt-2">
         <Button size="sm" onClick={copy}>

--- a/apps/web/core/components/runners/runners-tabs.tsx
+++ b/apps/web/core/components/runners/runners-tabs.tsx
@@ -27,9 +27,7 @@ export function RunnersTabs() {
           end={tab.end}
           className={({ isActive }) =>
             `flex h-9 items-center border-b-2 px-3 text-13 font-medium transition-colors ${
-              isActive
-                ? "border-custom-primary-100 text-primary"
-                : "border-transparent text-secondary hover:text-primary"
+              isActive ? "border-accent-strong text-primary" : "border-transparent text-secondary hover:text-primary"
             }`
           }
         >


### PR DESCRIPTION
## PDASHOSS01-18 — some UI components don't recognize the theme

### Problem

Several recently-added Pi Dash feature surfaces rendered with fixed/default colors that didn't flip when toggling dark/light.

**Root cause** (verified by compiling `@pi-dash/tailwind-config` through `@tailwindcss/postcss`): this project's Tailwind v4 theme wipes the default color palette — `--color-*: initial` in `packages/tailwind-config/variables.css` — and exposes only a curated set of **semantic tokens** (`bg-canvas`, `text-primary`, `bg-accent-primary`, `text-danger-primary`, …) plus `white`/`black`. Any class outside that set compiles to **no CSS**, so the element inherits a default color that doesn't respond to the theme. The offending classes were:

- legacy Plane `custom-*` tokens (`bg-custom-background-100`, `text-custom-text-300`, `bg-custom-primary-100`, …)
- raw Tailwind palette (`text-red-500`, `bg-green-500`, `border-red-500`, `dark:text-green-300`, …)
- invented tokens that don't exist here: `brand-accent`, `bg-layer-0`, `bg-layer-base`, `border-primary`, `text-destructive`/`border-destructive`, `ring-accent-primary`

Because the theme is applied via `data-theme` (next-themes) and the semantic tokens are CSS-variable backed, the fix also removes the need for any `dark:` overrides — the tokens flip automatically via `[data-theme*="dark"]`.

### Fix

Replaced every dead theme-color class on these surfaces with its live semantic-token equivalent, e.g.:

| dead | live |
| --- | --- |
| `text-custom-text-300` | `text-tertiary` |
| `bg-custom-primary-100` / `text-white` | `bg-accent-primary` / `text-on-color` |
| `border-custom-border-200` | `border-subtle` |
| `bg-layer-0` / `bg-layer-base` | `bg-surface-1` / `bg-canvas` |
| `border-primary` (active) / `hover:border-primary` | `border-accent-strong` / `hover:border-strong` |
| `text-destructive`, `text-red-500` | `text-danger-primary` |
| `border-green-500/30 bg-green-500/10 text-green-700 dark:text-green-300` | `border-success-subtle bg-success-subtle text-success-primary` |
| `ring-accent-primary` | `ring-accent-strong` |

### Files (15)

Runners: `runners/page.tsx`, `runners/layout.tsx`, `runners/chat/[runnerId]/page.tsx`, `runners/detail/[runnerId]/page.tsx`, `runners-tabs.tsx`, `runner-cli-command.tsx`, `runner-agent-status-panel.tsx`, `create-pod-modal.tsx`. Schedulers/prompts/auth: `scheduler-bindings/{install-binding-modal,binding-schedule-fields,calendar/month-view,calendar/week-view}.tsx`, `schedulers/layout.tsx`, `prompts/[promptId]/page.tsx`, `auth/device/page.tsx`.

### Validation

- Compiled `@pi-dash/tailwind-config` via `@tailwindcss/postcss`: **every** replacement token emits CSS (LIVE); **no** dead theme-color class remains in the touched files.
- `oxlint` on the 15 changed files: 0 warnings / 0 errors. `oxfmt --check`: pass (classes sorted by the repo's formatter).
- `pnpm --filter web check:types` fails only on **pre-existing** errors in untouched files (`issue-layouts/utils.tsx`, `project/settings/github-sync.tsx`, `core/store/scheduler.store.ts` `toSorted`/es2023, `project-states/*`, `readonly/state.tsx`, `project/form.tsx`) — none of the 15 files here appear, and className-only edits cannot introduce type errors.
- Changes are presentational only.

### Out of scope / follow-up

Inherited legacy Plane components elsewhere (~25 files: `exporter/*`, `profile/activity/*`, `analytics/trend-piece`, `workspace/sidebar/favorites/*`, `onboarding/*`, `empty-state/*`, …) still use the same dead raw-palette classes app-wide. Fixing those needs per-component UX color decisions (which semantic role each color maps to), so it's deferred to a separate cleanup rather than bundled here. A few other dead non-palette tokens also live in legacy code (`text-gray`, `bg-gray-700`, `text-opacity-40`, `bg-pi-50`, `text-caption-md`, `shadow-sm`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
