### PR TITLE
PDASHOSS01-7 let's currently hide Stickies feature from user

### DIFF
--- a/apps/web/app/routes/core.ts
+++ b/apps/web/app/routes/core.ts
@@ -103,10 +103,9 @@ export const coreRoutes: RouteConfigEntry[] = [
           ),
         ]),
 
-        // Stickies
-        layout("./(all)/[workspaceSlug]/(projects)/stickies/layout.tsx", [
-          route(":workspaceSlug/stickies", "./(all)/[workspaceSlug]/(projects)/stickies/page.tsx"),
-        ]),
+        // Stickies — hidden from users (PDASHOSS01-7). The page/layout/header
+        // components are kept in place so the feature can be restored by
+        // re-registering this route; it is intentionally not reachable by URL.
 
         // Prompts (prompt templates: view for members, create/edit for workspace admins)
         layout("./(all)/[workspaceSlug]/prompts/layout.tsx", [

--- a/apps/web/core/components/home/home-dashboard-widgets.tsx
+++ b/apps/web/core/components/home/home-dashboard-widgets.tsx
@@ -73,13 +73,18 @@ export const DashboardWidgets = observer(function DashboardWidgets() {
   // theme hook
   const { resolvedTheme } = useTheme();
   // store hooks
-  const { toggleWidgetSettings, widgetsMap, showWidgetSettings, orderedWidgets, isAnyWidgetEnabled, loading } =
-    useHome();
+  const { toggleWidgetSettings, widgetsMap, showWidgetSettings, orderedWidgets, loading } = useHome();
   const { loader } = useProject();
   // pi dash hooks
   const { t } = useTranslation();
   // derived values
   const noWidgetsResolvedPath = resolvedTheme === "light" ? lightWidgetsAsset : darkWidgetsAsset;
+  // Only consider widgets that are actually surfaced to users when deciding
+  // between the dashboard and the empty state. `my_stickies` is hidden
+  // (PDASHOSS01-7) and renders nothing, so an enabled-but-hidden stickies
+  // widget must not suppress the "all widgets off" empty state.
+  const visibleWidgets = orderedWidgets.filter((key) => !HIDDEN_HOME_WIDGET_KEYS.has(key));
+  const isAnyVisibleWidgetEnabled = visibleWidgets.some((key) => widgetsMap[key]?.is_enabled);
 
   // derived values
   const isWikiApp = pathname.includes(`/${workspaceSlug.toString()}/pages`);
@@ -96,9 +101,9 @@ export const DashboardWidgets = observer(function DashboardWidgets() {
       />
       {!isWikiApp && <NoProjectsEmptyState />}
 
-      {isAnyWidgetEnabled ? (
+      {isAnyVisibleWidgetEnabled ? (
         <div className="flex flex-col">
-          {orderedWidgets.map((key) => {
+          {visibleWidgets.map((key) => {
             const WidgetComponent = HOME_WIDGETS_LIST[key]?.component;
             const isEnabled = widgetsMap[key]?.is_enabled;
             if (!WidgetComponent || !isEnabled) return null;

--- a/apps/web/core/components/home/home-dashboard-widgets.tsx
+++ b/apps/web/core/components/home/home-dashboard-widgets.tsx
@@ -59,6 +59,12 @@ export const HOME_WIDGETS_LIST: {
   },
 };
 
+// Widgets hidden from users. `my_stickies` is part of the inherited Stickies
+// feature, which Pi Dash does not surface (PDASHOSS01-7). Its dashboard
+// component is already `null`, but the Manage Widgets modal still enumerates
+// every server-provided widget key — so it must be filtered there too.
+export const HIDDEN_HOME_WIDGET_KEYS: ReadonlySet<THomeWidgetKeys> = new Set(["my_stickies"]);
+
 export const DashboardWidgets = observer(function DashboardWidgets() {
   // router
   const { workspaceSlug } = useParams();
@@ -107,7 +113,9 @@ export const DashboardWidgets = observer(function DashboardWidgets() {
         <div className="grid h-full w-full place-items-center">
           <SimpleEmptyState
             title={t("It's Quiet Without Widgets, Turn Them On")}
-            description={t("It looks like all your widgets are turned off. Enable them\nnow to enhance your experience!")}
+            description={t(
+              "It looks like all your widgets are turned off. Enable them\nnow to enhance your experience!"
+            )}
             assetPath={noWidgetsResolvedPath}
           />
         </div>

--- a/apps/web/core/components/home/widgets/manage/widget-list.tsx
+++ b/apps/web/core/components/home/widgets/manage/widget-list.tsx
@@ -13,6 +13,7 @@ import { observer } from "mobx-react";
 import { useTranslation } from "@pi-dash/i18n";
 import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
 import { useHome } from "@/hooks/store/use-home";
+import { HIDDEN_HOME_WIDGET_KEYS } from "../../home-dashboard-widgets";
 import { WidgetItem } from "./widget-item";
 import type { TargetData } from "./widget.helpers";
 import { getInstructionFromPayload } from "./widget.helpers";
@@ -20,6 +21,9 @@ import { getInstructionFromPayload } from "./widget.helpers";
 export const WidgetList = observer(function WidgetList({ workspaceSlug }: { workspaceSlug: string }) {
   const { orderedWidgets, reorderWidget, toggleWidget } = useHome();
   const { t } = useTranslation();
+  // Exclude widgets that are hidden from users (e.g. Stickies — PDASHOSS01-7)
+  // so they don't appear as toggleable rows in the Manage Widgets modal.
+  const visibleWidgets = orderedWidgets.filter((widget) => !HIDDEN_HOME_WIDGET_KEYS.has(widget));
 
   const handleDrop = (self: DropTargetRecord, source: ElementDragPayload, location: DragLocationHistory) => {
     const dropTargets = location?.current?.dropTargets ?? [];
@@ -37,13 +41,13 @@ export const WidgetList = observer(function WidgetList({ workspaceSlug }: { work
     if (!sourceData.id) return;
     if (droppedId) {
       reorderWidget(workspaceSlug, sourceData.id, droppedId, instruction)
-        .then(() => {
+        .then(() =>
           setToast({
             type: TOAST_TYPE.SUCCESS,
             title: t("Success!"),
             message: t("Widget reordered successfully."),
-          });
-        })
+          })
+        )
         .catch(() => {
           setToast({
             type: TOAST_TYPE.ERROR,
@@ -56,11 +60,11 @@ export const WidgetList = observer(function WidgetList({ workspaceSlug }: { work
 
   return (
     <div className="my-4">
-      {orderedWidgets.map((widget, index) => (
+      {visibleWidgets.map((widget, index) => (
         <WidgetItem
           key={widget}
           widgetId={widget}
-          isLastChild={index === orderedWidgets.length - 1}
+          isLastChild={index === visibleWidgets.length - 1}
           handleDrop={handleDrop}
           handleToggle={toggleWidget}
         />


### PR DESCRIPTION
## What

Hide the inherited **Stickies** feature (from Plane) from end users. Pi Dash is an agent-oriented platform and doesn't surface Stickies.

The sidebar nav item, the customize-navigation toggle, and the home dashboard widget render are **already** hidden on `main`. This PR closes the two remaining user-visible surfaces:

1. **`/stickies` route** — was still reachable by typing the URL directly. Removed its registration in `apps/web/app/routes/core.ts`. The page/layout/header components are intentionally left in place so the feature can be restored by simply re-adding the route.
2. **Manage Widgets modal "Your stickies" toggle** — the modal enumerates every server-provided widget key, so it rendered a stickies toggle even though the dashboard widget's component is already `null`. Added a `HIDDEN_HOME_WIDGET_KEYS` set in `home-dashboard-widgets.tsx` and applied it in `widget-list.tsx`.

No backend, store, or service code is removed — the feature remains fully restorable.

## Testing

- `pnpm turbo run check:types --filter=web` — the three changed files introduce no new type errors (the remaining failures are a pre-existing baseline, confirmed by stashing the changes and re-running: identical failures in `github-sync` / `readonly/state` / `scheduler.store`, none in the changed files).
- `oxlint --deny-warnings` on the three changed files — 0 warnings, 0 errors.

## Notes

- Sidebar and customize-navigation already exclude Stickies on `main`; no change needed there.
- The `allStickiesModal` command-palette path is only triggered by `StickyActionBar`, which is dead code (never imported), so it is not user-facing.

PDASHOSS01-7
