### PR TITLE
perf(runner): make the session long-poll an async view

### DIFF
--- a/apps/api/pi_dash/runner/services/outbox.py
+++ b/apps/api/pi_dash/runner/services/outbox.py
@@ -149,6 +149,46 @@ def _ensure_group(client, runner_id: UUID | str) -> None:
         raise
 
 
+async def _aensure_group(client, runner_id: UUID | str) -> None:
+    """Async twin of :func:`_ensure_group`."""
+    sk = stream_key(runner_id)
+    gn = group_name(runner_id)
+    try:
+        await client.xgroup_create(name=sk, groupname=gn, id="$", mkstream=True)
+    except Exception as exc:
+        if "BUSYGROUP" in str(exc):
+            return
+        raise
+
+
+def _decode_read_result(result) -> List[Dict[str, Any]]:
+    """Decode an XREADGROUP reply into the entry dicts the poll returns."""
+    out: List[Dict[str, Any]] = []
+    if not result:
+        return out
+    for _, entries in result:
+        for stream_id, fields in entries:
+            sid = stream_id.decode() if isinstance(stream_id, bytes) else str(stream_id)
+            decoded = {}
+            for k, v in fields.items():
+                key = k.decode() if isinstance(k, bytes) else k
+                val = v.decode() if isinstance(v, bytes) else v
+                decoded[key] = val
+            try:
+                body = json.loads(decoded.get("payload") or "{}")
+            except (TypeError, ValueError):
+                body = {}
+            out.append(
+                {
+                    "stream_id": sid,
+                    "mid": decoded.get("mid") or body.get("mid") or "",
+                    "type": decoded.get("type") or body.get("type") or "",
+                    "body": body,
+                }
+            )
+    return out
+
+
 def ensure_stream_group(runner_id: UUID | str) -> None:
     """Idempotent ``XGROUP CREATE ... MKSTREAM`` for the runner stream."""
     client = redis_instance()
@@ -433,30 +473,45 @@ def read_for_session(
     except Exception:
         logger.exception("xreadgroup failed for runner %s", runner_id)
         return []
-    out: List[Dict[str, Any]] = []
-    if not result:
-        return out
-    for _, entries in result:
-        for stream_id, fields in entries:
-            sid = stream_id.decode() if isinstance(stream_id, bytes) else str(stream_id)
-            decoded = {}
-            for k, v in fields.items():
-                key = k.decode() if isinstance(k, bytes) else k
-                val = v.decode() if isinstance(v, bytes) else v
-                decoded[key] = val
-            try:
-                body = json.loads(decoded.get("payload") or "{}")
-            except (TypeError, ValueError):
-                body = {}
-            out.append(
-                {
-                    "stream_id": sid,
-                    "mid": decoded.get("mid") or body.get("mid") or "",
-                    "type": decoded.get("type") or body.get("type") or "",
-                    "body": body,
-                }
-            )
-    return out
+    return _decode_read_result(result)
+
+
+async def aread_for_session(
+    runner_id: UUID | str,
+    session_id: UUID | str,
+    *,
+    block_ms: int,
+    count: int = 100,
+    use_zero: bool = False,
+) -> List[Dict[str, Any]]:
+    """Async twin of :func:`read_for_session`.
+
+    Used by the async long-poll view so a blocking ``XREADGROUP`` awaits
+    on the event loop instead of pinning a worker thread for the block
+    window.
+    """
+    from pi_dash.settings.redis import async_redis_instance
+
+    client = async_redis_instance()
+    if client is None:
+        return []
+    await _aensure_group(client, runner_id)
+    sk = stream_key(runner_id)
+    gn = group_name(runner_id)
+    cn = consumer_name(session_id)
+    last_id = "0" if use_zero else ">"
+    try:
+        result = await client.xreadgroup(
+            groupname=gn,
+            consumername=cn,
+            streams={sk: last_id},
+            count=count,
+            block=block_ms,
+        )
+    except Exception:
+        logger.exception("xreadgroup failed for runner %s", runner_id)
+        return []
+    return _decode_read_result(result)
 
 
 def ack_for_session(

--- a/apps/api/pi_dash/runner/services/session_service.py
+++ b/apps/api/pi_dash/runner/services/session_service.py
@@ -32,7 +32,7 @@ OFFLINE_GRACE_SECS = 60
 
 # Grace window protecting freshly-assigned runs from the reaper.
 #
-# The reaper runs on every long-poll request (`RunnerSessionPollEndpoint`)
+# The reaper runs on every long-poll request (`runner_session_poll`)
 # *before* the outbox is drained for that same response. So the very poll
 # that's about to deliver an Assign to the runner is the poll where the
 # runner still legitimately reports `in_flight_run=null` (it hasn't seen

--- a/apps/api/pi_dash/runner/urls.py
+++ b/apps/api/pi_dash/runner/urls.py
@@ -41,7 +41,7 @@ from pi_dash.runner.views import (
     RunnerSelfRevokeEndpoint,
     RunnerSessionDeleteEndpoint,
     RunnerSessionOpenEndpoint,
-    RunnerSessionPollEndpoint,
+    runner_session_poll,
 )
 
 app_name = "runner"
@@ -97,7 +97,7 @@ urlpatterns = [
     ),
     path(
         "runners/<uuid:runner_id>/sessions/<uuid:sid>/poll",
-        RunnerSessionPollEndpoint.as_view(),
+        runner_session_poll,
         name="runner-session-poll",
     ),
     # Run-lifecycle + event upstream.

--- a/apps/api/pi_dash/runner/views/__init__.py
+++ b/apps/api/pi_dash/runner/views/__init__.py
@@ -65,7 +65,7 @@ from .runs import (
 from .sessions import (
     RunnerSessionDeleteEndpoint,
     RunnerSessionOpenEndpoint,
-    RunnerSessionPollEndpoint,
+    runner_session_poll,
 )
 
 __all__ = [
@@ -123,5 +123,5 @@ __all__ = [
     "RunStreamUpgradeEndpoint",
     "RunnerSessionDeleteEndpoint",
     "RunnerSessionOpenEndpoint",
-    "RunnerSessionPollEndpoint",
+    "runner_session_poll",
 ]

--- a/apps/api/pi_dash/runner/views/sessions.py
+++ b/apps/api/pi_dash/runner/views/sessions.py
@@ -16,15 +16,19 @@ See ``.ai_design/move_to_https/design.md`` §7.1 / §7.3. Three verbs:
 
 from __future__ import annotations
 
+import json
 import logging
 import time
 import uuid as _uuid
 from typing import Any, Dict, List
 
+from asgiref.sync import sync_to_async
 from django.conf import settings
 from django.db import transaction
+from django.http import JsonResponse
 from django.utils import timezone
 from redis.exceptions import RedisError
+from rest_framework import exceptions as drf_exceptions
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -255,209 +259,269 @@ class RunnerSessionDeleteEndpoint(APIView):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
-class RunnerSessionPollEndpoint(APIView):
-    """``POST /runners/<rid>/sessions/<sid>/poll`` — long-poll."""
+def _authenticate_poll_runner(request):
+    """Run :class:`RunnerAccessTokenAuthentication` outside DRF.
 
-    authentication_classes = [RunnerAccessTokenAuthentication]
-    permission_classes: list = []
-    throttle_classes: list = []
+    The long-poll view is a plain Django async view (DRF's ``APIView``
+    cannot await), so the auth class is invoked directly. Raises
+    ``rest_framework.exceptions.AuthenticationFailed`` exactly like the
+    DRF dispatch path; returns the authenticated runner or ``None``
+    when no bearer credential was presented.
+    """
+    result = RunnerAccessTokenAuthentication().authenticate(request)
+    if result is None:
+        return None
+    return getattr(request, "auth_runner", None)
 
-    def post(self, request, runner_id, sid):
-        runner = getattr(request, "auth_runner", None)
-        if runner is None or str(runner.id) != str(runner_id):
-            return Response(
-                {"error": "runner_id_mismatch"},
-                status=status.HTTP_403_FORBIDDEN,
-            )
 
-        try:
-            session = RunnerSession.objects.get(id=sid, runner=runner)
-        except RunnerSession.DoesNotExist:
-            return Response(
-                {"error": "session_evicted"},
-                status=status.HTTP_409_CONFLICT,
-            )
-        if session.revoked_at is not None:
-            return Response(
-                {"error": "session_evicted", "reason": session.revoked_reason},
-                status=status.HTTP_409_CONFLICT,
-            )
+def _poll_bookkeeping(runner, body: Dict[str, Any], sid):
+    """Sync pre-wait phase of the long poll: session checks, heartbeat,
+    stale-run reaping, acks, and drain scheduling.
 
-        body = request.data or {}
-        ack_ids: List[str] = list(body.get("ack") or [])
-        raw_status = body.get("status") or {}
-        status_entry: Dict[str, Any] = raw_status if isinstance(raw_status, dict) else {}
-
-        # 2. Update session.last_seen_at.
-        session.last_seen_at = timezone.now()
-        session.save(update_fields=["last_seen_at"])
-
-        # 3. Update runner.last_heartbeat_at + reap stale busy runs.
-        from pi_dash.runner.models import Runner
-        from pi_dash.runner.services.matcher import (
-            HEARTBEAT_GRACE,
-            drain_for_runner_by_id,
+    Returns ``(error, plan)`` — exactly one is non-None. ``error`` is
+    ``{"payload": ..., "status": ...}`` for an early rejection; ``plan``
+    carries ``block_ms`` / ``use_zero`` for the async wait phase.
+    """
+    try:
+        session = RunnerSession.objects.get(id=sid, runner=runner)
+    except RunnerSession.DoesNotExist:
+        return (
+            {"payload": {"error": "session_evicted"}, "status": status.HTTP_409_CONFLICT},
+            None,
+        )
+    if session.revoked_at is not None:
+        return (
+            {
+                "payload": {"error": "session_evicted", "reason": session.revoked_reason},
+                "status": status.HTTP_409_CONFLICT,
+            },
+            None,
         )
 
-        # Capture prior heartbeat/status from the DB so we can detect when this
-        # poll makes the runner eligible for queued work again.
-        now_ts = timezone.now()
-        with transaction.atomic():
-            runner_snapshot = (
-                Runner.objects.select_for_update().filter(pk=runner.id).values("last_heartbeat_at", "status").get()
-            )
-            prior_hb = runner_snapshot["last_heartbeat_at"]
-            prior_status = runner_snapshot["status"]
-            was_stale = prior_hb is None or (now_ts - prior_hb) > HEARTBEAT_GRACE
-            reported_status = status_entry.get("status")
-            reports_busy = reported_status == "busy"
-            reports_available = reported_status in {"idle", "online"}
-            became_available = prior_status == RunnerStatus.BUSY and reports_available
-            status_allows_drain = reports_available or (not status_entry and prior_status != RunnerStatus.BUSY)
+    ack_ids: List[str] = list(body.get("ack") or [])
+    raw_status = body.get("status") or {}
+    status_entry: Dict[str, Any] = raw_status if isinstance(raw_status, dict) else {}
 
-            Runner.objects.filter(pk=runner.id).update(
-                last_heartbeat_at=now_ts,
-                status=RunnerStatus.BUSY if reports_busy else RunnerStatus.ONLINE,
-            )
-            if status_entry:
-                session_service.reap_stale_busy_runs(runner, status_entry)
+    # 2. Update session.last_seen_at.
+    session.last_seen_at = timezone.now()
+    session.save(update_fields=["last_seen_at"])
+
+    # 3. Update runner.last_heartbeat_at + reap stale busy runs.
+    from pi_dash.runner.models import Runner
+    from pi_dash.runner.services.matcher import (
+        HEARTBEAT_GRACE,
+        drain_for_runner_by_id,
+    )
+
+    # Capture prior heartbeat/status from the DB so we can detect when this
+    # poll makes the runner eligible for queued work again.
+    now_ts = timezone.now()
+    with transaction.atomic():
+        runner_snapshot = (
+            Runner.objects.select_for_update().filter(pk=runner.id).values("last_heartbeat_at", "status").get()
+        )
+        prior_hb = runner_snapshot["last_heartbeat_at"]
+        prior_status = runner_snapshot["status"]
+        was_stale = prior_hb is None or (now_ts - prior_hb) > HEARTBEAT_GRACE
+        reported_status = status_entry.get("status")
+        reports_busy = reported_status == "busy"
+        reports_available = reported_status in {"idle", "online"}
+        became_available = prior_status == RunnerStatus.BUSY and reports_available
+        status_allows_drain = reports_available or (not status_entry and prior_status != RunnerStatus.BUSY)
+
+        Runner.objects.filter(pk=runner.id).update(
+            last_heartbeat_at=now_ts,
+            status=RunnerStatus.BUSY if reports_busy else RunnerStatus.ONLINE,
+        )
         if status_entry:
-            # Volatile observability snapshot — see
-            # `.ai_design/runner_agent_bridge/design.md` §4.5.2.
-            # Pre-observability runners send no snapshot fields and the
-            # helper short-circuits. Failures here must never break the
-            # poll path: a malformed snapshot or a transient DB error
-            # would otherwise return 500 and spin the runner's retry loop.
+            session_service.reap_stale_busy_runs(runner, status_entry)
+    if status_entry:
+        # Volatile observability snapshot — see
+        # `.ai_design/runner_agent_bridge/design.md` §4.5.2.
+        # Pre-observability runners send no snapshot fields and the
+        # helper short-circuits. Failures here must never break the
+        # poll path: a malformed snapshot or a transient DB error
+        # would otherwise return 500 and spin the runner's retry loop.
+        try:
+            session_service.upsert_runner_live_state(runner, status_entry)
+        except Exception:
+            logger.exception(
+                "upsert_runner_live_state failed for runner %s",
+                runner.id,
+            )
+
+    # 5. XACK explicit ids.
+    if ack_ids:
+        outbox.ack_for_session(runner.id, ack_ids)
+
+    # 6. XREADGROUP — first poll uses 0 (replay PEL), subsequent
+    # polls use >.
+    use_zero = not outbox.is_pel_drained(sid)
+
+    # A session-open alone is not proof that the daemon is actually
+    # polling. Drain on either stale-heartbeat recovery or the first
+    # real poll for this session, after the heartbeat/status update
+    # makes the runner assignable. Keep this as one trigger so a first
+    # poll with no prior heartbeat does not double-dispatch.
+    if (
+        (was_stale or became_available or use_zero)
+        and status_allows_drain
+        and not status_entry.get("in_flight_run")
+    ):
+
+        def _drain_poll_ready_runner(rid=runner.id):
             try:
-                session_service.upsert_runner_live_state(runner, status_entry)
+                drain_for_runner_by_id(rid)
             except Exception:
                 logger.exception(
-                    "upsert_runner_live_state failed for runner %s",
-                    runner.id,
+                    "drain_for_runner_by_id failed for poll-ready runner %s",
+                    rid,
                 )
 
-        # 5. XACK explicit ids.
-        if ack_ids:
-            outbox.ack_for_session(runner.id, ack_ids)
+        transaction.on_commit(_drain_poll_ready_runner)
 
-        # 6. XREADGROUP — first poll uses 0 (replay PEL), subsequent
-        # polls use >.
-        use_zero = not outbox.is_pel_drained(sid)
+    block_ms = max(1, settings.LONG_POLL_INTERVAL_SECS * 1000) if not use_zero else 0
+    return None, {"block_ms": block_ms, "use_zero": use_zero}
 
-        # A session-open alone is not proof that the daemon is actually
-        # polling. Drain on either stale-heartbeat recovery or the first
-        # real poll for this session, after the heartbeat/status update
-        # makes the runner assignable. Keep this as one trigger so a first
-        # poll with no prior heartbeat does not double-dispatch.
-        if (
-            (was_stale or became_available or use_zero)
-            and status_allows_drain
-            and not status_entry.get("in_flight_run")
-        ):
 
-            def _drain_poll_ready_runner(rid=runner.id):
-                try:
-                    drain_for_runner_by_id(rid)
-                except Exception:
-                    logger.exception(
-                        "drain_for_runner_by_id failed for poll-ready runner %s",
-                        rid,
-                    )
+async def _aread_with_eviction_awareness(
+    *,
+    runner_id,
+    session_id,
+    block_ms: int,
+    use_zero: bool,
+) -> list[dict]:
+    """Await messages for the session, breaking early on eviction.
 
-            transaction.on_commit(_drain_poll_ready_runner)
-
-        block_ms = max(1, settings.LONG_POLL_INTERVAL_SECS * 1000) if not use_zero else 0
-        try:
-            messages = self._read_with_eviction_awareness(
-                runner_id=runner.id,
-                session_id=sid,
-                sid=sid,
-                block_ms=block_ms,
-                use_zero=use_zero,
-            )
-        except _SessionEvictedDuringPoll:
-            return Response(
-                {"error": "session_evicted"},
-                status=status.HTTP_409_CONFLICT,
-            )
-        if use_zero:
-            outbox.mark_pel_drained(sid)
-
-        return Response(
-            {
-                "messages": messages,
-                "server_time": timezone.now().isoformat(),
-                "long_poll_interval_secs": settings.LONG_POLL_INTERVAL_SECS,
-            }
+    Runs on the event loop (async Redis), so the long block window holds
+    no worker thread — the whole point of the async poll view. A sync
+    DRF view would pin the per-process ``thread_sensitive`` thread for
+    the full block window, serializing every other sync request behind
+    it (observed in production as 5s+ page loads with a handful of
+    connected runners).
+    """
+    if block_ms <= 0:
+        if not use_zero:
+            return []
+        # The initial PEL replay uses STREAMS ... 0 and must remain
+        # nonblocking. The dangerous Redis case is BLOCK 0 with ">".
+        return await outbox.aread_for_session(
+            runner_id=runner_id,
+            session_id=session_id,
+            block_ms=0,
+            count=100,
+            use_zero=use_zero,
         )
 
-    def _read_with_eviction_awareness(
-        self,
-        *,
-        runner_id,
-        session_id,
-        sid,
-        block_ms: int,
-        use_zero: bool,
-    ) -> list[dict]:
-        if block_ms <= 0:
-            if not use_zero:
+    from pi_dash.settings.redis import async_redis_instance
+
+    client = async_redis_instance()
+    if client is None:
+        return await outbox.aread_for_session(
+            runner_id=runner_id,
+            session_id=session_id,
+            block_ms=block_ms,
+            count=100,
+            use_zero=use_zero,
+        )
+
+    pubsub = client.pubsub(ignore_subscribe_messages=True)
+    try:
+        await pubsub.subscribe(outbox.session_eviction_channel(runner_id))
+        deadline = time.monotonic() + (block_ms / 1000.0)
+        while True:
+            remaining_ms = max(0, int((deadline - time.monotonic()) * 1000))
+            # CRITICAL: bail BEFORE calling Redis when the deadline
+            # has expired. `XREADGROUP BLOCK 0 STREAMS … >` means
+            # "block forever" in Redis (BLOCK 0 is documented as
+            # "block indefinitely"), not "do not block." If we let
+            # `slice_ms` reach 0 and call aread_for_session, the
+            # underlying XREADGROUP parks the request indefinitely —
+            # well beyond the runner's HTTP timeout — and any assign
+            # message that lands later gets claimed by this dead
+            # consumer's PEL where the live session can never see it.
+            # Observed in production: poll handlers stuck for 4+
+            # hours on evicted sessions, blocking gunicorn workers
+            # and reaping unrelated runs whose assigns couldn't
+            # reach the live runner.
+            if remaining_ms <= 0:
                 return []
-            # The initial PEL replay uses STREAMS ... 0 and must remain
-            # nonblocking. The dangerous Redis case is BLOCK 0 with ">".
-            return outbox.read_for_session(
+            slice_ms = min(_POLL_SLICE_MS, remaining_ms)
+            messages = await outbox.aread_for_session(
                 runner_id=runner_id,
                 session_id=session_id,
-                block_ms=0,
+                block_ms=slice_ms,
                 count=100,
                 use_zero=use_zero,
             )
+            if messages:
+                return messages
+            use_zero = False
+            if await pubsub.get_message(timeout=0) is not None:
+                raise _SessionEvictedDuringPoll
+    finally:
+        await pubsub.close()
 
-        from pi_dash.settings.redis import redis_instance
 
-        client = redis_instance()
-        if client is None:
-            return outbox.read_for_session(
-                runner_id=runner_id,
-                session_id=session_id,
-                block_ms=block_ms,
-                count=100,
-                use_zero=use_zero,
-            )
+async def runner_session_poll(request, runner_id, sid):
+    """``POST /runners/<rid>/sessions/<sid>/poll`` — long-poll.
 
-        pubsub = client.pubsub(ignore_subscribe_messages=True)
+    A plain Django **async** view rather than a DRF ``APIView``: the
+    request spends up to ``LONG_POLL_INTERVAL_SECS`` (~25s) parked
+    waiting for control-plane messages, and under ASGI every sync view
+    in a worker shares one ``thread_sensitive`` thread — a sync long
+    poll therefore blocks every other request on that worker for the
+    whole window. Auth and DB bookkeeping stay sync (briefly, via
+    ``sync_to_async``); only the wait is async.
+    """
+    if request.method != "POST":
+        return JsonResponse({"detail": f'Method "{request.method}" not allowed.'}, status=405)
+
+    try:
+        runner = await sync_to_async(_authenticate_poll_runner)(request)
+    except drf_exceptions.AuthenticationFailed as exc:
+        return JsonResponse({"detail": str(exc.detail)}, status=status.HTTP_401_UNAUTHORIZED)
+    if runner is None or str(runner.id) != str(runner_id):
+        return JsonResponse({"error": "runner_id_mismatch"}, status=status.HTTP_403_FORBIDDEN)
+
+    body: Dict[str, Any] = {}
+    if request.body:
         try:
-            pubsub.subscribe(outbox.session_eviction_channel(runner_id))
-            deadline = time.monotonic() + (block_ms / 1000.0)
-            while True:
-                remaining_ms = max(0, int((deadline - time.monotonic()) * 1000))
-                # CRITICAL: bail BEFORE calling Redis when the deadline
-                # has expired. `XREADGROUP BLOCK 0 STREAMS … >` means
-                # "block forever" in Redis (BLOCK 0 is documented as
-                # "block indefinitely"), not "do not block." If we let
-                # `slice_ms` reach 0 and call read_for_session, the
-                # underlying XREADGROUP parks the worker indefinitely —
-                # well beyond the runner's HTTP timeout — and any assign
-                # message that lands later gets claimed by this dead
-                # consumer's PEL where the live session can never see it.
-                # Observed in production: poll handlers stuck for 4+
-                # hours on evicted sessions, blocking gunicorn workers
-                # and reaping unrelated runs whose assigns couldn't
-                # reach the live runner.
-                if remaining_ms <= 0:
-                    return []
-                slice_ms = min(_POLL_SLICE_MS, remaining_ms)
-                messages = outbox.read_for_session(
-                    runner_id=runner_id,
-                    session_id=session_id,
-                    block_ms=slice_ms,
-                    count=100,
-                    use_zero=use_zero,
-                )
-                if messages:
-                    return messages
-                use_zero = False
-                if pubsub.get_message(timeout=0) is not None:
-                    raise _SessionEvictedDuringPoll
-        finally:
-            pubsub.close()
+            parsed = json.loads(request.body)
+        except ValueError:
+            return JsonResponse({"detail": "JSON parse error"}, status=status.HTTP_400_BAD_REQUEST)
+        if isinstance(parsed, dict):
+            body = parsed
+
+    error, plan = await sync_to_async(_poll_bookkeeping)(runner, body, sid)
+    if error is not None:
+        return JsonResponse(error["payload"], status=error["status"])
+
+    try:
+        messages = await _aread_with_eviction_awareness(
+            runner_id=runner.id,
+            session_id=sid,
+            block_ms=plan["block_ms"],
+            use_zero=plan["use_zero"],
+        )
+    except _SessionEvictedDuringPoll:
+        return JsonResponse({"error": "session_evicted"}, status=status.HTTP_409_CONFLICT)
+    if plan["use_zero"]:
+        await sync_to_async(outbox.mark_pel_drained)(sid)
+
+    return JsonResponse(
+        {
+            "messages": messages,
+            "server_time": timezone.now().isoformat(),
+            "long_poll_interval_secs": settings.LONG_POLL_INTERVAL_SECS,
+        }
+    )
+
+
+# Django 4.2's ``@csrf_exempt`` wraps the view in a *sync* function, which
+# hides the coroutine from the handler's async detection (the request then
+# returns an un-awaited coroutine). Async decorator support only landed in
+# Django 5.0, so mark the attribute directly. The runner daemon authenticates
+# with a bearer token, never cookies, so CSRF does not apply — this mirrors
+# DRF's csrf-exempt dispatch the endpoint had as an ``APIView``.
+runner_session_poll.csrf_exempt = True

--- a/apps/api/pi_dash/settings/redis.py
+++ b/apps/api/pi_dash/settings/redis.py
@@ -6,12 +6,17 @@ import threading
 from urllib.parse import unquote, urlparse
 
 import redis
+import redis.asyncio as aioredis
 from django.conf import settings
 
 
 _redis_client = None
 _redis_client_key = None
 _redis_lock = threading.Lock()
+
+_async_redis_client = None
+_async_redis_client_key = None
+_async_redis_lock = threading.Lock()
 
 
 def _float_setting(name: str, default: float) -> float:
@@ -109,3 +114,74 @@ def redis_instance():
             _redis_client = redis.Redis.from_url(settings.REDIS_URL, db=0, **kwargs)
         _redis_client_key = key
         return _redis_client
+
+
+async def close_async_redis_instance():
+    """Close the cached asyncio Redis client for this process."""
+
+    global _async_redis_client, _async_redis_client_key
+    client = None
+    with _async_redis_lock:
+        client = _async_redis_client
+        _async_redis_client = None
+        _async_redis_client_key = None
+    if client is not None:
+        await client.aclose()
+
+
+def async_redis_instance():
+    """Asyncio twin of :func:`redis_instance`.
+
+    Same URL, timeouts, and ``db=0`` pinning as the sync client so the
+    two clients always observe the same keyspace. Used by async views
+    (runner long-poll, chat SSE) that must block on Redis without
+    holding a worker thread.
+    """
+
+    if not settings.REDIS_URL:
+        raise RuntimeError("REDIS_URL is required to create a Redis client")
+
+    connect_timeout = _float_setting("REDIS_SOCKET_CONNECT_TIMEOUT", 2.0)
+    socket_timeout = _float_setting("REDIS_SOCKET_TIMEOUT", 5.0)
+    health_check_interval = _int_setting("REDIS_HEALTH_CHECK_INTERVAL", 30)
+    max_connections = _optional_int_setting("REDIS_MAX_CONNECTIONS")
+    key = (
+        settings.REDIS_URL,
+        bool(settings.REDIS_SSL),
+        connect_timeout,
+        socket_timeout,
+        health_check_interval,
+        max_connections,
+    )
+
+    global _async_redis_client, _async_redis_client_key
+    if _async_redis_client is not None and _async_redis_client_key == key:
+        return _async_redis_client
+
+    with _async_redis_lock:
+        if _async_redis_client is not None and _async_redis_client_key == key:
+            return _async_redis_client
+
+        kwargs = {
+            "socket_connect_timeout": connect_timeout,
+            "socket_timeout": socket_timeout,
+            "health_check_interval": health_check_interval,
+        }
+        if max_connections is not None:
+            kwargs["max_connections"] = max_connections
+        if settings.REDIS_SSL:
+            url = urlparse(settings.REDIS_URL)
+            password = unquote(url.password) if url.password is not None else None
+            _async_redis_client = aioredis.Redis(
+                host=url.hostname,
+                port=url.port,
+                password=password,
+                db=0,
+                ssl=True,
+                ssl_cert_reqs=None,
+                **kwargs,
+            )
+        else:
+            _async_redis_client = aioredis.Redis.from_url(settings.REDIS_URL, db=0, **kwargs)
+        _async_redis_client_key = key
+        return _async_redis_client

--- a/apps/api/pi_dash/tests/unit/runner/test_https_transport_run_endpoints.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_https_transport_run_endpoints.py
@@ -108,7 +108,7 @@ def test_session_open_waits_for_first_poll_before_dispatch(
     sid = open_resp.data["session_id"]
     with (
         patch("pi_dash.runner.views.sessions.outbox.is_pel_drained", return_value=False),
-        patch("pi_dash.runner.views.sessions.outbox.read_for_session", return_value=[]),
+        patch("pi_dash.runner.views.sessions.outbox.aread_for_session", return_value=[]),
         patch("pi_dash.runner.views.sessions.outbox.mark_pel_drained"),
         patch("django.db.transaction.on_commit", side_effect=lambda fn, **kw: fn()),
     ):

--- a/apps/api/pi_dash/tests/unit/runner/test_long_poll_deadline.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_long_poll_deadline.py
@@ -7,8 +7,8 @@
 Background: ``XREADGROUP BLOCK 0 STREAMS … >`` means "block forever" in
 Redis (BLOCK 0 is documented as "block indefinitely"), not "do not
 block." If the poll loop's deadline expires and we still call
-``outbox.read_for_session(block_ms=0)``, Redis parks the worker
-indefinitely — the gunicorn worker is stuck, the runner's HTTP timeout
+``outbox.aread_for_session(block_ms=0)``, Redis parks the request
+indefinitely — the request is stuck, the runner's HTTP timeout
 fires unnoticed, and any new assign message that lands later is claimed
 into the dead consumer's PEL where the live session can never see it.
 
@@ -19,10 +19,15 @@ dead consumer's PEL.
 
 The fix: bail with `[]` BEFORE calling Redis whenever the deadline has
 expired.
+
+The wait loop is async (``_aread_with_eviction_awareness``) so the block
+window parks on the event loop instead of pinning the per-process
+``thread_sensitive`` thread; these tests drive it with ``asyncio.run``.
 """
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 from unittest.mock import patch
 
@@ -30,7 +35,7 @@ import pytest
 from redis.exceptions import ConnectionError as RedisConnectionError
 
 from pi_dash.runner.views.sessions import (
-    RunnerSessionPollEndpoint,
+    _aread_with_eviction_awareness,
     _session_open_side_effect,
 )
 
@@ -57,32 +62,31 @@ def test_loop_returns_empty_without_calling_redis_when_deadline_expired():
     """When `block_ms=0` arrives at the loop entry, never invoke Redis.
 
     Asserts the structural fix: the deadline check happens BEFORE
-    `read_for_session` — not after — so the helper cannot accidentally
+    `aread_for_session` — not after — so the helper cannot accidentally
     issue ``XREADGROUP BLOCK 0`` (= block forever) on the
     deadline-already-expired path.
     """
-    endpoint = RunnerSessionPollEndpoint()
     runner_id = "11111111-1111-1111-1111-111111111111"
     session_id = "22222222-2222-2222-2222-222222222222"
 
     read_calls: list[dict[str, Any]] = []
 
-    def _spy_read_for_session(**kwargs):
+    async def _spy_aread_for_session(**kwargs):
         read_calls.append(kwargs)
         return []
 
-    # Mock redis_instance so the helper takes the eviction-aware branch
-    # rather than the no-redis fallback. The mock object only needs to
-    # support `pubsub()` returning an object with `subscribe()`,
-    # `get_message()`, and `close()`.
+    # Mock async_redis_instance so the helper takes the eviction-aware
+    # branch rather than the no-redis fallback. The mock object only
+    # needs to support `pubsub()` returning an object with awaitable
+    # `subscribe()`, `get_message()`, and `close()`.
     class _FakePubsub:
-        def subscribe(self, _channel):
+        async def subscribe(self, _channel):
             pass
 
-        def get_message(self, timeout=0):
+        async def get_message(self, timeout=0):
             return None
 
-        def close(self):
+        async def close(self):
             pass
 
     class _FakeRedis:
@@ -91,20 +95,21 @@ def test_loop_returns_empty_without_calling_redis_when_deadline_expired():
 
     with (
         patch(
-            "pi_dash.runner.views.sessions.outbox.read_for_session",
-            side_effect=_spy_read_for_session,
+            "pi_dash.runner.services.outbox.aread_for_session",
+            side_effect=_spy_aread_for_session,
         ),
         patch(
-            "pi_dash.settings.redis.redis_instance",
+            "pi_dash.settings.redis.async_redis_instance",
             return_value=_FakeRedis(),
         ),
     ):
-        result = endpoint._read_with_eviction_awareness(
-            runner_id=runner_id,
-            session_id=session_id,
-            sid=session_id,
-            block_ms=0,  # ← deadline already expired at entry
-            use_zero=False,
+        result = asyncio.run(
+            _aread_with_eviction_awareness(
+                runner_id=runner_id,
+                session_id=session_id,
+                block_ms=0,  # ← deadline already expired at entry
+                use_zero=False,
+            )
         )
 
     assert result == []
@@ -113,33 +118,33 @@ def test_loop_returns_empty_without_calling_redis_when_deadline_expired():
     # regressed to AFTER the read and we've reintroduced the BLOCK 0
     # forever-park bug.
     assert read_calls == [], (
-        f"read_for_session must not be called when block_ms=0; got: {read_calls}"
+        f"aread_for_session must not be called when block_ms=0; got: {read_calls}"
     )
 
 
 @pytest.mark.unit
 def test_initial_pel_replay_still_reads_with_zero_budget():
     """`use_zero=True` is a nonblocking PEL replay, not a long poll for `>`."""
-    endpoint = RunnerSessionPollEndpoint()
     runner_id = "11111111-1111-1111-1111-111111111111"
     session_id = "22222222-2222-2222-2222-222222222222"
     replayed = [{"stream_id": "1-0", "type": "assign"}]
     read_calls: list[dict[str, Any]] = []
 
-    def _spy_read_for_session(**kwargs):
+    async def _spy_aread_for_session(**kwargs):
         read_calls.append(kwargs)
         return replayed
 
     with patch(
-        "pi_dash.runner.views.sessions.outbox.read_for_session",
-        side_effect=_spy_read_for_session,
+        "pi_dash.runner.services.outbox.aread_for_session",
+        side_effect=_spy_aread_for_session,
     ):
-        result = endpoint._read_with_eviction_awareness(
-            runner_id=runner_id,
-            session_id=session_id,
-            sid=session_id,
-            block_ms=0,
-            use_zero=True,
+        result = asyncio.run(
+            _aread_with_eviction_awareness(
+                runner_id=runner_id,
+                session_id=session_id,
+                block_ms=0,
+                use_zero=True,
+            )
         )
 
     assert result == replayed
@@ -156,17 +161,16 @@ def test_initial_pel_replay_still_reads_with_zero_budget():
 
 @pytest.mark.unit
 def test_pubsub_is_closed_when_subscribe_fails():
-    endpoint = RunnerSessionPollEndpoint()
     runner_id = "11111111-1111-1111-1111-111111111111"
     session_id = "22222222-2222-2222-2222-222222222222"
 
     class _FailingPubsub:
         closed = False
 
-        def subscribe(self, _channel):
+        async def subscribe(self, _channel):
             raise RedisConnectionError("too many connections")
 
-        def close(self):
+        async def close(self):
             self.closed = True
 
     pubsub = _FailingPubsub()
@@ -175,14 +179,15 @@ def test_pubsub_is_closed_when_subscribe_fails():
         def pubsub(self, ignore_subscribe_messages=True):
             return pubsub
 
-    with patch("pi_dash.settings.redis.redis_instance", return_value=_FakeRedis()):
+    with patch("pi_dash.settings.redis.async_redis_instance", return_value=_FakeRedis()):
         with pytest.raises(RedisConnectionError, match="too many connections"):
-            endpoint._read_with_eviction_awareness(
-                runner_id=runner_id,
-                session_id=session_id,
-                sid=session_id,
-                block_ms=100,
-                use_zero=False,
+            asyncio.run(
+                _aread_with_eviction_awareness(
+                    runner_id=runner_id,
+                    session_id=session_id,
+                    block_ms=100,
+                    use_zero=False,
+                )
             )
 
     assert pubsub.closed is True

--- a/apps/api/pi_dash/tests/unit/runner/test_poll_heartbeat_drain.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_poll_heartbeat_drain.py
@@ -106,11 +106,11 @@ def _patched_poll_dependencies(*, drain_side_effect=None, is_pel_drained=True):
         ),
         patch("pi_dash.runner.views.sessions.outbox.mark_pel_drained"),
         patch(
-            "pi_dash.runner.views.sessions.outbox.read_for_session",
+            "pi_dash.runner.views.sessions.outbox.aread_for_session",
             return_value=[],
         ),
         # Eviction-aware reader's pubsub fallback — short-circuit it.
-        patch("pi_dash.settings.redis.redis_instance", return_value=None),
+        patch("pi_dash.settings.redis.async_redis_instance", return_value=None),
         # Fire on_commit callbacks inline so the drain assertion is synchronous.
         patch(
             "django.db.transaction.on_commit",

--- a/apps/api/pi_dash/tests/unit/runner/test_poll_heartbeat_drain.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_poll_heartbeat_drain.py
@@ -282,3 +282,32 @@ def test_drain_failure_does_not_fail_poll_response(db, api_client, enrolled_runn
 
     assert resp.status_code == 200, resp.data
     mock_drain.assert_called_once_with(enrolled_runner.id)
+
+
+@pytest.mark.unit
+def test_poll_endpoint_is_csrf_exempt(db, enrolled_runner, runner_token, runner_session):
+    """Regression: the poll view must stay CSRF-exempt.
+
+    It replaced a DRF ``APIView`` (csrf-exempt by default) with a plain
+    Django async view, which CsrfViewMiddleware *does* enforce unless the
+    view carries ``csrf_exempt``. The runner posts bearer-only with no CSRF
+    token, so dropping the exemption would 403 every poll in production.
+
+    DRF's ``APIClient`` (used by the other tests here) bypasses CSRF, so it
+    can't catch that regression — this uses Django's test ``Client`` with
+    ``enforce_csrf_checks=True`` to actually run CsrfViewMiddleware.
+    """
+    from django.test import Client
+
+    client = Client(enforce_csrf_checks=True)
+    with _patched_poll_dependencies():
+        resp = client.post(
+            f"/api/v1/runner/runners/{enrolled_runner.id}/sessions/{runner_session.id}/poll",
+            data="{}",
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {runner_token}",
+        )
+
+    # 200 = passed CSRF + auth + bookkeeping. A CSRF rejection would be 403
+    # with a CSRF failure reason, which is exactly the regression we guard.
+    assert resp.status_code == 200, resp.content


### PR DESCRIPTION
## Why

Production incident 2026-06-10: page loads took 5+ seconds with only ~3 connected runners. Under ASGI, every sync DRF view in a gunicorn worker shares one `thread_sensitive` thread, so each ~25s runner long-poll wedged an entire worker. With 4 workers and ~3 runner sessions polling continuously, UI API requests queued behind the polls.

The cloud Dockerfile's rationale for UvicornWorker assumed long-polls were "cheap coroutines" — this PR makes that actually true.

## What

- `runner_session_poll` is now a plain Django **async** view (DRF's `APIView` cannot await). Auth (`RunnerAccessTokenAuthentication`) and all DB bookkeeping run sync, briefly, via `sync_to_async`; only the ~25s block window awaits on the event loop.
- New `async_redis_instance()` in `pi_dash/settings/redis.py` — asyncio twin of `redis_instance()` (same URL/timeouts/`db=0` pinning).
- New `outbox.aread_for_session()` — async twin of `read_for_session()`; the XREADGROUP reply decoding is extracted into a shared `_decode_read_result()`.
- The BLOCK-0-means-forever deadline guard and the eviction pub/sub behavior carry over 1:1; the deadline regression tests now drive the async loop via `asyncio.run`.
- `csrf_exempt` is set as a function attribute instead of the decorator: Django 4.2's `@csrf_exempt` wraps the view in a sync function, which hides the coroutine from the handler and silently breaks async dispatch (async decorator support landed in Django 5.0).

## Behavior preserved

- 401/403/409 payloads and status codes unchanged
- PEL replay (`use_zero`) → `mark_pel_drained` ordering unchanged
- heartbeat update, stale-run reaping, drain-on-commit triggers unchanged

## Testing

- `pi_dash/tests/unit/runner/`: 301 passed; the only 2 failures (`test_runs_views.py` skip-dispatch-header tests) also fail on unmodified `main`
- ruff clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)