### PR TITLE
fix(db): merge 0145/0146 migration leaves to unblock fresh migrate

### DIFF
--- a/apps/api/pi_dash/db/migrations/0147_merge_fable_audit_and_scheduler_outcome.py
+++ b/apps/api/pi_dash/db/migrations/0147_merge_fable_audit_and_scheduler_outcome.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Merge the two leaf migrations off 0144_issuecomment_speaker_metadata:
+fable security-audit seed (#216) and schedulerbinding outcome_mode (#214)."""
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("db", "0145_seed_fable_security_audit"),
+        ("db", "0146_schedulerbinding_outcome_mode"),
+    ]
+
+    operations = []


### PR DESCRIPTION
## Problem

`main` has a forked migration graph in the `db` app. Two migrations branched off `0144_issuecomment_speaker_metadata` and were merged independently:

- `0145_seed_fable_security_audit` — from #216
- `0145_schedulerbinding_pod` → `0146_schedulerbinding_outcome_mode` — from #214

This leaves **two leaf nodes**, so `manage.py migrate` on a fresh database fails:

```
CommandError: Conflicting migrations detected; multiple leaf nodes in the migration graph:
(0145_seed_fable_security_audit, 0146_schedulerbinding_outcome_mode in db).
To fix them run 'python manage.py makemigrations --merge'
```

### Impact
- **Prod / any fresh `migrate` deploy** — blocked (the DB never finishes migrating).
- **Local `docker-compose-local.yml` migrator** — fails on a clean volume; the API comes up against a partially-migrated DB.
- **Tests are *not* affected** — `pytest.ini` sets `--nomigrations`, so the test DB is built directly from models and never walks the migration graph. That's why CI stayed green and this went unnoticed.

## Fix

Add an empty merge migration (`0147_merge_fable_audit_and_scheduler_outcome`) depending on both leaves, following the repo's existing merge-migration convention (`0130`/`0136`/`0138_merge_*`). No schema operations — it only re-linearizes the graph, so it's safe for environments that already applied either or both branches.

## Test plan
- [x] Fresh DB: `docker compose -f docker-compose-local.yml down -v && up --build` → migrator + `manage.py migrate` complete cleanly through `0147_merge_*`.
- [x] `makemigrations db --merge` reports no remaining conflict (single leaf).
- [x] API serves on `:8000` against the fully-migrated fresh DB.

## Note (out of scope)
`makemigrations --check` also surfaces a separate, pre-existing field-alter drift (a would-be `0148_alter_…` touching FK fields on `scheduler`/`schedulerbinding`/`clidevicecode`/`issueagentticker`). It predates this change (this merge migration is empty) and isn't CI-gated. Left for a separate PR to keep this one a clean conflict fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)