### PR TITLE
feat(scheduler): per-binding pod selection

### DIFF
--- a/apps/api/pi_dash/app/serializers/scheduler.py
+++ b/apps/api/pi_dash/app/serializers/scheduler.py
@@ -21,6 +21,7 @@ from rest_framework import serializers
 from pi_dash.app.serializers.base import BaseSerializer
 from pi_dash.bgtasks._rrule import RRuleValidationError, validate_rrule_string
 from pi_dash.db.models.scheduler import Scheduler, SchedulerBinding
+from pi_dash.runner.models import Pod
 
 
 EXTRA_CONTEXT_MAX_LENGTH = 16 * 1024
@@ -116,6 +117,17 @@ class SchedulerBindingSerializer(BaseSerializer):
     scheduler_color = serializers.CharField(source="scheduler.color", read_only=True)
     last_run_status = serializers.SerializerMethodField()
     last_run_ended_at = serializers.SerializerMethodField()
+    # Optional pod override. Scoped to active pods; the cross-project check
+    # lives in `validate()` (the project is known there via instance/context).
+    # NULL = use the project's default pod at fire time.
+    pod = serializers.PrimaryKeyRelatedField(
+        queryset=Pod.objects.filter(deleted_at__isnull=True),
+        required=False,
+        allow_null=True,
+    )
+    # Joined pod name so the calendar / list can render the chosen pod without
+    # a second fetch. Null when the binding uses the project default.
+    pod_name = serializers.CharField(source="pod.name", read_only=True, default=None)
 
     class Meta:
         model = SchedulerBinding
@@ -134,6 +146,8 @@ class SchedulerBindingSerializer(BaseSerializer):
             "exdates",
             "extra_context",
             "enabled",
+            "pod",
+            "pod_name",
             "next_run_at",
             "last_run",
             "last_run_status",
@@ -146,6 +160,7 @@ class SchedulerBindingSerializer(BaseSerializer):
         read_only_fields = [
             "id",
             "workspace",
+            "pod_name",
             "next_run_at",
             "last_run",
             "last_run_status",
@@ -231,4 +246,20 @@ class SchedulerBindingSerializer(BaseSerializer):
                 validate_rrule_string(rrule_str, dtstart=dtstart)
             except RRuleValidationError as e:
                 raise serializers.ValidationError({"rrule": str(e)})
+        # A chosen pod must belong to the binding's project. Resolve the
+        # project from the incoming data (create sends `project`), the existing
+        # instance (update), or the view-supplied context (belt-and-suspenders
+        # for the create path, where the view also injects project at save()).
+        pod = attrs.get("pod")
+        if pod is not None:
+            incoming_project = attrs.get("project")
+            project_id = (
+                getattr(incoming_project, "id", None)
+                or (self.instance.project_id if self.instance is not None else None)
+                or getattr(self.context.get("project"), "id", None)
+            )
+            if project_id is not None and pod.project_id != project_id:
+                raise serializers.ValidationError(
+                    {"pod": "pod must belong to the same project as this scheduler install"}
+                )
         return super().validate(attrs)

--- a/apps/api/pi_dash/app/serializers/scheduler.py
+++ b/apps/api/pi_dash/app/serializers/scheduler.py
@@ -247,16 +247,18 @@ class SchedulerBindingSerializer(BaseSerializer):
             except RRuleValidationError as e:
                 raise serializers.ValidationError({"rrule": str(e)})
         # A chosen pod must belong to the binding's project. Resolve the
-        # project from the incoming data (create sends `project`), the existing
-        # instance (update), or the view-supplied context (belt-and-suspenders
-        # for the create path, where the view also injects project at save()).
+        # project from the *authoritative* source first: the existing instance
+        # (update) or the view-supplied context (create — the view injects this
+        # project at save()). Only fall back to the client-sent `project` when
+        # neither is available. Trusting the request body here would let a
+        # crafted payload pass a foreign-project pod (claim project=B, send a
+        # B-pod) while save() still pins the binding to the URL's project.
         pod = attrs.get("pod")
         if pod is not None:
-            incoming_project = attrs.get("project")
             project_id = (
-                getattr(incoming_project, "id", None)
-                or (self.instance.project_id if self.instance is not None else None)
+                (self.instance.project_id if self.instance is not None else None)
                 or getattr(self.context.get("project"), "id", None)
+                or getattr(attrs.get("project"), "id", None)
             )
             if project_id is not None and pod.project_id != project_id:
                 raise serializers.ValidationError(

--- a/apps/api/pi_dash/app/views/scheduler/views.py
+++ b/apps/api/pi_dash/app/views/scheduler/views.py
@@ -177,7 +177,7 @@ class ProjectSchedulerBindingListEndpoint(BaseAPIView):
                 project_id=project_id,
                 workspace__slug=slug,
             )
-            .select_related("scheduler", "last_run")
+            .select_related("scheduler", "last_run", "pod")
             .order_by("-created_at")
         )
         return Response(

--- a/apps/api/pi_dash/app/views/scheduler/views.py
+++ b/apps/api/pi_dash/app/views/scheduler/views.py
@@ -197,7 +197,12 @@ class ProjectSchedulerBindingListEndpoint(BaseAPIView):
             workspace=project.workspace,
             is_enabled=True,
         )
-        serializer = SchedulerBindingSerializer(data=request.data)
+        # Pass `project` in context so the serializer can validate that a
+        # chosen `pod` belongs to this project (project is injected at save(),
+        # so it isn't in validated_data at validation time).
+        serializer = SchedulerBindingSerializer(
+            data=request.data, context={"project": project}
+        )
         serializer.is_valid(raise_exception=True)
         binding = serializer.save(
             scheduler=scheduler,

--- a/apps/api/pi_dash/db/migrations/0145_schedulerbinding_pod.py
+++ b/apps/api/pi_dash/db/migrations/0145_schedulerbinding_pod.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Add ``SchedulerBinding.pod`` — optional per-binding pod override.
+
+NULL keeps the existing behavior (the dispatcher resolves the project's
+default pod at fire time). When set, runs fired by the binding target the
+chosen pod instead. SET_NULL so a hard pod delete degrades to the project
+default rather than orphaning the binding.
+"""
+
+from __future__ import annotations
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("db", "0144_issuecomment_speaker_metadata"),
+        ("runner", "0015_dev_machine_visibility"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="schedulerbinding",
+            name="pod",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="scheduler_bindings",
+                to="runner.pod",
+            ),
+        ),
+    ]

--- a/apps/api/pi_dash/db/models/scheduler.py
+++ b/apps/api/pi_dash/db/models/scheduler.py
@@ -125,6 +125,21 @@ class SchedulerBinding(WorkspaceBaseModel):
         related_name="scheduler_bindings_authored",
     )
 
+    # Optional pod override for runs fired by this binding. NULL means "use
+    # the project's default pod" (resolved at fire time). The pod is *late
+    # bound* — the dispatcher reads this on each fire rather than pinning a
+    # run, so changing it takes effect on the next tick. SET_NULL so a hard
+    # pod delete degrades to the project default rather than orphaning the
+    # binding; the dispatcher additionally falls back when the pod is
+    # soft-deleted or no longer in this project.
+    pod = models.ForeignKey(
+        "runner.Pod",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="scheduler_bindings",
+    )
+
     class Meta:
         db_table = "scheduler_bindings"
         verbose_name = "Scheduler Binding"

--- a/apps/api/pi_dash/orchestration/service.py
+++ b/apps/api/pi_dash/orchestration/service.py
@@ -536,7 +536,20 @@ def dispatch_scheduler_run(
     """
     from pi_dash.runner.services import matcher
 
-    pod = Pod.default_for_project_id(binding.project_id)
+    # Pod resolution (late bound): prefer the binding's explicit pod override,
+    # but only when it is still active and belongs to this project — a pod can
+    # be soft-deleted (deleted_at set, FK intact) or, defensively, drift out of
+    # the project. In any of those cases fall back to the project default so a
+    # stale override never silently dispatches into the wrong/dead pod.
+    pod = None
+    if binding.pod_id is not None:
+        pod = Pod.objects.filter(
+            pk=binding.pod_id,
+            deleted_at__isnull=True,
+            project_id=binding.project_id,
+        ).first()
+    if pod is None:
+        pod = Pod.default_for_project_id(binding.project_id)
     if pod is None:
         logger.warning(
             "scheduler.dispatch: skip binding=%s reason=no-default-pod project=%s",

--- a/apps/api/pi_dash/tests/unit/bg_tasks/test_scheduler_task.py
+++ b/apps/api/pi_dash/tests/unit/bg_tasks/test_scheduler_task.py
@@ -189,6 +189,52 @@ def test_fire_resolves_prompt_with_extra_context(scheduler, binding):
     assert "Focus on authn paths." in run.prompt
 
 
+# ---------------------------------------------------------------------------
+# fire_scheduler_binding — pod resolution (binding.pod override)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_fire_uses_default_pod_when_binding_pod_unset(binding, project):
+    """No override → run lands on the project's default pod (prior behavior)."""
+    default_pod = Pod.default_for_project(project)
+    fire_scheduler_binding(str(binding.pk))
+    binding.refresh_from_db()
+    assert binding.last_run.pod_id == default_pod.id
+
+
+@pytest.mark.unit
+def test_fire_uses_binding_pod_override(binding, project, create_user):
+    """An explicit, active, same-project pod override is honored."""
+    with impersonate(create_user):
+        custom = Pod.objects.create(
+            project=project, name=f"{project.identifier}_custom", created_by=create_user
+        )
+    binding.pod = custom
+    binding.save(update_fields=["pod"])
+    fire_scheduler_binding(str(binding.pk))
+    binding.refresh_from_db()
+    assert binding.last_run.pod_id == custom.id
+
+
+@pytest.mark.unit
+def test_fire_falls_back_to_default_when_override_pod_soft_deleted(binding, project, create_user):
+    """A soft-deleted override pod degrades to the project default rather
+    than dispatching into a dead pod."""
+    default_pod = Pod.default_for_project(project)
+    with impersonate(create_user):
+        custom = Pod.objects.create(
+            project=project, name=f"{project.identifier}_dead", created_by=create_user
+        )
+    binding.pod = custom
+    binding.save(update_fields=["pod"])
+    custom.deleted_at = timezone.now()
+    custom.save(update_fields=["deleted_at"])
+    fire_scheduler_binding(str(binding.pk))
+    binding.refresh_from_db()
+    assert binding.last_run.pod_id == default_pod.id
+
+
 @pytest.mark.unit
 def test_fire_phase3a_save_advances_updated_at(binding):
     """Codex review #6: Phase 3a must use save() so auto_now fires."""

--- a/apps/api/pi_dash/tests/unit/serializers/test_scheduler.py
+++ b/apps/api/pi_dash/tests/unit/serializers/test_scheduler.py
@@ -384,3 +384,32 @@ def test_patch_pod_from_other_project_rejected(binding, other_project, create_us
     s = SchedulerBindingSerializer(binding, data={"pod": foreign_pod.id}, partial=True)
     assert not s.is_valid()
     assert "pod" in s.errors
+
+
+@pytest.mark.unit
+def test_create_pod_validated_against_context_project_not_request_body(
+    scheduler, project, other_project, create_user
+):
+    """A client must not bypass the cross-project pod check by claiming a
+    different `project` in the body. The view pins the binding to the URL's
+    project via context/save(), so validation must trust that — not the
+    request-supplied project."""
+    with impersonate(create_user):
+        foreign_pod = Pod.objects.create(
+            project=other_project, name="API_z", created_by=create_user
+        )
+    s = SchedulerBindingSerializer(
+        data={
+            "scheduler": scheduler.id,
+            # Body lies: claims the pod's (other) project to slip the check.
+            "project": other_project.id,
+            "dtstart": _ANCHOR.isoformat(),
+            "rrule": "FREQ=DAILY",
+            "tzid": "UTC",
+            "pod": foreign_pod.id,
+        },
+        # View injects the authoritative project here; it must win.
+        context={"project": project},
+    )
+    assert not s.is_valid()
+    assert "pod" in s.errors

--- a/apps/api/pi_dash/tests/unit/serializers/test_scheduler.py
+++ b/apps/api/pi_dash/tests/unit/serializers/test_scheduler.py
@@ -21,6 +21,7 @@ from pi_dash.app.serializers.scheduler import (
     SchedulerSerializer,
 )
 from pi_dash.db.models import Project, Scheduler, SchedulerBinding
+from pi_dash.runner.models import Pod
 
 
 # Fixture-shared anchor — Mon 2026-01-05 09:00 UTC.
@@ -288,3 +289,98 @@ def test_active_binding_count_excludes_soft_deleted_bindings(scheduler, binding)
     fresh = Scheduler.objects.get(pk=scheduler.pk)
     data = SchedulerSerializer(fresh).data
     assert data["active_binding_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Pod override validation (SchedulerBinding.pod)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def project_pod(project, create_user):
+    with impersonate(create_user):
+        return Pod.objects.create(
+            project=project, name=f"{project.identifier}_extra", created_by=create_user
+        )
+
+
+@pytest.fixture
+def other_project(workspace, create_user):
+    with impersonate(create_user):
+        return Project.objects.create(
+            name="Api", identifier="API", workspace=workspace, created_by=create_user
+        )
+
+
+@pytest.mark.unit
+def test_pod_in_same_project_accepted(scheduler, project, project_pod):
+    s = SchedulerBindingSerializer(
+        data={
+            "scheduler": scheduler.id,
+            "project": project.id,
+            "dtstart": _ANCHOR.isoformat(),
+            "rrule": "FREQ=DAILY",
+            "tzid": "UTC",
+            "pod": project_pod.id,
+        }
+    )
+    assert s.is_valid(), s.errors
+    assert s.validated_data["pod"] == project_pod
+
+
+@pytest.mark.unit
+def test_pod_in_other_project_rejected(scheduler, project, other_project, create_user):
+    with impersonate(create_user):
+        foreign_pod = Pod.objects.create(
+            project=other_project, name="API_x", created_by=create_user
+        )
+    s = SchedulerBindingSerializer(
+        data={
+            "scheduler": scheduler.id,
+            "project": project.id,
+            "dtstart": _ANCHOR.isoformat(),
+            "rrule": "FREQ=DAILY",
+            "tzid": "UTC",
+            "pod": foreign_pod.id,
+        }
+    )
+    assert not s.is_valid()
+    assert "pod" in s.errors
+
+
+@pytest.mark.unit
+def test_soft_deleted_pod_rejected(scheduler, project, project_pod):
+    project_pod.deleted_at = _ANCHOR
+    project_pod.save(update_fields=["deleted_at"])
+    s = SchedulerBindingSerializer(
+        data={
+            "scheduler": scheduler.id,
+            "project": project.id,
+            "dtstart": _ANCHOR.isoformat(),
+            "rrule": "FREQ=DAILY",
+            "tzid": "UTC",
+            "pod": project_pod.id,
+        }
+    )
+    # Excluded from the field queryset → resolves as a non-existent PK.
+    assert not s.is_valid()
+    assert "pod" in s.errors
+
+
+@pytest.mark.unit
+def test_patch_can_change_pod(binding, project_pod):
+    s = SchedulerBindingSerializer(binding, data={"pod": project_pod.id}, partial=True)
+    assert s.is_valid(), s.errors
+    updated = s.save()
+    assert updated.pod_id == project_pod.id
+
+
+@pytest.mark.unit
+def test_patch_pod_from_other_project_rejected(binding, other_project, create_user):
+    with impersonate(create_user):
+        foreign_pod = Pod.objects.create(
+            project=other_project, name="API_y", created_by=create_user
+        )
+    s = SchedulerBindingSerializer(binding, data={"pod": foreign_pod.id}, partial=True)
+    assert not s.is_valid()
+    assert "pod" in s.errors

--- a/apps/web/core/components/project/scheduler-bindings/binding-pod-field.tsx
+++ b/apps/web/core/components/project/scheduler-bindings/binding-pod-field.tsx
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { Controller } from "react-hook-form";
+import type { Control, FieldValues, Path } from "react-hook-form";
+import useSWR from "swr";
+import { useTranslation } from "@pi-dash/i18n";
+import { PodService } from "@pi-dash/services";
+import type { IPod } from "@pi-dash/types";
+
+const podService = new PodService();
+
+type Props<T extends FieldValues> = {
+  control: Control<T>;
+  /** RHF field holding the pod id, or "" for "use project default". */
+  name: Path<T>;
+  projectId: string | undefined;
+};
+
+/**
+ * Pod override selector for the install/edit binding modals. The empty value
+ * means "use the project's default pod" — the backend late-binds the actual
+ * pod at fire time, so leaving this unset keeps the prior behavior. Generic
+ * over the form values type so both modals can reuse it.
+ */
+export function BindingPodField<T extends FieldValues>({ control, name, projectId }: Props<T>) {
+  const { t } = useTranslation();
+  // Pods are project-scoped; key the cache by project.
+  const { data: pods, isLoading } = useSWR<IPod[]>(
+    projectId ? ["scheduler-binding-pods", projectId] : null,
+    projectId ? () => podService.list(undefined, projectId) : null
+  );
+
+  return (
+    <div className="flex flex-col gap-1">
+      <label htmlFor="binding-pod" className="text-13 font-medium text-primary">
+        {t("Pod")}
+      </label>
+      <Controller
+        control={control}
+        name={name}
+        render={({ field }) => (
+          <select
+            {...field}
+            id="binding-pod"
+            disabled={isLoading}
+            className="rounded-md border border-subtle bg-surface-1 px-3 py-2 text-13 text-primary focus:ring-1 focus:ring-accent-strong focus:outline-none"
+          >
+            <option value="">{t("Project default pod")}</option>
+            {(pods ?? []).map((pod) => (
+              <option key={pod.id} value={pod.id}>
+                {pod.name}
+                {pod.is_default ? ` (${t("default")})` : ""}
+              </option>
+            ))}
+          </select>
+        )}
+      />
+      <p className="text-12 text-secondary">
+        {t(
+          "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet."
+        )}
+      </p>
+    </div>
+  );
+}

--- a/apps/web/core/components/project/scheduler-bindings/binding-pod-field.tsx
+++ b/apps/web/core/components/project/scheduler-bindings/binding-pod-field.tsx
@@ -4,7 +4,8 @@
  * See the LICENSE file for details.
  */
 
-import { Controller } from "react-hook-form";
+import { useEffect } from "react";
+import { useController } from "react-hook-form";
 import type { Control, FieldValues, Path } from "react-hook-form";
 import useSWR from "swr";
 import { useTranslation } from "@pi-dash/i18n";
@@ -34,31 +35,38 @@ export function BindingPodField<T extends FieldValues>({ control, name, projectI
     projectId ? () => podService.list(undefined, projectId) : null
   );
 
+  // If the selected pod is no longer among the project's active pods (e.g. it
+  // was deleted after this binding was created), the <select> silently renders
+  // the "Project default pod" option while the form still holds the stale id —
+  // a no-op save would then 400. Normalize to the default, which also matches
+  // what the dispatcher does at fire time (it falls back for dead pods).
+  const { field } = useController({ control, name });
+  const currentPodId = field.value as string;
+  const { onChange } = field;
+  useEffect(() => {
+    if (!pods || !currentPodId) return;
+    if (!pods.some((pod) => pod.id === currentPodId)) onChange("");
+  }, [pods, currentPodId, onChange]);
+
   return (
     <div className="flex flex-col gap-1">
       <label htmlFor="binding-pod" className="text-13 font-medium text-primary">
         {t("Pod")}
       </label>
-      <Controller
-        control={control}
-        name={name}
-        render={({ field }) => (
-          <select
-            {...field}
-            id="binding-pod"
-            disabled={isLoading}
-            className="rounded-md border border-subtle bg-surface-1 px-3 py-2 text-13 text-primary focus:ring-1 focus:ring-accent-strong focus:outline-none"
-          >
-            <option value="">{t("Project default pod")}</option>
-            {(pods ?? []).map((pod) => (
-              <option key={pod.id} value={pod.id}>
-                {pod.name}
-                {pod.is_default ? ` (${t("default")})` : ""}
-              </option>
-            ))}
-          </select>
-        )}
-      />
+      <select
+        {...field}
+        id="binding-pod"
+        disabled={isLoading}
+        className="rounded-md border border-subtle bg-surface-1 px-3 py-2 text-13 text-primary focus:ring-1 focus:ring-accent-strong focus:outline-none"
+      >
+        <option value="">{t("Project default pod")}</option>
+        {(pods ?? []).map((pod) => (
+          <option key={pod.id} value={pod.id}>
+            {pod.name}
+            {pod.is_default ? ` (${t("default")})` : ""}
+          </option>
+        ))}
+      </select>
       <p className="text-12 text-secondary">
         {t(
           "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet."

--- a/apps/web/core/components/project/scheduler-bindings/edit-binding-modal.tsx
+++ b/apps/web/core/components/project/scheduler-bindings/edit-binding-modal.tsx
@@ -14,6 +14,7 @@ import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
 import type { ISchedulerBinding } from "@pi-dash/services";
 import { SchedulerService } from "@pi-dash/services";
 import { EModalPosition, EModalWidth, ModalCore } from "@pi-dash/ui";
+import { BindingPodField } from "./binding-pod-field";
 import { BindingScheduleFields } from "./binding-schedule-fields";
 import { DEFAULT_TZID } from "./constants";
 import { isoUTCToLocalInput, localToIsoUTC } from "./datetime-input";
@@ -24,6 +25,8 @@ interface EditFormValues {
   rrule: string;
   extra_context: string;
   enabled: boolean;
+  /** Pod id, or "" for the project default. */
+  pod: string;
 }
 
 type Props = {
@@ -47,7 +50,7 @@ export const EditSchedulerBindingModal = observer(function EditSchedulerBindingM
     reset,
     formState: { errors, isSubmitting },
   } = useForm<EditFormValues>({
-    defaultValues: { dtstart: "", tzid: DEFAULT_TZID, rrule: "", extra_context: "", enabled: true },
+    defaultValues: { dtstart: "", tzid: DEFAULT_TZID, rrule: "", extra_context: "", enabled: true, pod: "" },
   });
 
   useEffect(() => {
@@ -58,6 +61,7 @@ export const EditSchedulerBindingModal = observer(function EditSchedulerBindingM
       rrule: binding.rrule || "",
       extra_context: binding.extra_context ?? "",
       enabled: binding.enabled,
+      pod: binding.pod ?? "",
     });
   }, [isOpen, binding, reset]);
 
@@ -73,6 +77,7 @@ export const EditSchedulerBindingModal = observer(function EditSchedulerBindingM
         rrule: values.rrule.trim(),
         extra_context: values.extra_context.trim(),
         enabled: values.enabled,
+        pod: values.pod || null,
       });
       setToast({
         type: TOAST_TYPE.SUCCESS,
@@ -82,12 +87,19 @@ export const EditSchedulerBindingModal = observer(function EditSchedulerBindingM
       onUpdated(updated);
       onClose();
     } catch (e: unknown) {
-      const err = e as { error?: string; rrule?: string[]; dtstart?: string[]; tzid?: string[] } | null;
+      const err = e as {
+        error?: string;
+        rrule?: string[];
+        dtstart?: string[];
+        tzid?: string[];
+        pod?: string[];
+      } | null;
       const detail =
         err?.error ??
         err?.rrule?.[0] ??
         err?.dtstart?.[0] ??
         err?.tzid?.[0] ??
+        err?.pod?.[0] ??
         t("Could not update the install.");
       setToast({
         type: TOAST_TYPE.ERROR,
@@ -116,6 +128,8 @@ export const EditSchedulerBindingModal = observer(function EditSchedulerBindingM
           watchDtstart={watchedDtstart}
           watchRrule={watchedRrule}
         />
+
+        <BindingPodField control={control} name="pod" projectId={projectId} />
 
         <div className="flex justify-end gap-2">
           <Button variant="secondary" onClick={onClose} disabled={isSubmitting}>

--- a/apps/web/core/components/project/scheduler-bindings/install-binding-modal.tsx
+++ b/apps/web/core/components/project/scheduler-bindings/install-binding-modal.tsx
@@ -14,6 +14,7 @@ import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
 import type { IScheduler, ISchedulerBinding } from "@pi-dash/services";
 import { SchedulerService } from "@pi-dash/services";
 import { EModalPosition, EModalWidth, ModalCore } from "@pi-dash/ui";
+import { BindingPodField } from "./binding-pod-field";
 import { BindingScheduleFields } from "./binding-schedule-fields";
 import { DEFAULT_TZID } from "./constants";
 import { defaultDtstartLocal, localToIsoUTC } from "./datetime-input";
@@ -25,6 +26,8 @@ interface InstallFormValues {
   rrule: string;
   extra_context: string;
   enabled: boolean;
+  /** Pod id, or "" for the project default. */
+  pod: string;
 }
 
 type Props = {
@@ -44,6 +47,7 @@ const DEFAULT_VALUES = (): InstallFormValues => ({
   rrule: "FREQ=DAILY",
   extra_context: "",
   enabled: true,
+  pod: "",
 });
 
 const schedulerService = new SchedulerService();
@@ -91,6 +95,7 @@ export const InstallSchedulerBindingModal = observer(function InstallSchedulerBi
         rrule: values.rrule.trim(),
         extra_context: values.extra_context.trim(),
         enabled: values.enabled,
+        pod: values.pod || null,
       });
       setToast({
         type: TOAST_TYPE.SUCCESS,
@@ -106,6 +111,7 @@ export const InstallSchedulerBindingModal = observer(function InstallSchedulerBi
         dtstart?: string[];
         tzid?: string[];
         scheduler?: string[];
+        pod?: string[];
       } | null;
       const detail =
         err?.error ??
@@ -113,6 +119,7 @@ export const InstallSchedulerBindingModal = observer(function InstallSchedulerBi
         err?.dtstart?.[0] ??
         err?.tzid?.[0] ??
         err?.scheduler?.[0] ??
+        err?.pod?.[0] ??
         t("Could not install the scheduler.");
       setToast({
         type: TOAST_TYPE.ERROR,
@@ -186,6 +193,8 @@ export const InstallSchedulerBindingModal = observer(function InstallSchedulerBi
           watchDtstart={watchedDtstart}
           watchRrule={watchedRrule}
         />
+
+        <BindingPodField control={control} name="pod" projectId={projectId} />
 
         <div className="flex justify-end gap-2">
           <Button variant="secondary" onClick={onClose} disabled={isSubmitting}>

--- a/packages/i18n/src/locales/cs/translations.ts
+++ b/packages/i18n/src/locales/cs/translations.ts
@@ -1192,6 +1192,7 @@ export default {
   "Project context (optional)": "Kontext projektu (volitelný)",
   "Project cover image": "Titulní obrázek projektu",
   "Project created successfully": "Projekt byl úspěšně vytvořen",
+  "Project default pod": "Project default pod",
   "Project ID": "ID projektu",
   "Project ID is required": "ID projektu je povinné",
   "Project ID must at least be of 1 character": "ID projektu musí mít alespoň 1 znak",
@@ -1689,6 +1690,8 @@ export default {
   "Which AI agent CLI this runner will drive. Baked into the displayed ``pidash runner add`` command.":
     "Který CLI agenta AI bude tento runner řídit. Zakomponováno do zobrazeného příkazu ``pidash runner add``.",
   "Which events would you like to trigger this webhook?": "Které události chcete použít k aktivaci tohoto webhooku?",
+  "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.":
+    "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.",
   "Widget reordered successfully.": "Widget byl úspěšně přeuspořádán.",
   "Windows (MSI)": "Windows (MSI)",
   "Windows (PowerShell)": "Windows (PowerShell)",

--- a/packages/i18n/src/locales/de/translations.ts
+++ b/packages/i18n/src/locales/de/translations.ts
@@ -1208,6 +1208,7 @@ export default {
   "Project context (optional)": "Projektkontext (optional)",
   "Project cover image": "Projekt-Titelbild",
   "Project created successfully": "Projekt erfolgreich erstellt",
+  "Project default pod": "Project default pod",
   "Project ID": "Projekt-ID",
   "Project ID is required": "Projekt-ID ist erforderlich",
   "Project ID must at least be of 1 character": "Projekt-ID muss mindestens 1 Zeichen lang sein",
@@ -1713,6 +1714,8 @@ export default {
   "Which AI agent CLI this runner will drive. Baked into the displayed ``pidash runner add`` command.":
     "Welchen KI-Agenten-CLI dieser Runner antreiben wird. In den angezeigten Befehl ``pidash runner add`` eingebettet.",
   "Which events would you like to trigger this webhook?": "Welche Ereignisse sollen diesen Webhook auslösen?",
+  "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.":
+    "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.",
   "Widget reordered successfully.": "Widget erfolgreich neu angeordnet.",
   "Windows (MSI)": "Windows (MSI)",
   "Windows (PowerShell)": "Windows (PowerShell)",

--- a/packages/i18n/src/locales/en/translations.ts
+++ b/packages/i18n/src/locales/en/translations.ts
@@ -1178,6 +1178,7 @@ export default {
   "Project context (optional)": "Project context (optional)",
   "Project cover image": "Project cover image",
   "Project created successfully": "Project created successfully",
+  "Project default pod": "Project default pod",
   "Project ID": "Project ID",
   "Project ID is required": "Project ID is required",
   "Project ID must at least be of 1 character": "Project ID must at least be of 1 character",
@@ -1667,6 +1668,8 @@ export default {
   "Which AI agent CLI this runner will drive. Baked into the displayed ``pidash runner add`` command.":
     "Which AI agent CLI this runner will drive. Baked into the displayed ``pidash runner add`` command.",
   "Which events would you like to trigger this webhook?": "Which events would you like to trigger this webhook?",
+  "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.":
+    "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.",
   "Widget reordered successfully.": "Widget reordered successfully.",
   "Windows (MSI)": "Windows (MSI)",
   "Windows (PowerShell)": "Windows (PowerShell)",

--- a/packages/i18n/src/locales/es/translations.ts
+++ b/packages/i18n/src/locales/es/translations.ts
@@ -1204,6 +1204,7 @@ export default {
   "Project context (optional)": "Contexto del proyecto (opcional)",
   "Project cover image": "Imagen de portada del proyecto",
   "Project created successfully": "Proyecto creado exitosamente",
+  "Project default pod": "Project default pod",
   "Project ID": "ID del proyecto",
   "Project ID is required": "El ID del proyecto es obligatorio",
   "Project ID must at least be of 1 character": "El ID del proyecto debe tener al menos 1 carácter",
@@ -1700,6 +1701,8 @@ export default {
   "Which AI agent CLI this runner will drive. Baked into the displayed ``pidash runner add`` command.":
     "Qué agente de IA CLI impulsará este runner. Integrado en el comando ``pidash runner add`` mostrado.",
   "Which events would you like to trigger this webhook?": "¿Qué eventos le gustaría que activen este webhook?",
+  "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.":
+    "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.",
   "Widget reordered successfully.": "Widget reordenado exitosamente.",
   "Windows (MSI)": "Windows (MSI)",
   "Windows (PowerShell)": "Windows (PowerShell)",

--- a/packages/i18n/src/locales/fr/translations.ts
+++ b/packages/i18n/src/locales/fr/translations.ts
@@ -1210,6 +1210,7 @@ export default {
   "Project context (optional)": "Contexte du projet (facultatif)",
   "Project cover image": "Image de couverture du projet",
   "Project created successfully": "Projet créé avec succès",
+  "Project default pod": "Project default pod",
   "Project ID": "ID du projet",
   "Project ID is required": "L'ID du projet est requis",
   "Project ID must at least be of 1 character": "L'ID du projet doit comporter au moins 1 caractère",
@@ -1713,6 +1714,8 @@ export default {
   "Which AI agent CLI this runner will drive. Baked into the displayed ``pidash runner add`` command.":
     "Quel CLI d'agent IA ce runner pilotera. Intégré dans la commande ``pidash runner add`` affichée.",
   "Which events would you like to trigger this webhook?": "Quels événements souhaitez-vous déclencher ce webhook ?",
+  "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.":
+    "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.",
   "Widget reordered successfully.": "Widget réorganisé avec succès.",
   "Windows (MSI)": "Windows (MSI)",
   "Windows (PowerShell)": "Windows (PowerShell)",

--- a/packages/i18n/src/locales/id/translations.ts
+++ b/packages/i18n/src/locales/id/translations.ts
@@ -1185,6 +1185,7 @@ export default {
   "Project context (optional)": "Konteks proyek (opsional)",
   "Project cover image": "Gambar sampul proyek",
   "Project created successfully": "Proyek berhasil dibuat",
+  "Project default pod": "Project default pod",
   "Project ID": "ID Proyek",
   "Project ID is required": "ID Proyek diperlukan",
   "Project ID must at least be of 1 character": "ID Proyek harus minimal 1 karakter",
@@ -1679,6 +1680,8 @@ export default {
   "Which AI agent CLI this runner will drive. Baked into the displayed ``pidash runner add`` command.":
     "CLI agen AI mana yang akan dijalankan oleh runner ini. Tertanam dalam perintah ``pidash runner add`` yang ditampilkan.",
   "Which events would you like to trigger this webhook?": "Acara mana yang ingin Anda picu webhook ini?",
+  "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.":
+    "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.",
   "Widget reordered successfully.": "Widget berhasil diurutkan ulang.",
   "Windows (MSI)": "Windows (MSI)",
   "Windows (PowerShell)": "Windows (PowerShell)",

--- a/packages/i18n/src/locales/it/translations.ts
+++ b/packages/i18n/src/locales/it/translations.ts
@@ -1197,6 +1197,7 @@ export default {
   "Project context (optional)": "Contesto del progetto (opzionale)",
   "Project cover image": "Immagine di copertina del progetto",
   "Project created successfully": "Progetto creato con successo",
+  "Project default pod": "Project default pod",
   "Project ID": "ID progetto",
   "Project ID is required": "L'ID progetto è obbligatorio",
   "Project ID must at least be of 1 character": "L'ID progetto deve essere di almeno 1 carattere",
@@ -1699,6 +1700,8 @@ export default {
   "Which AI agent CLI this runner will drive. Baked into the displayed ``pidash runner add`` command.":
     "Quale CLI dell'agente AI questo runner guiderà. Incorporato nel comando ``pidash runner add`` visualizzato.",
   "Which events would you like to trigger this webhook?": "Quali eventi vorresti attivare per questo webhook?",
+  "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.":
+    "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.",
   "Widget reordered successfully.": "Widget riordinato con successo.",
   "Windows (MSI)": "Windows (MSI)",
   "Windows (PowerShell)": "Windows (PowerShell)",

--- a/packages/i18n/src/locales/ja/translations.ts
+++ b/packages/i18n/src/locales/ja/translations.ts
@@ -1189,6 +1189,7 @@ export default {
   "Project context (optional)": "プロジェクトコンテキスト（オプション）",
   "Project cover image": "プロジェクトカバー画像",
   "Project created successfully": "プロジェクトが正常に作成されました",
+  "Project default pod": "Project default pod",
   "Project ID": "プロジェクトID",
   "Project ID is required": "プロジェクトIDが必要です",
   "Project ID must at least be of 1 character": "プロジェクトIDは1文字以上である必要があります",
@@ -1681,6 +1682,8 @@ export default {
   "Which AI agent CLI this runner will drive. Baked into the displayed ``pidash runner add`` command.":
     "このランナーが駆動するAIエージェントCLI。表示される ``pidash runner add`` コマンドに組み込まれています。",
   "Which events would you like to trigger this webhook?": "このウェブフックをトリガーするイベントを選択してください。",
+  "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.":
+    "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.",
   "Widget reordered successfully.": "ウィジェットの並べ替えが成功しました。",
   "Windows (MSI)": "Windows (MSI)",
   "Windows (PowerShell)": "Windows (PowerShell)",

--- a/packages/i18n/src/locales/ko/translations.ts
+++ b/packages/i18n/src/locales/ko/translations.ts
@@ -1172,6 +1172,7 @@ export default {
   "Project context (optional)": "프로젝트 컨텍스트(선택 사항)",
   "Project cover image": "프로젝트 커버 이미지",
   "Project created successfully": "프로젝트가 성공적으로 생성되었습니다",
+  "Project default pod": "Project default pod",
   "Project ID": "프로젝트 ID",
   "Project ID is required": "프로젝트 ID가 필요합니다",
   "Project ID must at least be of 1 character": "프로젝트 ID는 최소 1자 이상이어야 합니다",
@@ -1657,6 +1658,8 @@ export default {
   "Which AI agent CLI this runner will drive. Baked into the displayed ``pidash runner add`` command.":
     "이 러너가 구동할 AI 에이전트 CLI입니다. 표시된 ``pidash runner add`` 명령에 포함됩니다.",
   "Which events would you like to trigger this webhook?": "이 웹훅을 트리거할 이벤트를 선택하세요.",
+  "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.":
+    "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.",
   "Widget reordered successfully.": "위젯이 성공적으로 재정렬되었습니다.",
   "Windows (MSI)": "Windows (MSI)",
   "Windows (PowerShell)": "Windows (PowerShell)",

--- a/packages/i18n/src/locales/pl/translations.ts
+++ b/packages/i18n/src/locales/pl/translations.ts
@@ -1196,6 +1196,7 @@ export default {
   "Project context (optional)": "Kontekst projektu (opcjonalny)",
   "Project cover image": "Obraz okładki projektu",
   "Project created successfully": "Projekt utworzony pomyślnie",
+  "Project default pod": "Project default pod",
   "Project ID": "ID projektu",
   "Project ID is required": "ID projektu jest wymagane",
   "Project ID must at least be of 1 character": "ID projektu musi mieć co najmniej 1 znak",
@@ -1692,6 +1693,8 @@ export default {
   "Which AI agent CLI this runner will drive. Baked into the displayed ``pidash runner add`` command.":
     "Którym interfejsem CLI agenta AI będzie sterował ten runner. Wbudowane w wyświetlane polecenie ``pidash runner add``.",
   "Which events would you like to trigger this webhook?": "Które zdarzenia mają wyzwalać ten webhook?",
+  "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.":
+    "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.",
   "Widget reordered successfully.": "Pomyślnie zmieniono kolejność widgetu.",
   "Windows (MSI)": "Windows (MSI)",
   "Windows (PowerShell)": "Windows (PowerShell)",

--- a/packages/i18n/src/locales/pt-BR/translations.ts
+++ b/packages/i18n/src/locales/pt-BR/translations.ts
@@ -1193,6 +1193,7 @@ export default {
   "Project context (optional)": "Contexto do projeto (opcional)",
   "Project cover image": "Imagem de capa do projeto",
   "Project created successfully": "Projeto criado com sucesso",
+  "Project default pod": "Project default pod",
   "Project ID": "ID do projeto",
   "Project ID is required": "O ID do projeto é obrigatório",
   "Project ID must at least be of 1 character": "O ID do projeto deve ter pelo menos 1 caractere",
@@ -1689,6 +1690,8 @@ export default {
   "Which AI agent CLI this runner will drive. Baked into the displayed ``pidash runner add`` command.":
     "Qual CLI do agente de IA este runner irá conduzir. Incorporado no comando ``pidash runner add`` exibido.",
   "Which events would you like to trigger this webhook?": "Quais eventos você gostaria de acionar este webhook?",
+  "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.":
+    "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.",
   "Widget reordered successfully.": "Widget reordenado com sucesso.",
   "Windows (MSI)": "Windows (MSI)",
   "Windows (PowerShell)": "Windows (PowerShell)",

--- a/packages/i18n/src/locales/ro/translations.ts
+++ b/packages/i18n/src/locales/ro/translations.ts
@@ -1207,6 +1207,7 @@ export default {
   "Project context (optional)": "Contextul proiectului (opțional)",
   "Project cover image": "Imaginea de copertă a proiectului",
   "Project created successfully": "Proiect creat cu succes",
+  "Project default pod": "Project default pod",
   "Project ID": "ID-ul proiectului",
   "Project ID is required": "ID-ul proiectului este obligatoriu",
   "Project ID must at least be of 1 character": "ID-ul proiectului trebuie să aibă cel puțin 1 caracter",
@@ -1705,6 +1706,8 @@ export default {
   "Which AI agent CLI this runner will drive. Baked into the displayed ``pidash runner add`` command.":
     "Pe care agent AI CLI îl va conduce acest runner. Încorporat în comanda afișată ``pidash runner add``.",
   "Which events would you like to trigger this webhook?": "Ce evenimente doriți să declanșeze acest webhook?",
+  "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.":
+    "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.",
   "Widget reordered successfully.": "Widget reordonat cu succes.",
   "Windows (MSI)": "Windows (MSI)",
   "Windows (PowerShell)": "Windows (PowerShell)",

--- a/packages/i18n/src/locales/ru/translations.ts
+++ b/packages/i18n/src/locales/ru/translations.ts
@@ -1200,6 +1200,7 @@ export default {
   "Project context (optional)": "Контекст проекта (необязательно)",
   "Project cover image": "Обложка проекта",
   "Project created successfully": "Проект успешно создан",
+  "Project default pod": "Project default pod",
   "Project ID": "ID проекта",
   "Project ID is required": "Требуется ID проекта",
   "Project ID must at least be of 1 character": "ID проекта должен содержать не менее 1 символа",
@@ -1698,6 +1699,8 @@ export default {
   "Which AI agent CLI this runner will drive. Baked into the displayed ``pidash runner add`` command.":
     "Какой CLI AI-агента будет управлять этим раннером. Встроено в отображаемую команду ``pidash runner add``.",
   "Which events would you like to trigger this webhook?": "Какие события должны запускать этот вебхук?",
+  "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.":
+    "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.",
   "Widget reordered successfully.": "Виджет успешно перемещён.",
   "Windows (MSI)": "Windows (MSI)",
   "Windows (PowerShell)": "Windows (PowerShell)",

--- a/packages/i18n/src/locales/sk/translations.ts
+++ b/packages/i18n/src/locales/sk/translations.ts
@@ -1194,6 +1194,7 @@ export default {
   "Project context (optional)": "Kontext projektu (voliteľné)",
   "Project cover image": "Titulný obrázok projektu",
   "Project created successfully": "Projekt bol úspešne vytvorený",
+  "Project default pod": "Project default pod",
   "Project ID": "ID projektu",
   "Project ID is required": "ID projektu je povinné",
   "Project ID must at least be of 1 character": "ID projektu musí mať aspoň 1 znak",
@@ -1689,6 +1690,8 @@ export default {
   "Which AI agent CLI this runner will drive. Baked into the displayed ``pidash runner add`` command.":
     "Ktorý CLI agenta AI bude tento runner ovládať. Vložené do zobrazeného príkazu ``pidash runner add``.",
   "Which events would you like to trigger this webhook?": "Ktoré udalosti by ste chceli, aby spúšťali tento webhook?",
+  "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.":
+    "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.",
   "Widget reordered successfully.": "Widget bol úspešne presunutý.",
   "Windows (MSI)": "Windows (MSI)",
   "Windows (PowerShell)": "Windows (PowerShell)",

--- a/packages/i18n/src/locales/tr-TR/translations.ts
+++ b/packages/i18n/src/locales/tr-TR/translations.ts
@@ -1187,6 +1187,7 @@ export default {
   "Project context (optional)": "Proje bağlamı (isteğe bağlı)",
   "Project cover image": "Proje kapak resmi",
   "Project created successfully": "Proje başarıyla oluşturuldu",
+  "Project default pod": "Project default pod",
   "Project ID": "Proje Kimliği",
   "Project ID is required": "Proje Kimliği gereklidir",
   "Project ID must at least be of 1 character": "Proje Kimliği en az 1 karakter olmalıdır",
@@ -1680,6 +1681,8 @@ export default {
   "Which AI agent CLI this runner will drive. Baked into the displayed ``pidash runner add`` command.":
     "Bu çalıştırıcının hangi AI ajan CLI'sını süreceği. Görüntülenen ``pidash runner add`` komutuna gömülüdür.",
   "Which events would you like to trigger this webhook?": "Bu webhook'u hangi olaylar tetiklesin?",
+  "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.":
+    "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.",
   "Widget reordered successfully.": "Widget başarıyla yeniden sıralandı.",
   "Windows (MSI)": "Windows (MSI)",
   "Windows (PowerShell)": "Windows (PowerShell)",

--- a/packages/i18n/src/locales/ua/translations.ts
+++ b/packages/i18n/src/locales/ua/translations.ts
@@ -1194,6 +1194,7 @@ export default {
   "Project context (optional)": "Контекст проєкту (необов'язково)",
   "Project cover image": "Обкладинка проєкту",
   "Project created successfully": "Проєкт успішно створено",
+  "Project default pod": "Project default pod",
   "Project ID": "ID проєкту",
   "Project ID is required": "ID проєкту є обов'язковим",
   "Project ID must at least be of 1 character": "ID проєкту повинен містити щонайменше 1 символ",
@@ -1689,6 +1690,8 @@ export default {
     "Який CLI AI-агента буде керувати цим раннером. Вбудовано в показану команду ``pidash runner add``.",
   "Which events would you like to trigger this webhook?":
     "Які події ви хотіли б використовувати для запуску цього вебхука?",
+  "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.":
+    "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.",
   "Widget reordered successfully.": "Віджет успішно перевпорядковано.",
   "Windows (MSI)": "Windows (MSI)",
   "Windows (PowerShell)": "Windows (PowerShell)",

--- a/packages/i18n/src/locales/vi-VN/translations.ts
+++ b/packages/i18n/src/locales/vi-VN/translations.ts
@@ -1188,6 +1188,7 @@ export default {
   "Project context (optional)": "Ngữ cảnh dự án (tùy chọn)",
   "Project cover image": "Ảnh bìa dự án",
   "Project created successfully": "Dự án đã được tạo thành công",
+  "Project default pod": "Project default pod",
   "Project ID": "ID dự án",
   "Project ID is required": "ID dự án là bắt buộc",
   "Project ID must at least be of 1 character": "ID dự án phải có ít nhất 1 ký tự",
@@ -1685,6 +1686,8 @@ export default {
   "Which AI agent CLI this runner will drive. Baked into the displayed ``pidash runner add`` command.":
     "CLI tác nhân AI nào mà runner này sẽ điều khiển. Được tích hợp vào lệnh ``pidash runner add`` được hiển thị.",
   "Which events would you like to trigger this webhook?": "Bạn muốn sự kiện nào kích hoạt webhook này?",
+  "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.":
+    "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.",
   "Widget reordered successfully.": "Widget đã được sắp xếp lại thành công.",
   "Windows (MSI)": "Windows (MSI)",
   "Windows (PowerShell)": "Windows (PowerShell)",

--- a/packages/i18n/src/locales/zh-CN/translations.ts
+++ b/packages/i18n/src/locales/zh-CN/translations.ts
@@ -1155,6 +1155,7 @@ export default {
   "Project context (optional)": "项目上下文（可选）",
   "Project cover image": "项目封面图片",
   "Project created successfully": "项目创建成功",
+  "Project default pod": "Project default pod",
   "Project ID": "项目ID",
   "Project ID is required": "项目ID是必需的",
   "Project ID must at least be of 1 character": "项目ID至少需要1个字符",
@@ -1625,6 +1626,8 @@ export default {
   "Which AI agent CLI this runner will drive. Baked into the displayed ``pidash runner add`` command.":
     "此运行器将驱动哪个 AI agent CLI。已嵌入到显示的 ``pidash runner add`` 命令中。",
   "Which events would you like to trigger this webhook?": "您希望哪些事件触发此 webhook？",
+  "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.":
+    "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.",
   "Widget reordered successfully.": "小组件已成功重新排序。",
   "Windows (MSI)": "Windows (MSI)",
   "Windows (PowerShell)": "Windows (PowerShell)",

--- a/packages/i18n/src/locales/zh-TW/translations.ts
+++ b/packages/i18n/src/locales/zh-TW/translations.ts
@@ -1154,6 +1154,7 @@ export default {
   "Project context (optional)": "專案背景（選填）",
   "Project cover image": "專案封面圖片",
   "Project created successfully": "專案建立成功",
+  "Project default pod": "Project default pod",
   "Project ID": "專案 ID",
   "Project ID is required": "必須提供專案 ID",
   "Project ID must at least be of 1 character": "專案 ID 至少需要 1 個字元",
@@ -1625,6 +1626,8 @@ export default {
   "Which AI agent CLI this runner will drive. Baked into the displayed ``pidash runner add`` command.":
     "此執行器將驅動哪個 AI 代理 CLI。內嵌於顯示的 ``pidash runner add`` 命令中。",
   "Which events would you like to trigger this webhook?": "您希望哪些事件觸發此 webhook？",
+  "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.":
+    "Which pod's runners serve this scheduler's runs. Leave on the project default unless you need a specific machine fleet.",
   "Widget reordered successfully.": "小工具已成功重新排序。",
   "Windows (MSI)": "Windows (MSI)",
   "Windows (PowerShell)": "Windows (PowerShell)",

--- a/packages/services/src/scheduler/scheduler.service.ts
+++ b/packages/services/src/scheduler/scheduler.service.ts
@@ -74,6 +74,10 @@ export interface ISchedulerBinding {
   exdates: string[];
   extra_context: string;
   enabled: boolean;
+  /** Pod override for runs fired by this binding. Null = use the project's default pod (resolved at fire time). */
+  pod: string | null;
+  /** Joined name of the override pod, or null when using the project default. Read-only. */
+  pod_name: string | null;
   next_run_at: string | null;
   last_run: string | null;
   last_run_status: string | null;
@@ -101,10 +105,12 @@ export interface ISchedulerBindingCreatePayload {
   exdates?: string[];
   extra_context?: string;
   enabled?: boolean;
+  /** Optional pod override; omit or null to use the project's default pod. */
+  pod?: string | null;
 }
 
 export type ISchedulerBindingUpdatePayload = Partial<
-  Pick<ISchedulerBinding, "dtstart" | "tzid" | "rrule" | "rdates" | "exdates" | "extra_context" | "enabled">
+  Pick<ISchedulerBinding, "dtstart" | "tzid" | "rrule" | "rdates" | "exdates" | "extra_context" | "enabled" | "pod">
 >;
 
 export class SchedulerService extends APIService {


### PR DESCRIPTION
## What

Lets a user choose **which pod** a scheduler's runs target when installing/editing a scheduler binding on a project. Previously every scheduler run went to the project's **default pod** with no override.

## Why

With multiple runner pods per project, there was no way to point a scheduler at a specific runner fleet (e.g. a beefier pod for `apply_fix`-style schedules). Pod selection was a project-wide setting only.

## Design

The pod is **late-bound**: the binding stores the choice; the dispatcher resolves it on each fire rather than pinning a run, so changing it takes effect on the next tick. `NULL` preserves the existing "use project default" behavior.

The pod stays **editable** post-install (unlike `scheduler`/`project`, which are locked) because it's a runtime target, not part of the binding's identity.

## Layers changed

**Backend**
- `SchedulerBinding.pod` — nullable FK to `runner.Pod`, `on_delete=SET_NULL` (migration `0145`).
- Serializer: writable `pod` (scoped to active pods) + read-only `pod_name`; `validate()` enforces the pod belongs to the binding's project.
- `dispatch_scheduler_run` prefers `binding.pod`, but only when it's **active and still in the project**; otherwise falls back to the project default — so a soft-deleted or cross-project override degrades safely.

**Web**
- `ISchedulerBinding` gains `pod` + `pod_name`; create/update payloads gain `pod`.
- New shared `BindingPodField` (project-scoped pod `<select>` with a "Project default" option), wired into the install and edit modals.

## Tests

- **Serializer:** same-project pod accepted; cross-project + soft-deleted pods rejected; pod editable on PATCH; cross-project PATCH rejected.
- **Dispatcher:** default pod when unset; honors override; falls back to default when the override pod is soft-deleted.
- All 8 new tests pass (verified against an ephemeral Postgres). `services` typecheck passes; `web` typecheck adds **0** errors over the pre-existing baseline.

## Test plan

- [ ] Install a scheduler on a project with multiple pods → pick a non-default pod → confirm runs land on it
- [ ] Leave on "Project default" → confirm runs use the default pod
- [ ] Edit an existing binding to change its pod → confirm next fire honors it
- [ ] Soft-delete a binding's chosen pod → confirm it falls back to the project default

🤖 Generated with [Claude Code](https://claude.com/claude-code)