### PR TITLE
PDASHOSS01-10 add parent issue content as context for the issue when sending to agent

### DIFF
--- a/apps/api/pi_dash/prompting/context.py
+++ b/apps/api/pi_dash/prompting/context.py
@@ -32,6 +32,43 @@ def _issue_description_markdown(issue: Issue) -> str:
     return ""
 
 
+def _issue_identifier(issue: Issue) -> str:
+    """Workspace-scoped identifier, e.g. ``TP-12``.
+
+    Always uses the issue's *own* project identifier — a parent may live in a
+    different project than its child, so this must not assume the child's
+    project.
+    """
+    return f"{issue.project.identifier}-{issue.sequence_id}"
+
+
+def _issue_comment_count(issue: Issue) -> int:
+    """Count of comments on ``issue`` — matches what ``pidash comment list``
+    returns. Surfaced for a parent so the agent learns the discussion volume
+    without inlining the parent's comment bodies into this prompt.
+    """
+    from pi_dash.db.models.issue import IssueComment
+
+    return IssueComment.objects.filter(issue=issue).count()
+
+
+def _ancestor_chain(issue: Issue) -> list[Issue]:
+    """Return ``[issue, parent, grandparent, ... root]``.
+
+    Walks the ``parent`` self-FK upward. The FK has no DB-level acyclicity
+    guarantee, so defend against accidental cycles with a visited-id set and a
+    hard depth cap — a malformed graph must never spin the renderer.
+    """
+    chain: list[Issue] = []
+    seen: set[Any] = set()
+    current: Issue | None = issue
+    while current is not None and current.id not in seen and len(chain) < 50:
+        chain.append(current)
+        seen.add(current.id)
+        current = current.parent
+    return chain
+
+
 def _absolute_issue_url(issue: Issue) -> str:
     """Return a best-effort deep link. Full URL construction lives in the
     web layer; we return a relative path so templates still have something
@@ -165,6 +202,9 @@ def build_context(issue: Issue, run: AgentRun) -> Dict[str, Any]:
 
     attempt = _compute_attempt(issue, run)
 
+    # Walk the parent chain once: [issue, parent, grandparent, ... root].
+    ancestors = _ancestor_chain(issue)
+
     return {
         "issue": {
             "id": str(issue.id),
@@ -197,11 +237,27 @@ def build_context(issue: Issue, run: AgentRun) -> Dict[str, Any]:
         },
         "parent": (
             {
-                "identifier": f"{parent.project.identifier}-{parent.sequence_id}",
+                "identifier": _issue_identifier(parent),
                 "title": parent.name or "",
                 "work_branch": (getattr(parent, "git_work_branch", "") or None),
+                "description": _issue_description_markdown(parent),
+                "comments_count": _issue_comment_count(parent),
             }
             if parent is not None
+            else None
+        ),
+        # Multi-level lineage (current -> parent -> ... -> root). Only set when
+        # there's a grandparent or higher: for a single parent the `parent`
+        # block already carries everything, so the template renders the lineage
+        # tree only when ``lineage`` is truthy. We do NOT inline ancestor
+        # content beyond the direct parent — the agent is told to fetch it via
+        # the CLI on demand.
+        "lineage": (
+            [
+                {"identifier": _issue_identifier(node), "title": node.name or ""}
+                for node in ancestors
+            ]
+            if len(ancestors) > 2
             else None
         ),
         "run": {

--- a/apps/api/pi_dash/prompting/fragments/01_intro.md
+++ b/apps/api/pi_dash/prompting/fragments/01_intro.md
@@ -23,6 +23,23 @@ No description provided.
 
 Comments to date (chronological — humans and the agent's own prior runs):
 {{ comments_section }}
+{% if parent %}
+
+Parent issue context (this issue is a sub-issue of {{ parent.identifier }}):
+- Parent {{ parent.identifier }}: {{ parent.title }}
+- Parent description:
+{% if parent.description %}
+{{ parent.description }}
+{% else %}
+(no description on the parent issue)
+{% endif %}
+- The parent has {{ parent.comments_count }} comment(s); their contents are not included here. Run `pidash comment list {{ parent.identifier }}` to read them.
+{% if lineage %}
+- This issue has a multi-level parent lineage. Full chain, current issue first up to the root:
+{% for node in lineage %}{{ node.identifier }}: {{ node.title }}{% if loop.first %} (current){% endif %}{% if not loop.last %} → {% endif %}{% endfor %}
+- Only the direct parent's content is shown above. To learn about any ancestor, run `pidash issue get <ANCESTOR-ID>` and `pidash comment list <ANCESTOR-ID>` (for example, the root issue is `pidash issue get {{ lineage[-1].identifier }}`).
+{% endif %}
+{% endif %}
 
 Repository:
 {% if repo.url %}

--- a/apps/api/pi_dash/tests/unit/prompting/test_context.py
+++ b/apps/api/pi_dash/tests/unit/prompting/test_context.py
@@ -151,6 +151,89 @@ def test_context_parent_work_branch_empty_surfaces_as_none(
 
 
 @pytest.mark.unit
+def test_context_parent_includes_description_and_comment_count(
+    workspace, project, state, create_user, run, issue
+):
+    from pi_dash.db.models import IssueComment
+
+    parent = Issue.objects.create(
+        name="Umbrella epic",
+        workspace=workspace,
+        project=project,
+        state=state,
+        created_by=create_user,
+        description_html="<p>Parent framing and acceptance criteria.</p>",
+    )
+    for body in ("<p>first</p>", "<p>second</p>"):
+        IssueComment.objects.create(
+            issue=parent,
+            workspace=workspace,
+            project=project,
+            created_by=create_user,
+            comment_html=body,
+        )
+    issue.parent = parent
+    issue.save(update_fields=["parent"])
+
+    ctx = build_context(issue, run)
+    assert ctx["parent"]["description"] == "Parent framing and acceptance criteria."
+    # Comment count surfaces the discussion volume without inlining bodies.
+    assert ctx["parent"]["comments_count"] == 2
+
+
+@pytest.mark.unit
+def test_context_lineage_is_none_for_single_parent(
+    workspace, project, state, create_user, run, issue
+):
+    # A direct parent with no ancestors → the `parent` block carries
+    # everything, so no separate lineage tree is emitted.
+    parent = Issue.objects.create(
+        name="Lone parent",
+        workspace=workspace,
+        project=project,
+        state=state,
+        created_by=create_user,
+    )
+    issue.parent = parent
+    issue.save(update_fields=["parent"])
+
+    ctx = build_context(issue, run)
+    assert ctx["parent"] is not None
+    assert ctx["lineage"] is None
+
+
+@pytest.mark.unit
+def test_context_lineage_populated_for_grandparent(
+    workspace, project, state, create_user, run, issue
+):
+    grandparent = Issue.objects.create(
+        name="Root epic",
+        workspace=workspace,
+        project=project,
+        state=state,
+        created_by=create_user,
+    )
+    parent = Issue.objects.create(
+        name="Mid epic",
+        workspace=workspace,
+        project=project,
+        state=state,
+        created_by=create_user,
+        parent=grandparent,
+    )
+    issue.parent = parent
+    issue.save(update_fields=["parent"])
+
+    ctx = build_context(issue, run)
+    lineage = ctx["lineage"]
+    assert lineage is not None
+    # Ordered current -> parent -> grandparent (root).
+    assert [n["title"] for n in lineage] == ["Make button blue", "Mid epic", "Root epic"]
+    assert lineage[0]["identifier"] == ctx["issue"]["identifier"]
+    assert lineage[-1]["title"] == "Root epic"
+
+
+@pytest.mark.unit
 def test_context_includes_project_description_when_set(
     workspace, create_user
 ):

--- a/apps/api/pi_dash/tests/unit/prompting/test_fragments.py
+++ b/apps/api/pi_dash/tests/unit/prompting/test_fragments.py
@@ -120,6 +120,9 @@ def _ctx_from_db(
     base_branch="trunk",
     has_parent=False,
     project_description="",
+    parent_description="",
+    parent_comment_count=0,
+    has_grandparent=False,
 ):
     """Build the Jinja context for these fragment tests via the production
     ``prompting.context.build_context``.
@@ -148,6 +151,7 @@ def _ctx_from_db(
     """
     from pi_dash.db.models import (
         Issue,
+        IssueComment,
         Project,
         State,
         Workspace,
@@ -181,13 +185,31 @@ def _ctx_from_db(
 
     parent = None
     if has_parent:
+        grandparent = None
+        if has_grandparent:
+            grandparent = Issue.objects.create(
+                name="Root epic",
+                workspace=workspace,
+                project=project,
+                created_by=owner,
+            )
         parent = Issue.objects.create(
             name="Umbrella",
             workspace=workspace,
             project=project,
             created_by=owner,
             git_work_branch=parent_branch or "",
+            parent=grandparent,
+            description_html=(f"<p>{parent_description}</p>" if parent_description else ""),
         )
+        for n in range(parent_comment_count):
+            IssueComment.objects.create(
+                issue=parent,
+                workspace=workspace,
+                project=project,
+                created_by=owner,
+                comment_html=f"<p>comment {n}</p>",
+            )
     issue = Issue.objects.create(
         name="Make button blue",
         workspace=workspace,
@@ -247,6 +269,53 @@ def test_assemble_renders_existing_work_branch_skips_base_resolution():
     # repo.work_branch path → checkout existing branch directly, no BASE= resolution.
     assert "git checkout feat/pinned" in body
     assert "BASE=" not in body
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_assemble_renders_no_parent_context_for_independent_issue():
+    body = render(assemble(), _ctx_from_db())
+    # Independent issue → no parent-context block at all.
+    assert "Parent issue context" not in body
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_assemble_renders_parent_context_block_with_content_and_comment_count():
+    body = render(
+        assemble(),
+        _ctx_from_db(
+            has_parent=True,
+            parent_description="Parent acceptance criteria here.",
+            parent_comment_count=3,
+        ),
+    )
+    assert "Parent issue context (this issue is a sub-issue of TP-" in body
+    # Parent content is inlined...
+    assert "Parent acceptance criteria here." in body
+    # ...but the parent's comment bodies are not — only the count + the exact
+    # ready-to-run command to read them.
+    assert "has 3 comment(s)" in body
+    assert "pidash comment list TP-" in body
+    # Single parent (no grandparent) → no lineage tree.
+    assert "multi-level parent lineage" not in body
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_assemble_renders_lineage_tree_when_grandparent_exists():
+    body = render(
+        assemble(),
+        _ctx_from_db(has_parent=True, has_grandparent=True),
+    )
+    # Lineage tree is emitted with the current issue marked and arrows between
+    # ancestors, ending at the root.
+    assert "multi-level parent lineage" in body
+    assert "(current)" in body
+    assert "→" in body
+    assert "Root epic" in body
+    # And the agent is pointed at the CLI to fetch any ancestor's details.
+    assert "pidash issue get <ANCESTOR-ID>" in body
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## What

When Pi Dash builds the prompt for an issue that has a **parent**, include the parent's context so the agent inherits the framing the sub-issue sits inside. Implements the rules from PDASHOSS01-10:

1. **Direct parent** — inline the parent's description content, report its **comment count** (count only, not the bodies), and give the exact ready-to-run command to read them: `pidash comment list <parent-id>`.
2. **Grandparent or higher** — instead of dumping every ancestor's content, render the **lineage tree** `current (current) → parent → grandparent → … → root`, and tell the agent to run `pidash issue get <ancestor>` / `pidash comment list <ancestor>` to fetch any ancestor's details on demand. Only the direct parent's content is inlined.

## Changes

- **`prompting/context.py`** — the `parent` context dict now also exposes `description` and `comments_count`; a new top-level `lineage` key carries the `current → … → root` chain, set **only** when the chain is deeper than two levels (a single parent needs no separate tree). The ancestor walk (`_ancestor_chain`) guards against accidental FK cycles with a visited-id set and a depth cap.
- **`prompting/fragments/01_intro.md`** — renders the parent-context block (description, comment count, comment-list command) and, when a grandparent exists, the lineage chain plus the ancestor-CLI guidance.

## Testing

`pytest pi_dash/tests/unit/prompting/` → **37 passed** (run in a `python:3.12-slim` container against Postgres 15.7, matching CI). 6 new tests cover: parent description + comment count in context; `lineage` is `None` for a single parent and populated/ordered for a grandparent; the rendered parent block (content + count + `pidash comment list`); the rendered lineage tree + ancestor CLI prompt; and no parent block for an independent issue. No regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
