### PR TITLE
fix(web): constrain auth screen header width

### DIFF
--- a/apps/web/core/components/auth-screens/auth-base.tsx
+++ b/apps/web/core/components/auth-screens/auth-base.tsx
@@ -16,8 +16,10 @@ type AuthBaseProps = {
 export function AuthBase({ authType }: AuthBaseProps) {
   return (
     <div className="relative z-10 flex h-screen w-screen flex-col items-center overflow-hidden overflow-y-auto px-8 pt-6 pb-10">
-      <AuthHeader type={authType} />
-      <AuthRoot authMode={authType} />
+      <div className="mx-auto flex w-full max-w-[30rem] flex-grow flex-col items-center">
+        <AuthHeader type={authType} />
+        <AuthRoot authMode={authType} />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Problem

On the login/auth screen, the header row (`AuthHeaderBase`) uses `w-full` + `justify-between`. On wide screens this pushes the Pi logo to the far-left viewport edge and the "New to Pi Dash? Sign up" link to the far-right edge, leaving a large gap between them and detaching them from the centered login card below.

## Fix

Wrap the auth header and login card in a centered `max-w-[30rem]` (480px) container in `auth-base.tsx`. The header content now stays aligned with the card width instead of spreading across the full viewport. `flex-grow flex-col items-center` is preserved so the card still centers vertically as before.

## Testing

- [ ] Verify on a wide viewport that logo + sign-up link stay together near the card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)