### PR TITLE
fix(runner): close leaked DB connections in chat SSE endpoint

### DIFF
--- a/apps/api/pi_dash/runner/views/chat.py
+++ b/apps/api/pi_dash/runner/views/chat.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 import time
@@ -12,8 +11,9 @@ from types import SimpleNamespace
 from typing import Optional
 
 import redis.asyncio as aioredis
+from channels.db import database_sync_to_async
 from django.conf import settings
-from django.db import transaction
+from django.db import close_old_connections, transaction
 from django.db.models import Q
 from django.http import JsonResponse, StreamingHttpResponse
 from django.utils import timezone
@@ -767,13 +767,22 @@ class ChatClosedEndpoint(_ChatRunnerEndpointBase):
 
 
 async def chat_event_stream(request, session_id):
-    if not await asyncio.to_thread(_session_authenticates, request):
+    # ``database_sync_to_async`` (not ``asyncio.to_thread``): these helpers
+    # run ORM queries. ``asyncio.to_thread`` dispatches to Python's default
+    # ThreadPoolExecutor (~cpu+4 threads), and a Django connection opened in
+    # one of those pool threads is never closed — ``close_old_connections``
+    # only fires on the HTTP request cycle, not in arbitrary pool threads —
+    # so the connections accumulate (observed in prod 2026-06-10: ~94 idle
+    # connections exhausting the shared Postgres host). ``database_sync_to_async``
+    # routes the call onto Django's shared thread-sensitive executor and
+    # closes stale connections around it.
+    if not await database_sync_to_async(_session_authenticates)(request):
         return JsonResponse(
             {"error": "authentication required"},
             status=status.HTTP_403_FORBIDDEN,
         )
     session = await AgentChatSession.objects.filter(pk=session_id).afirst()
-    if session is None or not await asyncio.to_thread(chat_service.can_read_chat, request.user, session):
+    if session is None or not await database_sync_to_async(chat_service.can_read_chat)(request.user, session):
         return JsonResponse({"error": "not found"}, status=status.HTTP_404_NOT_FOUND)
 
     after_raw = request.GET.get("after") or request.headers.get("Last-Event-ID") or "0"
@@ -824,5 +833,13 @@ async def chat_event_stream(request, session_id):
                 await pubsub.close()
             except Exception:
                 logger.exception("failed to close chat SSE pubsub for session %s", session_id)
+            # The initial event replay above uses the async ORM, which runs on
+            # the shared thread-sensitive executor. Close that connection on the
+            # same thread when the (potentially long-lived) stream ends so it
+            # doesn't sit idle for the life of the connection.
+            try:
+                await database_sync_to_async(close_old_connections)()
+            except Exception:
+                logger.exception("failed to close DB connection after chat SSE for session %s", session_id)
 
     return StreamingHttpResponse(_events(), content_type="text/event-stream")


### PR DESCRIPTION
## Why

Reduces the Postgres connection leak behind the **2026-06-10 production incident** — the `api` container climbed to ~94 idle connections and exhausted the shared host's `max_connections=100`, 500ing both pidash and home-page (`remaining connection slots are reserved for SUPERUSER`).

`chat_event_stream` ran its two auth/permission ORM checks via `asyncio.to_thread`, which dispatches to Python's **default ThreadPoolExecutor** (`min(32, os.cpu_count()+4)` = **6 threads** on the 2-vCPU box — verified). A Django connection opened in one of those pool threads is **never closed**: `close_old_connections` only fires on the HTTP request cycle, not in arbitrary pool threads. So every dashboard chat-open leaves connections behind.

## What

- Both `asyncio.to_thread(orm_fn, ...)` → `database_sync_to_async(orm_fn)(...)`. Channels' helper routes the ORM onto Django's **shared thread-sensitive executor** (bounded ~1 connection/worker instead of a 6-thread pool) and **closes stale connections around each call** (verified: `DatabaseSyncToAsync.thread_handler` calls `close_old_connections`).
- `close_old_connections` in the SSE generator's `finally` — the initial event replay uses the async ORM on the same shared thread.

## Honest scope — this reduces the leak, verify it eliminates it

The `to_thread` pool is capped at **6/worker**, so it directly accounts for **~24** live connections across 4 workers — **not the full 94**. The remainder is most likely connections **orphaned by gunicorn worker recycling** (`--max-requests 1200±1000`), which Postgres reaps slowly via TCP keepalive (~2h default).

This change removes the live pool **and** cuts per-recycle orphans ~7× (a recycled worker now leaves ~1 connection instead of ~7), so idle connections should drop substantially. But it is **deploy-then-measure**: watch `pg_stat_activity` after rollout. If connections still climb, the follow-up levers are gunicorn `--max-requests` tuning, Postgres TCP keepalives, or the pgbouncer sidecar (private-pi-dash #36, on the shelf) as a hard ceiling.

## Why not `asyncio.to_thread` + manual `connection.close()`

That preserves a 6-thread pool whose parallelism buys nothing for two millisecond-scale auth checks, and leaves the same footgun armed for the next `to_thread(orm_call)`. `database_sync_to_async` makes connection hygiene the default behavior of the idiom and is canonical in a Channels codebase.

## Testing

- Full runner suite: **301 passed**, 2 failures pre-existing on `main` (`test_runs_views.py`, need a Celery broker) and unrelated to this change
- chat module imports under Django; `channels.db.DatabaseSyncToAsync.thread_handler` confirmed (by source) to call `close_old_connections`; ruff clean
- Exhaustive search confirmed these are the only two `asyncio.to_thread` sites; no `thread_sensitive=False` or raw ORM thread pools; the runner WebSocket consumer is a deprecated stub (no ORM)

### Note for future test authors

No test exercises `chat_event_stream` (SSE). If you add one, use `transactional_db` / a non-shared-connection setup — `database_sync_to_async` closes the connection around each call, which trips pytest-django's transactional `db` fixture with "connection is closed."

🤖 Generated with [Claude Code](https://claude.com/claude-code)