### PR TITLE
feat(scheduler): add outcome_mode to steer what scheduler runs do wit…

### DIFF
--- a/apps/api/pi_dash/app/serializers/scheduler.py
+++ b/apps/api/pi_dash/app/serializers/scheduler.py
@@ -146,6 +146,7 @@ class SchedulerBindingSerializer(BaseSerializer):
             "exdates",
             "extra_context",
             "enabled",
+            "outcome_mode",
             "pod",
             "pod_name",
             "next_run_at",

--- a/apps/api/pi_dash/bgtasks/scheduler.py
+++ b/apps/api/pi_dash/bgtasks/scheduler.py
@@ -37,7 +37,11 @@ from django.db.models import Q
 from django.utils import timezone
 
 from pi_dash.bgtasks._rrule import next_fire_from_rrule
-from pi_dash.db.models.scheduler import LAST_ERROR_MAX_LEN, SchedulerBinding
+from pi_dash.db.models.scheduler import (
+    LAST_ERROR_MAX_LEN,
+    SchedulerBinding,
+    outcome_mode_directive,
+)
 from pi_dash.runner.models import AgentRunStatus
 from pi_dash.utils.iso_datetime import coerce_iso_datetimes
 
@@ -202,12 +206,20 @@ def fire_scheduler_binding(self, binding_id: str) -> bool:
             binding.last_error = ""
         binding.save(update_fields=["next_run_at", "last_error", "updated_at"])
 
-        # Resolve prompt while we still have the row in scope.
+        # Resolve prompt while we still have the row in scope. Order:
+        # scheduler task prompt, optional per-install extra context, then the
+        # work-mode directive (what to do with findings — file issues / open
+        # fix PRs / fix + review). outcome_mode is per-binding, so the same
+        # scheduler can behave differently across projects. The directive is
+        # appended here rather than composed in a template because the scheduler
+        # prompt path does not yet go through the prompt composer (deferred; see
+        # OutcomeMode docstring).
         base_prompt = binding.scheduler.prompt or ""
+        parts = [base_prompt.strip()]
         if binding.extra_context:
-            prompt = f"{base_prompt}\n\n{binding.extra_context}".strip()
-        else:
-            prompt = base_prompt.strip()
+            parts.append(binding.extra_context.strip())
+        parts.append(outcome_mode_directive(binding.outcome_mode))
+        prompt = "\n\n".join(p for p in parts if p)
 
     # ----- Phase 2: Dispatch outside the transaction -----
     from pi_dash.orchestration.service import dispatch_scheduler_run

--- a/apps/api/pi_dash/db/migrations/0146_schedulerbinding_outcome_mode.py
+++ b/apps/api/pi_dash/db/migrations/0146_schedulerbinding_outcome_mode.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Add ``SchedulerBinding.outcome_mode`` — what an install does with findings.
+
+The field lives on the per-project binding (not the workspace ``Scheduler``)
+so the same scheduler can behave differently across projects. The scheduler
+layer still never creates issues or edits code itself; this steers the
+dispatched agent run by appending a work-mode directive to its prompt (create
+issues / apply fix / fix and open for review). Defaults to ``create_issue`` so
+existing installs keep their current behavior with no backfill.
+"""
+
+from __future__ import annotations
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("db", "0145_schedulerbinding_pod"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="schedulerbinding",
+            name="outcome_mode",
+            field=models.CharField(
+                choices=[
+                    ("create_issue", "Create issues"),
+                    ("apply_fix", "Apply fix (open PR)"),
+                    ("fix_and_review", "Fix & open for review"),
+                ],
+                default="create_issue",
+                max_length=16,
+            ),
+        ),
+    ]

--- a/apps/api/pi_dash/db/models/scheduler.py
+++ b/apps/api/pi_dash/db/models/scheduler.py
@@ -27,6 +27,81 @@ class SchedulerSource(models.TextChoices):
     MANIFEST = "manifest", "Manifest"
 
 
+class OutcomeMode(models.TextChoices):
+    """What a scheduler run should *do* with whatever it finds.
+
+    Stored per-install on :attr:`SchedulerBinding.outcome_mode` (not on the
+    workspace ``Scheduler``), so the same scheduler can behave differently
+    across projects. The scheduler layer never creates issues or edits code
+    itself — it only dispatches an agent run. ``outcome_mode`` steers that run
+    by appending a work-mode directive to the dispatched prompt (see
+    ``OUTCOME_MODE_DIRECTIVES`` and ``pi_dash.bgtasks.scheduler``). The agent
+    still does the work via the same ``pidash`` CLI / git tools a user-driven
+    run uses.
+
+    A future PR unifies this into the prompt composer (one composer for issue
+    *and* scheduler runs); for now the directive is appended to the prompt.
+    """
+
+    CREATE_ISSUE = "create_issue", "Create issues"
+    APPLY_FIX = "apply_fix", "Apply fix (open PR)"
+    FIX_AND_REVIEW = "fix_and_review", "Fix & open for review"
+
+
+#: Work-mode directive appended to a scheduler run's prompt, keyed by
+#: ``OutcomeMode``. Single source of truth so the dispatcher, tests, and any
+#: future composer share the same wording. Kept terse — the scheduler's own
+#: prompt carries the task; this only fixes *what to do with findings*.
+OUTCOME_MODE_DIRECTIVES: dict[str, str] = {
+    OutcomeMode.CREATE_ISSUE: (
+        "## Work mode: create issues\n\n"
+        "For each distinct finding, file a Pi Dash issue with the `pidash` CLI:\n"
+        "    pidash issue create --project <PROJ> --title \"<short summary>\" \\\n"
+        "        --description \"<file path, line range, evidence, severity, "
+        'suggested fix>"\n'
+        "Before creating an issue, list existing open issues and skip any "
+        "finding that already has a corresponding open issue (de-dupe by file "
+        "+ root cause, not by exact title). Do NOT modify code."
+    ),
+    OutcomeMode.APPLY_FIX: (
+        "## Work mode: apply fix\n\n"
+        "For each finding you are confident about, implement the fix and open a "
+        "pull request for human review — do NOT merge it. Keep one PR per "
+        "logical fix where practical. If a fix is risky, ambiguous, or larger "
+        "than a focused change, do NOT force it: create a Pi Dash issue "
+        "describing the finding instead (same form as create-issue mode)."
+    ),
+    OutcomeMode.FIX_AND_REVIEW: (
+        "## Work mode: fix and open for review\n\n"
+        "For each distinct finding, do ALL of the following:\n"
+        "1. File a Pi Dash issue with the `pidash` CLI (de-dupe against existing "
+        "open issues by file + root cause, as in create-issue mode), and note "
+        "the issue identifier it returns:\n"
+        "    pidash issue create --project <PROJ> --title \"<short summary>\" \\\n"
+        "        --description \"<file path, line range, evidence, severity, "
+        'suggested fix>"\n'
+        "2. Implement the fix and open a pull request for human review — do NOT "
+        "merge it. Reference the issue identifier in the PR.\n"
+        "3. Move the issue straight to the review column so a human picks it up:\n"
+        "    pidash issue patch <IDENT> --state \"In Review\"\n"
+        "If a fix is risky, ambiguous, or larger than a focused change, do NOT "
+        "force it: leave the issue in its default state (do NOT move it to In "
+        "Review) and describe the blocker in the issue instead of opening a PR."
+    ),
+}
+
+
+def outcome_mode_directive(mode: str) -> str:
+    """Return the prompt directive for ``mode``.
+
+    Falls back to the ``CREATE_ISSUE`` directive for an unknown value so a
+    stale row can never dispatch a run with no work-mode guidance at all.
+    """
+    return OUTCOME_MODE_DIRECTIVES.get(
+        mode, OUTCOME_MODE_DIRECTIVES[OutcomeMode.CREATE_ISSUE]
+    )
+
+
 class Scheduler(BaseModel):
     """A reusable scheduler definition: a slug + prompt + workspace-level
     enable flag. Definitions are workspace-scoped (mirrors
@@ -103,6 +178,17 @@ class SchedulerBinding(WorkspaceBaseModel):
 
     extra_context = models.TextField(blank=True, default="")
     enabled = models.BooleanField(default=True)
+
+    # What a run of THIS install does with its findings (file issues / open
+    # fix PRs / fix + move to review). Lives on the binding, not the Scheduler,
+    # so the same workspace scheduler can behave differently per project. Steers
+    # the dispatched prompt (see OutcomeMode); defaults to CREATE_ISSUE to match
+    # the pre-existing builtin behavior.
+    outcome_mode = models.CharField(
+        max_length=16,
+        choices=OutcomeMode.choices,
+        default=OutcomeMode.CREATE_ISSUE,
+    )
 
     next_run_at = models.DateTimeField(null=True, blank=True)
     # Single source of truth for "last run state": the AgentRun itself.

--- a/apps/api/pi_dash/tests/unit/bg_tasks/test_scheduler_task.py
+++ b/apps/api/pi_dash/tests/unit/bg_tasks/test_scheduler_task.py
@@ -22,6 +22,7 @@ from pi_dash.bgtasks.scheduler import (
     scan_due_bindings,
 )
 from pi_dash.db.models import Project, Scheduler, SchedulerBinding
+from pi_dash.db.models.scheduler import OutcomeMode, outcome_mode_directive
 from pi_dash.runner.models import AgentRun, AgentRunStatus, Pod, Runner, RunnerStatus
 
 
@@ -233,6 +234,62 @@ def test_fire_falls_back_to_default_when_override_pod_soft_deleted(binding, proj
     fire_scheduler_binding(str(binding.pk))
     binding.refresh_from_db()
     assert binding.last_run.pod_id == default_pod.id
+
+
+# ---------------------------------------------------------------------------
+# fire_scheduler_binding — outcome_mode work-mode directive
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_fire_appends_create_issue_directive_by_default(binding):
+    """A scheduler with the default outcome_mode (create_issue) appends the
+    create-issue directive after the task prompt."""
+    fire_scheduler_binding(str(binding.pk))
+    binding.refresh_from_db()
+    prompt = binding.last_run.prompt
+    assert "Work mode: create issues" in prompt
+    assert "pidash issue create" in prompt
+    # Task prompt comes first; directive is appended after it.
+    assert prompt.index("Scan the project.") < prompt.index("Work mode: create issues")
+
+
+@pytest.mark.unit
+def test_fire_appends_apply_fix_directive(binding):
+    binding.outcome_mode = OutcomeMode.APPLY_FIX
+    binding.save(update_fields=["outcome_mode"])
+    fire_scheduler_binding(str(binding.pk))
+    binding.refresh_from_db()
+    prompt = binding.last_run.prompt
+    assert "Work mode: apply fix" in prompt
+    assert "open a pull request" in prompt
+    assert "do NOT merge" in prompt
+    # The other modes' directives must not leak in.
+    assert "Work mode: create issues" not in prompt
+    assert "Work mode: fix and open for review" not in prompt
+
+
+@pytest.mark.unit
+def test_fire_appends_fix_and_review_directive(binding):
+    """fix_and_review files an issue, applies the fix, and moves the issue
+    straight to In Review — the directive must instruct all three steps."""
+    binding.outcome_mode = OutcomeMode.FIX_AND_REVIEW
+    binding.save(update_fields=["outcome_mode"])
+    fire_scheduler_binding(str(binding.pk))
+    binding.refresh_from_db()
+    prompt = binding.last_run.prompt
+    assert "Work mode: fix and open for review" in prompt
+    assert "pidash issue create" in prompt
+    assert "open a pull request" in prompt
+    assert 'pidash issue patch <IDENT> --state "In Review"' in prompt
+
+
+@pytest.mark.unit
+def test_outcome_mode_directive_falls_back_for_unknown_value():
+    """A stale / unrecognized mode never yields an empty directive — it falls
+    back to the create-issue guidance so a run is never dispatched without a
+    work-mode instruction."""
+    assert "Work mode: create issues" in outcome_mode_directive("nonexistent_mode")
 
 
 @pytest.mark.unit

--- a/apps/web/app/(all)/[workspaceSlug]/schedulers/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/schedulers/page.tsx
@@ -106,9 +106,7 @@ const SchedulersListPage = observer(function SchedulersListPage() {
     }
   };
 
-  const pageTitle = currentWorkspace?.name
-    ? `${currentWorkspace.name} · ${t("Schedulers")}`
-    : t("Schedulers");
+  const pageTitle = currentWorkspace?.name ? `${currentWorkspace.name} · ${t("Schedulers")}` : t("Schedulers");
 
   return (
     <div className="flex flex-col gap-6 p-6">
@@ -117,7 +115,11 @@ const SchedulersListPage = observer(function SchedulersListPage() {
       <header className="flex items-start justify-between gap-4">
         <div>
           <h1 className="text-16 font-semibold text-primary">{t("Schedulers")}</h1>
-          <p className="mt-1 text-13 text-secondary">{t("Reusable scheduler definitions for this workspace. Install one on a project to run its prompt against the project on a cron.")}</p>
+          <p className="mt-1 text-13 text-secondary">
+            {t(
+              "Reusable scheduler definitions for this workspace. Install one on a project to run its prompt against the project on a cron."
+            )}
+          </p>
         </div>
         {canEdit && <Button onClick={() => setCreateOpen(true)}>{t("New scheduler")}</Button>}
       </header>

--- a/apps/web/core/components/project/scheduler-bindings/binding-outcome-mode-field.tsx
+++ b/apps/web/core/components/project/scheduler-bindings/binding-outcome-mode-field.tsx
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { Controller } from "react-hook-form";
+import type { Control, FieldValues, Path } from "react-hook-form";
+import { useTranslation } from "@pi-dash/i18n";
+import type { SchedulerOutcomeMode } from "@pi-dash/services";
+
+// English source strings double as i18n keys (see packages/i18n: en is empty,
+// t() falls back to the key). Each option's label/help is translated per-locale.
+const OUTCOME_MODE_OPTIONS: ReadonlyArray<{ value: SchedulerOutcomeMode; label: string; help: string }> = [
+  {
+    value: "create_issue",
+    label: "Create issues",
+    help: "File a Pi Dash issue for each finding, skipping ones already tracked by an open issue.",
+  },
+  {
+    value: "apply_fix",
+    label: "Apply fix",
+    help: "Implement the fix and open a pull request for review (never merged automatically). Risky or ambiguous findings become issues instead.",
+  },
+  {
+    value: "fix_and_review",
+    label: "Fix & open for review",
+    help: "File an issue for each finding, implement the fix, open a pull request (never merged automatically), and move the issue straight to In Review for a human.",
+  },
+];
+
+// Matches the backend default and pre-existing builtin behavior.
+export const DEFAULT_OUTCOME_MODE: SchedulerOutcomeMode = "create_issue";
+
+const outcomeModeHelp = (value: SchedulerOutcomeMode): string =>
+  (OUTCOME_MODE_OPTIONS.find((o) => o.value === value) ??
+    OUTCOME_MODE_OPTIONS.find((o) => o.value === DEFAULT_OUTCOME_MODE)!).help;
+
+type Props<T extends FieldValues> = {
+  control: Control<T>;
+  /** RHF field holding the SchedulerOutcomeMode value. */
+  name: Path<T>;
+};
+
+/**
+ * Outcome-mode selector for the install/edit binding modals — what a run of
+ * THIS install does with its findings. Lives on the binding (not the workspace
+ * Scheduler), so the same scheduler can file issues on one project and open fix
+ * PRs on another. Generic over the form values type so both modals reuse it.
+ */
+export function BindingOutcomeModeField<T extends FieldValues>({ control, name }: Props<T>) {
+  const { t } = useTranslation();
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="text-13 font-medium text-primary">{t("What to do with findings")}</span>
+      <Controller
+        control={control}
+        name={name}
+        render={({ field: { value, onChange } }) => {
+          const current = (value as SchedulerOutcomeMode) ?? DEFAULT_OUTCOME_MODE;
+          return (
+            <div className="flex flex-col gap-2">
+              <div className="flex flex-wrap gap-2" role="radiogroup" aria-label={t("What to do with findings")}>
+                {OUTCOME_MODE_OPTIONS.map((opt) => {
+                  const active = current === opt.value;
+                  return (
+                    <button
+                      key={opt.value}
+                      type="button"
+                      role="radio"
+                      aria-checked={active}
+                      onClick={() => onChange(opt.value)}
+                      className={`rounded-md border px-3 py-1.5 text-13 ${
+                        active
+                          ? "border-primary bg-primary/10 font-medium text-primary"
+                          : "border-subtle text-secondary hover:text-primary"
+                      }`}
+                    >
+                      {t(opt.label)}
+                    </button>
+                  );
+                })}
+              </div>
+              <p className="text-12 text-secondary">{t(outcomeModeHelp(current))}</p>
+            </div>
+          );
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/web/core/components/project/scheduler-bindings/edit-binding-modal.tsx
+++ b/apps/web/core/components/project/scheduler-bindings/edit-binding-modal.tsx
@@ -11,9 +11,10 @@ import { useForm, useWatch } from "react-hook-form";
 import { useTranslation } from "@pi-dash/i18n";
 import { Button } from "@pi-dash/propel/button";
 import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
-import type { ISchedulerBinding } from "@pi-dash/services";
+import type { ISchedulerBinding, SchedulerOutcomeMode } from "@pi-dash/services";
 import { SchedulerService } from "@pi-dash/services";
 import { EModalPosition, EModalWidth, ModalCore } from "@pi-dash/ui";
+import { BindingOutcomeModeField, DEFAULT_OUTCOME_MODE } from "./binding-outcome-mode-field";
 import { BindingPodField } from "./binding-pod-field";
 import { BindingScheduleFields } from "./binding-schedule-fields";
 import { DEFAULT_TZID } from "./constants";
@@ -25,6 +26,7 @@ interface EditFormValues {
   rrule: string;
   extra_context: string;
   enabled: boolean;
+  outcome_mode: SchedulerOutcomeMode;
   /** Pod id, or "" for the project default. */
   pod: string;
 }
@@ -50,7 +52,15 @@ export const EditSchedulerBindingModal = observer(function EditSchedulerBindingM
     reset,
     formState: { errors, isSubmitting },
   } = useForm<EditFormValues>({
-    defaultValues: { dtstart: "", tzid: DEFAULT_TZID, rrule: "", extra_context: "", enabled: true, pod: "" },
+    defaultValues: {
+      dtstart: "",
+      tzid: DEFAULT_TZID,
+      rrule: "",
+      extra_context: "",
+      enabled: true,
+      outcome_mode: DEFAULT_OUTCOME_MODE,
+      pod: "",
+    },
   });
 
   useEffect(() => {
@@ -61,6 +71,7 @@ export const EditSchedulerBindingModal = observer(function EditSchedulerBindingM
       rrule: binding.rrule || "",
       extra_context: binding.extra_context ?? "",
       enabled: binding.enabled,
+      outcome_mode: binding.outcome_mode ?? DEFAULT_OUTCOME_MODE,
       pod: binding.pod ?? "",
     });
   }, [isOpen, binding, reset]);
@@ -77,6 +88,7 @@ export const EditSchedulerBindingModal = observer(function EditSchedulerBindingM
         rrule: values.rrule.trim(),
         extra_context: values.extra_context.trim(),
         enabled: values.enabled,
+        outcome_mode: values.outcome_mode,
         pod: values.pod || null,
       });
       setToast({
@@ -128,6 +140,8 @@ export const EditSchedulerBindingModal = observer(function EditSchedulerBindingM
           watchDtstart={watchedDtstart}
           watchRrule={watchedRrule}
         />
+
+        <BindingOutcomeModeField control={control} name="outcome_mode" />
 
         <BindingPodField control={control} name="pod" projectId={projectId} />
 

--- a/apps/web/core/components/project/scheduler-bindings/install-binding-modal.tsx
+++ b/apps/web/core/components/project/scheduler-bindings/install-binding-modal.tsx
@@ -11,9 +11,10 @@ import { Controller, useForm, useWatch } from "react-hook-form";
 import { useTranslation } from "@pi-dash/i18n";
 import { Button } from "@pi-dash/propel/button";
 import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
-import type { IScheduler, ISchedulerBinding } from "@pi-dash/services";
+import type { IScheduler, ISchedulerBinding, SchedulerOutcomeMode } from "@pi-dash/services";
 import { SchedulerService } from "@pi-dash/services";
 import { EModalPosition, EModalWidth, ModalCore } from "@pi-dash/ui";
+import { BindingOutcomeModeField, DEFAULT_OUTCOME_MODE } from "./binding-outcome-mode-field";
 import { BindingPodField } from "./binding-pod-field";
 import { BindingScheduleFields } from "./binding-schedule-fields";
 import { DEFAULT_TZID } from "./constants";
@@ -26,6 +27,7 @@ interface InstallFormValues {
   rrule: string;
   extra_context: string;
   enabled: boolean;
+  outcome_mode: SchedulerOutcomeMode;
   /** Pod id, or "" for the project default. */
   pod: string;
 }
@@ -47,6 +49,7 @@ const DEFAULT_VALUES = (): InstallFormValues => ({
   rrule: "FREQ=DAILY",
   extra_context: "",
   enabled: true,
+  outcome_mode: DEFAULT_OUTCOME_MODE,
   pod: "",
 });
 
@@ -95,6 +98,7 @@ export const InstallSchedulerBindingModal = observer(function InstallSchedulerBi
         rrule: values.rrule.trim(),
         extra_context: values.extra_context.trim(),
         enabled: values.enabled,
+        outcome_mode: values.outcome_mode,
         pod: values.pod || null,
       });
       setToast({
@@ -193,6 +197,8 @@ export const InstallSchedulerBindingModal = observer(function InstallSchedulerBi
           watchDtstart={watchedDtstart}
           watchRrule={watchedRrule}
         />
+
+        <BindingOutcomeModeField control={control} name="outcome_mode" />
 
         <BindingPodField control={control} name="pod" projectId={projectId} />
 

--- a/apps/web/core/components/schedulers/scheduler-form-modal.tsx
+++ b/apps/web/core/components/schedulers/scheduler-form-modal.tsx
@@ -78,9 +78,7 @@ export const SchedulerFormModal = observer(function SchedulerFormModal(props: Pr
   return (
     <ModalCore isOpen={isOpen} handleClose={onClose} position={EModalPosition.CENTER} width={EModalWidth.XXL}>
       <form onSubmit={handleSubmit(handleFormSubmit)} className="flex flex-col gap-5 p-5">
-        <div className="text-18 font-medium text-primary">
-          {isEdit ? t("Edit scheduler") : t("New scheduler")}
-        </div>
+        <div className="text-18 font-medium text-primary">{isEdit ? t("Edit scheduler") : t("New scheduler")}</div>
 
         <div className="flex flex-col gap-1">
           <label htmlFor="scheduler-slug" className="text-13 font-medium text-primary">
@@ -111,7 +109,9 @@ export const SchedulerFormModal = observer(function SchedulerFormModal(props: Pr
               />
             )}
           />
-          <p className="text-12 text-secondary">{t("Lowercase identifier used in URLs. Cannot be changed after creation.")}</p>
+          <p className="text-12 text-secondary">
+            {t("Lowercase identifier used in URLs. Cannot be changed after creation.")}
+          </p>
           {errors.slug?.message && <p className="text-12 text-danger-primary">{errors.slug.message}</p>}
         </div>
 
@@ -182,7 +182,11 @@ export const SchedulerFormModal = observer(function SchedulerFormModal(props: Pr
               />
             )}
           />
-          <p className="text-12 text-secondary">{t("The base prompt the agent runs each tick. Per-project context is appended at install time, so keep this prompt project-agnostic.")}</p>
+          <p className="text-12 text-secondary">
+            {t(
+              "The base prompt the agent runs each tick. Per-project context is appended at install time, so keep this prompt project-agnostic."
+            )}
+          </p>
           {errors.prompt?.message && <p className="text-12 text-danger-primary">{errors.prompt.message}</p>}
         </div>
 
@@ -210,13 +214,17 @@ export const SchedulerFormModal = observer(function SchedulerFormModal(props: Pr
               </div>
             )}
           />
-          <p className="text-12 text-secondary">{t("Used to color this scheduler's blocks on the project calendar.")}</p>
+          <p className="text-12 text-secondary">
+            {t("Used to color this scheduler's blocks on the project calendar.")}
+          </p>
         </div>
 
         <div className="flex items-start justify-between gap-4">
           <div className="flex flex-col">
             <span className="text-13 font-medium text-primary">{t("Enabled")}</span>
-            <span className="text-12 text-secondary">{t("Disabled schedulers cannot be installed on new projects, and existing bindings will not fire.")}</span>
+            <span className="text-12 text-secondary">
+              {t("Disabled schedulers cannot be installed on new projects, and existing bindings will not fire.")}
+            </span>
           </div>
           <Controller
             control={control}
@@ -230,13 +238,7 @@ export const SchedulerFormModal = observer(function SchedulerFormModal(props: Pr
             {t("Cancel")}
           </Button>
           <Button variant="primary" type="submit" loading={isSubmitting} disabled={isSubmitting}>
-            {isEdit
-              ? isSubmitting
-                ? t("Saving…")
-                : t("Save")
-              : isSubmitting
-                ? t("Creating…")
-                : t("Create scheduler")}
+            {isEdit ? (isSubmitting ? t("Saving…") : t("Save")) : isSubmitting ? t("Creating…") : t("Create scheduler")}
           </Button>
         </div>
       </form>

--- a/packages/services/src/scheduler/scheduler.service.ts
+++ b/packages/services/src/scheduler/scheduler.service.ts
@@ -24,6 +24,16 @@ import { APIService } from "../api.service";
 
 export type SchedulerSource = "builtin" | "manifest";
 
+/**
+ * What a scheduler run does with its findings. The scheduler layer never
+ * creates issues or edits code itself; this steers the dispatched agent run.
+ * - `create_issue`   — file a Pi Dash issue per finding (default).
+ * - `apply_fix`      — implement the fix and open a PR for review (no merge).
+ * - `fix_and_review` — file an issue, fix it, open a PR, and move the issue
+ *                      straight to In Review for a human.
+ */
+export type SchedulerOutcomeMode = "create_issue" | "apply_fix" | "fix_and_review";
+
 export interface IScheduler {
   id: string;
   workspace: string;
@@ -74,6 +84,8 @@ export interface ISchedulerBinding {
   exdates: string[];
   extra_context: string;
   enabled: boolean;
+  /** What a run of this install does with its findings. Per-project; steers the dispatched prompt. */
+  outcome_mode: SchedulerOutcomeMode;
   /** Pod override for runs fired by this binding. Null = use the project's default pod (resolved at fire time). */
   pod: string | null;
   /** Joined name of the override pod, or null when using the project default. Read-only. */
@@ -105,12 +117,17 @@ export interface ISchedulerBindingCreatePayload {
   exdates?: string[];
   extra_context?: string;
   enabled?: boolean;
+  /** What to do with findings; omit to default to create_issue. */
+  outcome_mode?: SchedulerOutcomeMode;
   /** Optional pod override; omit or null to use the project's default pod. */
   pod?: string | null;
 }
 
 export type ISchedulerBindingUpdatePayload = Partial<
-  Pick<ISchedulerBinding, "dtstart" | "tzid" | "rrule" | "rdates" | "exdates" | "extra_context" | "enabled" | "pod">
+  Pick<
+    ISchedulerBinding,
+    "dtstart" | "tzid" | "rrule" | "rdates" | "exdates" | "extra_context" | "enabled" | "outcome_mode" | "pod"
+  >
 >;
 
 export class SchedulerService extends APIService {


### PR DESCRIPTION
…h findings

Schedulers can now declare what a run should do with whatever it finds: report only, create Pi Dash issues, or implement a fix and open a PR for review. The scheduler layer still never creates issues or edits code itself — outcome_mode appends a work-mode directive to the dispatched agent prompt, and the agent acts via the same pidash CLI / git tools a user-driven run uses.

Backend:
- Scheduler.outcome_mode (TextChoices: report_only | create_issue | apply_fix), default create_issue to preserve existing builtin behavior.
- OUTCOME_MODE_DIRECTIVES + outcome_mode_directive() as the single source of the per-mode prompt text; falls back to create_issue for unknown values so a run never dispatches without work-mode guidance.
- fire_scheduler_binding appends the directive after the task prompt and optional per-install extra_context.
- Serializer exposes outcome_mode (writable).
- Migration 0142 (additive, no backfill).

Web:
- SchedulerOutcomeMode union on IScheduler + create/update payloads.
- 3-way selector with per-mode help in the scheduler form, threaded through create/update.

Note: the scheduler prompt path still bypasses the prompt composer; a follow-up unifies issue + scheduler runs under one composer and moves the directive into a "scheduler" template. See OutcomeMode docstring.

### Description
<!-- Provide a detailed description of the changes in this PR -->

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->