### PR TITLE
chore(runner): bump version to 0.1.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1382,7 +1382,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pidash"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "axoupdater",

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pidash"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2024"
 rust-version = "1.93"
 description = "Pi Dash local runner: connects a dev machine to the Pi Dash cloud and drives Codex for assigned tasks."


### PR DESCRIPTION
Bumps the runner (`pidash` crate) from 0.1.13 → 0.1.14 ahead of cutting the `pidash-v0.1.14` release tag.

Releases the worktree-pooling runner change (#227). `Cargo.toml` and `Cargo.lock` updated together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)