### PR TITLE
docs(design): worktree pooling — decouple runners from work dirs

### DIFF
--- a/.ai_design/worktree_pooling/design.md
+++ b/.ai_design/worktree_pooling/design.md
@@ -1,0 +1,533 @@
+# Worktree Pooling — Design
+
+A `pidash` daemon manages a **pool of git worktrees per work dir**, decoupling
+runners (agent configurations) from working directories (execution resources).
+N runners can share one work dir; concurrency is bounded by the pool size, not
+the runner count. When every worktree is in use, assigned runs **wait in a
+local queue** owned by the daemon instead of failing.
+
+This supersedes the one-runner-one-working-dir binding enforced today by
+config validation (`runner/src/config/schema.rs:452-476`, the
+`DuplicateWorkingDir` / `NestedWorkingDir` errors), and builds on the
+multi-runner daemon (`../n_runners_in_same_machine/design.md`): runner
+instances, the shared cloud transport (wire v4 — per-runner HTTPS long-poll,
+`runner/src/cloud/protocol.rs:6`), and single-tenancy per instance are all
+unchanged.
+
+The mental model (used throughout this doc):
+
+> Pi Dash cloud is the **boss**, an issue is a **job task**, a runner is an
+> **employee**, a work dir is an **office**, and a worktree is a **desk**. The
+> boss assigns tasks to employees and keeps the books; the office manages its
+> own desks. An employee with a task but no free desk waits — visibly, on the
+> boss's books — until a desk frees up.
+
+---
+
+## 1. Goals
+
+- **N runners per work dir.** A codex runner and a claude_code runner can
+  serve the same repo checkout; issues route to a specific agent (see the
+  companion agent-aware-routing work) without duplicating clones.
+- **One canonical clone per repo per machine.** History is stored once;
+  worktrees share its object database. Repo size stops being a reason to avoid
+  multiple runners.
+- **Worktree pool with leases.** A run leases a clean worktree at start,
+  releases it at the end (success, failure, or cancel); the worktree is
+  cleaned and returned to the pool.
+- **Wait, don't fail.** When the pool is exhausted, runs queue locally in the
+  daemon (FIFO per work dir) until a worktree frees up.
+- **Cloud stays the source of record.** Queued-locally is a first-class,
+  cloud-visible run state; cancel works while queued; the local queue is
+  rebuildable from cloud state after a daemon restart.
+- **Warm pools.** Cleaning preserves gitignored files (dependency installs,
+  build caches) by default, so pooled worktrees stay cheap to reuse even in
+  very large repos.
+
+## 2. Non-goals
+
+- **Concurrent runs within one runner instance.** Instances stay
+  single-tenant (≤ 1 in-flight run). Concurrency still comes from multiple
+  instances; the pool bounds how many of them can _execute_ at once.
+- **Cloud-side modelling of desks.** The cloud never sees worktree identities,
+  branch locks, or pool internals. It sees runner readiness, a per-run
+  waiting state, and an aggregate capacity hint — nothing more.
+- **Cross-machine work-dir identity.** A work dir is a per-machine resource.
+  Two machines cloning the same repo are two unrelated offices.
+- **Worktree pooling for non-git work dirs.** The pool requires a git repo;
+  the existing single-dir behavior remains for anything else.
+- **Idle-worktree eviction (disk reclaim by TTL).** Deferred; see §13.
+
+## 3. Vocabulary
+
+| Term                | Meaning                                                                                                                                                  |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Work dir**        | A named, daemon-managed entity (`[[workdir]]` in config): one repo on this machine. Owns the canonical clone, the pool, and the local queue. The office. |
+| **Canonical clone** | The git repo at `workdir.path`. Holds the shared object database. Agents never execute in it.                                                            |
+| **Worktree**        | A `git worktree` checkout off the canonical clone, materialized under the pool dir. The desk.                                                            |
+| **Pool**            | The set of worktrees for one work dir, capped at `pool_size`. Worktrees are created lazily up to the cap.                                                |
+| **Lease**           | Exclusive ownership of one worktree by one run or chat session, held from acquisition until cleanup completes. Crash-safe (on-disk lock file).           |
+| **Local queue**     | Per-work-dir FIFO of runs that have been assigned to a runner but cannot acquire a lease yet.                                                            |
+| **Branch lock**     | The git-enforced invariant that one branch is checked out in at most one worktree (including the canonical clone) at a time.                             |
+
+## 4. Pool mechanics
+
+### 4.1 Layout
+
+```
+data_dir/
+  worktrees/
+    <workdir-name>/
+      wt-1/                  # a git worktree of the canonical clone
+      wt-2/
+      locks/
+        wt-1.lock.json       # { lease_kind, run_id|session_id, runner_id, acquired_at }
+        wt-2.lock.json
+```
+
+Worktrees live under `data_dir`, **not** inside the work dir path — nesting a
+worktree inside the repo it belongs to recreates the path-collision hazard the
+old validation existed to prevent. `workdir.worktrees_dir` overrides the
+location (e.g. to keep worktrees on the same filesystem as a huge repo).
+
+The canonical clone at `workdir.path` is the user's existing checkout —
+typically the directory they already pointed a runner at today. After this
+change, agents never run in it again; it serves the object database and the
+user can keep using it by hand.
+
+### 4.2 Initialization and lazy growth
+
+The pool is initialized when the first runner binds to the work dir (daemon
+startup or `pidash runner add`). Initialization verifies the canonical clone
+exists (clone it via the existing `workspace::resolve` path if the dir is
+empty), runs `git worktree prune`, and reaps stale locks (§8). It does **not**
+materialize worktrees upfront.
+
+Worktrees are created on demand: when a lease is requested, no clean worktree
+is free, and `live worktree count < pool_size`, the daemon runs
+`git worktree add <pool>/wt-<n> --detach` and then runs the work dir's
+`setup_command` (if configured) once in the new worktree — this is where
+`.env` provisioning and the first dependency install happen. Default
+`pool_size` is **2**; editable per work dir in the TUI and CLI (§10).
+
+### 4.3 Lease acquisition
+
+A run (or chat session) can acquire a lease when **both** hold:
+
+1. A clean worktree is free (or can be lazily created under the cap).
+2. Its target branch is not currently checked out in any other worktree **or
+   in the canonical clone** (the branch lock — git enforces this at checkout;
+   the daemon checks first so the run queues instead of erroring).
+
+Acquisition writes the lock file, checks out the run's work branch in the
+leased worktree (`workspace::git::checkout_work_branch`, pointed at the
+worktree path), and hands the worktree path to the agent bridge as its cwd.
+
+The canonical clone's currently-checked-out branch is treated as permanently
+locked. The daemon logs a warning at pool init suggesting the canonical clone
+be parked on a detached HEAD or a dedicated parking branch if its branch ever
+collides with run traffic.
+
+### 4.4 Lease release and cleaning
+
+On run end — completed, failed, cancelled, refused, crashed — the lease is
+always released. Release runs, in order:
+
+1. **Salvage (failed/crashed/cancelled runs only):** if the tree is dirty,
+   commit everything to the run's work branch as a WIP commit
+   (`wip(pidash): salvaged working state from <terminal-status> run <run_id>`)
+   and push it, best-effort. A failed run's tree is debugging evidence;
+   recycling the desk must never destroy it. Salvage failure is logged loudly
+   but does not block release.
+2. **Clean:** per `workdir.clean_mode`:
+   - `keep-ignored` (default): `git reset --hard` + `git clean -fd`. Drops
+     tracked modifications and stray untracked files; **keeps gitignored
+     files** — `node_modules`, build caches, `.env` — so the worktree stays
+     warm.
+   - `allowlist`: `git clean -fdx` everything **except** the work dir's
+     `keep_paths` globs (e.g. `["node_modules/**", ".env"]`). Warm where it
+     matters, pristine everywhere else.
+   - `full`: also `git clean -fdx`. Pristine but cold; the next lease pays
+     `setup_command` again (the daemon re-runs it after a `full` clean).
+
+   **Isolation tradeoff, stated plainly:** `keep-ignored` means gitignored
+   files written by one run survive into the next run's lease — including
+   files a buggy (or prompt-injected) agent planted in `node_modules` or
+   build output that a later run might execute. All runs in one work dir are
+   the same repo and trust domain, which is why warm-by-default is
+   acceptable; work dirs wanting stronger isolation choose `allowlist` (cache
+   dirs only) or `full`. This is a per-work-dir knob precisely because the
+   right answer is repo-dependent.
+
+3. **Park:** detach HEAD (`git checkout --detach`) so the worktree holds no
+   branch lock while idle.
+4. **Unlock:** delete the lock file; notify the queue (§5).
+
+Fetches into the shared object database are serialized with one async mutex
+per work dir — concurrent fetches are mostly safe in git, but serializing
+them is free and removes a class of flaky failures.
+
+### 4.5 Chat sessions
+
+Interactive sessions (`AgentChatSession`) lease a worktree exactly like runs,
+holding it for the whole session (open → close), and count against pool
+capacity. The lock file records `lease_kind: "session"`. Session leases clean
+with the same release path; salvage applies if the session left a dirty tree.
+
+## 5. The local queue
+
+One FIFO queue per work dir, owned by the daemon. The cloud keeps assigning
+runs to runners exactly as today (a runner accepts at most one run); the queue
+exists because a runner holding an accepted run may still lack a desk —
+possible whenever `pool_size <` the number of runners on the work dir, or when
+a branch lock blocks the head run.
+
+**Enqueue.** When a `RunnerLoop` receives `Assign` and lease acquisition
+fails, it enqueues the run and reports the waiting state to the cloud (§6.1).
+It does **not** post `accept` — the accept lifecycle endpoint transitions the
+run to `RUNNING` (`apps/api/pi_dash/runner/views/run_endpoints.py`,
+`RunAcceptEndpoint`), which would make a desk-less run look live. `accept` is
+posted at lease acquisition instead. The instance's status stays `Busy` (it
+is single-tenant and committed to this run).
+
+Because instances are single-tenant, a work dir's queue is really an ordered
+set of _instances_, each holding its one assigned run. The daemon never holds
+more queued runs per work dir than the work dir has runners.
+
+**Dequeue.** Every lease release re-evaluates the queue in FIFO order with
+**head-of-line bypass for branch locks only**: a run blocked solely because
+its branch is leased elsewhere is skipped (it stays queued); the next run that
+can acquire both a worktree and its branch lock starts. Capacity contention
+never reorders; only branch contention does. This keeps follow-up runs on the
+same branch naturally serialized without letting them stall unrelated work.
+
+**Cancel while queued.** `Cancel { run_id }` from the cloud removes the run
+from the queue (no agent process exists yet) and emits `RunCancelled`
+immediately. Same for `RemoveRunner`: the removed instance's queued run is
+cancelled and reported.
+
+**Rebuild on restart.** The queue is **not** persisted locally. The cloud's
+assignment record is the durable truth: when an instance re-opens its session
+after a daemon restart, the session-open response carries redelivery of the
+instance's outstanding `ASSIGNED` / `WAITING_FOR_WORKTREE` run, if any (§6.3
+— this is a new cloud behavior, not today's resume path); the instance
+re-attempts lease acquisition and re-enqueues if needed. Queue order after a
+restart follows session-open order; exact original order is not guaranteed
+and does not matter.
+
+## 6. Cloud touchpoints
+
+Deliberately minimal — the boss's books, not the office's floor plan. These
+land in the Django repo (`apps/api/pi_dash/runner/`).
+
+### 6.1 New run status: `WAITING_FOR_WORKTREE`
+
+`AgentRunStatus` (`apps/api/pi_dash/runner/models.py:185`) gains:
+
+```python
+WAITING_FOR_WORKTREE = "waiting_for_worktree", "Waiting for Worktree"
+```
+
+Non-terminal, sits between `ASSIGNED` and `RUNNING`. The UI renders it as
+"queued on <runner's machine> (position N)".
+
+**Transport.** The wire is v4 HTTP long-poll
+(`runner/src/cloud/protocol.rs:6`): run lifecycle messages are POSTs to
+explicit per-run endpoints, not frames. `RunQueued` is a new lifecycle verb
+alongside `accept`/`started`/`complete`:
+
+```
+POST /api/v1/runner/runs/<run_id>/queued     body: { queue_position: u32 }
+```
+
+Runner-side, `ClientMsg::RunQueued { run_id, queue_position }` dispatches via
+`post_run_lifecycle(run_id, "queued", …)` (`runner/src/cloud/http.rs`,
+`dispatch_client_msg`), with the same idempotency-key dedupe as its siblings.
+Posted on enqueue and again when the position changes (positions only
+decrease). The cloud endpoint (`RunQueuedEndpoint`, next to
+`RunAcceptEndpoint` in `views/run_endpoints.py`) transitions
+`ASSIGNED → WAITING_FOR_WORKTREE` and stores the position; it refuses the
+transition from `RUNNING` or any terminal state (late/duplicate queued posts
+are acknowledged and dropped, matching the dedupe idiom there).
+
+**Accept moves to lease time.** Today's `accept` endpoint sets the run to
+`RUNNING` (`RunAcceptEndpoint`). A queued run therefore must **not** post
+`accept` on enqueue. The lifecycle becomes:
+
+```
+desk free at Assign:   ASSIGNED ──accept──► RUNNING ──started──► RUNNING …
+pool exhausted:        ASSIGNED ──queued──► WAITING_FOR_WORKTREE ──accept──► RUNNING …
+```
+
+`accept` is posted at lease acquisition in both paths; `accept` semantics are
+unchanged cloud-side.
+
+### 6.2 Status-set and reaper integration
+
+The new status must join the hard-coded status sets, or queued runs fall
+through the cloud's bookkeeping:
+
+- **`NON_TERMINAL_STATUSES` and `BUSY_STATUSES`**
+  (`apps/api/pi_dash/runner/services/matcher.py:50-66`): both. A queued run
+  occupies its single-tenant runner and must block pod deletion exactly like
+  `ASSIGNED`.
+- **Heartbeat reaper** (`session_service.py`, `_reap_stale_runs`): the reaper
+  fails any `BUSY_STATUSES` run assigned before the cutoff that the runner
+  does not report as `in_flight_run`. Because instances are single-tenant, an
+  instance's queued run _is_ its one outstanding run — the runner reports it
+  as `in_flight_run` in the poll status body while it waits. No reaper change
+  is needed beyond adding the status to `BUSY_STATUSES`; a daemon that truly
+  lost the run (crash without restart) stops reporting it and the reaper
+  correctly fails it, exactly as for `RUNNING` today.
+- **Cancel path**: `WAITING_FOR_WORKTREE` must be accepted as a cancellable
+  state; the daemon gains the dequeue branch (§5).
+
+### 6.3 Redelivery at session open
+
+Today, session open only _resumes_: the runner reports `in_flight_run` and
+the cloud builds a resume ack for it
+(`apps/api/pi_dash/runner/views/sessions.py:204`). Nothing pushes work the
+runner doesn't already know about. That is insufficient here: after a daemon
+restart, the local queue is gone and the runner does not know its queued run
+exists.
+
+Extend session open: when the opening runner has an outstanding run in
+`ASSIGNED` or `WAITING_FOR_WORKTREE` that it did not report as in-flight, the
+open response carries a `redeliver` payload mirroring the `Assign` body. The
+instance treats it exactly like a fresh `Assign`: attempt a lease, start or
+enqueue. (At most one such run exists per runner — single-tenancy.) `RUNNING`
+runs the daemon lost remain the reaper's job, unchanged.
+
+### 6.4 Capacity hint for the matcher
+
+In wire v4 there is no Heartbeat frame — runner status rides the long-poll
+request body (`{"ack": …, "status": …}`, `runner/src/cloud/http.rs:639`).
+The status object gains an optional field:
+
+```json
+"free_worktrees": 1    // free desks in this runner's work dir pool
+```
+
+The poll handler stores it on the runner row.
+`select_runner_in_pod` (`apps/api/pi_dash/runner/services/matcher.py:96`)
+uses it as a **preference, not a gate**: among eligible idle runners, prefer
+one whose office reports a free desk; fall back to today's oldest-heartbeat
+choice. The matcher never refuses to assign because capacity looks full — the
+local queue absorbs the overflow, and stale hints therefore cost at most some
+queue time, never a stuck run. With agent-targeted routing there is often
+exactly one eligible runner anyway; this hint only improves the multi-eligible
+case.
+
+## 7. Config shape
+
+```toml
+# config.toml
+
+[daemon]
+cloud_url = "https://cloud.pidash.so"
+
+[[workdir]]
+name = "main-repo"
+path = "/home/rich/work/main"          # canonical clone (agents never run here)
+pool_size = 2                          # default 2; max concurrent leases
+clean_mode = "keep-ignored"            # or "allowlist" or "full" (§4.4)
+# keep_paths = ["node_modules/**"]     # allowlist mode only
+setup_command = "pnpm install"         # optional; runs once per new worktree,
+                                       # and after every `full` clean
+# worktrees_dir = "/big-disk/pidash-worktrees/main-repo"   # optional override
+
+[[runner]]
+name = "codex-main"
+runner_id = "..."
+workdir = "main-repo"                  # replaces [runner.workspace].working_dir
+[runner.agent]
+kind = "codex"
+
+[[runner]]
+name = "fable-main"
+runner_id = "..."
+workdir = "main-repo"                  # same office, different employee
+[runner.agent]
+kind = "claude_code"
+```
+
+**Validation changes** (`runner/src/config/schema.rs`):
+
+- `DuplicateWorkingDir` / `NestedWorkingDir` across **runners** are deleted —
+  sharing is the point now.
+- The same checks move to **work dirs**: two `[[workdir]]` entries must not
+  have equal or nested `path`s (nor equal/nested `worktrees_dir`s).
+- Every `runner.workdir` must name an existing `[[workdir]]` (hard error,
+  mirroring `MissingProjectSlug`).
+- `pool_size` must be ≥ 1; values above 16 warn (a desk cap, not an
+  abuse cap — the §16 instance cap of the multi-runner design still governs
+  runner count).
+
+**Migration.** Per the multi-runner rollout (§13 there), there are no
+production runner users; no compatibility shim is built. On first run with the
+new schema, the daemon refuses a config containing `[runner.workspace]` with a
+clear message, and `pidash configure --migrate-workdirs` rewrites it: each
+distinct `working_dir` becomes a `[[workdir]]` named after the runner (or
+dir basename), `pool_size = 2`, and runners get `workdir = <name>` references.
+
+## 8. Crash safety
+
+Locks are on disk so a daemon crash cannot strand desks:
+
+- **Lock files** (`locks/wt-N.lock.json`) are written before checkout and
+  deleted after cleaning. They name the lease holder (`run_id` /
+  `session_id`, `runner_id`, `acquired_at`).
+- **On daemon start**, per work dir: `git worktree prune`; then every lock
+  file is stale by definition (no leases survive the process) — each locked
+  worktree goes through the full release path (salvage → clean → park →
+  unlock) before the pool accepts leases. Salvage on reaped locks uses the
+  `run_id` from the lock file for the WIP commit message, preserving the
+  pre-crash tree on the run's branch.
+- **Worktree corruption** (manual deletion, disk issues): a worktree that
+  fails cleaning or `git status` is removed (`git worktree remove --force` +
+  prune) and the pool recreates lazily. The pool never repairs in place.
+
+The local queue needs no crash handling — it is rebuilt from cloud state
+(§5, §6.3).
+
+## 9. Failure semantics
+
+| Scenario                                                 | Behaviour                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Pool exhausted on `Assign`                               | Run enqueues; `RunQueued` → cloud shows `WAITING_FOR_WORKTREE`. Never fails for capacity.                                                                                                                                                                                                                                                                                                                                                                                           |
+| Run's branch leased by another worktree                  | Run enqueues (or is bypassed at dequeue) until the branch lock frees. Serializes same-branch follow-ups.                                                                                                                                                                                                                                                                                                                                                                            |
+| Run's branch checked out in the canonical clone          | Same as above, but the lock may never free — surfaced in `pidash status` and daemon logs ("branch X held by canonical clone; park it").                                                                                                                                                                                                                                                                                                                                             |
+| Cancel while queued                                      | Dequeued, `RunCancelled` emitted immediately.                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| Run fails / agent crashes with dirty tree                | Salvage WIP commit pushed to the work branch (best-effort), then clean and release. Evidence preserved, desk recycled.                                                                                                                                                                                                                                                                                                                                                              |
+| Daemon crash mid-run                                     | On restart: stale locks reaped (salvage + clean), queue rebuilt from cloud re-delivery. In-flight runs are lost as today (run fails cloud-side via lease expiry).                                                                                                                                                                                                                                                                                                                   |
+| `setup_command` fails on a new worktree                  | One retry with backoff; on second failure the waiting run fails terminally (`RunFailed`, reason `WorkspaceSetup` — matching today's `supervisor.rs` resolve-failure path) and the **work dir is marked unhealthy**: no new leases, queued runs fail fast with the same reason, state surfaced in `pidash status`/TUI. Cleared by config reload or an explicit retry verb. A broken work dir is a config error, not capacity contention — it must never present as an eternal queue. |
+| Two runs race for the last worktree                      | Lease acquisition is serialized per work dir (single async owner task); no race exists.                                                                                                                                                                                                                                                                                                                                                                                             |
+| `pool_size` lowered below live worktree count (TUI edit) | Existing leases finish; surplus clean worktrees are removed on release until the count fits.                                                                                                                                                                                                                                                                                                                                                                                        |
+| `RemoveRunner` while its run is queued                   | Queued run cancelled and reported; lease never acquired; other queue entries unaffected.                                                                                                                                                                                                                                                                                                                                                                                            |
+| Stale `free_worktrees` hint in heartbeat                 | Matcher may pick a deskless runner; run queues locally. Cost is latency, never correctness.                                                                                                                                                                                                                                                                                                                                                                                         |
+
+## 10. CLI / TUI surface
+
+- `pidash workdir add --name main-repo --path ~/work/main [--pool-size N]
+[--clean-mode keep-ignored|full] [--setup-command "pnpm install"]` — create
+  the entity; `pidash workdir list` / `remove` round it out. `remove` refuses
+  while any runner references the work dir.
+- `pidash runner add --workdir main-repo ...` — replaces `--working-dir`.
+- `pidash status` shows, per work dir: pool occupancy (`2/2 desks busy`),
+  queue depth, and per-worktree lease holders.
+- **TUI**: the work-dir view exposes `pool_size` (the user-requested knob),
+  `clean_mode`, and `setup_command` for editing; a pool panel shows desks,
+  lease holders, and the queue. Edits apply live where safe (`pool_size` up:
+  immediate; down: drains per §9).
+
+## 11. ADR — queue location: daemon, not cloud
+
+**Considered**: capacity-aware dispatch — the cloud only assigns a run when
+the runner can actually start it (free desk), keeping all queueing in the
+existing `QUEUED` state and `drain_pod`.
+
+**Why rejected**: whether a run can start depends on facts only the daemon
+knows at execution time — desk occupancy _and branch locks_ (a run can be
+blocked because its branch is checked out at another desk, or in the
+canonical clone). Gating cloud-side would require the cloud to model
+branch-level locks, leaking office-interior detail upward, and the daemon
+needs deferral machinery for branch contention regardless. Once that exists,
+"all desks busy" is just another reason to defer.
+
+**What the cloud-side option got right** is preserved as four guardrails,
+all in this design: (1) a cloud-visible `WAITING_FOR_WORKTREE` state with
+queue position (§6.1); (2) cancel works while queued (§6.2); (3) the cloud's
+assignment record is the durable truth and the local queue is rebuilt from it
+(§5, §6.3); (4) desk availability flows back as an assignment _hint_ (§6.4).
+The boss doesn't manage desks, but the books always say where every task is,
+the boss can recall any task, and the boss glances at the "how busy" sign
+before choosing between two equally qualified employees.
+
+## 12. ADR — pool from day one, not per-runner worktrees
+
+**Considered**: one persistent worktree per runner (no pool, no queue) —
+strictly simpler, and sufficient for the motivating two-agents-one-repo case.
+
+**Why rejected as the end state**: it re-couples capacity to runner count
+(N runners = N worktrees of disk forever, even if only 2 ever run at once),
+gives no clean-tree guarantee between runs, and has no answer for chat
+sessions and runs contending for the same tree. The pool decouples the
+capacity knob (`pool_size`) from the routing concept (runners), which is the
+actual point of this design. Accepted cost: lease/queue/cleaning machinery
+that per-runner worktrees would not need — judged worth building once,
+correctly, rather than migrating later.
+
+## 13. Deferred
+
+- **Idle-worktree eviction**: removing clean worktrees after a TTL to reclaim
+  disk. Lazy creation bounds the waste at "high-water mark of concurrent
+  leases"; eviction can come later without protocol changes.
+- **Sparse checkout / partial clone** (`--filter=blob:none`) for very large
+  repos: pure work-dir-level optimizations, addable behind `[[workdir]]`
+  flags later.
+- **Priority or per-agent-kind queue ordering**: FIFO with branch bypass
+  until real usage says otherwise.
+- **Worktree-per-run for parallel runs inside one instance**: would lift
+  single-tenancy; out of scope (multi-runner design §1 still governs).
+
+## 14. Files most affected
+
+### Runner (`runner/`)
+
+| File                            | Change                                                                                                                             |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `src/workspace/pool.rs` (new)   | Pool: lease/release, lazy creation, cleaning, salvage, branch locks, lock files, crash reaping, per-work-dir queue.                |
+| `src/workspace/resolve.rs`      | Resolves the **canonical clone** for a work dir instead of a runner's dir; unchanged clone-if-empty semantics.                     |
+| `src/workspace/git.rs`          | Adds `worktree_add/remove/prune`, `detach_head`, `reset_clean(mode)`, `salvage_wip(run_id)`; fetch mutex per work dir.             |
+| `src/config/schema.rs`          | `[[workdir]]` entity; runner `workdir` reference; validation flip (§7); `pool_size`/`clean_mode`/`setup_command` fields.           |
+| `src/daemon/supervisor.rs`      | `RunnerLoop` acquires a lease before spawning the agent bridge; enqueue path; dequeue-on-release wakeups; cancel-dequeue.          |
+| `src/cloud/protocol.rs`         | `ClientMsg::RunQueued { run_id, queue_position }` variant.                                                                         |
+| `src/cloud/http.rs`             | Dispatch `RunQueued` via `post_run_lifecycle(…, "queued", …)`; `free_worktrees` in the poll status body; 404 feature-detect (§15). |
+| `src/cli/{runner,configure}.rs` | `pidash workdir` verbs; `runner add --workdir`; `--migrate-workdirs`.                                                              |
+| `src/ipc/protocol.rs`           | `StatusSnapshot` gains per-work-dir pool/queue info.                                                                               |
+| `src/tui/*`                     | Work-dir view: pool panel, `pool_size` editing.                                                                                    |
+
+### Cloud (`apps/api/pi_dash/runner/`)
+
+| File                          | Change                                                                                                              |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `models.py`                   | `AgentRunStatus.WAITING_FOR_WORKTREE`; queue-position field on `AgentRun` (display only).                           |
+| `views/run_endpoints.py`      | New `RunQueuedEndpoint` (lifecycle verb `queued`, `ASSIGNED → WAITING_FOR_WORKTREE`).                               |
+| `views/sessions.py`           | Session open gains the `redeliver` payload for outstanding unreported runs (§6.3).                                  |
+| `services/matcher.py`         | Add status to `NON_TERMINAL_STATUSES` + `BUSY_STATUSES` (`:50-66`); free-desk preference in `select_runner_in_pod`. |
+| `services/session_service.py` | Poll status accepts `free_worktrees`; reaper covers the new status via `BUSY_STATUSES` (no logic change).           |
+| cancel path                   | `WAITING_FOR_WORKTREE` is cancellable.                                                                              |
+
+### Web / types (pnpm workspace)
+
+| File                                                               | Change                                                       |
+| ------------------------------------------------------------------ | ------------------------------------------------------------ |
+| `packages/types/src/runner.ts:99`                                  | Add `"waiting_for_worktree"` to the `TAgentRunStatus` union. |
+| `apps/web/core/components/issues/issue-detail/agent-status.tsx:38` | Add to `ACTIVE_RUN_STATUSES`; render label + queue position. |
+| `apps/web/app/(all)/[workspaceSlug]/runners/runs/page.tsx`         | Status filter/label maps gain the new value.                 |
+| mobile vendored runner types (if present)                          | Mirror the union change.                                     |
+
+## 15. Rollout
+
+1. **Runner repo**: pool module + config schema + lease-before-run, behind the
+   new config shape (old shape refuses with the migration hint, §7). The
+   daemon stays functional against an unmodified cloud via explicit feature
+   detection — on HTTP there is no "frame dropping": a POST to the unknown
+   `…/queued` endpoint returns 404. The runner treats a 404 from `queued` as
+   "cloud predates this feature": log once per session, stop posting `queued`,
+   and **post `accept` on enqueue instead** (legacy behavior — the run shows
+   `RUNNING` while it waits, exactly as an old cloud expects; degraded
+   visibility, no stuck states). Unknown poll-status fields
+   (`free_worktrees`) are ignored by old clouds — additive and safe.
+2. **Cloud repo**: new status + `RunQueuedEndpoint` + status-set additions
+   (§6.2) + session-open redelivery (§6.3) + cancellable state. One deploy —
+   the status must not land without the matcher/reaper set additions, or
+   queued runs are invisible to the busy/reaper logic (§6.2).
+3. **Matcher hint + web UI/types** last: pure polish, no correctness
+   dependency (the TS union addition ships with step 2's API change, since
+   the serializer starts emitting the new value then).
+
+Companion work (separate doc): **agent-aware routing** — runners report
+`agent.kind`/model at registration, issues carry an agent preference, matcher
+filters on it. Together with this design it completes "route this issue to
+codex, that one to fable, same repo, one machine."

--- a/.ai_design/worktree_pooling/implementation-plan.md
+++ b/.ai_design/worktree_pooling/implementation-plan.md
@@ -1,0 +1,293 @@
+# Implementation Plan — Worktree Pooling
+
+Phased rollout of `design.md`. Each phase is independently mergeable and
+leaves the system in a working state. Phases 1–3 are runner-side and run
+end-to-end against an **unmodified cloud** (the design's §15 feature-detect
+guarantee is built in from the start, not retrofitted). Phases 4–5 are
+cloud-side. Phases 6–7 join the two. Phase 8 is surface polish.
+
+Per the multi-runner rollout (`../n_runners_in_same_machine/design.md` §13)
+there are no production runner users; the old `[runner.workspace]` config
+shape gets a migration command, not a compatibility shim.
+
+---
+
+## Phase 1 — Runner: `[[workdir]]` config entity (execution unchanged)
+
+**Goal**: the work dir exists as a named, shared entity in config; runners
+reference it. Agents still execute directly in the canonical clone, exactly as
+today — this phase is config plumbing only.
+
+- `runner/src/config/schema.rs`:
+  - New `WorkdirConfig { name, path, pool_size (default 2), clean_mode
+(default keep-ignored), keep_paths, setup_command, worktrees_dir }`;
+    `Config.workdirs: Vec<WorkdirConfig>`.
+  - `RunnerConfig` drops `workspace: WorkspaceSection`, gains
+    `workdir: String` (reference by name).
+  - Validation flip (design §7): delete the runner-pair
+    `DuplicateWorkingDir` / `NestedWorkingDir` checks (`schema.rs:452-476`);
+    add the same equal/nested-path checks **across `[[workdir]]` entries**
+    (both `path` and `worktrees_dir`); hard error on a `runner.workdir` that
+    names no `[[workdir]]` (mirror `MissingProjectSlug`); duplicate workdir
+    names; `pool_size ≥ 1`, warn above 16.
+  - **Temporary guard, removed in phase 3**: at most one runner per workdir.
+    Until the pool exists, two runners sharing a canonical clone is exactly
+    the corruption hazard the old validation prevented. The error message
+    says the cap lifts with pooling.
+- `pidash configure --migrate-workdirs` (`runner/src/cli/configure.rs`):
+  rewrites an old-shape config — each distinct `working_dir` becomes a
+  `[[workdir]]` (named after the runner or dir basename), runners get
+  `workdir = <name>`. A config containing `[runner.workspace]` refuses to
+  start with a message naming this command.
+- CLI: `pidash workdir add|list|remove` (config-file writes + IPC reload);
+  `pidash runner add --workdir <name>` replaces `--working-dir`. `workdir
+remove` refuses while any runner references it.
+- `runner/src/daemon/supervisor.rs` `handle_assign` (~`:2272`): resolve
+  `runner.workdir → workdir.path` and proceed exactly as today
+  (`workspace::resolve` into the canonical clone).
+
+**Done when**: fresh install with the new shape runs a real assignment
+end-to-end in the canonical clone; `--migrate-workdirs` round-trips an
+old-shape config; two workdirs with nested paths refuse startup with a clear
+error; two runners on one workdir refuse startup (temporary guard).
+
+## Phase 2 — Runner: worktree primitives + pool library (unwired)
+
+**Goal**: `WorktreePool` exists as a fully-tested library. Nothing in the
+daemon calls it yet.
+
+- `runner/src/workspace/git.rs` additions (all shelling out via the existing
+  `git_output` helper, branch names through `validate_branch_name`):
+  - `worktree_add(repo, path)` (`git worktree add --detach`),
+    `worktree_remove(repo, path, force)`, `worktree_prune(repo)`.
+  - `detach_head(worktree)` (`git checkout --detach`).
+  - `reset_clean(worktree, mode, keep_paths)` — `reset --hard` plus
+    `clean -fd` / `clean -fdx` with `--exclude` globs for `allowlist`.
+  - `salvage_wip(worktree, branch, holder_id)` — stage-all, WIP commit with
+    the design's message shape, best-effort push.
+  - `checked_out_branches(repo) -> map<branch, path>` — parse
+    `git worktree list --porcelain` (covers the canonical clone too); this is
+    the branch-lock source of truth.
+- `runner/src/workspace/pool.rs` (new) — one owner task per workdir; all
+  lease/queue state lives inside it, so acquisition is serialized by
+  construction (design §9 "no race exists"):
+  - `acquire(LeaseRequest { kind: Run|Session, holder_id, branch }) →
+oneshot<LeaseGrant>` — grants immediately, or parks the request in the
+    FIFO queue (granted later via the oneshot; this _is_ the local queue).
+  - Grant path: free worktree (or lazy `worktree_add` under `pool_size` +
+    `setup_command` with one retry/backoff), branch-lock check via
+    `checked_out_branches`, write `locks/wt-N.lock.json`, checkout branch.
+  - `release(lease, outcome)`: salvage (non-success outcomes, dirty tree
+    only) → clean per `clean_mode` → `detach_head` → unlock → re-evaluate the
+    queue FIFO with branch-lock-only head-of-line bypass (design §5).
+  - `cancel(holder_id)`: remove a parked request from the queue (resolves the
+    oneshot with `Cancelled`).
+  - `PoolHealth::Unhealthy { reason }` after the bounded `setup_command`
+    retry fails: new acquires and parked requests fail fast (design §9);
+    cleared by config reload or an explicit retry verb.
+  - Startup reap: `worktree_prune`, then every lock file (stale by
+    definition) goes through the full release path; corrupted worktrees are
+    force-removed and recreated lazily (design §8).
+  - Per-workdir async fetch mutex, exposed for the resolve/fetch paths.
+  - `snapshot()` for IPC/TUI: per-worktree lease holder, queue contents,
+    health.
+- Tests (tempdir git repos, like `resolve.rs`'s existing tests): lease/release
+  round-trip per clean mode; lazy growth stops at cap; branch-lock bypass
+  ordering; cancel-while-parked; salvage on failure outcome; crash reap from
+  a hand-written lock file; unhealthy after two setup failures; corrupted
+  worktree replaced.
+
+**Done when**: `cargo test` covers the matrix above green; no daemon behavior
+change.
+
+## Phase 3 — Runner: wire the pool into the supervisor (legacy reporting)
+
+**Goal**: runs and chat sessions execute in pooled worktrees; N runners per
+workdir works; queueing works — all against an **unmodified cloud** using the
+design §15 legacy fallback (post `accept` on enqueue; the run shows `RUNNING`
+while it waits).
+
+- Supervisor startup: build one `WorktreePool` per configured workdir
+  (initialization = canonical-clone resolve + reap, design §4.2); log the
+  canonical clone's checked-out branch warning (design §4.3).
+- `handle_assign`: replace the direct `workspace::resolve` call with
+  `pool.acquire(...)`. Immediate grant → post `accept` → spawn the agent
+  bridge with the worktree path as cwd. Parked → post `accept` (legacy mode;
+  flips in phase 6) and await the oneshot; on grant, proceed.
+- **Reaper protection**: while a run is parked, the instance reports it as
+  `in_flight_run` in the poll status body. Without this, the cloud's
+  heartbeat reaper fails any queued run older than the assignment grace
+  (design §6.2). This must ship in the same PR as the queue.
+- Every terminal path (`RunCompleted` / `RunFailed` / `RunCancelled` /
+  refusal / bridge crash) calls `pool.release(lease, outcome)`; the
+  `Cancel` handler gains the dequeue branch (`pool.cancel(run_id)` → emit
+  `RunCancelled` immediately).
+- Unhealthy workdir: parked runs fail with `RunFailed { reason:
+WorkspaceSetup }` (same `FailureReason` as today's resolve failures,
+  `supervisor.rs:2288`).
+- Chat sessions (`runner_direct_chat` path) acquire/release leases with
+  `lease_kind: Session`, held open → close.
+- Remove phase 1's temporary one-runner-per-workdir guard.
+
+**Done when**: two runners (codex + claude_code) on one workdir with
+`pool_size = 1` run two concurrent assignments — the second waits, then runs,
+both produce pushed branches; `kill -9` mid-run, restart: stale lock reaped,
+dirty tree salvaged to the run's branch; cancel of a parked run reports
+`RunCancelled` without ever leasing; all against an unmodified cloud.
+
+## Phase 4 — Cloud: `WAITING_FOR_WORKTREE` + `queued` endpoint + status sets
+
+**Goal**: the waiting state is first-class on the boss's books.
+
+- `apps/api/pi_dash/runner/models.py`: `AgentRunStatus.WAITING_FOR_WORKTREE`;
+  nullable `queue_position` small-int on `AgentRun` (display only) +
+  migration.
+- `views/run_endpoints.py`: `RunQueuedEndpoint` (URL verb `queued`, wired in
+  the runner urlconf next to `accept`/`started`): same `_RunEndpointBase` +
+  dedupe idiom; transitions `ASSIGNED → WAITING_FOR_WORKTREE` and updates
+  `queue_position` (also accepts `WAITING → WAITING` position refreshes);
+  acknowledges-and-drops from `RUNNING` or terminal states.
+- `services/matcher.py:50-66`: add the status to both `NON_TERMINAL_STATUSES`
+  and `BUSY_STATUSES`.
+- Cancel path: the user-facing cancel view treats `WAITING_FOR_WORKTREE` as
+  cancellable (delivers `Cancel` to the runner as for `RUNNING`).
+- Serializers expose the new status + `queue_position`;
+  `packages/types/src/runner.ts:99` union + status maps gain the value in the
+  same PR (the API starts emitting it now — web must not choke on it; full
+  rendering is phase 8).
+- Tests: endpoint transition matrix; queued run blocks pod deletion; reaper
+  kills an _unreported_ queued run and spares a _reported_ one (this is the
+  contract phase 3's reporting depends on); cancel from waiting.
+
+**Done when**: contract tests pass; a phase-3 runner pointed at this cloud
+gets 200 from `…/queued` (used in phase 6) and nothing else changes for it.
+
+## Phase 5 — Cloud: session-open redelivery
+
+**Goal**: a restarted daemon learns about the queued run it forgot.
+
+- `views/sessions.py` (session open, after the resume-ack step at `:204`):
+  query the opening runner's outstanding run in `ASSIGNED` /
+  `WAITING_FOR_WORKTREE` that it did **not** report as `in_flight_run`; if
+  one exists (at most one — single-tenancy), include a `redeliver` payload in
+  the open response mirroring the `Assign` envelope body (built by the same
+  helper the matcher uses, `services/matcher.py` assign-envelope
+  construction).
+- Tests: waiting run + reopen with no `in_flight` → `redeliver` present;
+  reopen _with_ the run reported → resume ack only, no redeliver; `RUNNING`
+  runs never redeliver (reaper's job).
+
+**Done when**: integration test proves both paths; old runners (which ignore
+unknown response fields) are unaffected.
+
+## Phase 6 — Runner: first-class queued reporting + redelivery handling
+
+**Goal**: the legacy fallback becomes the fallback; the real protocol becomes
+the default.
+
+- `runner/src/cloud/protocol.rs`: `ClientMsg::RunQueued { run_id,
+queue_position }`.
+- `runner/src/cloud/http.rs` `dispatch_client_msg`: route it via
+  `post_run_lifecycle(run_id, "queued", …)`. **Feature detection**: a 404
+  from the `queued` verb sets a per-session "cloud predates queued" flag —
+  log once, stop posting `queued`, revert to accept-on-enqueue (phase 3
+  behavior). Any other error follows the normal lifecycle retry path.
+- Enqueue path flips: post `queued` instead of `accept`; post `accept` at
+  lease grant (design §6.1 lifecycle diagram); post position refreshes as the
+  queue drains (positions only decrease).
+- Session open: parse the `redeliver` payload and feed it into the
+  `handle_assign` path verbatim.
+- Fake-cloud test double (`runner/tests/…`) gains the `queued` endpoint and
+  a 404 mode to exercise both branches.
+
+**Done when**: against a phase-5 cloud, a parked run shows
+`WAITING_FOR_WORKTREE` with a position in the API, flips to `RUNNING` at
+lease grant, and survives a daemon restart via redelivery (re-queued, then
+runs); against the 404 fake, behavior is byte-identical to phase 3.
+
+## Phase 7 — Capacity hint for the matcher
+
+**Goal**: the boss glances at the "how busy" sign when choosing between two
+eligible employees.
+
+- Runner: the long-poll status body (`http.rs:639`) gains
+  `free_worktrees: u32` — free desks in _this instance's_ workdir pool at
+  poll time.
+- Cloud: poll handler persists it (nullable int on `Runner` + migration);
+  `select_runner_in_pod` (`matcher.py:96`) orders eligible runners by
+  free-desk-reported first, then today's oldest-heartbeat. Preference, never
+  a gate — `None` (old runner) sorts with the no-free-desk group.
+- Tests: two eligible runners, one reporting a free desk → it wins; both
+  `None` → today's ordering unchanged.
+
+**Done when**: matcher test matrix passes; assignment latency for the
+two-runner-one-desk topology visibly improves in the integration test (first
+assign goes to the runner whose pool has the free desk).
+
+## Phase 8 — CLI / TUI / Web surface
+
+**Goal**: the pool is operable and observable (design §10).
+
+- `runner/src/ipc/protocol.rs`: `StatusSnapshot` gains per-workdir
+  `{ pool: [{worktree, lease_holder, branch}], queue: [run_id…], health }`
+  from `pool.snapshot()`; bump IPC version.
+- `pidash status`: per-workdir occupancy line (`2/2 desks busy, 1 queued`),
+  unhealthy reason, canonical-clone branch warning.
+- `pidash workdir retry <name>`: clears `Unhealthy` and re-attempts setup.
+- TUI: workdir view with pool panel (desks, lease holders, queue) and editing
+  for `pool_size` (the user-requested knob), `clean_mode`, `setup_command`.
+  `pool_size` up applies live; down drains on release (design §9).
+- `pidash doctor`: per-workdir checks — canonical clone resolvable, branch
+  parking advice, worktree dir writable, disk headroom, setup_command
+  exit status.
+- Web: `agent-status.tsx:38` adds the status to `ACTIVE_RUN_STATUSES` with a
+  "queued on machine (position N)" label; runs page filter/label maps;
+  mobile vendored types mirrored.
+
+**Done when**: a user can watch a run wait and start from both `pidash tui`
+and the web run view, and resize the pool from the TUI without a restart.
+
+---
+
+## Cross-cutting work
+
+- **Logging**: pool operations log under a per-workdir tracing span
+  (`workdir`, `worktree`, `lease_kind`, `holder_id`); salvage results always
+  logged at `warn` or above.
+- **Metrics**: gauges for pool occupancy, queue depth, workdir health; a
+  histogram for lease wait time (queue latency is the number that says
+  whether `pool_size` defaults are right).
+- **Contract tests**: the v4 wire contract suite gains the `queued` verb,
+  the `redeliver` open-response field, and `free_worktrees` in poll status.
+- **Docs**: `pidash runner add` help text, README quick-start, and the
+  install-script template move from `--working-dir` to `--workdir`.
+
+## Risk register
+
+| Risk                                                                             | Likelihood | Mitigation                                                                                                                                                                                    |
+| -------------------------------------------------------------------------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Reaper kills parked runs (runner forgets to report `in_flight_run` while queued) | Medium     | Reporting ships in phase 3, _before_ any cloud change; phase 4 adds the contract test that fails if either side regresses.                                                                    |
+| Branch-lock starvation: canonical clone permanently holds a branch runs need     | Medium     | Init warning + `pidash status` surfacing + doctor check (phases 3/8). The failure mode is a visible never-draining queue entry, not corruption.                                               |
+| Salvage push fails (auth, network) and the WIP commit never leaves the machine   | Medium     | The commit still exists on the local branch ref in the shared object database — `git log` in the canonical clone finds it. Push is best-effort by design; the log line names the commit hash. |
+| Flaky `setup_command` (network installs) trips workdir-unhealthy too eagerly     | Medium     | One retry with backoff before unhealthy; `pidash workdir retry` is one command; health is per-workdir, never daemon-wide.                                                                     |
+| Concurrent git ops against the shared object DB (fetch vs auto-gc vs checkout)   | Low        | Fetch mutex per workdir (phase 2); set `gc.auto = 0` on the canonical clone at pool init and let doctor recommend manual gc.                                                                  |
+| Cancel races lease grant (cancel arrives the instant the oneshot fires)          | Low        | All transitions happen inside the single pool owner task; a granted lease that races cancel follows the normal running-cancel path (design §6.2 note). Property test in phase 2.              |
+| Disk growth from N worktrees of a huge repo                                      | Low        | Lazy creation bounds at the concurrency high-water mark; `keep-ignored` reuses installs; eviction is the designed follow-up (design §13).                                                     |
+| Old-shape config on a dev machine fails to start after upgrade                   | Low        | Refusal message names `pidash configure --migrate-workdirs`; migration is lossless and tested in phase 1.                                                                                     |
+
+## Estimated scope
+
+| Phase | PRs | Notes                                                                               |
+| ----- | --- | ----------------------------------------------------------------------------------- |
+| 1     | 1–2 | Config/validation churn is wide but mechanical; migration command needs care.       |
+| 2     | 1–2 | The big one by line count, but pure library + tests; no integration risk.           |
+| 3     | 1–2 | The risky one — supervisor lifecycle paths. Reaper-protection must land atomically. |
+| 4     | 1   | Focused Django change; the contract tests are the bulk.                             |
+| 5     | 1   | Small, surgical.                                                                    |
+| 6     | 1   | Protocol flip + feature detection; fake-cloud work dominates.                       |
+| 7     | 1   | Small on both sides.                                                                |
+| 8     | 2–3 | TUI editing + web rendering are the long pole; independently shippable pieces.      |
+
+Total: ~9–13 PRs. Phases 1→2→3 are strictly sequential (runner repo);
+4→5 sequential (cloud repo) and can start any time after the design lands;
+6 needs 3+5; 7 needs 6; 8 trails everything and can be parallelized.


### PR DESCRIPTION
## Summary

Design doc for worktree pooling (`.ai_design/worktree_pooling/design.md`): a daemon-managed pool of git worktrees per work dir, so N runners (e.g. a codex runner and a claude_code runner) can serve one repo from one canonical clone, with a per-work-dir local queue ("wait, don't fail") when all worktrees are leased.

Key points:

- **Pool mechanics**: lazy worktree creation up to `pool_size` (default 2), crash-safe on-disk leases, branch-lock awareness (git's one-branch-one-worktree rule), detached-HEAD parking for idle worktrees, salvage-before-clean so failed runs never lose their tree.
- **Local queue, cloud-visible**: FIFO per work dir with head-of-line bypass for branch contention only. New `WAITING_FOR_WORKTREE` run status via a new `queued` lifecycle endpoint (wire v4 HTTP); `accept` moves to lease-acquisition time; session-open redelivery rebuilds the queue after a daemon restart; cancel works while queued.
- **Matcher integration**: status joins `NON_TERMINAL_STATUSES`/`BUSY_STATUSES`; optional `free_worktrees` poll-status field as an assignment preference (hint, not gate).
- **Clean modes**: `keep-ignored` (default, warm pools) / `allowlist` / `full`, with the isolation tradeoff documented; `setup_command` failures get bounded retry then terminal `WorkspaceSetup` failure + workdir-unhealthy state.
- Two ADRs: queue lives in the daemon (with four cloud-visibility guardrails), and pool-from-day-one vs per-runner worktrees.

Companion work (separate doc, not included): agent-aware routing so issues can target a specific agent kind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)