### PR TITLE
feat(runner): per-runner LLM model selection for add-runner flow

### DIFF
--- a/apps/web/core/components/runners/add-runner-modal.tsx
+++ b/apps/web/core/components/runners/add-runner-modal.tsx
@@ -18,6 +18,12 @@ import type { IPod, TPartialProject } from "@pi-dash/types";
 import { CustomSelect, EModalPosition, EModalWidth, Input, ModalCore } from "@pi-dash/ui";
 // app
 import { RunnerCliCommand } from "@/components/runners/runner-cli-command";
+import {
+  DEFAULT_MODEL_ID,
+  RUNNER_MODEL_OPTIONS,
+  resolveRunnerModel,
+  runnerModelLabel,
+} from "@/components/runners/runner-models";
 import { ProjectService } from "@/services/project";
 
 type Props = {
@@ -41,9 +47,16 @@ interface FormValues {
   name: string;
   workingDir: string;
   agent: TAgent;
+  /** Selected model-catalog option id (``"default"`` = agent's own default). */
+  model: string;
 }
 
-type RunnerCommandValues = Pick<FormValues, "projectIdentifier" | "podName" | "name" | "workingDir" | "agent">;
+type RunnerCommandValues = Pick<FormValues, "projectIdentifier" | "podName" | "name" | "workingDir" | "agent"> & {
+  /** Resolved ``--model`` value; undefined for the default sentinel. */
+  model?: string;
+  /** Resolved ``--reasoning-effort`` value; codex only. */
+  reasoningEffort?: string;
+};
 
 const DEFAULT_VALUES: FormValues = {
   projectIdentifier: "",
@@ -51,6 +64,7 @@ const DEFAULT_VALUES: FormValues = {
   name: "",
   workingDir: "",
   agent: DEFAULT_AGENT,
+  model: DEFAULT_MODEL_ID,
 };
 
 const podService = new PodService();
@@ -143,13 +157,24 @@ export const AddRunnerModal = observer(function AddRunnerModal(props: Props) {
     return t("Codex");
   };
 
+  // Model options are agent-specific, so a stale selection from a previous
+  // agent would generate an inapplicable ``--model``. Reset to the default
+  // sentinel whenever the agent changes.
+  const selectedAgent = watch("agent");
+  useEffect(() => {
+    setValue("model", DEFAULT_MODEL_ID);
+  }, [selectedAgent, setValue]);
+
   const onSubmit: SubmitHandler<FormValues> = (values) => {
+    const { model, reasoningEffort } = resolveRunnerModel(values.agent, values.model);
     setRunnerCommand({
       projectIdentifier: values.projectIdentifier,
       podName: values.podName,
       name: values.name.trim(),
       workingDir: values.workingDir,
       agent: values.agent,
+      model,
+      reasoningEffort,
     });
   };
 
@@ -323,6 +348,40 @@ export const AddRunnerModal = observer(function AddRunnerModal(props: Props) {
             </p>
           </div>
 
+          <div className="flex flex-col gap-1">
+            <label htmlFor="add-runner-model" className="text-13 font-medium text-primary">
+              {t("Model (optional)")}
+            </label>
+            <Controller
+              control={control}
+              name="model"
+              render={({ field }) => (
+                <CustomSelect
+                  value={field.value}
+                  label={runnerModelLabel(selectedAgent, field.value)}
+                  onChange={field.onChange}
+                  buttonClassName="border border-subtle"
+                  input
+                  maxHeight="lg"
+                  placement="bottom-start"
+                >
+                  <>
+                    {RUNNER_MODEL_OPTIONS[selectedAgent].map((opt) => (
+                      <CustomSelect.Option key={opt.id} value={opt.id}>
+                        {opt.label}
+                      </CustomSelect.Option>
+                    ))}
+                  </>
+                </CustomSelect>
+              )}
+            />
+            <p className="text-12 text-secondary">
+              {t(
+                "Default model this runner's agent uses. ``Default`` lets the agent pick its own; the choice is baked into the displayed ``pidash runner add`` command."
+              )}
+            </p>
+          </div>
+
           <div className="flex justify-end gap-2">
             <Button variant="secondary" onClick={onClose}>
               {t("Cancel")}
@@ -347,6 +406,8 @@ export const AddRunnerModal = observer(function AddRunnerModal(props: Props) {
             name={runnerCommand.name}
             workingDir={runnerCommand.workingDir}
             agent={runnerCommand.agent}
+            model={runnerCommand.model}
+            reasoningEffort={runnerCommand.reasoningEffort}
             isUsingBrowserOrigin={isUsingBrowserOrigin}
           />
 

--- a/apps/web/core/components/runners/add-runner-modal.tsx
+++ b/apps/web/core/components/runners/add-runner-modal.tsx
@@ -19,7 +19,7 @@ import { CustomSelect, EModalPosition, EModalWidth, Input, ModalCore } from "@pi
 // app
 import { RunnerCliCommand } from "@/components/runners/runner-cli-command";
 import {
-  DEFAULT_MODEL_ID,
+  DEFAULT_MODEL_BY_AGENT,
   RUNNER_MODEL_OPTIONS,
   resolveRunnerModel,
   runnerModelLabel,
@@ -64,7 +64,7 @@ const DEFAULT_VALUES: FormValues = {
   name: "",
   workingDir: "",
   agent: DEFAULT_AGENT,
-  model: DEFAULT_MODEL_ID,
+  model: DEFAULT_MODEL_BY_AGENT[DEFAULT_AGENT],
 };
 
 const podService = new PodService();
@@ -162,7 +162,7 @@ export const AddRunnerModal = observer(function AddRunnerModal(props: Props) {
   // sentinel whenever the agent changes.
   const selectedAgent = watch("agent");
   useEffect(() => {
-    setValue("model", DEFAULT_MODEL_ID);
+    setValue("model", DEFAULT_MODEL_BY_AGENT[selectedAgent]);
   }, [selectedAgent, setValue]);
 
   const onSubmit: SubmitHandler<FormValues> = (values) => {

--- a/apps/web/core/components/runners/runner-cli-command.tsx
+++ b/apps/web/core/components/runners/runner-cli-command.tsx
@@ -17,6 +17,8 @@ type Props = {
   name?: string;
   workingDir?: string;
   agent?: string;
+  model?: string;
+  reasoningEffort?: string;
   isUsingBrowserOrigin?: boolean;
 };
 
@@ -79,7 +81,18 @@ function oneLineCommand(command: string, shell: TShell, args: Array<[string, str
 }
 
 export function RunnerCliCommand(props: Props) {
-  const { cloudUrl, workspaceSlug, projectIdentifier, podName, name, workingDir, agent, isUsingBrowserOrigin } = props;
+  const {
+    cloudUrl,
+    workspaceSlug,
+    projectIdentifier,
+    podName,
+    name,
+    workingDir,
+    agent,
+    model,
+    reasoningEffort,
+    isUsingBrowserOrigin,
+  } = props;
   const { t } = useTranslation();
   const [justCopied, setJustCopied] = useState(false);
   const [shell, setShell] = useState<TShell>("posix");
@@ -93,10 +106,12 @@ export function RunnerCliCommand(props: Props) {
       ["--name", name],
       ["--working-dir", workingDir],
       ["--agent", agent],
+      ["--model", model],
+      ["--reasoning-effort", reasoningEffort],
     ];
     if (shell === "posix") return posixCommandLines("pidash runner add", args).join("\n");
     return oneLineCommand("pidash runner add", shell, args);
-  }, [agent, cloudUrl, name, podName, projectIdentifier, shell, workspaceSlug, workingDir]);
+  }, [agent, cloudUrl, model, name, podName, projectIdentifier, reasoningEffort, shell, workspaceSlug, workingDir]);
 
   const shellLabel = (value: TShell): string => {
     if (value === "powershell") return t("PowerShell");
@@ -143,7 +158,9 @@ export function RunnerCliCommand(props: Props) {
         {command}
       </pre>
       {isUsingBrowserOrigin && (
-        <p className="mt-2 text-12 text-secondary">{t("Using the current browser origin as the cloud URL because VITE_API_BASE_URL is not configured.")}</p>
+        <p className="mt-2 text-12 text-secondary">
+          {t("Using the current browser origin as the cloud URL because VITE_API_BASE_URL is not configured.")}
+        </p>
       )}
       <div className="mt-2">
         <Button size="sm" onClick={copy}>

--- a/apps/web/core/components/runners/runner-models.ts
+++ b/apps/web/core/components/runners/runner-models.ts
@@ -102,6 +102,18 @@ export const RUNNER_MODEL_OPTIONS: Record<TRunnerAgent, IRunnerModelOption[]> = 
   "cursor-agent": [DEFAULT_OPTION, ...CURSOR_OPTIONS],
 };
 
+/**
+ * Pre-selected model option id per agent in the "Add runner" form. Claude
+ * runners default to Fable 5; the others fall back to the agent's own
+ * built-in model (the ``"default"`` sentinel). The id must exist in that
+ * agent's `RUNNER_MODEL_OPTIONS` list.
+ */
+export const DEFAULT_MODEL_BY_AGENT: Record<TRunnerAgent, string> = {
+  "claude-code": "claude-fable-5",
+  codex: DEFAULT_MODEL_ID,
+  "cursor-agent": DEFAULT_MODEL_ID,
+};
+
 /** Look up a selected option's label; falls back to the default label. */
 export function runnerModelLabel(agent: TRunnerAgent, id: string): string {
   const opt = RUNNER_MODEL_OPTIONS[agent].find((o) => o.id === id);

--- a/apps/web/core/components/runners/runner-models.ts
+++ b/apps/web/core/components/runners/runner-models.ts
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+/**
+ * Per-agent LLM model catalogs for the "Add runner" form. Selecting an
+ * option appends `--model` (and, for Codex, `--reasoning-effort`) to the
+ * generated `pidash runner add` command; the runner persists it as the
+ * agent's `model_default` in its local config.toml.
+ *
+ * The runner itself does NOT validate against these exact strings — it only
+ * checks that a model is *applicable* to the chosen agent (see
+ * runner/src/cli/runner_ops.rs::model_applies_to_agent) and otherwise falls
+ * back to the agent's built-in default. So a stale entry here downgrades to
+ * the agent default rather than failing enrollment.
+ */
+
+// Mirrors the runner CLI's ``--agent`` value-enum (kebab-case).
+export type TRunnerAgent = "claude-code" | "codex" | "cursor-agent";
+
+export interface IRunnerModelOption {
+  /** Unique select value within an agent's list. */
+  id: string;
+  /** Human-facing label shown in the dropdown. */
+  label: string;
+  /** `--model` value. Omitted for the "default" sentinel. */
+  model?: string;
+  /** `--reasoning-effort` value. Codex only. */
+  reasoningEffort?: string;
+}
+
+/** Sentinel id for "use the agent's built-in default" (omits `--model`). */
+export const DEFAULT_MODEL_ID = "default";
+
+const DEFAULT_OPTION: IRunnerModelOption = {
+  id: DEFAULT_MODEL_ID,
+  label: "Default (agent's built-in model)",
+};
+
+// Codex: model × reasoning effort. The effort tier is sent on `turn/start`;
+// `xhigh` is Codex's "extra high" tier.
+const CODEX_MODELS: Array<{ label: string; model: string }> = [
+  { label: "GPT-5.5", model: "gpt-5.5" },
+  { label: "GPT-5.4", model: "gpt-5.4" },
+  { label: "GPT-5.4 Mini", model: "gpt-5.4-mini" },
+];
+const CODEX_EFFORTS: Array<{ label: string; value: string }> = [
+  { label: "Low", value: "low" },
+  { label: "Medium", value: "medium" },
+  { label: "High", value: "high" },
+  { label: "Extra High", value: "xhigh" },
+];
+const CODEX_OPTIONS: IRunnerModelOption[] = CODEX_MODELS.flatMap((m) =>
+  CODEX_EFFORTS.map((e) => ({
+    id: `${m.model}:${e.value}`,
+    label: `${m.label} (${e.label})`,
+    model: m.model,
+    reasoningEffort: e.value,
+  }))
+);
+
+// Claude Code: model ids are Anthropic slugs; `[1m]` selects the 1M-context
+// variant.
+const CLAUDE_OPTIONS: IRunnerModelOption[] = [
+  { id: "claude-opus-4-8", label: "Opus 4.8", model: "claude-opus-4-8" },
+  { id: "claude-fable-5", label: "Fable 5", model: "claude-fable-5" },
+  { id: "claude-sonnet-4-6", label: "Sonnet 4.6", model: "claude-sonnet-4-6" },
+  { id: "claude-sonnet-4-6-1m", label: "Sonnet 4.6 (1M context)", model: "claude-sonnet-4-6[1m]" },
+];
+
+// Cursor: a curated subset of `cursor-agent models`. Cursor bakes the
+// reasoning tier into the slug itself, so there is no separate effort flag.
+// Update this list as Cursor's catalog changes (run `cursor-agent models`).
+const CURSOR_OPTIONS: IRunnerModelOption[] = [
+  { id: "auto", label: "Auto", model: "auto" },
+  { id: "composer-2.5", label: "Composer 2.5", model: "composer-2.5" },
+  { id: "gpt-5.5-high", label: "GPT-5.5 (High)", model: "gpt-5.5-high" },
+  { id: "gpt-5.5-extra-high", label: "GPT-5.5 (Extra High)", model: "gpt-5.5-extra-high" },
+  { id: "gpt-5.4-medium", label: "GPT-5.4", model: "gpt-5.4-medium" },
+  { id: "gpt-5.4-mini-medium", label: "GPT-5.4 Mini", model: "gpt-5.4-mini-medium" },
+  { id: "claude-opus-4-8-high", label: "Claude Opus 4.8", model: "claude-opus-4-8-high" },
+  {
+    id: "claude-opus-4-8-thinking-high",
+    label: "Claude Opus 4.8 (Thinking)",
+    model: "claude-opus-4-8-thinking-high",
+  },
+  { id: "claude-4.6-sonnet-medium", label: "Claude Sonnet 4.6", model: "claude-4.6-sonnet-medium" },
+  {
+    id: "claude-4.6-sonnet-medium-thinking",
+    label: "Claude Sonnet 4.6 (Thinking)",
+    model: "claude-4.6-sonnet-medium-thinking",
+  },
+  { id: "gemini-3.1-pro", label: "Gemini 3.1 Pro", model: "gemini-3.1-pro" },
+  { id: "grok-4.3", label: "Grok 4.3", model: "grok-4.3" },
+];
+
+export const RUNNER_MODEL_OPTIONS: Record<TRunnerAgent, IRunnerModelOption[]> = {
+  "claude-code": [DEFAULT_OPTION, ...CLAUDE_OPTIONS],
+  codex: [DEFAULT_OPTION, ...CODEX_OPTIONS],
+  "cursor-agent": [DEFAULT_OPTION, ...CURSOR_OPTIONS],
+};
+
+/** Look up a selected option's label; falls back to the default label. */
+export function runnerModelLabel(agent: TRunnerAgent, id: string): string {
+  const opt = RUNNER_MODEL_OPTIONS[agent].find((o) => o.id === id);
+  return opt?.label ?? DEFAULT_OPTION.label;
+}
+
+/**
+ * Resolve a selected option id to the CLI args it contributes. Returns an
+ * empty object for the "default" sentinel (so no `--model` is emitted).
+ */
+export function resolveRunnerModel(agent: TRunnerAgent, id: string): { model?: string; reasoningEffort?: string } {
+  const opt = RUNNER_MODEL_OPTIONS[agent].find((o) => o.id === id);
+  if (!opt) return {};
+  return { model: opt.model, reasoningEffort: opt.reasoningEffort };
+}

--- a/packages/i18n/src/locales/en/translations.ts
+++ b/packages/i18n/src/locales/en/translations.ts
@@ -903,6 +903,9 @@ export default {
   "Missing headings": "Missing headings",
   "Missing images": "Missing images",
   Modal: "Modal",
+  "Model (optional)": "Model (optional)",
+  "Default model this runner's agent uses. ``Default`` lets the agent pick its own; the choice is baked into the displayed ``pidash runner add`` command.":
+    "Default model this runner's agent uses. ``Default`` lets the agent pick its own; the choice is baked into the displayed ``pidash runner add`` command.",
   Modern: "Modern",
   Module: "Module",
   "Module actions": "Module actions",

--- a/runner/src/agent/mod.rs
+++ b/runner/src/agent/mod.rs
@@ -329,6 +329,7 @@ impl AgentBridge {
                     &runner.codex.binary,
                     cwd,
                     selected_model(model_override, runner.codex.model_default.clone()),
+                    runner.codex.effort_default.clone(),
                 )
                 .await?;
                 Ok(AgentBridge::Codex(b))

--- a/runner/src/cli/auth/login.rs
+++ b/runner/src/cli/auth/login.rs
@@ -520,6 +520,8 @@ async fn maybe_offer_runner_add(
             pod: None,
             working_dir: None,
             agent: crate::config::schema::AgentKind::default(),
+            model: None,
+            reasoning_effort: None,
         },
         paths,
     )

--- a/runner/src/cli/connect.rs
+++ b/runner/src/cli/connect.rs
@@ -49,6 +49,17 @@ pub struct Args {
     #[arg(long, value_enum)]
     pub agent: Option<AgentKind>,
 
+    /// Default LLM model for this runner's agent. Omit to use the agent's
+    /// own default. A model that doesn't apply to ``--agent`` is ignored
+    /// with a warning.
+    #[arg(long)]
+    pub model: Option<String>,
+
+    /// Codex reasoning-effort tier (``low`` / ``medium`` / ``high`` /
+    /// ``xhigh``). Only applies when ``--agent codex``.
+    #[arg(long)]
+    pub reasoning_effort: Option<String>,
+
     /// Skip the post-enroll doctor + service install. Useful in CI.
     #[arg(long)]
     pub skip_service: bool,
@@ -178,6 +189,12 @@ pub async fn run(args: Args, paths: &Paths) -> Result<()> {
         .clone()
         .unwrap_or_else(|| paths.runner_dir(resp.runner_id).join("workspace"));
 
+    let agent_kind = args.agent.unwrap_or_default();
+    let (codex, claude_code, cursor_agent) = crate::cli::runner_ops::agent_sections_for(
+        agent_kind,
+        args.model.as_deref(),
+        args.reasoning_effort.as_deref(),
+    );
     let new_runner_block = RunnerConfig {
         name: resp.runner_name.clone(),
         runner_id: resp.runner_id,
@@ -185,12 +202,10 @@ pub async fn run(args: Args, paths: &Paths) -> Result<()> {
         project_slug: Some(resp.project_identifier.clone()),
         pod_id: None,
         workspace: WorkspaceSection { working_dir },
-        agent: AgentSection {
-            kind: args.agent.unwrap_or_default(),
-        },
-        codex: Default::default(),
-        claude_code: Default::default(),
-        cursor_agent: Default::default(),
+        agent: AgentSection { kind: agent_kind },
+        codex,
+        claude_code,
+        cursor_agent,
         approval_policy: Default::default(),
     };
 

--- a/runner/src/cli/runner.rs
+++ b/runner/src/cli/runner.rs
@@ -69,6 +69,18 @@ pub struct AddArgs {
     /// Which agent CLI this runner drives.
     #[arg(long, value_enum, default_value_t = AgentKind::Codex)]
     pub agent: AgentKind,
+
+    /// Default LLM model for this runner's agent (e.g. `claude-opus-4-8`
+    /// for claude-code, `gpt-5.5` for codex, a `cursor-agent` slug for
+    /// cursor-agent). Omit to use the agent's own default. A model that
+    /// doesn't apply to `--agent` is ignored with a warning.
+    #[arg(long)]
+    pub model: Option<String>,
+
+    /// Codex reasoning-effort tier (`low` / `medium` / `high` / `xhigh`).
+    /// Only applies when `--agent codex`; ignored for other agents.
+    #[arg(long)]
+    pub reasoning_effort: Option<String>,
 }
 
 #[derive(Debug, ClapArgs)]
@@ -189,6 +201,8 @@ pub async fn add(args: AddArgs, paths: &Paths) -> Result<RunnerConfig> {
         &cloud_url,
         args.working_dir.clone(),
         args.agent,
+        args.model.as_deref(),
+        args.reasoning_effort.as_deref(),
     )
     .await
     {

--- a/runner/src/cli/runner_ops.rs
+++ b/runner/src/cli/runner_ops.rs
@@ -50,13 +50,19 @@ fn warn_model_fallback(msg: &str) {
 ///   `gpt-*`, `gemini-*`, `grok-*`, `composer-*`, `auto`, `kimi-*`, …),
 ///   so we accept any non-empty value and let `cursor-agent` reject
 ///   unknown slugs itself rather than wrongly dropping a valid one.
+///
+/// A bare dash-terminated prefix (`"claude-"`, `"gpt-"`) is rejected — it
+/// is an incomplete slug, not a model — so it can't be written as a bogus
+/// `model_default`.
 fn model_applies_to_agent(kind: AgentKind, model: &str) -> bool {
     let m = model.trim().to_ascii_lowercase();
+    // `prefix` followed by at least one more character.
+    let has = |prefix: &str| m.strip_prefix(prefix).is_some_and(|rest| !rest.is_empty());
     match kind {
-        AgentKind::ClaudeCode => m.starts_with("claude-"),
-        AgentKind::Codex => {
-            m.starts_with("gpt-") || m.starts_with("o3") || m.starts_with("o4") || m.starts_with("codex")
-        }
+        AgentKind::ClaudeCode => has("claude-"),
+        // `o3` / `o4` are valid bare model names; the dash-terminated
+        // families (`gpt-`, `codex`) require a suffix.
+        AgentKind::Codex => has("gpt-") || m == "o3" || m == "o4" || has("o3-") || has("o4-") || has("codex"),
         AgentKind::CursorAgent => !m.is_empty(),
     }
 }
@@ -75,30 +81,9 @@ pub fn agent_sections_for(
     let model = model.map(str::trim).filter(|s| !s.is_empty());
     let effort = reasoning_effort.map(str::trim).filter(|s| !s.is_empty());
 
-    // Reasoning effort only applies to Codex; validate the tier name.
-    let effort = match (agent_kind, effort) {
-        (_, None) => None,
-        (AgentKind::Codex, Some(e)) if CODEX_EFFORTS.contains(&e.to_ascii_lowercase().as_str()) => {
-            Some(e.to_ascii_lowercase())
-        }
-        (AgentKind::Codex, Some(e)) => {
-            warn_model_fallback(&format!(
-                "reasoning effort {e:?} is not a recognized Codex tier \
-                 (expected one of {}); using the model's default effort.",
-                CODEX_EFFORTS.join(", ")
-            ));
-            None
-        }
-        (_, Some(_)) => {
-            warn_model_fallback(&format!(
-                "--reasoning-effort only applies to the codex agent, not {}; ignoring it.",
-                agent_kind.display_name()
-            ));
-            None
-        }
-    };
-
-    // Model: drop it (with a warning) when it's not applicable to the agent.
+    // Resolve the model first: drop it (with a warning) when it isn't
+    // applicable to the chosen agent. `effort` below is keyed off the
+    // resolved model, so this has to run first.
     let model = match model {
         None => None,
         Some(m) if model_applies_to_agent(agent_kind, m) => Some(m.to_string()),
@@ -106,6 +91,38 @@ pub fn agent_sections_for(
             warn_model_fallback(&format!(
                 "model {m:?} is not applicable to the {} agent; \
                  using the agent's default model instead.",
+                agent_kind.display_name()
+            ));
+            None
+        }
+    };
+
+    // Reasoning effort only applies to Codex, and only alongside an explicit
+    // model — it is meaningless on its own (see `CodexSection::effort_default`),
+    // so it is dropped when the model was absent or rejected above.
+    let effort = match (agent_kind, effort) {
+        (_, None) => None,
+        (AgentKind::Codex, Some(e))
+            if !CODEX_EFFORTS.contains(&e.to_ascii_lowercase().as_str()) =>
+        {
+            warn_model_fallback(&format!(
+                "reasoning effort {e:?} is not a recognized Codex tier \
+                 (expected one of {}); using the model's default effort.",
+                CODEX_EFFORTS.join(", ")
+            ));
+            None
+        }
+        (AgentKind::Codex, Some(e)) if model.is_some() => Some(e.to_ascii_lowercase()),
+        (AgentKind::Codex, Some(_)) => {
+            // Valid tier, but no applicable model to attach it to.
+            warn_model_fallback(
+                "--reasoning-effort needs an applicable --model for the codex agent; ignoring it.",
+            );
+            None
+        }
+        (_, Some(_)) => {
+            warn_model_fallback(&format!(
+                "--reasoning-effort only applies to the codex agent, not {}; ignoring it.",
                 agent_kind.display_name()
             ));
             None
@@ -482,6 +499,43 @@ mod tests {
     fn blank_model_is_treated_as_unset() {
         let (codex, _, _) = agent_sections_for(AgentKind::Codex, Some("   "), None);
         assert_eq!(codex.model_default, None);
+    }
+
+    #[test]
+    fn codex_effort_dropped_when_model_inapplicable() {
+        // A Claude model handed to codex: the model is dropped, and the
+        // effort meant for it must not survive onto codex's default model.
+        let (codex, _, _) =
+            agent_sections_for(AgentKind::Codex, Some("claude-opus-4-8"), Some("high"));
+        assert_eq!(codex.model_default, None);
+        assert_eq!(codex.effort_default, None);
+    }
+
+    #[test]
+    fn codex_effort_dropped_without_a_model() {
+        // Effort is meaningless without an explicit model (see the
+        // CodexSection::effort_default contract).
+        let (codex, _, _) = agent_sections_for(AgentKind::Codex, None, Some("high"));
+        assert_eq!(codex.model_default, None);
+        assert_eq!(codex.effort_default, None);
+    }
+
+    #[test]
+    fn bare_prefix_models_are_rejected() {
+        // A dash-terminated prefix with nothing after it is an incomplete
+        // slug, not a model — it must not become a bogus model_default.
+        let (_, claude, _) = agent_sections_for(AgentKind::ClaudeCode, Some("claude-"), None);
+        assert_eq!(claude.model_default, None);
+        let (codex, _, _) = agent_sections_for(AgentKind::Codex, Some("gpt-"), None);
+        assert_eq!(codex.model_default, None);
+    }
+
+    #[test]
+    fn bare_openai_reasoning_models_are_accepted() {
+        // `o3` / `o4` are valid bare model names; the bare-prefix guard
+        // must not reject them.
+        let (codex, _, _) = agent_sections_for(AgentKind::Codex, Some("o3"), None);
+        assert_eq!(codex.model_default.as_deref(), Some("o3"));
     }
 
     fn paths_for(root: &std::path::Path) -> Paths {

--- a/runner/src/cli/runner_ops.rs
+++ b/runner/src/cli/runner_ops.rs
@@ -17,7 +17,114 @@ use crate::config::schema::{
     Config, DaemonConfig, RunnerConfig, WorkspaceSection,
 };
 use crate::util::paths::Paths;
+use std::io::IsTerminal;
 use uuid::Uuid;
+
+/// Codex reasoning-effort tiers accepted by `--reasoning-effort` / the
+/// cloud dropdown. Passed verbatim to codex `turn/start`; the exact set a
+/// given codex build honours can vary, so an unrecognized value here is a
+/// soft warning, not a hard error.
+const CODEX_EFFORTS: &[&str] = &["low", "medium", "high", "xhigh"];
+
+/// Print an orange (256-color 208) warning to stderr. Used when a
+/// `--model` / `--reasoning-effort` value can't be applied to the chosen
+/// agent: we never fail the enrollment over it, just tell the operator we
+/// fell back to the agent's default. Color is suppressed when stderr is
+/// not a TTY (logs / CI) and when `NO_COLOR` is set.
+fn warn_model_fallback(msg: &str) {
+    let color = std::io::stderr().is_terminal() && std::env::var_os("NO_COLOR").is_none();
+    if color {
+        eprintln!("\x1b[38;5;208m⚠ {msg}\x1b[0m");
+    } else {
+        eprintln!("⚠ {msg}");
+    }
+}
+
+/// Whether a model id is meaningful for the given agent. The cloud "add
+/// runner" dropdown only offers each agent's own models, so this guards
+/// the hand-typed-CLI case (`--agent claude-code --model gpt-5.5`).
+///
+/// - **Claude Code** drives Anthropic models only (`claude-…`).
+/// - **Codex** drives OpenAI models (`gpt-…`, `o3`/`o4`, `codex…`).
+/// - **Cursor** has a broad, account-specific slug space (`claude-*`,
+///   `gpt-*`, `gemini-*`, `grok-*`, `composer-*`, `auto`, `kimi-*`, …),
+///   so we accept any non-empty value and let `cursor-agent` reject
+///   unknown slugs itself rather than wrongly dropping a valid one.
+fn model_applies_to_agent(kind: AgentKind, model: &str) -> bool {
+    let m = model.trim().to_ascii_lowercase();
+    match kind {
+        AgentKind::ClaudeCode => m.starts_with("claude-"),
+        AgentKind::Codex => {
+            m.starts_with("gpt-") || m.starts_with("o3") || m.starts_with("o4") || m.starts_with("codex")
+        }
+        AgentKind::CursorAgent => !m.is_empty(),
+    }
+}
+
+/// Build the three per-agent config sections for a fresh `[[runner]]`,
+/// applying the operator's `--model` / `--reasoning-effort` to whichever
+/// agent was selected. Inapplicable combinations are non-fatal: an orange
+/// warning is printed and that knob falls back to the agent default (left
+/// unset in the config). Shared by `pidash runner add` and the deprecated
+/// `pidash connect`.
+pub fn agent_sections_for(
+    agent_kind: AgentKind,
+    model: Option<&str>,
+    reasoning_effort: Option<&str>,
+) -> (CodexSection, ClaudeCodeSection, CursorAgentSection) {
+    let model = model.map(str::trim).filter(|s| !s.is_empty());
+    let effort = reasoning_effort.map(str::trim).filter(|s| !s.is_empty());
+
+    // Reasoning effort only applies to Codex; validate the tier name.
+    let effort = match (agent_kind, effort) {
+        (_, None) => None,
+        (AgentKind::Codex, Some(e)) if CODEX_EFFORTS.contains(&e.to_ascii_lowercase().as_str()) => {
+            Some(e.to_ascii_lowercase())
+        }
+        (AgentKind::Codex, Some(e)) => {
+            warn_model_fallback(&format!(
+                "reasoning effort {e:?} is not a recognized Codex tier \
+                 (expected one of {}); using the model's default effort.",
+                CODEX_EFFORTS.join(", ")
+            ));
+            None
+        }
+        (_, Some(_)) => {
+            warn_model_fallback(&format!(
+                "--reasoning-effort only applies to the codex agent, not {}; ignoring it.",
+                agent_kind.display_name()
+            ));
+            None
+        }
+    };
+
+    // Model: drop it (with a warning) when it's not applicable to the agent.
+    let model = match model {
+        None => None,
+        Some(m) if model_applies_to_agent(agent_kind, m) => Some(m.to_string()),
+        Some(m) => {
+            warn_model_fallback(&format!(
+                "model {m:?} is not applicable to the {} agent; \
+                 using the agent's default model instead.",
+                agent_kind.display_name()
+            ));
+            None
+        }
+    };
+
+    let mut codex = CodexSection::default();
+    let mut claude_code = ClaudeCodeSection::default();
+    let mut cursor_agent = CursorAgentSection::default();
+    match agent_kind {
+        AgentKind::Codex => {
+            codex.model_default = model;
+            codex.effort_default = effort;
+        }
+        AgentKind::ClaudeCode => claude_code.model_default = model,
+        AgentKind::CursorAgent => cursor_agent.model_default = model,
+    }
+    (codex, claude_code, cursor_agent)
+}
 
 /// Read the user's CLI token from `[cli].token` in `config.toml`.
 /// Returns `Ok(None)` when no config exists yet or the section is
@@ -193,10 +300,14 @@ pub async fn apply_enroll_response(
     cloud_url: &str,
     working_dir: Option<PathBuf>,
     agent_kind: AgentKind,
+    model: Option<&str>,
+    reasoning_effort: Option<&str>,
 ) -> Result<AppliedRunner> {
     let working_dir =
         working_dir.unwrap_or_else(|| paths.runner_dir(resp.runner_id).join("workspace"));
 
+    let (codex, claude_code, cursor_agent) =
+        agent_sections_for(agent_kind, model, reasoning_effort);
     let new_runner = RunnerConfig {
         name: resp.runner_name.clone(),
         runner_id: resp.runner_id,
@@ -205,9 +316,9 @@ pub async fn apply_enroll_response(
         pod_id: None,
         workspace: WorkspaceSection { working_dir },
         agent: AgentSection { kind: agent_kind },
-        codex: CodexSection::default(),
-        claude_code: ClaudeCodeSection::default(),
-        cursor_agent: CursorAgentSection::default(),
+        codex,
+        claude_code,
+        cursor_agent,
         approval_policy: ApprovalPolicySection::default(),
     };
 
@@ -315,6 +426,64 @@ mod tests {
     use tempfile::tempdir;
     use uuid::Uuid;
 
+    #[test]
+    fn model_routes_to_selected_agent_section() {
+        let (codex, claude, cursor) =
+            agent_sections_for(AgentKind::ClaudeCode, Some("claude-opus-4-8"), None);
+        assert_eq!(claude.model_default.as_deref(), Some("claude-opus-4-8"));
+        assert_eq!(codex.model_default, None);
+        assert_eq!(cursor.model_default, None);
+    }
+
+    #[test]
+    fn codex_model_and_effort_are_applied_together() {
+        let (codex, _, _) = agent_sections_for(AgentKind::Codex, Some("gpt-5.5"), Some("High"));
+        assert_eq!(codex.model_default.as_deref(), Some("gpt-5.5"));
+        // Effort is normalized to lowercase.
+        assert_eq!(codex.effort_default.as_deref(), Some("high"));
+    }
+
+    #[test]
+    fn mismatched_model_falls_back_to_agent_default() {
+        // The user's example: a Codex model handed to the Claude agent.
+        // Non-fatal — the model is dropped (warning printed) and the
+        // section is left at its default (None).
+        let (_, claude, _) = agent_sections_for(AgentKind::ClaudeCode, Some("gpt-5.5"), None);
+        assert_eq!(claude.model_default, None);
+    }
+
+    #[test]
+    fn effort_ignored_for_non_codex_agents() {
+        let (_, claude, _) =
+            agent_sections_for(AgentKind::ClaudeCode, Some("claude-opus-4-8"), Some("high"));
+        // Model still applies; effort has no home on the claude section.
+        assert_eq!(claude.model_default.as_deref(), Some("claude-opus-4-8"));
+    }
+
+    #[test]
+    fn unknown_codex_effort_is_dropped() {
+        let (codex, _, _) =
+            agent_sections_for(AgentKind::Codex, Some("gpt-5.5"), Some("turbo"));
+        assert_eq!(codex.model_default.as_deref(), Some("gpt-5.5"));
+        assert_eq!(codex.effort_default, None);
+    }
+
+    #[test]
+    fn cursor_accepts_any_nonempty_slug() {
+        let (_, _, cursor) =
+            agent_sections_for(AgentKind::CursorAgent, Some("claude-opus-4-8-thinking-high"), None);
+        assert_eq!(
+            cursor.model_default.as_deref(),
+            Some("claude-opus-4-8-thinking-high")
+        );
+    }
+
+    #[test]
+    fn blank_model_is_treated_as_unset() {
+        let (codex, _, _) = agent_sections_for(AgentKind::Codex, Some("   "), None);
+        assert_eq!(codex.model_default, None);
+    }
+
     fn paths_for(root: &std::path::Path) -> Paths {
         Paths {
             config_dir: root.join("config"),
@@ -352,6 +521,8 @@ mod tests {
             "https://example.com",
             Some(tmp.path().join("wd")),
             AgentKind::Codex,
+            None,
+            None,
         )
         .await
         .unwrap();
@@ -373,6 +544,8 @@ mod tests {
             "https://example.com",
             Some(tmp.path().join("wd1")),
             AgentKind::Codex,
+            None,
+            None,
         )
         .await
         .unwrap();
@@ -384,6 +557,8 @@ mod tests {
             "https://example.com",
             Some(tmp.path().join("wd2")),
             AgentKind::Codex,
+            None,
+            None,
         )
         .await
         .unwrap();
@@ -407,6 +582,8 @@ mod tests {
             "https://cloud-a.example.com",
             Some(tmp.path().join("wd1")),
             AgentKind::Codex,
+            None,
+            None,
         )
         .await
         .unwrap();
@@ -418,6 +595,8 @@ mod tests {
             "https://cloud-b.example.com",
             Some(tmp.path().join("wd2")),
             AgentKind::Codex,
+            None,
+            None,
         )
         .await
         .unwrap_err();

--- a/runner/src/codex/bridge.rs
+++ b/runner/src/codex/bridge.rs
@@ -20,6 +20,10 @@ use crate::codex::schema::{
 pub struct Bridge {
     pub server: AppServer,
     pub model_default: Option<String>,
+    /// Reasoning-effort tier sent on every `turn/start` (`low`/`medium`/
+    /// `high`/`xhigh`). `None` omits the field so codex uses the model's
+    /// default effort. Sourced from `[runner.codex].effort_default`.
+    pub effort_default: Option<String>,
     initialized: bool,
     thread_id: Option<String>,
     /// Notifications that arrived while we were waiting for an RPC response
@@ -30,11 +34,17 @@ pub struct Bridge {
 }
 
 impl Bridge {
-    pub async fn spawn(binary: &str, cwd: &Path, model_default: Option<String>) -> Result<Self> {
+    pub async fn spawn(
+        binary: &str,
+        cwd: &Path,
+        model_default: Option<String>,
+        effort_default: Option<String>,
+    ) -> Result<Self> {
         let server = AppServer::spawn(binary, cwd).await?;
         Ok(Self {
             server,
             model_default,
+            effort_default,
             initialized: false,
             thread_id: None,
             pending: std::collections::VecDeque::new(),
@@ -47,6 +57,7 @@ impl Bridge {
         Self {
             server,
             model_default,
+            effort_default: None,
             initialized: false,
             thread_id: None,
             pending: std::collections::VecDeque::new(),
@@ -150,7 +161,7 @@ impl Bridge {
                     text: payload.prompt.clone(),
                 }],
                 model: payload.model.clone().or_else(|| self.model_default.clone()),
-                effort: None,
+                effort: self.effort_default.clone(),
             },
         )?;
         self.server.send_raw(&line).await

--- a/runner/src/config/schema.rs
+++ b/runner/src/config/schema.rs
@@ -166,6 +166,12 @@ pub struct CodexSection {
     pub binary: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_default: Option<String>,
+    /// Reasoning-effort tier passed to codex `turn/start` (`low` / `medium`
+    /// / `high` / `xhigh`). `None` omits the field so codex applies the
+    /// model's own default effort. Only meaningful alongside `model_default`
+    /// — `pidash runner add --reasoning-effort` writes this.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort_default: Option<String>,
 }
 
 impl Default for CodexSection {
@@ -178,6 +184,7 @@ impl Default for CodexSection {
         Self {
             binary: "codex".to_string(),
             model_default: None,
+            effort_default: None,
         }
     }
 }

--- a/runner/tests/pidash_runner_add_auth.rs
+++ b/runner/tests/pidash_runner_add_auth.rs
@@ -209,6 +209,8 @@ async fn runner_add_checks_local_cap_before_auth_bootstrap() {
             pod: None,
             working_dir: None,
             agent: AgentKind::Codex,
+            model: None,
+            reasoning_effort: None,
         },
         &paths,
     )
@@ -243,6 +245,8 @@ async fn runner_add_rejects_invalid_name_before_auth_bootstrap() {
             pod: None,
             working_dir: None,
             agent: AgentKind::Codex,
+            model: None,
+            reasoning_effort: None,
         },
         &paths,
     )
@@ -282,6 +286,8 @@ async fn runner_add_bootstraps_auth_when_cli_token_is_missing() {
             pod: None,
             working_dir: None,
             agent: AgentKind::Codex,
+            model: None,
+            reasoning_effort: None,
         },
         &paths,
     )
@@ -349,6 +355,8 @@ async fn runner_add_auth_bootstrap_uses_explicit_workspace_without_prompt() {
             pod: None,
             working_dir: None,
             agent: AgentKind::Codex,
+            model: None,
+            reasoning_effort: None,
         },
         &paths,
     )


### PR DESCRIPTION
## Summary

Lets operators pin the **default model** a runner's agent uses — both from the CLI (`pidash runner add --model …`) and from the cloud **Add runner** modal (agent-dependent model dropdown). Option A: one `--model` flag routed by `--agent`, with a non-fatal applicability check, plus full Codex reasoning-effort plumbing.

Because the modal **generates a `pidash runner add` command** (it doesn't POST), the model lands in the runner's local `config.toml` — **no Django/ORM/wire-protocol changes needed**. The existing per-run `expected_codex_model` override still wins when present; this only sets the fallback default.

## Runner (Rust)
- `--model` + codex-only `--reasoning-effort` on `pidash runner add` (and the deprecated `connect`), routed into the selected agent's config section.
- `runner_ops::agent_sections_for` validates **applicability**: a model that doesn't fit the chosen agent (e.g. `--agent claude-code --model gpt-5.5`) is dropped with an **orange warning** and falls back to the agent default — never fails enrollment. Claude → `claude-*`; Codex → `gpt-*`/`o3`/`o4`/`codex`; Cursor → any non-empty slug (its space is huge/account-specific).
- Codex reasoning effort plumbed end-to-end: new `CodexSection.effort_default` → `AgentBridge` → codex `turn/start.effort` (was hardcoded `None`).
- 7 new unit tests; all runner tests pass, `clippy -D warnings` clean.

## Cloud UI (web)
- Agent-dependent **model dropdown** in the add-runner modal (default = agent's own model); resets when the agent changes; appends `--model`/`--reasoning-effort` to the generated command.
- New `runner-models.ts` catalog:
  - **Codex**: GPT-5.5 / 5.4 / 5.4-mini × Low/Medium/High/Extra-High (`xhigh`).
  - **Claude**: Opus 4.8, Fable 5, Sonnet 4.6, Sonnet 4.6 (1M → `claude-sonnet-4-6[1m]`).
  - **Cursor**: curated subset from live `cursor-agent models`.

## Verify before merge
- **`xhigh`**: the effort string is passed straight to `codex app-server`; confirm your Codex build accepts `xhigh` (older builds: low/medium/high only).
- The **Cursor** list mirrors today's `cursor-agent models` and will drift as Cursor updates — refresh `runner-models.ts` accordingly.

## Test plan
- [x] `cargo test` (runner) — 320 pass, incl. 7 new
- [x] `cargo clippy -- -D warnings` — clean
- [x] `oxlint` on the 3 touched web files — clean
- [x] `pidash runner add --help` shows `--model` / `--reasoning-effort`
- [ ] Manual: generate a command in the modal per agent; confirm `--model`/`--reasoning-effort` appear and a mismatched hand-typed model warns + falls back

Note: `pnpm check:types --filter=web` reports errors, but all are pre-existing in unrelated files (`scheduler.store.ts`, `github-sync.tsx`, `rrule-text.ts`, …) — none in files touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)