### PR TITLE
feat(scheduler): add Claude Mythos/Fable System Security Audit builtin

### DIFF
--- a/apps/api/pi_dash/db/migrations/0145_seed_fable_security_audit.py
+++ b/apps/api/pi_dash/db/migrations/0145_seed_fable_security_audit.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Backfill the ``fable-security-audit`` builtin scheduler into every
+existing workspace's catalog.
+
+New workspaces get the full BUILTINS catalog via the ``Workspace``
+post_save signal; this migration is the one-time backfill so existing
+workspaces end up with the same new template in their schedulers tab.
+
+Seeds ONLY the ``fable-security-audit`` slug — unlike the original
+``0133`` seed it deliberately does not re-touch other builtins, so any
+per-workspace edits to ``security-audit`` are left intact.
+
+Idempotent: if the post_save signal already created the row between
+deploy and this migration running, the existing row is refreshed rather
+than failing the ``(workspace, slug)`` unique constraint.
+
+See ``.ai_design/project_scheduler/design.md`` §6.6.
+"""
+
+from django.db import migrations
+
+TARGET_SLUG = "fable-security-audit"
+
+
+def _seed_fable_audit(apps, schema_editor):
+    Workspace = apps.get_model("db", "Workspace")
+    Scheduler = apps.get_model("db", "Scheduler")
+
+    # Pull the prompt/name/description from the single source of truth so
+    # the text lives in exactly one place (the builtins registry).
+    from pi_dash.scheduler.builtins import BUILTINS
+
+    builtin = next((b for b in BUILTINS if b.slug == TARGET_SLUG), None)
+    if builtin is None:
+        # Builtin was removed from the registry before this migration ran;
+        # nothing to seed.
+        return
+
+    for workspace in Workspace.objects.filter(deleted_at__isnull=True).iterator():
+        existing = Scheduler.objects.filter(
+            workspace=workspace,
+            slug=builtin.slug,
+            deleted_at__isnull=True,
+        ).first()
+        if existing is not None:
+            existing.name = builtin.name
+            existing.description = builtin.description
+            existing.prompt = builtin.prompt
+            existing.source = "builtin"
+            existing.save(
+                update_fields=["name", "description", "prompt", "source", "updated_at"]
+            )
+        else:
+            Scheduler.objects.create(
+                workspace=workspace,
+                slug=builtin.slug,
+                name=builtin.name,
+                description=builtin.description,
+                prompt=builtin.prompt,
+                source="builtin",
+            )
+
+
+def _noop_reverse(apps, schema_editor):
+    # Forward seed is idempotent; reverse intentionally leaves the rows in
+    # place so a rollback doesn't strip data the post_save signal would
+    # also have created. Operators wanting to purge can soft-delete the
+    # `fable-security-audit` rows after rolling back.
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("db", "0144_issuecomment_speaker_metadata"),
+    ]
+
+    operations = [
+        migrations.RunPython(_seed_fable_audit, _noop_reverse),
+    ]

--- a/apps/api/pi_dash/db/migrations/0145_seed_fable_security_audit.py
+++ b/apps/api/pi_dash/db/migrations/0145_seed_fable_security_audit.py
@@ -20,7 +20,7 @@ than failing the ``(workspace, slug)`` unique constraint.
 See ``.ai_design/project_scheduler/design.md`` §6.6.
 """
 
-from django.db import migrations
+from django.db import IntegrityError, migrations, transaction
 
 TARGET_SLUG = "fable-security-audit"
 
@@ -39,6 +39,15 @@ def _seed_fable_audit(apps, schema_editor):
         # nothing to seed.
         return
 
+    def _apply_defaults(row):
+        row.name = builtin.name
+        row.description = builtin.description
+        row.prompt = builtin.prompt
+        row.source = "builtin"
+        row.save(
+            update_fields=["name", "description", "prompt", "source", "updated_at"]
+        )
+
     for workspace in Workspace.objects.filter(deleted_at__isnull=True).iterator():
         existing = Scheduler.objects.filter(
             workspace=workspace,
@@ -46,22 +55,30 @@ def _seed_fable_audit(apps, schema_editor):
             deleted_at__isnull=True,
         ).first()
         if existing is not None:
-            existing.name = builtin.name
-            existing.description = builtin.description
-            existing.prompt = builtin.prompt
-            existing.source = "builtin"
-            existing.save(
-                update_fields=["name", "description", "prompt", "source", "updated_at"]
-            )
-        else:
-            Scheduler.objects.create(
+            _apply_defaults(existing)
+            continue
+        # The Workspace post_save signal can insert this same row between our
+        # SELECT and INSERT (e.g. a signup during a rolling deploy). Wrap the
+        # create in a savepoint so the conflicting INSERT doesn't abort the
+        # whole migration transaction, then converge by updating the winner.
+        try:
+            with transaction.atomic():
+                Scheduler.objects.create(
+                    workspace=workspace,
+                    slug=builtin.slug,
+                    name=builtin.name,
+                    description=builtin.description,
+                    prompt=builtin.prompt,
+                    source="builtin",
+                )
+        except IntegrityError:
+            winner = Scheduler.objects.filter(
                 workspace=workspace,
                 slug=builtin.slug,
-                name=builtin.name,
-                description=builtin.description,
-                prompt=builtin.prompt,
-                source="builtin",
-            )
+                deleted_at__isnull=True,
+            ).first()
+            if winner is not None:
+                _apply_defaults(winner)
 
 
 def _noop_reverse(apps, schema_editor):

--- a/apps/api/pi_dash/scheduler/builtins/__init__.py
+++ b/apps/api/pi_dash/scheduler/builtins/__init__.py
@@ -79,15 +79,19 @@ path and line range, category (security|correctness) and a specific subtype,
 severity (high|medium|low), confidence (high|medium|low), a 1-3 sentence
 explanation of the exploit path or failure mode, and a concrete fix.
 
-For each NEW finding, create a Pi Dash issue with the `pi-dash` CLI:
+For each NEW finding, create a Pi Dash issue with the `pi-dash` CLI. Use the
+title prefix "[fable-security]" for security findings and "[fable-bug]" for
+correctness findings (a dedicated namespace so this audit does not collide with
+the basic "[security]" Security Audit scheduler):
     pi-dash issue create \\
-      --title "[security] <short summary>"   # use [bug] for correctness findings
+      --title "[fable-security] <short summary>" \\
       --description "<file path + line range, category/subtype, severity,
                      confidence, explanation, and suggested fix>"
 
-Before creating an issue, list existing open issues with the "[security]" or
-"[bug]" title prefix and skip any finding that already has a corresponding open
-issue (de-dupe by file + subtype, not by exact title). Never refile duplicates.
+Before creating an issue, list existing open issues with the "[fable-security]"
+or "[fable-bug]" title prefix and skip any finding that already has a
+corresponding open issue (de-dupe by file + subtype, not by exact title). Never
+refile duplicates.
 
 End with a one-line summary: issues filed, duplicates skipped, breakdown by
 severity. If there are no new findings, file nothing and report "No new findings".

--- a/apps/api/pi_dash/scheduler/builtins/__init__.py
+++ b/apps/api/pi_dash/scheduler/builtins/__init__.py
@@ -45,6 +45,55 @@ corresponding open issue (de-dupe by file + rule, not by exact title).
 """
 
 
+FABLE_AUDIT_PROMPT = """\
+You are performing a scheduled, read-only security and correctness audit of this
+repository. Run autonomously to completion — no human is available to answer
+questions, so make reasonable assumptions and note them rather than stopping.
+
+Scope: the entire repository at the current working directory — application code,
+configuration, infrastructure-as-code, dependency manifests, and CI/CD
+definitions. This is authorized defensive review of the project owner's own code.
+
+Find:
+1. Security vulnerabilities — injection (SQL, command, XSS, SSRF, path traversal,
+   template, deserialization); broken authn/authz (missing checks, IDOR,
+   privilege escalation, weak sessions); secrets committed or logged;
+   cryptographic misuse; insecure configuration (permissive CORS, verbose prod
+   errors, open cloud resources, unauthenticated endpoints); vulnerable or
+   outdated dependencies with known CVEs (read manifests + lockfiles; if a
+   scanner such as npm audit / pip-audit / osv-scanner / trivy is available, run
+   it and fold in the results); unsafe file handling and redirects.
+2. Correctness bugs — logic errors that could cause wrong behavior, data loss,
+   crashes, race conditions, or resource leaks, traced through real data flow
+   (not lint-level nits).
+
+Method: work at high thoroughness. Trace data from untrusted inputs to sensitive
+sinks and reason about WHY each finding is exploitable or wrong, not just whether
+a pattern matches. Read the actual code paths. Where deterministic tooling exists
+in the repo (SAST, dependency scanners, type checkers, the test suite), run it
+and incorporate the output. Do NOT modify code, commit, or open PRs — read-only.
+
+Report EVERY issue you find, including uncertain or low-severity ones; do not
+filter while finding. For each finding capture: a short specific title, the file
+path and line range, category (security|correctness) and a specific subtype,
+severity (high|medium|low), confidence (high|medium|low), a 1-3 sentence
+explanation of the exploit path or failure mode, and a concrete fix.
+
+For each NEW finding, create a Pi Dash issue with the `pi-dash` CLI:
+    pi-dash issue create \\
+      --title "[security] <short summary>"   # use [bug] for correctness findings
+      --description "<file path + line range, category/subtype, severity,
+                     confidence, explanation, and suggested fix>"
+
+Before creating an issue, list existing open issues with the "[security]" or
+"[bug]" title prefix and skip any finding that already has a corresponding open
+issue (de-dupe by file + subtype, not by exact title). Never refile duplicates.
+
+End with a one-line summary: issues filed, duplicates skipped, breakdown by
+severity. If there are no new findings, file nothing and report "No new findings".
+"""
+
+
 BUILTINS: List[BuiltinScheduler] = [
     BuiltinScheduler(
         slug="security-audit",
@@ -54,6 +103,16 @@ BUILTINS: List[BuiltinScheduler] = [
             "files Pi Dash issues for any new findings."
         ),
         prompt=SECURITY_AUDIT_PROMPT,
+    ),
+    BuiltinScheduler(
+        slug="fable-security-audit",
+        name="Claude Mythos/Fable System Security Audit",
+        description=(
+            "Comprehensive Fable-powered audit: scans the project for security "
+            "vulnerabilities and correctness bugs and files Pi Dash issues for "
+            "new findings."
+        ),
+        prompt=FABLE_AUDIT_PROMPT,
     ),
 ]
 


### PR DESCRIPTION
## What

Adds a second builtin scheduler — **`fable-security-audit`** ("Claude Mythos/Fable System Security Audit") — alongside the existing `security-audit`. After deploy, every workspace (new and existing) sees it in their Schedulers tab, ready to enable.

## Why

A comprehensive, Fable-tuned repo audit that goes beyond the thin `security-audit` builtin: it covers **both** security vulnerabilities **and** correctness bugs, traces real data flow, optionally runs available SAST/dependency scanners (`npm audit` / `pip-audit` / `osv-scanner` / `trivy`), and files de-duplicated Pi Dash issues with severity + confidence on each finding.

## Changes

- **`scheduler/builtins/__init__.py`** — new `BuiltinScheduler` entry + `FABLE_AUDIT_PROMPT`. Existing `security-audit` untouched.
- **`db/migrations/0145_seed_fable_security_audit.py`** — backfill for existing workspaces. Depends on the current leaf `0144`. Seeds **only** the new slug (leaves any per-workspace `security-audit` edits intact), idempotent, pulls prompt text from the registry (single source of truth).

## How it reaches all users

- **New workspaces** → seeded automatically by the existing `Workspace` post_save signal (now includes this builtin).
- **Existing workspaces** → backfilled by migration `0145` on deploy. Test deploy seeds the test DB; prod deploy seeds prod.

## Notes / not done

- The prompt is intentionally **model-agnostic** — "Fable" lives in the name; which model runs it is the dev-machine runner setting. Enforcing Fable would be a separate runner-routing change.
- Only **syntax-checked** locally (`py_compile`). The migration has **not** been run against a DB and the Django suite was not run here — please `migrate` in test and eyeball one workspace's Schedulers tab before prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)