### PR TITLE
fix(runner): send correct Codex app-server sandbox field on thread/start

### DIFF
--- a/runner/src/codex/bridge.rs
+++ b/runner/src/codex/bridge.rs
@@ -124,7 +124,7 @@ impl Bridge {
                 cwd: cwd.to_string_lossy().to_string(),
                 model: self.model_default.clone(),
                 // Match Claude Code's MVP `bypassPermissions` posture.
-                sandbox_policy: "danger-full-access".into(),
+                sandbox: "danger-full-access".into(),
                 approval_policy: "never".into(),
             },
         )?;

--- a/runner/src/codex/schema.rs
+++ b/runner/src/codex/schema.rs
@@ -71,7 +71,7 @@ pub struct ThreadStartParams {
     // (`gpt-5-codex`), which is unavailable on ChatGPT-account auth.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
-    pub sandbox_policy: String,
+    pub sandbox: String,
     pub approval_policy: String,
 }
 

--- a/runner/tests/codex_bridge_fake.rs
+++ b/runner/tests/codex_bridge_fake.rs
@@ -44,7 +44,7 @@ fn fake_codex_script() -> &'static str {
         # thread/start
         read thread
         case "$thread" in
-          *'"sandboxPolicy":"danger-full-access"'*'"approvalPolicy":"never"'*) ;;
+          *'"sandbox":"danger-full-access"'*'"approvalPolicy":"never"'*) ;;
           *) printf '%s\n' '{"jsonrpc":"2.0","id":2,"error":{"code":-32600,"message":"expected bypassed codex thread/start policy"}}'; exit 0;;
         esac
         printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"threadId":"th_fake_001"}}'
@@ -70,7 +70,7 @@ async fn warm_bridge_reuses_initialized_thread_across_turns() {
         case "$initialized" in *'"method":"initialized"'*) ;; *) exit 1;; esac
         read thread
         case "$thread" in *'"method":"thread/start"'*) ;; *) printf '%s\n' '{"jsonrpc":"2.0","id":2,"error":{"code":-32600,"message":"expected thread/start"}}'; exit 0;; esac
-        case "$thread" in *'"sandboxPolicy":"danger-full-access"'*'"approvalPolicy":"never"'*) ;; *) printf '%s\n' '{"jsonrpc":"2.0","id":2,"error":{"code":-32600,"message":"expected bypassed codex thread/start policy"}}'; exit 0;; esac
+        case "$thread" in *'"sandbox":"danger-full-access"'*'"approvalPolicy":"never"'*) ;; *) printf '%s\n' '{"jsonrpc":"2.0","id":2,"error":{"code":-32600,"message":"expected bypassed codex thread/start policy"}}'; exit 0;; esac
         printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"threadId":"th_chat"}}'
         read turn1
         case "$turn1" in *'"method":"turn/start"'*) ;; *) printf '%s\n' '{"jsonrpc":"2.0","id":3,"error":{"code":-32600,"message":"expected first turn/start"}}'; exit 0;; esac


### PR DESCRIPTION
## Problem

The Codex runner (`mac_mini_codex`) reported `conclusion: success` on every run but produced **no comments, workpad updates, branches, or PRs** — while the Claude runner worked normally. Across 11 runs / 2 issues it posted **0 comments ever**, each ending `success` with an empty `turn.items`.

## Root cause

The runner sent `thread/start` with the field **`sandboxPolicy: "danger-full-access"`**, but the installed Codex app-server (0.134+ / 0.139) expects that field to be named **`sandbox`** on `thread/start`. The unknown `sandboxPolicy` key was silently ignored, so Codex fell back to its default **restricted** profile (read-only filesystem + restricted network).

The agent could read/explore, but every write-back failed:

```
pidash issue/comment/workpad   -> {"error":"... error sending request for url ..."}   # egress blocked
pidash workpad update <(cat <<EOF …)  -> zsh: can't create temp file ... operation not permitted   # read-only fs
```

Codex still emitted `turn/completed { conclusion: "success" }` with `turn.items: []`, which masked the failure on the dashboard.

Confirmed from the run's rollout (`turn_context`): `sandbox_policy: { type: "read-only" }`, `network: "restricted"`, despite the runner intending full access.

## Fix

Rename the serialized field `sandboxPolicy` → `sandbox` on `ThreadStartParams`.

Verified against the live app-server:
- `thread/start { sandbox: "danger-full-access" }` → applied `sandbox: { type: "dangerFullAccess" }`, network egress **on**.
- Old `thread/start { sandboxPolicy: "danger-full-access" }` → ignored → restricted (no egress).
- (`turn/start` uses a different shape — `sandboxPolicy: { type: "dangerFullAccess" }` — but the runner only sets the policy on `thread/start`, so this one-field change is sufficient.)

`approvalPolicy: "never"` is unchanged (it's a bare-string enum and was already honored).

## Test plan
- [x] `cargo test -p pidash --test codex_bridge_fake` (fake-bridge assertions updated to expect `"sandbox":"danger-full-access"`)
- [x] Live app-server smoke test returns `sandbox: { type: "dangerFullAccess" }`
- [ ] A fresh PRIVATEPI1-3 Codex run posts a comment and/or opens a PR (end-to-end)

## Follow-up (separate)
Server-side false-success guard: a run ending with `turn.items: []` and **no** side effects (comment/workpad/branch/PR) should not be recorded as `conclusion: success`. The runner relays Codex's conclusion and already fails the no-conclusion case; this needs a semantic check where side-effects are observable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)