### PR TITLE
feat(runner): record safety-classifier refusals as a distinct AgentRun outcome

### DIFF
--- a/apps/api/pi_dash/runner/migrations/0016_agent_run_refused.py
+++ b/apps/api/pi_dash/runner/migrations/0016_agent_run_refused.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Record safety-classifier refusals as a first-class AgentRun outcome.
+
+Adds the ``refused`` terminal status and a ``refusal_category`` column so a
+model decline (e.g. Claude Fable 5 cyber/bio) is queryable separately from a
+generic FAILED. See ``runner/services/run_lifecycle.py`` and the
+``RunFailedEndpoint`` ``reason="refusal"`` branch.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("runner", "0015_dev_machine_visibility"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="agentrun",
+            name="refusal_category",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("cyber", "Cyber"),
+                    ("bio", "Bio"),
+                    ("reasoning_extraction", "Reasoning Extraction"),
+                    ("unknown", "Unknown"),
+                ],
+                default="",
+                max_length=32,
+            ),
+        ),
+        migrations.AlterField(
+            model_name="agentrun",
+            name="status",
+            field=models.CharField(
+                choices=[
+                    ("queued", "Queued"),
+                    ("assigned", "Assigned"),
+                    ("running", "Running"),
+                    ("awaiting_approval", "Awaiting Approval"),
+                    ("awaiting_reauth", "Awaiting Reauth"),
+                    ("paused_awaiting_input", "Paused — Awaiting Input"),
+                    ("blocked", "Blocked"),
+                    ("completed", "Completed"),
+                    ("failed", "Failed"),
+                    ("cancelled", "Cancelled"),
+                    ("refused", "Refused"),
+                ],
+                db_index=True,
+                default="queued",
+                max_length=24,
+            ),
+        ),
+    ]

--- a/apps/api/pi_dash/runner/models.py
+++ b/apps/api/pi_dash/runner/models.py
@@ -193,6 +193,25 @@ class AgentRunStatus(models.TextChoices):
     COMPLETED = "completed", "Completed"
     FAILED = "failed", "Failed"
     CANCELLED = "cancelled", "Cancelled"
+    # Terminal: the model declined the task under a safety classifier
+    # (e.g. Claude Fable 5 cyber/bio). Kept distinct from FAILED so a policy
+    # decline is queryable separately from a crash; the category is recorded
+    # in ``AgentRun.refusal_category``.
+    REFUSED = "refused", "Refused"
+
+
+class RefusalCategory(models.TextChoices):
+    """Safety-classifier decline category, mirrored from the Messages API
+    ``stop_details.category`` (Anthropic refusals-and-fallback docs).
+
+    ``UNKNOWN`` covers a refusal that carried no named category (the API
+    returns ``null`` there).
+    """
+
+    CYBER = "cyber", "Cyber"
+    BIO = "bio", "Bio"
+    REASONING_EXTRACTION = "reasoning_extraction", "Reasoning Extraction"
+    UNKNOWN = "unknown", "Unknown"
 
 
 class ApprovalStatus(models.TextChoices):
@@ -760,6 +779,15 @@ class AgentRun(models.Model):
     lease_expires_at = models.DateTimeField(null=True, blank=True)
     done_payload = models.JSONField(null=True, blank=True)
     error = models.TextField(blank=True, default="")
+    # Set only when ``status == REFUSED``: the safety-classifier category the
+    # runner reported (mirrors Messages API ``stop_details.category``). Empty
+    # for every non-refusal terminal state.
+    refusal_category = models.CharField(
+        max_length=32,
+        choices=RefusalCategory.choices,
+        blank=True,
+        default="",
+    )
     llm_model = models.CharField(max_length=128, blank=True, default="")
     input_tokens = models.BigIntegerField(null=True, blank=True)
     output_tokens = models.BigIntegerField(null=True, blank=True)
@@ -820,6 +848,7 @@ class AgentRun(models.Model):
             AgentRunStatus.FAILED,
             AgentRunStatus.CANCELLED,
             AgentRunStatus.BLOCKED,
+            AgentRunStatus.REFUSED,
         }
 
     @property

--- a/apps/api/pi_dash/runner/serializers.py
+++ b/apps/api/pi_dash/runner/serializers.py
@@ -221,6 +221,7 @@ class AgentRunSerializer(serializers.ModelSerializer):
             "ended_at",
             "done_payload",
             "error",
+            "refusal_category",
             "llm_model",
             "input_tokens",
             "output_tokens",

--- a/apps/api/pi_dash/runner/services/run_lifecycle.py
+++ b/apps/api/pi_dash/runner/services/run_lifecycle.py
@@ -26,6 +26,7 @@ from django.utils import timezone
 from pi_dash.runner.models import (
     AgentRun,
     AgentRunStatus,
+    RefusalCategory,
     Runner,
     RunnerLiveState,
 )
@@ -37,12 +38,22 @@ TERMINAL_RUN_STATUSES = (
     AgentRunStatus.FAILED,
     AgentRunStatus.CANCELLED,
     AgentRunStatus.BLOCKED,
+    AgentRunStatus.REFUSED,
 )
 BIGINT_MAX = 2**63 - 1
+
+_VALID_REFUSAL_CATEGORIES = frozenset(c.value for c in RefusalCategory)
 
 
 def _normalize_model(raw: Any) -> str:
     return str(raw or "").strip()[:128]
+
+
+def _normalize_refusal_category(raw: Any) -> str:
+    """Map a runner-reported category to a known value, defaulting to
+    ``UNKNOWN`` for anything unrecognized or empty."""
+    value = str(raw or "").strip().lower()
+    return value if value in _VALID_REFUSAL_CATEGORIES else RefusalCategory.UNKNOWN.value
 
 
 def _coerce_token(raw: Any) -> Optional[int]:
@@ -347,6 +358,7 @@ def finalize_run_terminal(
     *,
     done_payload: Any = None,
     error_detail: str = "",
+    refusal_category: Any = None,
     tokens: Any = None,
     model: Any = None,
 ) -> None:
@@ -372,6 +384,12 @@ def finalize_run_terminal(
         updates["error"] = ""
     if new_status == AgentRunStatus.FAILED and error_detail:
         updates["error"] = error_detail[:16000]
+    if new_status == AgentRunStatus.REFUSED:
+        # A safety-classifier decline. Record the category (always set, so the
+        # column is queryable) and surface the explanation, if any, in `error`.
+        updates["refusal_category"] = _normalize_refusal_category(refusal_category)
+        if error_detail:
+            updates["error"] = error_detail[:16000]
     live_state = _matching_live_state(runner, run_id)
     updates.update(_usage_updates_from_live_state(live_state))
     updates.update(_token_updates(_payload_usage(done_payload)))

--- a/apps/api/pi_dash/runner/services/scheduler_hook.py
+++ b/apps/api/pi_dash/runner/services/scheduler_hook.py
@@ -27,8 +27,16 @@ def update_scheduler_binding_on_terminate(run: AgentRun) -> None:
         if binding.last_error:
             binding.last_error = ""
             binding.save(update_fields=["last_error", "updated_at"])
-    elif run.status in (AgentRunStatus.FAILED, AgentRunStatus.CANCELLED):
-        msg = (run.error or run.status)[:LAST_ERROR_MAX_LEN]
+    elif run.status in (AgentRunStatus.FAILED, AgentRunStatus.CANCELLED, AgentRunStatus.REFUSED):
+        if run.status == AgentRunStatus.REFUSED:
+            # Surface the decline category so the scheduler tab shows *why* the
+            # tick produced nothing (e.g. "refused (cyber)"), not a bare error.
+            raw = f"refused ({run.refusal_category or 'unknown'})"
+            if run.error:
+                raw = f"{raw}: {run.error}"
+        else:
+            raw = run.error or run.status
+        msg = raw[:LAST_ERROR_MAX_LEN]
         if binding.last_error != msg:
             binding.last_error = msg
             binding.save(update_fields=["last_error", "updated_at"])

--- a/apps/api/pi_dash/runner/views/run_endpoints.py
+++ b/apps/api/pi_dash/runner/views/run_endpoints.py
@@ -320,6 +320,21 @@ class RunFailedEndpoint(_RunEndpointBase):
                     locked_run=locked,
                 )
                 return Response({"ok": True, "rescheduled": True})
+            # A safety-classifier decline (e.g. Claude Fable 5 cyber/bio) is a
+            # terminal REFUSED, not a generic crash. The runner reports
+            # `reason: "refusal"` with a `category`; record both so a policy
+            # decline stays queryable apart from a FAILED.
+            if (request.data.get("reason") or "") == "refusal":
+                run_lifecycle.finalize_run_terminal(
+                    runner,
+                    run.id,
+                    AgentRunStatus.REFUSED,
+                    error_detail=request.data.get("detail") or "",
+                    refusal_category=request.data.get("category"),
+                    tokens=request.data.get("tokens") or request.data.get("usage"),
+                    model=request.data.get("model"),
+                )
+                return Response({"ok": True, "refused": True})
             run_lifecycle.finalize_run_terminal(
                 runner,
                 run.id,

--- a/apps/api/pi_dash/tests/unit/runner/test_https_transport_run_endpoints.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_https_transport_run_endpoints.py
@@ -346,6 +346,55 @@ def test_fail_endpoint_resume_unavailable_requeues_instead_of_terminating(
 
 
 @pytest.mark.unit
+def test_fail_endpoint_refusal_records_refused_and_category(
+    db, api_client, runner_token, assigned_run
+):
+    """A RunFailed{reason: refusal} is recorded as terminal REFUSED with the
+    safety-classifier category, not a generic FAILED. This is how a Claude
+    Fable 5 cyber/bio decline stays queryable apart from a crash.
+    """
+    resp = api_client.post(
+        f"/api/v1/runner/runs/{assigned_run.id}/fail/",
+        {
+            "reason": "refusal",
+            "category": "cyber",
+            "detail": "declined under cyber policy",
+            "model": "claude-fable-5",
+        },
+        format="json",
+        HTTP_AUTHORIZATION=f"Bearer {runner_token}",
+    )
+    assert resp.status_code == 200, resp.data
+    assert resp.data.get("refused") is True
+    assigned_run.refresh_from_db()
+    assert assigned_run.status == AgentRunStatus.REFUSED
+    assert assigned_run.refusal_category == "cyber"
+    assert assigned_run.error == "declined under cyber policy"
+    assert assigned_run.llm_model == "claude-fable-5"
+    assert assigned_run.ended_at is not None
+
+
+@pytest.mark.unit
+def test_fail_endpoint_refusal_unknown_category_normalizes(
+    db, api_client, runner_token, assigned_run
+):
+    """A refusal with a missing/unrecognized category is still recorded as
+    REFUSED, with the category normalized to ``unknown`` so the column is
+    always populated for a decline."""
+    resp = api_client.post(
+        f"/api/v1/runner/runs/{assigned_run.id}/fail/",
+        {"reason": "refusal", "category": "not_a_real_category"},
+        format="json",
+        HTTP_AUTHORIZATION=f"Bearer {runner_token}",
+    )
+    assert resp.status_code == 200, resp.data
+    assert resp.data.get("refused") is True
+    assigned_run.refresh_from_db()
+    assert assigned_run.status == AgentRunStatus.REFUSED
+    assert assigned_run.refusal_category == "unknown"
+
+
+@pytest.mark.unit
 def test_paused_endpoint_posts_question_to_issue_thread(
     db, api_client, runner_token, enrolled_runner, workspace, pod
 ):


### PR DESCRIPTION
## What

Makes a model **safety-classifier refusal** a first-class terminal outcome on `AgentRun`, instead of an indistinguishable generic `FAILED`. Applies to both **scheduler ticks** and **issue runs** (both terminate through the same endpoint).

## Why

Claude Fable 5 (and Mythos-class models) include classifiers that decline `cyber` / `bio` / `reasoning_extraction` requests. On the raw Messages API a decline returns `stop_reason: "refusal"` with no answer. Without this, such a run looks like a mysterious crash — you can't tell a policy decline from a real failure, can't measure how often it happens, and the Schedulers tab shows a bare error.

## Changes

| File | Change |
|---|---|
| `runner/models.py` | `AgentRunStatus.REFUSED` (terminal); `RefusalCategory` choices; `AgentRun.refusal_category`; `REFUSED` in `is_terminal` |
| `runner/services/run_lifecycle.py` | `REFUSED` in `TERMINAL_RUN_STATUSES`; `_normalize_refusal_category()`; `finalize_run_terminal(..., refusal_category=...)` records category + explanation |
| `runner/views/run_endpoints.py` | `RunFailedEndpoint` branches on `reason == "refusal"` → finalizes `REFUSED` (mirrors the existing `resume_unavailable` special case) |
| `runner/services/scheduler_hook.py` | Records `"refused (<category>)"` on `SchedulerBinding.last_error` |
| `runner/serializers.py` | Exposes `refusal_category` |
| `migrations/0016_agent_run_refused.py` | `AddField` + `AlterField(status)` |
| tests | Cyber refusal records `REFUSED`+category; unknown category normalizes to `unknown` |

## Runner contract (Rust follow-up)

The cloud records a refusal only if the runner reports it:
```
POST /api/v1/runner/runs/{id}/fail/
{ "reason": "refusal", "category": "cyber", "detail": "<explanation>", "model": "claude-fable-5" }
```
Detection lives in the Rust `runner/` (driving `codex app-server`) and depends on the app-server surfacing `stop_reason`/`stop_details.category`. **Note:** when server-side fallback is configured at the model-call layer, there is no refusal to report — the request silently succeeds on the fallback model, so this path only fires when fallback is off (or every fallback also declines).

## Verification

- All files compile; the two new endpoint tests are migration-independent, so CI's `--nomigrations` pytest **does** exercise them.
- Migration `0016` (`AddField` + `AlterField`) is **not** run by CI (`--nomigrations`); standard and low-risk, but run a real `migrate` before prod.

## Not in this PR (flagged, not skipped)

- **Rust runner detection** — separate layer; contract above.
- **Web UI** — label/badge for the `refused` status + show `refusal_category`.
- **Issue comment on REFUSED** — currently records on the `AgentRun` but does not comment on the issue (kept failure-comment behavior `FAILED`-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)