### PR TITLE
fix(api): workpad PATCH 500 — scope row lock to base row (FOR UPDATE on outer join)

### DIFF
--- a/apps/api/pi_dash/api/views/issue.py
+++ b/apps/api/pi_dash/api/views/issue.py
@@ -909,7 +909,18 @@ class IssueMoveAPIEndpoint(BaseAPIView):
             )
 
         with transaction.atomic():
-            issue = Issue.issue_objects.select_for_update().get(workspace__slug=slug, project_id=project_id, pk=pk)
+            # ``of=("self",)`` scopes the row lock to the base ``issues`` row.
+            # ``Issue.issue_objects`` excludes triage states via
+            # ``.exclude(state__group=...)`` and ``state`` is a nullable FK, so
+            # the queryset carries a LEFT OUTER JOIN to ``states``. A bare
+            # ``SELECT ... FOR UPDATE`` then asks Postgres to lock the nullable
+            # side of that outer join, which it refuses ("FOR UPDATE cannot be
+            # applied to the nullable side of an outer join") — a 500 on every
+            # move. Same fix as ``IssueWorkpadAPIEndpoint.patch``.
+            issue = (
+                Issue.issue_objects.select_for_update(of=("self",))
+                .get(workspace__slug=slug, project_id=project_id, pk=pk)
+            )
             lock_key = convert_uuid_to_integer(target_project.id)
             with connection.cursor() as cursor:
                 cursor.execute("SELECT pg_advisory_xact_lock(%s)", [lock_key])

--- a/apps/api/pi_dash/api/views/issue.py
+++ b/apps/api/pi_dash/api/views/issue.py
@@ -2881,9 +2881,19 @@ class IssueWorkpadAPIEndpoint(BaseAPIView):
         # The agent ticker can coalesce continuation runs but in-process
         # rapid updates from a single agent (phase + notes in quick
         # succession) still race without this.
+        #
+        # ``of=["self"]`` is required, not cosmetic: ``Issue.issue_objects``
+        # excludes triage states via ``.exclude(state__group=...)`` and
+        # ``state`` is a nullable FK, so the queryset carries a LEFT OUTER
+        # JOIN to ``states``. A bare ``SELECT ... FOR UPDATE`` then tries to
+        # lock every joined table, and Postgres rejects locking the nullable
+        # side of an outer join ("FOR UPDATE cannot be applied to the nullable
+        # side of an outer join") — surfacing as an unhandled 500 on every
+        # workpad write. Scoping the lock to the base ``issues`` row avoids the
+        # join entirely while still serializing concurrent writers.
         with transaction.atomic():
             issue = (
-                Issue.issue_objects.select_for_update()
+                Issue.issue_objects.select_for_update(of=("self",))
                 .get(workspace__slug=slug, project_id=project_id, pk=issue_id)
             )
             serializer = IssueWorkpadSerializer(issue, data=request.data, partial=True)

--- a/apps/api/pi_dash/tests/contract/api/test_move_endpoint.py
+++ b/apps/api/pi_dash/tests/contract/api/test_move_endpoint.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Contract tests for ``IssueMoveAPIEndpoint`` (move a work item across projects).
+
+Regression for the same ``FOR UPDATE``-on-outer-join 500 fixed for the workpad
+write path: ``POST .../move/`` locks the source row via
+``Issue.issue_objects.select_for_update()``. That manager excludes triage states
+through ``.exclude(state__group=...)`` and ``state`` is a nullable FK, so the
+queryset carries a LEFT OUTER JOIN to ``states``. A bare ``FOR UPDATE`` asks
+Postgres to lock the nullable side of that join — which it refuses — so every
+move returned HTTP 500. The fix scopes the lock to the base ``issues`` row via
+``of=("self",)``.
+
+These need a real Postgres row lock, so they run under ``pytest.mark.contract``
+with the standard ``django_db_setup`` surface (same as ``test_issue_search.py``).
+"""
+
+import pytest
+from rest_framework import status as http_status
+
+from pi_dash.db.models import (
+    Issue,
+    Project,
+    ProjectMember,
+    State,
+)
+
+
+@pytest.fixture
+def source_project(db, workspace, create_user):
+    project = Project.objects.create(
+        name="Move Source Project",
+        identifier="MVSRC",
+        workspace=workspace,
+        created_by=create_user,
+    )
+    ProjectMember.objects.create(
+        project=project,
+        member=create_user,
+        role=20,
+        is_active=True,
+    )
+    return project
+
+
+@pytest.fixture
+def target_project(db, workspace, create_user):
+    project = Project.objects.create(
+        name="Move Target Project",
+        identifier="MVDST",
+        workspace=workspace,
+        created_by=create_user,
+    )
+    ProjectMember.objects.create(
+        project=project,
+        member=create_user,
+        role=20,
+        is_active=True,
+    )
+    # The move endpoint requires a non-triage default workflow state on the
+    # target, otherwise it short-circuits with a 400 before reaching the lock.
+    State.objects.create(
+        name="Todo",
+        project=project,
+        workspace=workspace,
+        group="unstarted",
+        default=True,
+        created_by=create_user,
+    )
+    return project
+
+
+def _make_issue(project, user, *, state=None):
+    return Issue.objects.create(
+        name="move target",
+        description_html="<p>body</p>",
+        description_stripped="body",
+        project=project,
+        workspace=project.workspace,
+        state=state,
+        created_by=user,
+    )
+
+
+def _url(slug, project_id, issue_id):
+    return (
+        f"/api/v1/workspaces/{slug}/projects/{project_id}"
+        f"/work-items/{issue_id}/move/"
+    )
+
+
+@pytest.mark.contract
+class TestIssueMovePost:
+    @pytest.mark.django_db
+    def test_move_locks_through_outer_join_and_returns_200(
+        self, api_key_client, workspace, source_project, target_project, create_user
+    ):
+        """The core regression: moving a (null-state) issue must lock, move,
+        and return 200 — not 500 from ``FOR UPDATE`` on the manager's outer
+        join.
+        """
+        issue = _make_issue(source_project, create_user)
+        url = _url(workspace.slug, source_project.id, issue.id)
+
+        response = api_key_client.post(
+            url, {"project": target_project.identifier}, format="json"
+        )
+
+        assert response.status_code == http_status.HTTP_200_OK
+        issue.refresh_from_db()
+        assert str(issue.project_id) == str(target_project.id)

--- a/apps/api/pi_dash/tests/contract/api/test_workpad_endpoint.py
+++ b/apps/api/pi_dash/tests/contract/api/test_workpad_endpoint.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Contract tests for ``IssueWorkpadAPIEndpoint`` (the agent workpad).
+
+Regression for the workpad-write 500: ``PATCH .../workpad/`` locks the row
+with ``select_for_update`` through the ``Issue.issue_objects`` manager, which
+excludes triage states via ``.exclude(state__group=...)``. Because ``state``
+is a nullable FK that produces a LEFT OUTER JOIN, a bare ``FOR UPDATE`` asks
+Postgres to lock the nullable side of an outer join — which it refuses (the fix scopes the lock to the base
+``issues`` row via ``of=("self",)``), so
+every ``pidash workpad update`` returned HTTP 500. Reads (GET) and other issue
+writes use a plain ``.get()`` and were unaffected, which is why the failure was
+isolated to the workpad write path.
+
+These need a real Postgres row lock, so they run under ``pytest.mark.contract``
+with the standard ``django_db_setup`` surface (same as ``test_issue_search.py``).
+"""
+
+import pytest
+from rest_framework import status as http_status
+
+from pi_dash.db.models import (
+    Issue,
+    Project,
+    ProjectMember,
+    State,
+)
+
+
+@pytest.fixture
+def wp_project(db, workspace, create_user):
+    project = Project.objects.create(
+        name="Workpad Test Project",
+        identifier="WP",
+        workspace=workspace,
+        created_by=create_user,
+    )
+    ProjectMember.objects.create(
+        project=project,
+        member=create_user,
+        role=20,
+        is_active=True,
+    )
+    return project
+
+
+def _make_issue(project, user, *, state=None):
+    return Issue.objects.create(
+        name="workpad target",
+        description_html="<p>body</p>",
+        description_stripped="body",
+        project=project,
+        workspace=project.workspace,
+        state=state,
+        created_by=user,
+    )
+
+
+def _url(slug, project_id, issue_id):
+    return (
+        f"/api/v1/workspaces/{slug}/projects/{project_id}"
+        f"/work-items/{issue_id}/workpad/"
+    )
+
+
+@pytest.mark.contract
+class TestIssueWorkpadPatch:
+    @pytest.mark.django_db
+    def test_patch_persists_body_and_returns_200(
+        self, api_key_client, workspace, wp_project, create_user
+    ):
+        """The core regression: a valid ``{"body": ...}`` PATCH must lock,
+        write, and return 200 — not 500 from ``FOR UPDATE`` on the manager's
+        outer join.
+        """
+        issue = _make_issue(wp_project, create_user)
+        url = _url(workspace.slug, wp_project.id, issue.id)
+
+        response = api_key_client.patch(
+            url, {"body": "## Phase\n- implementing\n"}, format="json"
+        )
+
+        assert response.status_code == http_status.HTTP_200_OK
+        assert "updated_at" in response.data
+        issue.refresh_from_db()
+        assert "implementing" in issue.workpad
+
+    @pytest.mark.django_db
+    def test_patch_locks_through_outer_join_with_state(
+        self, api_key_client, workspace, wp_project, create_user
+    ):
+        """The outer join to ``states`` is present whether or not ``state`` is
+        NULL, so an issue *with* a state must also lock cleanly under the fix.
+        """
+        state = State.objects.create(
+            name="Todo",
+            project=wp_project,
+            workspace=workspace,
+            group="unstarted",
+            default=True,
+            created_by=create_user,
+        )
+        issue = _make_issue(wp_project, create_user, state=state)
+        url = _url(workspace.slug, wp_project.id, issue.id)
+
+        response = api_key_client.patch(url, {"body": "locked ok"}, format="json")
+
+        assert response.status_code == http_status.HTTP_200_OK
+        issue.refresh_from_db()
+        assert issue.workpad == "locked ok"
+
+    @pytest.mark.django_db
+    def test_patch_empty_body_clears_workpad(
+        self, api_key_client, workspace, wp_project, create_user
+    ):
+        issue = _make_issue(wp_project, create_user)
+        issue.workpad = "existing"
+        issue.save()
+        url = _url(workspace.slug, wp_project.id, issue.id)
+
+        response = api_key_client.patch(url, {"body": ""}, format="json")
+
+        assert response.status_code == http_status.HTTP_200_OK
+        issue.refresh_from_db()
+        assert issue.workpad == ""
+
+    @pytest.mark.django_db
+    def test_patch_missing_body_returns_400(
+        self, api_key_client, workspace, wp_project, create_user
+    ):
+        """Wrong wire key (model name instead of ``body``) is rejected
+        explicitly rather than silently no-op'ing under ``partial=True``.
+        """
+        issue = _make_issue(wp_project, create_user)
+        url = _url(workspace.slug, wp_project.id, issue.id)
+
+        response = api_key_client.patch(url, {"workpad": "wrong key"}, format="json")
+
+        assert response.status_code == http_status.HTTP_400_BAD_REQUEST


### PR DESCRIPTION
## Problem

`PATCH /api/v1/workspaces/<slug>/projects/<id>/work-items/<id>/workpad/` returns **HTTP 500 on every call**, so the coding agent can never persist its workpad via `pidash workpad update`. Surfaced now that the [Codex runner sandbox-egress fix](https://github.com/The-AI-Republic/pi-dash/pull/219) lets agents actually reach the write-back step — they immediately block on this 500.

Reproduced live against prod:

```
pidash issue get   PRIVATEPI1-4   -> 200
pidash workpad get PRIVATEPI1-4   -> 200
pidash comment add PRIVATEPI1-4   -> 200
pidash issue patch PRIVATEPI1-4 --title <same>   -> 200
pidash workpad update PRIVATEPI1-4 --body-file …  -> 500  {"error":"HTTP 500 Internal Server Error: server error"}
```

So it's isolated to the **workpad write path**, not the `issues` table (other issue writes succeed).

## Root cause

`IssueWorkpadAPIEndpoint.patch` locks the row with:

```python
Issue.issue_objects.select_for_update().get(...)
```

The `issue_objects` manager excludes triage states via `.exclude(state__group=...)`, and `Issue.state` is a **nullable** FK — so the queryset carries a `LEFT OUTER JOIN` to `states`. A bare `SELECT … FOR UPDATE` asks Postgres to lock *every* joined table, and Postgres rejects locking the nullable side of an outer join:

```
FOR UPDATE cannot be applied to the nullable side of an outer join
```

The unhandled `NotSupportedError` becomes a generic 500. `issue patch` uses a plain `Issue.objects.get()`, which is why the bug looked workpad-specific. The lock was introduced in the workpad code-review pass (`b7f8ba3d`, fix #4 — prevent lost updates); the 500 has existed since then but stayed hidden because the Codex runner never reached the write step.

### Sibling 500 in `IssueMoveAPIEndpoint`

There is a **second** bare `select_for_update()` on `issue_objects` — `IssueMoveAPIEndpoint.post` (`api/views/issue.py:912`), the cross-project move endpoint — with the identical defect: it locks the source issue through the same outer-joined manager, so **every** `POST .../move/` 500s against Postgres for exactly the same reason. (An earlier revision of this description claimed the workpad lock was the *only* such call — that was wrong.) Both are fixed here.

## Fix

```python
Issue.issue_objects.select_for_update(of=("self",)).get(...)
```

Lock only the base `issues` row, never the outer-joined `states`/`projects`. Lost-update protection is preserved. Matches existing precedent in `bgtasks/agent_ticker.py` and `bgtasks/scheduler.py`, which already use `of=("self",)` for the same reason. Applied to **both** call sites — `IssueWorkpadAPIEndpoint.patch` and `IssueMoveAPIEndpoint.post`.

## Test plan
- [x] Live repro against prod (above)
- [x] Adds `tests/contract/api/test_workpad_endpoint.py`: locked write returns 200 + persists (null-state **and** with-state issues, since the outer join is present either way), empty-body clears, missing-`body` → 400
- [x] Adds `tests/contract/api/test_move_endpoint.py`: moving a null-state issue across projects returns 200 + persists the project change (regression for the sibling move 500)
- [ ] CI runs the contract suite (no local Postgres/Django env available to run it here)
- [ ] Post-merge: a fresh PRIVATEPI1 Codex run persists its workpad and proceeds to comment/PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
