### PR TITLE
chore(runner): bump version to 0.1.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1382,7 +1382,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pidash"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "axoupdater",

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pidash"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2024"
 rust-version = "1.93"
 description = "Pi Dash local runner: connects a dev machine to the Pi Dash cloud and drives Codex for assigned tasks."


### PR DESCRIPTION
Bumps `runner/Cargo.toml` (and `Cargo.lock`) `0.1.12` → `0.1.13` to cut the next runner CLI release.

Unreleased runner work since `pidash-v0.1.12`:
- Cursor CLI support (#202)
- per-runner LLM model selection for the add-runner flow (#217)
- safety-classifier refusals recorded as a distinct AgentRun outcome (#218)
- **Codex app-server sandbox-field fix** (#219)

After this merges, `main` is tagged `pidash-v0.1.13`, which triggers the cargo-dist release pipeline (binaries + Homebrew formula + GitHub Release) and writes `LATEST_RUNNER_VERSION=0.1.13` to the cloud SSM params.

🤖 Generated with [Claude Code](https://claude.com/claude-code)