### PR TITLE
feat(workspace): /all-issues view with full list + spreadsheet UI

### DIFF
--- a/apps/api/pi_dash/app/views/view/base.py
+++ b/apps/api/pi_dash/app/views/view/base.py
@@ -47,6 +47,12 @@ from .. import BaseViewSet
 from pi_dash.db.models import UserFavorite
 from pi_dash.utils.filters import ComplexFilterBackend
 from pi_dash.utils.filters import IssueFilterSet
+from pi_dash.utils.grouper import (
+    issue_group_values,
+    issue_on_results,
+    issue_queryset_grouper,
+)
+from pi_dash.utils.paginator import GroupedOffsetPaginator, SubGroupedOffsetPaginator
 
 
 class WorkspaceViewViewSet(BaseViewSet):
@@ -243,7 +249,78 @@ class WorkspaceViewIssuesViewSet(BaseViewSet):
             issue_queryset=issue_queryset, order_by_param=order_by_param
         )
 
-        # List Paginate
+        # Group by
+        group_by = request.GET.get("group_by", False)
+        sub_group_by = request.GET.get("sub_group_by", False)
+
+        # Apply grouping to the issue queryset
+        issue_queryset = issue_queryset_grouper(
+            queryset=issue_queryset, group_by=group_by, sub_group_by=sub_group_by
+        )
+
+        # count filter shared by grouped paginators
+        count_filter = Q(
+            Q(issue_intake__status=1)
+            | Q(issue_intake__status=-1)
+            | Q(issue_intake__status=2)
+            | Q(issue_intake__isnull=True),
+            archived_at__isnull=True,
+            is_draft=False,
+        )
+
+        if group_by:
+            if sub_group_by:
+                if group_by == sub_group_by:
+                    return Response(
+                        {"error": "Group by and sub group by cannot have same parameters"},
+                        status=status.HTTP_400_BAD_REQUEST,
+                    )
+                return self.paginate(
+                    request=request,
+                    order_by=order_by_param,
+                    queryset=issue_queryset,
+                    total_count_queryset=total_issue_count_queryset,
+                    on_results=lambda issues: issue_on_results(
+                        group_by=group_by, issues=issues, sub_group_by=sub_group_by
+                    ),
+                    paginator_cls=SubGroupedOffsetPaginator,
+                    group_by_fields=issue_group_values(
+                        field=group_by,
+                        slug=slug,
+                        filters=filters,
+                        queryset=total_issue_count_queryset,
+                    ),
+                    sub_group_by_fields=issue_group_values(
+                        field=sub_group_by,
+                        slug=slug,
+                        filters=filters,
+                        queryset=total_issue_count_queryset,
+                    ),
+                    group_by_field_name=group_by,
+                    sub_group_by_field_name=sub_group_by,
+                    count_filter=count_filter,
+                )
+            # Group paginate
+            return self.paginate(
+                request=request,
+                order_by=order_by_param,
+                queryset=issue_queryset,
+                total_count_queryset=total_issue_count_queryset,
+                on_results=lambda issues: issue_on_results(
+                    group_by=group_by, issues=issues, sub_group_by=sub_group_by
+                ),
+                paginator_cls=GroupedOffsetPaginator,
+                group_by_fields=issue_group_values(
+                    field=group_by,
+                    slug=slug,
+                    filters=filters,
+                    queryset=total_issue_count_queryset,
+                ),
+                group_by_field_name=group_by,
+                count_filter=count_filter,
+            )
+
+        # List Paginate (ungrouped)
         return self.paginate(
             order_by=order_by_param,
             request=request,

--- a/apps/api/pi_dash/tests/contract/app/test_workspace_view_issues.py
+++ b/apps/api/pi_dash/tests/contract/app/test_workspace_view_issues.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Contract tests for the workspace-level "all issues" endpoint
+(``global-view-issues``).
+
+The endpoint historically returned a flat list only. These tests pin the
+contract that it now honours ``group_by`` and returns a grouped response
+(``results`` keyed by group), matching the project issues endpoint, so the
+web app can render the list layout at workspace scope.
+"""
+
+import pytest
+from django.urls import reverse
+from rest_framework import status as http_status
+
+from pi_dash.db.models import (
+    Issue,
+    ProjectMember,
+    State,
+)
+
+
+@pytest.fixture
+def view_project(workspace, create_user):
+    """The workspace default project with ``create_user`` as an active member.
+
+    The permission filter on the workspace issues endpoint only returns
+    issues from projects the requesting user is an active member of, so the
+    membership row is required for the issues to be visible.
+    """
+    from pi_dash.db.models.project import Project
+
+    project = Project.objects.get(workspace=workspace, identifier="DEF")
+    ProjectMember.objects.get_or_create(
+        project=project,
+        member=create_user,
+        defaults={"role": 20, "is_active": True},
+    )
+    return project
+
+
+@pytest.fixture
+def states(view_project, create_user):
+    todo = State.objects.create(
+        name="Todo",
+        project=view_project,
+        workspace=view_project.workspace,
+        group="unstarted",
+        default=True,
+        created_by=create_user,
+    )
+    done = State.objects.create(
+        name="Done",
+        project=view_project,
+        workspace=view_project.workspace,
+        group="completed",
+        created_by=create_user,
+    )
+    return todo, done
+
+
+@pytest.fixture
+def view_issues(view_project, create_user, states):
+    todo, done = states
+    Issue.objects.create(
+        name="Issue in Todo",
+        project=view_project,
+        workspace=view_project.workspace,
+        state=todo,
+        created_by=create_user,
+    )
+    Issue.objects.create(
+        name="Issue in Done",
+        project=view_project,
+        workspace=view_project.workspace,
+        state=done,
+        created_by=create_user,
+    )
+    return todo, done
+
+
+def _url(slug):
+    return reverse("global-view-issues", kwargs={"slug": slug})
+
+
+@pytest.mark.contract
+class TestWorkspaceViewIssuesGrouping:
+    @pytest.mark.django_db
+    def test_ungrouped_returns_flat_list(self, session_client, workspace, view_issues):
+        response = session_client.get(_url(workspace.slug))
+
+        assert response.status_code == http_status.HTTP_200_OK
+        assert response.data["grouped_by"] is None
+        assert isinstance(response.data["results"], list)
+        assert len(response.data["results"]) == 2
+
+    @pytest.mark.django_db
+    def test_group_by_state_returns_grouped_dict(self, session_client, workspace, view_issues):
+        todo, done = view_issues
+
+        response = session_client.get(_url(workspace.slug) + "?group_by=state_id")
+
+        assert response.status_code == http_status.HTTP_200_OK
+        assert response.data["grouped_by"] == "state_id"
+        results = response.data["results"]
+        # Grouped responses key results by the group value (here, state id).
+        assert isinstance(results, dict)
+        assert str(todo.id) in results
+        assert str(done.id) in results
+        assert results[str(todo.id)]["results"][0]["name"] == "Issue in Todo"
+        assert results[str(done.id)]["results"][0]["name"] == "Issue in Done"
+
+    @pytest.mark.django_db
+    def test_group_by_priority_returns_grouped_dict(self, session_client, workspace, view_issues):
+        response = session_client.get(_url(workspace.slug) + "?group_by=priority")
+
+        assert response.status_code == http_status.HTTP_200_OK
+        assert response.data["grouped_by"] == "priority"
+        assert isinstance(response.data["results"], dict)
+        # Both seeded issues default to "none" priority.
+        assert "none" in response.data["results"]
+
+    @pytest.mark.django_db
+    def test_same_group_and_sub_group_is_rejected(self, session_client, workspace, view_issues):
+        response = session_client.get(
+            _url(workspace.slug) + "?group_by=state_id&sub_group_by=state_id"
+        )
+
+        assert response.status_code == http_status.HTTP_400_BAD_REQUEST

--- a/apps/web/app/(all)/[workspaceSlug]/(projects)/all-issues/layout.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/(projects)/all-issues/layout.tsx
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { Outlet } from "react-router";
+import { AppHeader } from "@/components/core/app-header";
+import { ContentWrapper } from "@/components/core/content-wrapper";
+import { GlobalViewIdProvider } from "@/hooks/use-global-view-id";
+import { GlobalIssuesHeader } from "../workspace-views/header";
+
+// The `/all-issues` route pins the static "all-issues" view so the shared
+// global-issues header and layout root behave exactly like
+// `/workspace-views/all-issues` without relying on a `:globalViewId` param.
+export default function AllIssuesLayout() {
+  return (
+    <GlobalViewIdProvider value="all-issues">
+      <AppHeader header={<GlobalIssuesHeader />} />
+      <ContentWrapper>
+        <Outlet />
+      </ContentWrapper>
+    </GlobalViewIdProvider>
+  );
+}

--- a/apps/web/app/(all)/[workspaceSlug]/(projects)/all-issues/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/(projects)/all-issues/page.tsx
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useState } from "react";
+import { observer } from "mobx-react";
+// components
+import { PageHead } from "@/components/core/page-title";
+import { AllIssueLayoutRoot } from "@/components/issues/issue-layouts/roots/all-issue-layout-root";
+// hooks
+import { useWorkspace } from "@/hooks/store/use-workspace";
+
+// Workspace-wide "all work items" view. The active view id ("all-issues") is
+// provided by the route layout via GlobalViewIdProvider, so this renders the
+// same multi-layout root as `/workspace-views/all-issues`.
+function AllIssuesPage() {
+  // store hooks
+  const { currentWorkspace } = useWorkspace();
+  // states
+  const [isLoading, setIsLoading] = useState(false);
+
+  // derived values
+  const pageTitle = currentWorkspace?.name ? `${currentWorkspace?.name} - Work Items` : undefined;
+
+  // handlers
+  const toggleLoading = (value: boolean) => setIsLoading(value);
+
+  return (
+    <>
+      <PageHead title={pageTitle} />
+      <AllIssueLayoutRoot isDefaultView isLoading={isLoading} toggleLoading={toggleLoading} />
+    </>
+  );
+}
+
+export default observer(AllIssuesPage);

--- a/apps/web/app/(all)/[workspaceSlug]/(projects)/workspace-views/header.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/(projects)/workspace-views/header.tsx
@@ -32,6 +32,7 @@ import { WorkspaceViewQuickActions } from "@/components/workspace/views/quick-ac
 import { useGlobalView } from "@/hooks/store/use-global-view";
 import { useIssues } from "@/hooks/store/use-issues";
 import { useAppRouter } from "@/hooks/use-app-router";
+import { useGlobalViewId } from "@/hooks/use-global-view-id";
 import { GlobalViewLayoutSelection } from "@/pi-dash-web/components/views/helper";
 
 export const GlobalIssuesHeader = observer(function GlobalIssuesHeader() {
@@ -39,8 +40,8 @@ export const GlobalIssuesHeader = observer(function GlobalIssuesHeader() {
   const [createViewModal, setCreateViewModal] = useState(false);
   // router
   const router = useAppRouter();
-  const { workspaceSlug, globalViewId: routerGlobalViewId } = useParams();
-  const globalViewId = routerGlobalViewId ? routerGlobalViewId.toString() : undefined;
+  const { workspaceSlug } = useParams();
+  const globalViewId = useGlobalViewId();
   // store hooks
   const {
     issuesFilter: { filters, updateFilters },

--- a/apps/web/app/routes/core.ts
+++ b/apps/web/app/routes/core.ts
@@ -136,6 +136,11 @@ export const coreRoutes: RouteConfigEntry[] = [
           ),
         ]),
 
+        // Workspace-wide "All work items" (shorter alias of workspace-views/all-issues)
+        layout("./(all)/[workspaceSlug]/(projects)/all-issues/layout.tsx", [
+          route(":workspaceSlug/all-issues", "./(all)/[workspaceSlug]/(projects)/all-issues/page.tsx"),
+        ]),
+
         // Archived Projects
         layout("./(all)/[workspaceSlug]/(projects)/projects/(detail)/archives/layout.tsx", [
           route(

--- a/apps/web/ce/components/views/helper.tsx
+++ b/apps/web/ce/components/views/helper.tsx
@@ -4,7 +4,10 @@
  * See the LICENSE file for details.
  */
 
-import type { EIssueLayoutTypes, IProjectView } from "@pi-dash/types";
+import type { IProjectView } from "@pi-dash/types";
+import { EIssueLayoutTypes } from "@pi-dash/types";
+import { LayoutSelection } from "@/components/issues/issue-layouts/filters/header/layout-selection";
+import { GlobalIssueListLayout } from "@/components/issues/issue-layouts/list/roots/global-root";
 import type { TWorkspaceLayoutProps } from "@/components/views/helper";
 
 export type TLayoutSelectionProps = {
@@ -13,12 +16,22 @@ export type TLayoutSelectionProps = {
   workspaceSlug: string;
 };
 
-export function GlobalViewLayoutSelection(_props: TLayoutSelectionProps) {
-  return <></>;
+// Layouts supported by the workspace-level "all issues" view. Spreadsheet is
+// handled directly by WorkspaceActiveLayout; the rest are rendered here.
+const WORKSPACE_LAYOUTS: EIssueLayoutTypes[] = [EIssueLayoutTypes.LIST, EIssueLayoutTypes.SPREADSHEET];
+
+export function GlobalViewLayoutSelection(props: TLayoutSelectionProps) {
+  const { onChange, selectedLayout } = props;
+  return <LayoutSelection layouts={WORKSPACE_LAYOUTS} onChange={onChange} selectedLayout={selectedLayout} />;
 }
 
-export function WorkspaceAdditionalLayouts(_props: TWorkspaceLayoutProps) {
-  return <></>;
+export function WorkspaceAdditionalLayouts(props: TWorkspaceLayoutProps) {
+  switch (props.activeLayout) {
+    case EIssueLayoutTypes.LIST:
+      return <GlobalIssueListLayout />;
+    default:
+      return <></>;
+  }
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/apps/web/ce/components/views/helper.tsx
+++ b/apps/web/ce/components/views/helper.tsx
@@ -7,6 +7,7 @@
 import type { IProjectView } from "@pi-dash/types";
 import { EIssueLayoutTypes } from "@pi-dash/types";
 import { LayoutSelection } from "@/components/issues/issue-layouts/filters/header/layout-selection";
+import { GlobalIssueKanbanLayout } from "@/components/issues/issue-layouts/kanban/roots/global-root";
 import { GlobalIssueListLayout } from "@/components/issues/issue-layouts/list/roots/global-root";
 import type { TWorkspaceLayoutProps } from "@/components/views/helper";
 
@@ -18,7 +19,11 @@ export type TLayoutSelectionProps = {
 
 // Layouts supported by the workspace-level "all issues" view. Spreadsheet is
 // handled directly by WorkspaceActiveLayout; the rest are rendered here.
-const WORKSPACE_LAYOUTS: EIssueLayoutTypes[] = [EIssueLayoutTypes.LIST, EIssueLayoutTypes.SPREADSHEET];
+const WORKSPACE_LAYOUTS: EIssueLayoutTypes[] = [
+  EIssueLayoutTypes.LIST,
+  EIssueLayoutTypes.KANBAN,
+  EIssueLayoutTypes.SPREADSHEET,
+];
 
 export function GlobalViewLayoutSelection(props: TLayoutSelectionProps) {
   const { onChange, selectedLayout } = props;
@@ -29,6 +34,8 @@ export function WorkspaceAdditionalLayouts(props: TWorkspaceLayoutProps) {
   switch (props.activeLayout) {
     case EIssueLayoutTypes.LIST:
       return <GlobalIssueListLayout />;
+    case EIssueLayoutTypes.KANBAN:
+      return <GlobalIssueKanbanLayout />;
     default:
       return <></>;
   }

--- a/apps/web/core/components/issues/issue-layouts/kanban/base-kanban-root.tsx
+++ b/apps/web/core/components/issues/issue-layouts/kanban/base-kanban-root.tsx
@@ -12,8 +12,7 @@ import { autoScrollForElements } from "@atlaskit/pragmatic-drag-and-drop-auto-sc
 import { observer } from "mobx-react";
 import { useParams } from "next/navigation";
 import { EIssueFilterType, EUserPermissions, EUserPermissionsLevel } from "@pi-dash/constants";
-import type { EIssuesStoreType } from "@pi-dash/types";
-import { EIssueServiceType, EIssueLayoutTypes } from "@pi-dash/types";
+import { EIssuesStoreType, EIssueServiceType, EIssueLayoutTypes } from "@pi-dash/types";
 //hooks
 import { useIssueDetail } from "@/hooks/store/use-issue-detail";
 import { useIssues } from "@/hooks/store/use-issues";
@@ -39,6 +38,7 @@ export type KanbanStoreType =
   | EIssuesStoreType.CYCLE
   | EIssuesStoreType.PROJECT_VIEW
   | EIssuesStoreType.PROFILE
+  | EIssuesStoreType.GLOBAL
   | EIssuesStoreType.TEAM
   | EIssuesStoreType.TEAM_VIEW
   | EIssuesStoreType.EPIC;
@@ -122,12 +122,18 @@ export const BaseKanBanRoot = observer(function BaseKanBanRoot(props: IBaseKanBa
   const [draggedIssueId, setDraggedIssueId] = useState<string | undefined>(undefined);
   const [deleteIssueModal, setDeleteIssueModal] = useState(false);
 
+  // The global (workspace "all issues") board spans projects, so its create/edit
+  // gate is evaluated at the workspace level rather than per-project.
   const isEditingAllowed = allowPermissions(
     [EUserPermissions.ADMIN, EUserPermissions.MEMBER],
-    EUserPermissionsLevel.PROJECT
+    storeType === EIssuesStoreType.GLOBAL ? EUserPermissionsLevel.WORKSPACE : EUserPermissionsLevel.PROJECT
   );
 
-  const handleOnDrop = useGroupIssuesDragNDrop(storeType, orderBy, group_by, sub_group_by);
+  const handleGroupDrop = useGroupIssuesDragNDrop(storeType, orderBy, group_by, sub_group_by);
+  // Drag-to-move is disabled at workspace scope: columns (states) are
+  // project-specific, so a cross-project reorder/move has no single target.
+  // Cards remain editable via their inline property pills and quick actions.
+  const handleOnDrop = storeType === EIssuesStoreType.GLOBAL ? async () => {} : handleGroupDrop;
 
   const canEditProperties = useCallback(
     (projectId: string | undefined) => {

--- a/apps/web/core/components/issues/issue-layouts/kanban/roots/global-root.tsx
+++ b/apps/web/core/components/issues/issue-layouts/kanban/roots/global-root.tsx
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { observer } from "mobx-react";
+import { useParams } from "next/navigation";
+// pi dash imports
+import { EUserPermissions, EUserPermissionsLevel } from "@pi-dash/constants";
+// hooks
+import { useUserPermissions } from "@/hooks/store/user";
+import { useGlobalViewId } from "@/hooks/use-global-view-id";
+// local imports
+import { AllIssueQuickActions } from "../../quick-action-dropdowns";
+import { BaseKanBanRoot } from "../base-kanban-root";
+
+// Board (Kanban) layout for the workspace-level "all issues" view. Mirrors the
+// project kanban root but is driven by the GLOBAL issues store (set via context
+// by AllIssueLayoutRoot) and uses AllIssueQuickActions since issues span projects.
+export const GlobalIssueKanbanLayout = observer(function GlobalIssueKanbanLayout() {
+  // router
+  const { workspaceSlug } = useParams();
+  const globalViewId = useGlobalViewId();
+  // hooks
+  const { allowPermissions } = useUserPermissions();
+
+  if (!workspaceSlug) return null;
+
+  const canEditPropertiesBasedOnProject = (projectId: string) =>
+    allowPermissions(
+      [EUserPermissions.ADMIN, EUserPermissions.MEMBER],
+      EUserPermissionsLevel.PROJECT,
+      workspaceSlug.toString(),
+      projectId
+    );
+
+  return (
+    <BaseKanBanRoot
+      QuickActions={AllIssueQuickActions}
+      canEditPropertiesBasedOnProject={canEditPropertiesBasedOnProject}
+      viewId={globalViewId}
+    />
+  );
+});

--- a/apps/web/core/components/issues/issue-layouts/list/base-list-root.tsx
+++ b/apps/web/core/components/issues/issue-layouts/list/base-list-root.tsx
@@ -11,8 +11,8 @@ import { useParams } from "next/navigation";
 // pi dash constants
 import { EIssueFilterType, EUserPermissions, EUserPermissionsLevel } from "@pi-dash/constants";
 // types
-import type { EIssuesStoreType, GroupByColumnTypes, TGroupedIssues, TIssueKanbanFilters } from "@pi-dash/types";
-import { EIssueLayoutTypes } from "@pi-dash/types";
+import type { GroupByColumnTypes, TGroupedIssues, TIssueKanbanFilters } from "@pi-dash/types";
+import { EIssueLayoutTypes, EIssuesStoreType } from "@pi-dash/types";
 // constants
 // hooks
 import { useIssues } from "@/hooks/store/use-issues";
@@ -35,6 +35,7 @@ type ListStoreType =
   | EIssuesStoreType.PROFILE
   | EIssuesStoreType.ARCHIVED
   | EIssuesStoreType.WORKSPACE_DRAFT
+  | EIssuesStoreType.GLOBAL
   | EIssuesStoreType.TEAM
   | EIssuesStoreType.TEAM_VIEW
   | EIssuesStoreType.EPIC;
@@ -91,10 +92,11 @@ export const BaseListRoot = observer(function BaseListRoot(props: IBaseListRoot)
   }, [fetchIssues, storeType, group_by, viewId]);
 
   const groupedIssueIds = issues?.groupedIssueIds as TGroupedIssues | undefined;
-  // auth
+  // auth — the global (workspace "all issues") store spans projects, so its
+  // create/edit gate is evaluated at the workspace level rather than per-project.
   const isEditingAllowed = allowPermissions(
     [EUserPermissions.ADMIN, EUserPermissions.MEMBER],
-    EUserPermissionsLevel.PROJECT
+    storeType === EIssuesStoreType.GLOBAL ? EUserPermissionsLevel.WORKSPACE : EUserPermissionsLevel.PROJECT
   );
   const { enableInlineEditing, enableQuickAdd, enableIssueCreation } = issues?.viewFlags || {};
 
@@ -108,7 +110,10 @@ export const BaseListRoot = observer(function BaseListRoot(props: IBaseListRoot)
     [canEditPropertiesBasedOnProject, enableInlineEditing, isEditingAllowed]
   );
 
-  const handleOnDrop = useGroupIssuesDragNDrop(storeType, orderBy, group_by);
+  const handleGroupDrop = useGroupIssuesDragNDrop(storeType, orderBy, group_by);
+  // The workspace "all issues" list spans projects, so reorder/regroup via drag
+  // and drop is disabled there.
+  const handleOnDrop = storeType === EIssuesStoreType.GLOBAL ? async () => {} : handleGroupDrop;
 
   const renderQuickActions: TRenderQuickActions = useCallback(
     ({ issue, parentRef }) => (

--- a/apps/web/core/components/issues/issue-layouts/list/roots/global-root.tsx
+++ b/apps/web/core/components/issues/issue-layouts/list/roots/global-root.tsx
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { observer } from "mobx-react";
+import { useParams } from "next/navigation";
+// pi dash imports
+import { EUserPermissions, EUserPermissionsLevel } from "@pi-dash/constants";
+// hooks
+import { useUserPermissions } from "@/hooks/store/user";
+import { useGlobalViewId } from "@/hooks/use-global-view-id";
+// local imports
+import { AllIssueQuickActions } from "../../quick-action-dropdowns";
+import { BaseListRoot } from "../base-list-root";
+
+// List layout for the workspace-level "all issues" view. Mirrors the project
+// list root but is driven by the GLOBAL issues store (set via context by the
+// AllIssueLayoutRoot) and uses AllIssueQuickActions since issues span projects.
+export const GlobalIssueListLayout = observer(function GlobalIssueListLayout() {
+  // router
+  const { workspaceSlug } = useParams();
+  const globalViewId = useGlobalViewId();
+  // hooks
+  const { allowPermissions } = useUserPermissions();
+
+  if (!workspaceSlug) return null;
+
+  const canEditPropertiesBasedOnProject = (projectId: string) =>
+    allowPermissions(
+      [EUserPermissions.ADMIN, EUserPermissions.MEMBER],
+      EUserPermissionsLevel.PROJECT,
+      workspaceSlug.toString(),
+      projectId
+    );
+
+  return (
+    <BaseListRoot
+      QuickActions={AllIssueQuickActions}
+      canEditPropertiesBasedOnProject={canEditPropertiesBasedOnProject}
+      viewId={globalViewId}
+    />
+  );
+});

--- a/apps/web/core/components/issues/issue-layouts/quick-add/root.tsx
+++ b/apps/web/core/components/issues/issue-layouts/quick-add/root.tsx
@@ -15,7 +15,13 @@ import { useTranslation } from "@pi-dash/i18n";
 import { PlusIcon } from "@pi-dash/propel/icons";
 import { setPromiseToast } from "@pi-dash/propel/toast";
 import type { IProject, TIssue, EIssueLayoutTypes } from "@pi-dash/types";
+import { EIssuesStoreType } from "@pi-dash/types";
 import { cn, createIssuePayload } from "@pi-dash/utils";
+// components
+import { ProjectDropdown } from "@/components/dropdowns/project/dropdown";
+// hooks
+import { useProject } from "@/hooks/store/use-project";
+import { useIssueStoreType } from "@/hooks/use-issue-layout-store";
 // pi dash web imports
 import { QuickAddIssueFormRoot } from "@/pi-dash-web/components/issues/quick-add";
 // local imports
@@ -67,9 +73,26 @@ export const QuickAddIssueRoot = observer(function QuickAddIssueRoot(props: TQui
   // i18n
   const { t } = useTranslation();
   // router
-  const { workspaceSlug, projectId } = useParams();
+  const { workspaceSlug, projectId: routerProjectId } = useParams();
+  const paramProjectId = routerProjectId?.toString();
+  // store hooks
+  const storeType = useIssueStoreType();
+  const { joinedProjectIds } = useProject();
+  // At workspace scope (global "all issues") there is no project in the route,
+  // so the user picks one inline before the quick-add creates the issue.
+  const isWorkspaceLevel = storeType === EIssuesStoreType.GLOBAL && !paramProjectId;
   // states
   const [isOpen, setIsOpen] = useState(isQuickAddOpen ?? false);
+  const [selectedProjectId, setSelectedProjectId] = useState<string | undefined>(undefined);
+  // The effective project for creation: the route project, else the picked one.
+  const effectiveProjectId = paramProjectId ?? selectedProjectId;
+
+  // Default the inline picker to the first joined project at workspace scope.
+  useEffect(() => {
+    if (isWorkspaceLevel && !selectedProjectId && joinedProjectIds.length > 0) {
+      setSelectedProjectId(joinedProjectIds[0]);
+    }
+  }, [isWorkspaceLevel, selectedProjectId, joinedProjectIds]);
   // form info
   const {
     reset,
@@ -98,17 +121,17 @@ export const QuickAddIssueRoot = observer(function QuickAddIssueRoot(props: TQui
   };
 
   const onSubmitHandler = async (formData: TIssue) => {
-    if (isSubmitting || !workspaceSlug || !projectId) return;
+    if (isSubmitting || !workspaceSlug || !effectiveProjectId) return;
 
     reset({ ...defaultValues });
 
-    const payload = createIssuePayload(projectId.toString(), {
+    const payload = createIssuePayload(effectiveProjectId, {
       ...(prePopulatedData ?? {}),
       ...formData,
     });
 
     if (quickAddCallback) {
-      const quickAddPromise = quickAddCallback(projectId.toString(), { ...payload });
+      const quickAddPromise = quickAddCallback(effectiveProjectId, { ...payload });
       setPromiseToast<any>(quickAddPromise, {
         loading: isEpic ? t("Adding epic") : t("Adding work item"),
         success: {
@@ -118,7 +141,7 @@ export const QuickAddIssueRoot = observer(function QuickAddIssueRoot(props: TQui
             // TODO: Translate here
             <CreateIssueToastActionItems
               workspaceSlug={workspaceSlug.toString()}
-              projectId={projectId.toString()}
+              projectId={effectiveProjectId}
               issueId={data.id}
               isEpic={isEpic}
             />
@@ -134,7 +157,7 @@ export const QuickAddIssueRoot = observer(function QuickAddIssueRoot(props: TQui
     }
   };
 
-  if (!projectId) return null;
+  if (!effectiveProjectId) return null;
 
   return (
     <div
@@ -144,18 +167,32 @@ export const QuickAddIssueRoot = observer(function QuickAddIssueRoot(props: TQui
       )}
     >
       {isOpen ? (
-        <QuickAddIssueFormRoot
-          isOpen={isOpen}
-          layout={layout}
-          prePopulatedData={prePopulatedData}
-          projectId={projectId?.toString()}
-          hasError={errors && errors?.name && errors?.name?.message ? true : false}
-          setFocus={setFocus}
-          register={register}
-          onSubmit={handleSubmit(onSubmitHandler)}
-          onClose={() => handleIsOpen(false)}
-          isEpic={isEpic}
-        />
+        <div className="flex w-full items-stretch">
+          {isWorkspaceLevel && (
+            <div className="flex flex-shrink-0 items-center border-r border-subtle bg-surface-1 px-2">
+              <ProjectDropdown
+                multiple={false}
+                value={effectiveProjectId}
+                onChange={(val: string) => setSelectedProjectId(val)}
+                buttonVariant="border-with-text"
+              />
+            </div>
+          )}
+          <div className="flex-grow">
+            <QuickAddIssueFormRoot
+              isOpen={isOpen}
+              layout={layout}
+              prePopulatedData={prePopulatedData}
+              projectId={effectiveProjectId}
+              hasError={errors && errors?.name && errors?.name?.message ? true : false}
+              setFocus={setFocus}
+              register={register}
+              onSubmit={handleSubmit(onSubmitHandler)}
+              onClose={() => handleIsOpen(false)}
+              isEpic={isEpic}
+            />
+          </div>
+        </div>
       ) : (
         <>
           {QuickAddButton && <QuickAddButton isEpic={isEpic} onClick={() => handleIsOpen(true)} />}

--- a/apps/web/core/components/issues/issue-layouts/roots/all-issue-layout-root.tsx
+++ b/apps/web/core/components/issues/issue-layouts/roots/all-issue-layout-root.tsx
@@ -93,22 +93,22 @@ export const AllIssueLayoutRoot = observer(function AllIssueLayoutRoot(props: Pr
     { revalidateIfStale: false, revalidateOnFocus: false }
   );
 
-  // The list layout fetches its own grouped issues via BaseListRoot, so the
-  // root only fetches the flat list that the spreadsheet consumes. Filters are
-  // always fetched (the list layout reads display filters from the same store).
-  const isListLayout = activeLayout === EIssueLayoutTypes.LIST;
+  // The list and board (kanban) layouts fetch their own grouped issues via their
+  // roots, so the root here only fetches the flat list the spreadsheet consumes.
+  // Filters are always fetched (the other layouts read display filters too).
+  const selfFetchingLayout = activeLayout === EIssueLayoutTypes.LIST || activeLayout === EIssueLayoutTypes.KANBAN;
 
-  // Fetch issues. The key keys on isListLayout (not the raw layout) so the
+  // Fetch issues. The key keys on selfFetchingLayout (not the raw layout) so the
   // spreadsheet/default case stays a single key as activeLayout resolves from
   // undefined to its loaded value — otherwise the key would change and refetch.
   const { isLoading: issuesLoading } = useSWR(
     workspaceSlug && globalViewId
-      ? `WORKSPACE_GLOBAL_VIEW_ISSUES_${workspaceSlug}_${globalViewId}_${isListLayout ? "list" : "default"}`
+      ? `WORKSPACE_GLOBAL_VIEW_ISSUES_${workspaceSlug}_${globalViewId}_${selfFetchingLayout ? "self" : "default"}`
       : null,
     async () => {
       if (workspaceSlug && globalViewId) {
         await fetchFilters(workspaceSlug, globalViewId);
-        if (!isListLayout) {
+        if (!selfFetchingLayout) {
           clear();
           toggleLoading(true);
           await fetchIssues(workspaceSlug, globalViewId, groupedIssueIds ? "mutation" : "init-loader", {

--- a/apps/web/core/components/issues/issue-layouts/roots/all-issue-layout-root.tsx
+++ b/apps/web/core/components/issues/issue-layouts/roots/all-issue-layout-root.tsx
@@ -98,10 +98,12 @@ export const AllIssueLayoutRoot = observer(function AllIssueLayoutRoot(props: Pr
   // always fetched (the list layout reads display filters from the same store).
   const isListLayout = activeLayout === EIssueLayoutTypes.LIST;
 
-  // Fetch issues
+  // Fetch issues. The key keys on isListLayout (not the raw layout) so the
+  // spreadsheet/default case stays a single key as activeLayout resolves from
+  // undefined to its loaded value — otherwise the key would change and refetch.
   const { isLoading: issuesLoading } = useSWR(
     workspaceSlug && globalViewId
-      ? `WORKSPACE_GLOBAL_VIEW_ISSUES_${workspaceSlug}_${globalViewId}_${activeLayout ?? "default"}`
+      ? `WORKSPACE_GLOBAL_VIEW_ISSUES_${workspaceSlug}_${globalViewId}_${isListLayout ? "list" : "default"}`
       : null,
     async () => {
       if (workspaceSlug && globalViewId) {

--- a/apps/web/core/components/issues/issue-layouts/roots/all-issue-layout-root.tsx
+++ b/apps/web/core/components/issues/issue-layouts/roots/all-issue-layout-root.tsx
@@ -11,8 +11,7 @@ import useSWR from "swr";
 // pi dash imports
 import { GLOBAL_VIEW_TRACKER_ELEMENTS, ISSUE_DISPLAY_FILTERS_BY_PAGE } from "@pi-dash/constants";
 import { EmptyStateDetailed } from "@pi-dash/propel/empty-state";
-import type { EIssueLayoutTypes } from "@pi-dash/types";
-import { EIssuesStoreType, STATIC_VIEW_TYPES } from "@pi-dash/types";
+import { EIssueLayoutTypes, EIssuesStoreType, STATIC_VIEW_TYPES } from "@pi-dash/types";
 // assets
 // components
 import { IssuePeekOverview, IssuePeekUrlSync } from "@/components/issues/peek-overview";
@@ -23,6 +22,7 @@ import { WorkItemFiltersRow } from "@/components/work-item-filters/filters-row";
 import { useGlobalView } from "@/hooks/store/use-global-view";
 import { useIssues } from "@/hooks/store/use-issues";
 import { useAppRouter } from "@/hooks/use-app-router";
+import { useGlobalViewId } from "@/hooks/use-global-view-id";
 import { IssuesStoreContext } from "@/hooks/use-issue-layout-store";
 import { useWorkspaceIssueProperties } from "@/hooks/use-workspace-issue-properties";
 
@@ -36,9 +36,9 @@ export const AllIssueLayoutRoot = observer(function AllIssueLayoutRoot(props: Pr
   const { isDefaultView, isLoading = false, toggleLoading } = props;
   // router
   const router = useAppRouter();
-  const { workspaceSlug: routerWorkspaceSlug, globalViewId: routerGlobalViewId } = useParams();
+  const { workspaceSlug: routerWorkspaceSlug } = useParams();
   const workspaceSlug = routerWorkspaceSlug ? routerWorkspaceSlug.toString() : undefined;
-  const globalViewId = routerGlobalViewId ? routerGlobalViewId.toString() : undefined;
+  const globalViewId = useGlobalViewId();
   // search params
   const searchParams = useSearchParams();
   // store hooks
@@ -93,19 +93,28 @@ export const AllIssueLayoutRoot = observer(function AllIssueLayoutRoot(props: Pr
     { revalidateIfStale: false, revalidateOnFocus: false }
   );
 
+  // The list layout fetches its own grouped issues via BaseListRoot, so the
+  // root only fetches the flat list that the spreadsheet consumes. Filters are
+  // always fetched (the list layout reads display filters from the same store).
+  const isListLayout = activeLayout === EIssueLayoutTypes.LIST;
+
   // Fetch issues
   const { isLoading: issuesLoading } = useSWR(
-    workspaceSlug && globalViewId ? `WORKSPACE_GLOBAL_VIEW_ISSUES_${workspaceSlug}_${globalViewId}` : null,
+    workspaceSlug && globalViewId
+      ? `WORKSPACE_GLOBAL_VIEW_ISSUES_${workspaceSlug}_${globalViewId}_${activeLayout ?? "default"}`
+      : null,
     async () => {
       if (workspaceSlug && globalViewId) {
-        clear();
-        toggleLoading(true);
         await fetchFilters(workspaceSlug, globalViewId);
-        await fetchIssues(workspaceSlug, globalViewId, groupedIssueIds ? "mutation" : "init-loader", {
-          canGroup: false,
-          perPageCount: 100,
-        });
-        toggleLoading(false);
+        if (!isListLayout) {
+          clear();
+          toggleLoading(true);
+          await fetchIssues(workspaceSlug, globalViewId, groupedIssueIds ? "mutation" : "init-loader", {
+            canGroup: false,
+            perPageCount: 100,
+          });
+          toggleLoading(false);
+        }
       }
     },
     { revalidateIfStale: false, revalidateOnFocus: false }

--- a/apps/web/core/components/issues/issue-layouts/utils.tsx
+++ b/apps/web/core/components/issues/issue-layouts/utils.tsx
@@ -70,9 +70,7 @@ export const isWorkspaceLevel = (type: EIssuesStoreType) =>
     EIssuesStoreType.TEAM_VIEW,
     EIssuesStoreType.TEAM_PROJECT_WORK_ITEMS,
     EIssuesStoreType.WORKSPACE_DRAFT,
-  ].includes(type)
-    ? true
-    : false;
+  ].includes(type);
 
 type TGetGroupByColumns = {
   groupBy: GroupByColumnTypes | null;
@@ -88,7 +86,7 @@ type TGetGroupByColumns = {
 export const getGroupByColumns = ({
   groupBy,
   includeNone,
-  isWorkspaceLevel,
+  isWorkspaceLevel: isWorkspaceScoped,
   isEpic = false,
   projectId,
 }: TGetGroupByColumns): IGroupByColumn[] | undefined => {
@@ -125,7 +123,7 @@ export const getGroupByColumns = ({
   };
 
   // Get and return the columns for the specified group by option
-  return groupByColumnMap[groupBy]?.({ isWorkspaceLevel, projectId });
+  return groupByColumnMap[groupBy]?.({ isWorkspaceLevel: isWorkspaceScoped, projectId });
 };
 
 const getProjectColumns = (): IGroupByColumn[] | undefined => {
@@ -208,11 +206,15 @@ const getModuleColumns = (): IGroupByColumn[] | undefined => {
   return modules;
 };
 
-const getStateColumns = ({ projectId }: TGetColumns): IGroupByColumn[] | undefined => {
-  const { getProjectStates, projectStates } = store.state;
-  const _states = projectId ? getProjectStates(projectId) : projectStates;
+const getStateColumns = ({
+  isWorkspaceLevel: isWorkspaceScoped,
+  projectId,
+}: TGetColumns): IGroupByColumn[] | undefined => {
+  const { getProjectStates, projectStates, workspaceStates } = store.state;
+  const _states =
+    isWorkspaceScoped && !projectId ? workspaceStates : projectId ? getProjectStates(projectId) : projectStates;
   if (!_states) return;
-  // map project states to group by columns
+  // map states to group by columns
   return _states.map((state) => ({
     id: state.id,
     name: state.name,
@@ -251,11 +253,11 @@ const getPriorityColumns = (): IGroupByColumn[] => {
   }));
 };
 
-const getLabelsColumns = ({ isWorkspaceLevel }: TGetColumns): IGroupByColumn[] => {
+const getLabelsColumns = ({ isWorkspaceLevel: isWorkspaceScoped }: TGetColumns): IGroupByColumn[] => {
   const { workspaceLabels, projectLabels } = store.label;
   // map labels to group by columns
   const labels = [
-    ...(isWorkspaceLevel ? workspaceLabels || [] : projectLabels || []),
+    ...(isWorkspaceScoped ? workspaceLabels || [] : projectLabels || []),
     { id: "None", name: "None", color: "#666" },
   ];
   // map labels to group by columns
@@ -269,11 +271,14 @@ const getLabelsColumns = ({ isWorkspaceLevel }: TGetColumns): IGroupByColumn[] =
   }));
 };
 
-const getAssigneeColumns = ({ isWorkspaceLevel, projectId }: TGetColumns): IGroupByColumn[] | undefined => {
+const getAssigneeColumns = ({
+  isWorkspaceLevel: isWorkspaceScoped,
+  projectId,
+}: TGetColumns): IGroupByColumn[] | undefined => {
   // store values
   const { getUserDetails } = store.memberRoot;
   // derived values
-  const { memberIds, includeNone } = getScopeMemberIds({ isWorkspaceLevel, projectId });
+  const { memberIds, includeNone } = getScopeMemberIds({ isWorkspaceLevel: isWorkspaceScoped, projectId });
   const assigneeColumns: IGroupByColumn[] = [];
 
   if (!memberIds) return [];
@@ -452,8 +457,8 @@ const handleSortOrder = (
 
   if (destinationIssues && destinationIssues.length > 0) {
     if (destinationIndex === 0) {
-      const destinationIssueId = destinationIssues[0];
-      const destinationIssue = getIssueById(destinationIssueId);
+      const firstDestinationIssueId = destinationIssues[0];
+      const destinationIssue = getIssueById(firstDestinationIssueId);
       if (!destinationIssue) return currentIssueState;
 
       currentIssueState = {
@@ -461,8 +466,8 @@ const handleSortOrder = (
         sort_order: destinationIssue.sort_order - sortOrderDefaultValue,
       };
     } else if (destinationIndex === destinationIssues.length) {
-      const destinationIssueId = destinationIssues[destinationIssues.length - 1];
-      const destinationIssue = getIssueById(destinationIssueId);
+      const lastDestinationIssueId = destinationIssues[destinationIssues.length - 1];
+      const destinationIssue = getIssueById(lastDestinationIssueId);
       if (!destinationIssue) return currentIssueState;
 
       currentIssueState = {
@@ -731,7 +736,7 @@ export const isDisplayFiltersApplied = (filters: Partial<IIssueFilters>): boolea
     (key) => !filters.displayProperties?.[key as keyof IIssueDisplayProperties]
   );
 
-  const isDisplayFiltersApplied = Object.keys(filters.displayFilters ?? {}).some((key) => {
+  const displayFiltersApplied = Object.keys(filters.displayFilters ?? {}).some((key) => {
     const value = filters.displayFilters?.[key as keyof IIssueDisplayFilterOptions];
     if (!value) return false;
     // -create_at is the default order
@@ -741,7 +746,7 @@ export const isDisplayFiltersApplied = (filters: Partial<IIssueFilters>): boolea
     return true;
   });
 
-  return isDisplayPropertiesApplied || isDisplayFiltersApplied;
+  return isDisplayPropertiesApplied || displayFiltersApplied;
 };
 
 /**

--- a/apps/web/core/components/workspace/sidebar/projects-list.tsx
+++ b/apps/web/core/components/workspace/sidebar/projects-list.tsx
@@ -167,7 +167,12 @@ export const SidebarProjectsList = observer(function SidebarProjectsList() {
   // whenever the user lands on any of those routes so the active row is not
   // hidden behind a collapsed disclosure.
   useEffect(() => {
-    if (pathname.includes("projects") || pathname.includes("/drafts") || pathname.includes("/workspace-views")) {
+    if (
+      pathname.includes("projects") ||
+      pathname.includes("/drafts") ||
+      pathname.includes("/all-issues") ||
+      pathname.includes("/workspace-views")
+    ) {
       setIsAllProjectsListOpen(true);
       localStorage.setItem("isAllProjectsListOpen", "true");
     }
@@ -196,11 +201,7 @@ export const SidebarProjectsList = observer(function SidebarProjectsList() {
                 type="button"
                 className="flex w-full items-center gap-1 text-left text-13 font-semibold whitespace-nowrap text-placeholder"
                 onClick={() => toggleListDisclosure(!isAllProjectsListOpen)}
-                aria-label={t(
-                  isAllProjectsListOpen
-                    ? "Close projects menu"
-                    : "Open projects menu"
-                )}
+                aria-label={t(isAllProjectsListOpen ? "Close projects menu" : "Open projects menu")}
               >
                 <span className="text-13 font-semibold">{t("Projects")}</span>
               </Disclosure.Button>
@@ -229,11 +230,7 @@ export const SidebarProjectsList = observer(function SidebarProjectsList() {
                   iconClassName={cn("transition-transform", {
                     "rotate-90": isAllProjectsListOpen,
                   })}
-                  aria-label={t(
-                    isAllProjectsListOpen
-                      ? "Close projects menu"
-                      : "Open projects menu"
-                  )}
+                  aria-label={t(isAllProjectsListOpen ? "Close projects menu" : "Open projects menu")}
                 />
               </div>
             </div>
@@ -264,11 +261,11 @@ export const SidebarProjectsList = observer(function SidebarProjectsList() {
                         item={{
                           ...WORKSPACE_SIDEBAR_DYNAMIC_NAVIGATION_ITEMS["views"],
                           labelTranslationKey: "Work Items",
-                          // The base highlight only matches /workspace-views/all-issues/.
-                          // Since this row is now labelled "Work Items" (the section,
-                          // not a single page) it should stay active on every
-                          // /workspace-views/* route.
-                          highlight: (path: string) => path.includes("/workspace-views"),
+                          // "Work Items" points at the new /all-issues route but
+                          // represents the whole workspace work-items section, so it
+                          // stays active on the legacy /workspace-views/* routes too.
+                          highlight: (path: string) =>
+                            path.includes("/all-issues") || path.includes("/workspace-views"),
                         }}
                         additionalStaticItems={["views"]}
                       />
@@ -293,9 +290,7 @@ export const SidebarProjectsList = observer(function SidebarProjectsList() {
                           className="flex flex-grow items-center gap-1.5 text-13 font-medium text-tertiary"
                           id="extended-project-sidebar-toggle"
                           aria-label={t(
-                            isExtendedProjectSidebarOpened
-                              ? "Close extended sidebar"
-                              : "Open extended sidebar"
+                            isExtendedProjectSidebarOpened ? "Close extended sidebar" : "Open extended sidebar"
                           )}
                         >
                           <Ellipsis className="size-4 flex-shrink-0" />

--- a/apps/web/core/components/workspace/sidebar/workspace-menu.tsx
+++ b/apps/web/core/components/workspace/sidebar/workspace-menu.tsx
@@ -36,7 +36,7 @@ export const SidebarWorkspaceMenu = observer(function SidebarWorkspaceMenu() {
     {
       key: "views",
       labelTranslationKey: "Views",
-      href: `/${workspaceSlug}/workspace-views/all-issues/`,
+      href: `/${workspaceSlug}/all-issues/`,
       access: [EUserWorkspaceRoles.ADMIN, EUserWorkspaceRoles.MEMBER, EUserWorkspaceRoles.GUEST],
       Icon: ViewsIcon,
     },

--- a/apps/web/core/hooks/use-global-view-id.tsx
+++ b/apps/web/core/hooks/use-global-view-id.tsx
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { createContext, useContext } from "react";
+import { useParams } from "next/navigation";
+
+/**
+ * The workspace "global view" issues UI normally reads the active view id from
+ * the `:globalViewId` route param (e.g. `/workspace-views/all-issues`). The
+ * shorter `/all-issues` route has no such param, so this context lets the route
+ * pin a static view id (e.g. `"all-issues"`) for the subtree below it.
+ *
+ * Consumers should call {@link useGlobalViewId}, which prefers the context value
+ * and falls back to the route param so both URL shapes keep working.
+ */
+const GlobalViewIdContext = createContext<string | undefined>(undefined);
+
+export function GlobalViewIdProvider(props: { value: string; children: React.ReactNode }) {
+  return <GlobalViewIdContext.Provider value={props.value}>{props.children}</GlobalViewIdContext.Provider>;
+}
+
+export function useGlobalViewId(): string | undefined {
+  const contextValue = useContext(GlobalViewIdContext);
+  const { globalViewId: routerGlobalViewId } = useParams();
+  return contextValue ?? (routerGlobalViewId ? routerGlobalViewId.toString() : undefined);
+}

--- a/apps/web/core/hooks/use-group-dragndrop.ts
+++ b/apps/web/core/hooks/use-group-dragndrop.ts
@@ -22,6 +22,7 @@ type DNDStoreType =
   | EIssuesStoreType.PROFILE
   | EIssuesStoreType.ARCHIVED
   | EIssuesStoreType.WORKSPACE_DRAFT
+  | EIssuesStoreType.GLOBAL
   | EIssuesStoreType.TEAM
   | EIssuesStoreType.TEAM_VIEW
   | EIssuesStoreType.EPIC

--- a/apps/web/core/hooks/use-issues-actions.tsx
+++ b/apps/web/core/hooks/use-issues-actions.tsx
@@ -22,6 +22,7 @@ import type {
 } from "@pi-dash/types";
 import { EIssuesStoreType } from "@pi-dash/types";
 import { useIssues } from "./store/use-issues";
+import { useGlobalViewId } from "./use-global-view-id";
 
 export interface IssueActions {
   fetchIssues: (
@@ -670,16 +671,19 @@ const useArchivedIssueActions = () => {
 
 const useGlobalIssueActions = () => {
   // router
-  const { workspaceSlug: routerWorkspaceSlug, globalViewId: routerGlobalViewId } = useParams();
+  const { workspaceSlug: routerWorkspaceSlug } = useParams();
   const workspaceSlug = routerWorkspaceSlug?.toString();
-  const globalViewId = routerGlobalViewId?.toString();
+  // The view id comes from the route param on `/workspace-views/:globalViewId`
+  // and from context on the param-less `/all-issues` route.
+  const globalViewId = useGlobalViewId();
   // store hooks
   const { issues, issuesFilter } = useIssues(EIssuesStoreType.GLOBAL);
 
   const fetchIssues = useCallback(
-    async (loadType: TLoader, options: IssuePaginationOptions) => {
-      if (!workspaceSlug || !globalViewId) return;
-      return issues.fetchIssues(workspaceSlug.toString(), globalViewId.toString(), loadType, options);
+    async (loadType: TLoader, options: IssuePaginationOptions, viewId?: string) => {
+      const resolvedViewId = viewId ?? globalViewId;
+      if (!workspaceSlug || !resolvedViewId) return;
+      return issues.fetchIssues(workspaceSlug.toString(), resolvedViewId.toString(), loadType, options);
     },
     [issues.fetchIssues, workspaceSlug, globalViewId]
   );
@@ -693,6 +697,15 @@ const useGlobalIssueActions = () => {
 
   const createIssue = useCallback(
     async (projectId: string | undefined | null, data: Partial<TIssue>) => {
+      if (!workspaceSlug || !projectId) return;
+      return await issues.createIssue(workspaceSlug, projectId, data);
+    },
+    [issues.createIssue, workspaceSlug]
+  );
+  // The workspace store has no dedicated quick-add; inline creation at workspace
+  // scope picks a project and goes through the normal create path.
+  const quickAddIssue = useCallback(
+    async (projectId: string | undefined | null, data: TIssue) => {
       if (!workspaceSlug || !projectId) return;
       return await issues.createIssue(workspaceSlug, projectId, data);
     },
@@ -712,6 +725,13 @@ const useGlobalIssueActions = () => {
     },
     [issues.removeIssue, workspaceSlug]
   );
+  const archiveIssue = useCallback(
+    async (projectId: string | undefined | null, issueId: string) => {
+      if (!workspaceSlug || !projectId) return;
+      return await issues.archiveIssue(workspaceSlug, projectId, issueId);
+    },
+    [issues.archiveIssue, workspaceSlug]
+  );
 
   const updateFilters = useCallback(
     async (projectId: string, filterType: TSupportedFilterTypeForUpdate, filters: TSupportedFilterForUpdate) => {
@@ -726,11 +746,13 @@ const useGlobalIssueActions = () => {
       fetchIssues,
       fetchNextIssues,
       createIssue,
+      quickAddIssue,
       updateIssue,
       removeIssue,
+      archiveIssue,
       updateFilters,
     }),
-    [createIssue, updateIssue, removeIssue, updateFilters]
+    [fetchIssues, fetchNextIssues, createIssue, quickAddIssue, updateIssue, removeIssue, archiveIssue, updateFilters]
   );
 };
 

--- a/apps/web/core/store/issue/workspace/display-filter-defaults.ts
+++ b/apps/web/core/store/issue/workspace/display-filter-defaults.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import type { IIssueDisplayFilterOptions } from "@pi-dash/types";
+import { EIssueLayoutTypes } from "@pi-dash/types";
+
+export const WORKSPACE_ALL_ISSUES_DISPLAY_FILTERS: IIssueDisplayFilterOptions = {
+  layout: EIssueLayoutTypes.LIST,
+  group_by: "state",
+  order_by: "sort_order",
+  sub_issue: true,
+  show_empty_groups: true,
+};
+
+export const getWorkspaceDefaultDisplayFilters = (viewId: string): IIssueDisplayFilterOptions =>
+  viewId === "all-issues"
+    ? WORKSPACE_ALL_ISSUES_DISPLAY_FILTERS
+    : { layout: EIssueLayoutTypes.SPREADSHEET, order_by: "-created_at" };
+
+export const shouldUseAllIssuesDisplayDefaults = (
+  viewId: string,
+  savedDisplayFilters: IIssueDisplayFilterOptions | undefined
+): boolean => {
+  if (viewId !== "all-issues") return false;
+  if (!savedDisplayFilters?.layout) return true;
+
+  const isUngroupedList = savedDisplayFilters.layout === EIssueLayoutTypes.LIST && !savedDisplayFilters.group_by;
+  const isUngroupedKanban = savedDisplayFilters.layout === EIssueLayoutTypes.KANBAN && !savedDisplayFilters.group_by;
+  const isOldKanbanDefault =
+    savedDisplayFilters.layout === EIssueLayoutTypes.KANBAN &&
+    savedDisplayFilters.group_by === "state" &&
+    savedDisplayFilters.order_by === "-created_at";
+  const isOldSpreadsheetDefault =
+    savedDisplayFilters.layout === EIssueLayoutTypes.SPREADSHEET &&
+    !savedDisplayFilters.group_by &&
+    (!savedDisplayFilters.order_by || savedDisplayFilters.order_by === "-created_at");
+
+  return isUngroupedList || isUngroupedKanban || isOldKanbanDefault || isOldSpreadsheetDefault;
+};
+
+export const normalizeWorkspaceDisplayFilters = (
+  viewId: string,
+  displayFilters: IIssueDisplayFilterOptions,
+  savedDisplayFilters: IIssueDisplayFilterOptions | undefined
+): IIssueDisplayFilterOptions =>
+  shouldUseAllIssuesDisplayDefaults(viewId, savedDisplayFilters)
+    ? { ...displayFilters, ...WORKSPACE_ALL_ISSUES_DISPLAY_FILTERS }
+    : displayFilters;

--- a/apps/web/core/store/issue/workspace/filter.store.ts
+++ b/apps/web/core/store/issue/workspace/filter.store.ts
@@ -100,7 +100,13 @@ export class WorkspaceIssuesFilter extends IssueFilterHelperStore implements IWo
     const userFilters = this.getIssueFilters(viewId);
     if (!userFilters) return undefined;
 
-    const filteredParams = handleIssueQueryParamsByLayout(EIssueLayoutTypes.SPREADSHEET, "my_issues");
+    // Use the view's active layout (not a hardcoded spreadsheet) so layout-specific
+    // params like group_by/sub_group_by are sent to the server — otherwise the
+    // list/board layouts would never receive grouped issues.
+    const filteredParams = handleIssueQueryParamsByLayout(
+      userFilters?.displayFilters?.layout ?? EIssueLayoutTypes.SPREADSHEET,
+      "my_issues"
+    );
     if (!filteredParams) return undefined;
 
     const filteredRouteParams: Partial<Record<TIssueParams, string | boolean>> = this.computedFilteredParams(

--- a/apps/web/core/store/issue/workspace/filter.store.ts
+++ b/apps/web/core/store/issue/workspace/filter.store.ts
@@ -29,6 +29,7 @@ import { WorkspaceService } from "@/services/workspace.service";
 import type { IBaseIssueFilterStore, IIssueFilterHelperStore } from "../helpers/issue-filter-helper.store";
 import { IssueFilterHelperStore } from "../helpers/issue-filter-helper.store";
 import type { IIssueRootStore } from "../root.store";
+import { getWorkspaceDefaultDisplayFilters, normalizeWorkspaceDisplayFilters } from "./display-filter-defaults";
 
 type TWorkspaceFilters = TStaticViewTypes;
 
@@ -164,44 +165,30 @@ export class WorkspaceIssuesFilter extends IssueFilterHelperStore implements IWo
       sub_group_by: [],
     };
 
-    const _filters = this.handleIssuesLocalFilters.get(EIssuesStoreType.GLOBAL, workspaceSlug, undefined, viewId);
-    // The workspace "all work items" view defaults to a Board (Kanban) grouped by
-    // state group; other global views keep the spreadsheet default. Applies only
-    // when the user has no saved preference for the view.
-    const defaultDisplayFilters: IIssueDisplayFilterOptions =
-      viewId === "all-issues"
-        ? { layout: EIssueLayoutTypes.KANBAN, group_by: "state", order_by: "-created_at" }
-        : { layout: EIssueLayoutTypes.SPREADSHEET, order_by: "-created_at" };
-    displayFilters = this.computedDisplayFilters(_filters?.display_filters, defaultDisplayFilters);
-    // computedDisplayFilters only honors the defaults when NO local filters exist
-    // for the view. Ensure the work-items Board (grouped by state) is the default
-    // whenever the user hasn't explicitly chosen a layout, even if other local
-    // filters were saved.
-    if (viewId === "all-issues" && !_filters?.display_filters?.layout) {
-      displayFilters.layout = EIssueLayoutTypes.KANBAN;
-      if (!_filters?.display_filters?.group_by) {
-        displayFilters.group_by = "state";
-      }
-    }
-    displayProperties = this.computedDisplayProperties(_filters?.display_properties);
+    const localFilters = this.handleIssuesLocalFilters.get(EIssuesStoreType.GLOBAL, workspaceSlug, undefined, viewId);
+    const defaultDisplayFilters = getWorkspaceDefaultDisplayFilters(viewId);
+    displayFilters = this.computedDisplayFilters(localFilters?.display_filters, defaultDisplayFilters);
+    displayFilters = normalizeWorkspaceDisplayFilters(viewId, displayFilters, localFilters?.display_filters);
+    displayProperties = this.computedDisplayProperties(localFilters?.display_properties);
     kanbanFilters = {
-      group_by: _filters?.kanban_filters?.group_by || [],
-      sub_group_by: _filters?.kanban_filters?.sub_group_by || [],
+      group_by: localFilters?.kanban_filters?.group_by || [],
+      sub_group_by: localFilters?.kanban_filters?.sub_group_by || [],
     };
 
     // Get the view details if the view is not a static view
     if (STATIC_VIEW_TYPES.includes(viewId) === false) {
-      const _filters = await this.issueFilterService.getViewDetails(workspaceSlug, viewId);
-      richFilters = _filters?.rich_filters;
-      displayFilters = this.computedDisplayFilters(_filters?.display_filters, {
+      const viewFilters = await this.issueFilterService.getViewDetails(workspaceSlug, viewId);
+      richFilters = viewFilters?.rich_filters;
+      displayFilters = this.computedDisplayFilters(viewFilters?.display_filters, {
         layout: EIssueLayoutTypes.SPREADSHEET,
         order_by: "-created_at",
       });
-      displayProperties = this.computedDisplayProperties(_filters?.display_properties);
+      displayProperties = this.computedDisplayProperties(viewFilters?.display_properties);
     }
 
-    // override existing order by if ordered by manual sort_order
-    if (displayFilters.order_by === "sort_order") {
+    // Workspace custom views do not support manual project ordering as a default.
+    // The static Work Items view is the exception because it mirrors project issues.
+    if (viewId !== "all-issues" && displayFilters.order_by === "sort_order") {
       displayFilters.order_by = "-created_at";
     }
 

--- a/apps/web/core/store/issue/workspace/filter.store.ts
+++ b/apps/web/core/store/issue/workspace/filter.store.ts
@@ -255,10 +255,14 @@ export class WorkspaceIssuesFilter extends IssueFilterHelperStore implements IWo
             _filters.displayFilters.sub_group_by = null;
             updatedDisplayFilters.sub_group_by = null;
           }
-          // set group_by to state if layout is switched to kanban and group_by is null
+          // Set a default group_by when switching to the board with none set.
+          // This is the workspace ("all issues") store, which spans projects, so
+          // group by state GROUP (Backlog/Started/Completed/…) rather than raw
+          // per-project states — the latter would produce a column per state of
+          // every project.
           if (_filters.displayFilters.layout === "kanban" && _filters.displayFilters.group_by === null) {
-            _filters.displayFilters.group_by = "state";
-            updatedDisplayFilters.group_by = "state";
+            _filters.displayFilters.group_by = "state_detail.group";
+            updatedDisplayFilters.group_by = "state_detail.group";
           }
 
           runInAction(() => {

--- a/apps/web/core/store/issue/workspace/filter.store.ts
+++ b/apps/web/core/store/issue/workspace/filter.store.ts
@@ -159,10 +159,23 @@ export class WorkspaceIssuesFilter extends IssueFilterHelperStore implements IWo
     };
 
     const _filters = this.handleIssuesLocalFilters.get(EIssuesStoreType.GLOBAL, workspaceSlug, undefined, viewId);
-    displayFilters = this.computedDisplayFilters(_filters?.display_filters, {
-      layout: EIssueLayoutTypes.SPREADSHEET,
-      order_by: "-created_at",
-    });
+    // The workspace "all work items" view defaults to a Board (Kanban) grouped by
+    // state group; other global views keep the spreadsheet default. Applies only
+    // when the user has no saved preference for the view.
+    const defaultDisplayFilters: IIssueDisplayFilterOptions =
+      viewId === "all-issues"
+        ? { layout: EIssueLayoutTypes.KANBAN, group_by: "state_detail.group", order_by: "-created_at" }
+        : { layout: EIssueLayoutTypes.SPREADSHEET, order_by: "-created_at" };
+    displayFilters = this.computedDisplayFilters(_filters?.display_filters, defaultDisplayFilters);
+    // computedDisplayFilters only honors the defaults when NO local filters exist
+    // for the view. Ensure the work-items Board is the default whenever the user
+    // hasn't explicitly chosen a layout, even if other local filters were saved.
+    if (viewId === "all-issues" && !_filters?.display_filters?.layout) {
+      displayFilters.layout = EIssueLayoutTypes.KANBAN;
+      if (!_filters?.display_filters?.group_by) {
+        displayFilters.group_by = "state_detail.group";
+      }
+    }
     displayProperties = this.computedDisplayProperties(_filters?.display_properties);
     kanbanFilters = {
       group_by: _filters?.kanban_filters?.group_by || [],

--- a/apps/web/core/store/issue/workspace/filter.store.ts
+++ b/apps/web/core/store/issue/workspace/filter.store.ts
@@ -164,16 +164,17 @@ export class WorkspaceIssuesFilter extends IssueFilterHelperStore implements IWo
     // when the user has no saved preference for the view.
     const defaultDisplayFilters: IIssueDisplayFilterOptions =
       viewId === "all-issues"
-        ? { layout: EIssueLayoutTypes.KANBAN, group_by: "state_detail.group", order_by: "-created_at" }
+        ? { layout: EIssueLayoutTypes.KANBAN, group_by: "state", order_by: "-created_at" }
         : { layout: EIssueLayoutTypes.SPREADSHEET, order_by: "-created_at" };
     displayFilters = this.computedDisplayFilters(_filters?.display_filters, defaultDisplayFilters);
     // computedDisplayFilters only honors the defaults when NO local filters exist
-    // for the view. Ensure the work-items Board is the default whenever the user
-    // hasn't explicitly chosen a layout, even if other local filters were saved.
+    // for the view. Ensure the work-items Board (grouped by state) is the default
+    // whenever the user hasn't explicitly chosen a layout, even if other local
+    // filters were saved.
     if (viewId === "all-issues" && !_filters?.display_filters?.layout) {
       displayFilters.layout = EIssueLayoutTypes.KANBAN;
       if (!_filters?.display_filters?.group_by) {
-        displayFilters.group_by = "state_detail.group";
+        displayFilters.group_by = "state";
       }
     }
     displayProperties = this.computedDisplayProperties(_filters?.display_properties);
@@ -255,14 +256,12 @@ export class WorkspaceIssuesFilter extends IssueFilterHelperStore implements IWo
             _filters.displayFilters.sub_group_by = null;
             updatedDisplayFilters.sub_group_by = null;
           }
-          // Set a default group_by when switching to the board with none set.
-          // This is the workspace ("all issues") store, which spans projects, so
-          // group by state GROUP (Backlog/Started/Completed/…) rather than raw
-          // per-project states — the latter would produce a column per state of
-          // every project.
+          // Default the board to group by state when none is set (matches the
+          // project board). Users can switch to "State groups" for a single
+          // column per state group across projects via the Display dropdown.
           if (_filters.displayFilters.layout === "kanban" && _filters.displayFilters.group_by === null) {
-            _filters.displayFilters.group_by = "state_detail.group";
-            updatedDisplayFilters.group_by = "state_detail.group";
+            _filters.displayFilters.group_by = "state";
+            updatedDisplayFilters.group_by = "state";
           }
 
           runInAction(() => {

--- a/apps/web/tests/issues/workspace-display-filter-defaults.test.ts
+++ b/apps/web/tests/issues/workspace-display-filter-defaults.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import type { IIssueDisplayFilterOptions } from "@pi-dash/types";
+import { EIssueLayoutTypes } from "@pi-dash/types";
+import { describe, expect, it } from "vitest";
+
+import {
+  getWorkspaceDefaultDisplayFilters,
+  normalizeWorkspaceDisplayFilters,
+  shouldUseAllIssuesDisplayDefaults,
+  WORKSPACE_ALL_ISSUES_DISPLAY_FILTERS,
+} from "@/store/issue/workspace/display-filter-defaults";
+
+describe("workspace display filter defaults", () => {
+  it("defaults all work items to the project-style grouped list", () => {
+    expect(getWorkspaceDefaultDisplayFilters("all-issues")).toEqual(WORKSPACE_ALL_ISSUES_DISPLAY_FILTERS);
+  });
+
+  it("keeps other static workspace views on the spreadsheet default", () => {
+    expect(getWorkspaceDefaultDisplayFilters("assigned")).toEqual({
+      layout: EIssueLayoutTypes.SPREADSHEET,
+      order_by: "-created_at",
+    });
+  });
+
+  it("migrates stale all work items filters that would render a flat list", () => {
+    const flatListFilters: IIssueDisplayFilterOptions = {
+      layout: EIssueLayoutTypes.LIST,
+      order_by: "priority",
+    };
+
+    expect(shouldUseAllIssuesDisplayDefaults("all-issues", flatListFilters)).toBe(true);
+    expect(normalizeWorkspaceDisplayFilters("all-issues", flatListFilters, flatListFilters)).toEqual({
+      ...flatListFilters,
+      ...WORKSPACE_ALL_ISSUES_DISPLAY_FILTERS,
+    });
+  });
+
+  it("migrates the previous all work items board default", () => {
+    const oldBoardFilters: IIssueDisplayFilterOptions = {
+      layout: EIssueLayoutTypes.KANBAN,
+      group_by: "state",
+      order_by: "-created_at",
+    };
+
+    expect(shouldUseAllIssuesDisplayDefaults("all-issues", oldBoardFilters)).toBe(true);
+    expect(normalizeWorkspaceDisplayFilters("all-issues", oldBoardFilters, oldBoardFilters)).toEqual({
+      ...oldBoardFilters,
+      ...WORKSPACE_ALL_ISSUES_DISPLAY_FILTERS,
+    });
+  });
+
+  it("preserves deliberately grouped custom all work items filters", () => {
+    const groupedFilters: IIssueDisplayFilterOptions = {
+      layout: EIssueLayoutTypes.LIST,
+      group_by: "project",
+      order_by: "priority",
+    };
+
+    expect(shouldUseAllIssuesDisplayDefaults("all-issues", groupedFilters)).toBe(false);
+    expect(normalizeWorkspaceDisplayFilters("all-issues", groupedFilters, groupedFilters)).toBe(groupedFilters);
+  });
+});

--- a/packages/constants/src/issue/filter.ts
+++ b/packages/constants/src/issue/filter.ts
@@ -194,9 +194,9 @@ export const ISSUE_DISPLAY_FILTERS_BY_PAGE: TIssueFiltersToDisplayByPageType = {
       list: {
         display_properties: ISSUE_DISPLAY_PROPERTIES_KEYS,
         display_filters: {
-          // "state_detail.group" (state groups) rather than per-project "state"
-          // since the workspace view spans projects.
-          group_by: ["state_detail.group", "priority", "project", "labels", "assignees", "created_by", null],
+          // "state" groups by the projects' actual states; "state_detail.group"
+          // rolls them up into the shared state groups (cleaner across projects).
+          group_by: ["state", "state_detail.group", "priority", "project", "labels", "assignees", "created_by", null],
           order_by: ["sort_order", "-created_at", "-updated_at", "start_date", "-priority"],
           type: ["active", "backlog"],
         },
@@ -208,7 +208,7 @@ export const ISSUE_DISPLAY_FILTERS_BY_PAGE: TIssueFiltersToDisplayByPageType = {
       kanban: {
         display_properties: ISSUE_DISPLAY_PROPERTIES_KEYS,
         display_filters: {
-          group_by: ["state_detail.group", "priority", "project", "labels", "assignees"],
+          group_by: ["state", "state_detail.group", "priority", "project", "labels", "assignees"],
           order_by: ["sort_order", "-created_at", "-updated_at", "start_date", "-priority"],
           type: ["active", "backlog"],
         },

--- a/packages/constants/src/issue/filter.ts
+++ b/packages/constants/src/issue/filter.ts
@@ -194,11 +194,27 @@ export const ISSUE_DISPLAY_FILTERS_BY_PAGE: TIssueFiltersToDisplayByPageType = {
       list: {
         display_properties: ISSUE_DISPLAY_PROPERTIES_KEYS,
         display_filters: {
+          // "state_detail.group" (state groups) rather than per-project "state"
+          // since the workspace view spans projects.
+          group_by: ["state_detail.group", "priority", "project", "labels", "assignees", "created_by", null],
+          order_by: ["sort_order", "-created_at", "-updated_at", "start_date", "-priority"],
           type: ["active", "backlog"],
         },
         extra_options: {
           access: false,
-          values: [],
+          values: ["show_empty_groups"],
+        },
+      },
+      kanban: {
+        display_properties: ISSUE_DISPLAY_PROPERTIES_KEYS,
+        display_filters: {
+          group_by: ["state_detail.group", "priority", "project", "labels", "assignees"],
+          order_by: ["sort_order", "-created_at", "-updated_at", "start_date", "-priority"],
+          type: ["active", "backlog"],
+        },
+        extra_options: {
+          access: false,
+          values: ["show_empty_groups"],
         },
       },
     },

--- a/packages/constants/src/workspace.ts
+++ b/packages/constants/src/workspace.ts
@@ -203,7 +203,7 @@ export const WORKSPACE_SIDEBAR_DYNAMIC_NAVIGATION_ITEMS: Record<string, IWorkspa
   views: {
     key: "views",
     labelTranslationKey: "Views",
-    href: `/workspace-views/all-issues/`,
+    href: `/all-issues/`,
     access: [EUserWorkspaceRoles.ADMIN, EUserWorkspaceRoles.MEMBER, EUserWorkspaceRoles.GUEST],
     highlight: (pathname: string, url: string) => pathname.includes(url),
   },


### PR DESCRIPTION
## What

Makes the workspace-level "Work Items" view (`/<workspace>/all-issues`) render the **same multi-layout UI as project issues** (List + Spreadsheet) instead of the spreadsheet-only `/workspace-views/all-issues`. The "Work Items" sidebar item now routes to the new URL; `/workspace-views/*` keeps working unchanged.

Scope agreed with requester: **List + Spreadsheet** layouts, **inline project-picker** quick-add, **new `/all-issues` route while keeping the old route working**.

## Why this needed a backend change

The workspace view-issues endpoint only returned a flat list (`canGroup: false`). The list layout is fundamentally grouped (by state/priority/etc.), so the API had to learn grouping.

## Changes

**Backend (`apps/api`)**
- `WorkspaceViewIssuesViewSet.list()` now reads `group_by`/`sub_group_by` and returns grouped responses via `GroupedOffsetPaginator` / `SubGroupedOffsetPaginator`, mirroring `IssueViewSet.list()`. Ungrouped behavior is unchanged.
- New contract tests: `test_workspace_view_issues.py` (ungrouped flat list, group-by-state, group-by-priority, same-group/sub-group rejected).

**Frontend (`apps/web`)**
- New `/all-issues` route + `page.tsx`/`layout.tsx`, pinning the static `all-issues` view.
- `useGlobalViewId` context hook so the param-less route resolves the view id; consumed by `AllIssueLayoutRoot`, the global issues header, and `useGlobalIssueActions`.
- GLOBAL store wired into the list layout: `GLOBAL` added to `ListStoreType`, new `GlobalIssueListLayout` (`BaseListRoot` + `AllIssueQuickActions`), and implemented the previously-stubbed `WorkspaceAdditionalLayouts` + `GlobalViewLayoutSelection` (List + Spreadsheet switcher).
- `AllIssueLayoutRoot` fetches grouped data for the list layout (spreadsheet still flat); create/edit gated at the workspace permission level for the GLOBAL store.
- Quick-add at workspace scope shows an inline project picker before creating (uses the existing global `createIssue`).
- Drag-and-drop reorder disabled at workspace (cross-project) scope.
- Sidebar "Work Items" → `/all-issues`; highlight + disclosure auto-open also match the new route.

## Verification

- ✅ Backend contract tests pass against local Postgres (4/4).
- ✅ `check:types` for `web`: no errors in any touched/new file. (The repo's `web#check:types` is already red on `main` from unrelated stale `packages/types/dist` `TStateGroups "review"` + `github-*`/`scheduler.store` issues — not introduced here.)
- ✅ Lint: new files 0 warnings; modified files add 0 new warnings over `main`.
- ⏳ **Needs manual QA**: live click-through of `/all-issues` (list renders + groups, layout switcher, inline project-picker quick-add) — not run because the local pi-dash web dev server wasn't up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)