### PR TITLE
feat(web): independent scroll + async detail loading on runners/runs

### DIFF
--- a/apps/web/app/(all)/[workspaceSlug]/runners/runs/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/runs/page.tsx
@@ -14,7 +14,7 @@ import { RunnerService } from "@pi-dash/services";
 import type { IAgentRun, TAgentRunStatus } from "@pi-dash/types";
 import { AGENT_RUN_TERMINAL_STATUSES } from "@pi-dash/types";
 import type { TBadgeVariant } from "@pi-dash/ui";
-import { AlertModalCore, Badge, Button } from "@pi-dash/ui";
+import { AlertModalCore, Badge, Button, Spinner } from "@pi-dash/ui";
 import { PageHead } from "@/components/core/page-title";
 import { RunnersTabs } from "@/components/runners/runners-tabs";
 import { useWorkspace } from "@/hooks/store/use-workspace";
@@ -108,13 +108,13 @@ export const RunnerRunsPage = observer(function RunnerRunsPage() {
     : t("AI Agents");
 
   return (
-    <div className="flex flex-col gap-6">
+    <div className="flex h-full min-h-0 flex-col gap-6">
       <PageHead title={pageTitle} />
       <RunnersTabs />
-      <div className="grid grid-cols-[400px_1fr] gap-4">
-        <div className="rounded-md border border-subtle">
+      <div className="grid min-h-0 flex-1 grid-cols-[400px_1fr] gap-4 overflow-hidden">
+        <div className="overflow-auto rounded-md border border-subtle">
           <table className="w-full text-13">
-            <thead className="bg-layer-1 text-left text-secondary">
+            <thead className="sticky top-0 z-10 bg-layer-1 text-left text-secondary">
               <tr>
                 <th className="px-3 py-2">{t("Started")}</th>
                 <th className="px-3 py-2">{t("Status")}</th>
@@ -150,13 +150,18 @@ export const RunnerRunsPage = observer(function RunnerRunsPage() {
           </table>
         </div>
 
-        <div className="rounded-md border border-subtle p-4">
+        <div className="overflow-auto rounded-md border border-subtle p-4">
           {selected && detailError ? (
             <div className="text-13 text-danger-primary">
               {t("This run is not available. It may have been deleted or belong to a different workspace.")}
             </div>
-          ) : !detail ? (
+          ) : !selected ? (
             <div className="text-13 text-secondary">{t("Select a run on the left.")}</div>
+          ) : !detail ? (
+            <div className="flex items-center gap-2 text-13 text-secondary">
+              <Spinner height="16px" width="16px" />
+              {t("Loading run details…")}
+            </div>
           ) : (
             <div className="flex flex-col gap-3">
               <div className="flex items-center justify-between">

--- a/packages/i18n/src/locales/cs/translations.ts
+++ b/packages/i18n/src/locales/cs/translations.ts
@@ -872,6 +872,7 @@ export default {
   "Load more": "Načíst další",
   Loading: "Načítání",
   "Loading dev machines...": "Načítání vývojových strojů...",
+  "Loading run details…": "",
   "Loading…": "Načítání…",
   "local dev machine project working dir": "pracovní adresář projektu na místním vývojovém počítači",
   "Local path the daemon runs the agent CLI in — usually the project repo on disk. Defaults to a sandbox under the runner's data dir, which is rarely what you want.":

--- a/packages/i18n/src/locales/de/translations.ts
+++ b/packages/i18n/src/locales/de/translations.ts
@@ -886,6 +886,7 @@ export default {
   "Load more": "Mehr laden",
   Loading: "Laden",
   "Loading dev machines...": "Entwicklungsmaschinen werden geladen...",
+  "Loading run details…": "",
   "Loading…": "Laden…",
   "local dev machine project working dir": "Lokales Arbeitsverzeichnis des Projekts auf dem Entwicklungsrechner",
   "Local path the daemon runs the agent CLI in — usually the project repo on disk. Defaults to a sandbox under the runner's data dir, which is rarely what you want.":

--- a/packages/i18n/src/locales/en/translations.ts
+++ b/packages/i18n/src/locales/en/translations.ts
@@ -861,6 +861,7 @@ export default {
   "Load more": "Load more",
   Loading: "Loading",
   "Loading dev machines...": "Loading dev machines...",
+  "Loading run details…": "Loading run details…",
   "Loading…": "Loading…",
   "local dev machine project working dir": "local dev machine project working dir",
   "Local path the daemon runs the agent CLI in — usually the project repo on disk. Defaults to a sandbox under the runner's data dir, which is rarely what you want.":

--- a/packages/i18n/src/locales/es/translations.ts
+++ b/packages/i18n/src/locales/es/translations.ts
@@ -879,6 +879,7 @@ export default {
   "Load more": "Cargar más",
   Loading: "Cargando",
   "Loading dev machines...": "Cargando máquinas de desarrollo...",
+  "Loading run details…": "",
   "Loading…": "Cargando…",
   "local dev machine project working dir": "directorio de trabajo del proyecto de la máquina de desarrollo local",
   "Local path the daemon runs the agent CLI in — usually the project repo on disk. Defaults to a sandbox under the runner's data dir, which is rarely what you want.":

--- a/packages/i18n/src/locales/fr/translations.ts
+++ b/packages/i18n/src/locales/fr/translations.ts
@@ -883,6 +883,7 @@ export default {
   "Load more": "Charger plus",
   Loading: "Chargement",
   "Loading dev machines...": "Chargement des machines de développement...",
+  "Loading run details…": "",
   "Loading…": "Chargement…",
   "local dev machine project working dir": "répertoire de travail du projet sur la machine de développement locale",
   "Local path the daemon runs the agent CLI in — usually the project repo on disk. Defaults to a sandbox under the runner's data dir, which is rarely what you want.":

--- a/packages/i18n/src/locales/id/translations.ts
+++ b/packages/i18n/src/locales/id/translations.ts
@@ -866,6 +866,7 @@ export default {
   "Load more": "Muat lebih banyak",
   Loading: "Memuat",
   "Loading dev machines...": "Memuat mesin pengembangan...",
+  "Loading run details…": "",
   "Loading…": "Memuat…",
   "local dev machine project working dir": "direktori kerja proyek mesin dev lokal",
   "Local path the daemon runs the agent CLI in — usually the project repo on disk. Defaults to a sandbox under the runner's data dir, which is rarely what you want.":

--- a/packages/i18n/src/locales/it/translations.ts
+++ b/packages/i18n/src/locales/it/translations.ts
@@ -875,6 +875,7 @@ export default {
   "Load more": "Carica altro",
   Loading: "Caricamento",
   "Loading dev machines...": "Caricamento macchine di sviluppo...",
+  "Loading run details…": "",
   "Loading…": "Caricamento…",
   "local dev machine project working dir": "directory di lavoro del progetto della macchina di sviluppo locale",
   "Local path the daemon runs the agent CLI in — usually the project repo on disk. Defaults to a sandbox under the runner's data dir, which is rarely what you want.":

--- a/packages/i18n/src/locales/ja/translations.ts
+++ b/packages/i18n/src/locales/ja/translations.ts
@@ -872,6 +872,7 @@ export default {
   "Load more": "さらに読み込む",
   Loading: "読み込み中",
   "Loading dev machines...": "開発用マシンを読み込み中...",
+  "Loading run details…": "",
   "Loading…": "読み込み中…",
   "local dev machine project working dir": "ローカル開発マシンのプロジェクト作業ディレクトリ",
   "Local path the daemon runs the agent CLI in — usually the project repo on disk. Defaults to a sandbox under the runner's data dir, which is rarely what you want.":

--- a/packages/i18n/src/locales/ko/translations.ts
+++ b/packages/i18n/src/locales/ko/translations.ts
@@ -858,6 +858,7 @@ export default {
   "Load more": "더 불러오기",
   Loading: "로딩 중",
   "Loading dev machines...": "개발 머신 로딩 중...",
+  "Loading run details…": "",
   "Loading…": "로딩 중…",
   "local dev machine project working dir": "로컬 개발 머신 프로젝트 작업 디렉터리",
   "Local path the daemon runs the agent CLI in — usually the project repo on disk. Defaults to a sandbox under the runner's data dir, which is rarely what you want.":

--- a/packages/i18n/src/locales/pl/translations.ts
+++ b/packages/i18n/src/locales/pl/translations.ts
@@ -874,6 +874,7 @@ export default {
   "Load more": "Wczytaj więcej",
   Loading: "Wczytywanie",
   "Loading dev machines...": "Wczytywanie maszyn deweloperskich...",
+  "Loading run details…": "",
   "Loading…": "Ładowanie…",
   "local dev machine project working dir": "lokalny katalog roboczy projektu na maszynie deweloperskiej",
   "Local path the daemon runs the agent CLI in — usually the project repo on disk. Defaults to a sandbox under the runner's data dir, which is rarely what you want.":

--- a/packages/i18n/src/locales/pt-BR/translations.ts
+++ b/packages/i18n/src/locales/pt-BR/translations.ts
@@ -869,6 +869,7 @@ export default {
   "Load more": "Carregar mais",
   Loading: "Carregando",
   "Loading dev machines...": "Carregando máquinas de desenvolvimento...",
+  "Loading run details…": "",
   "Loading…": "Carregando…",
   "local dev machine project working dir": "diretório de trabalho do projeto da máquina de desenvolvimento local",
   "Local path the daemon runs the agent CLI in — usually the project repo on disk. Defaults to a sandbox under the runner's data dir, which is rarely what you want.":

--- a/packages/i18n/src/locales/ro/translations.ts
+++ b/packages/i18n/src/locales/ro/translations.ts
@@ -886,6 +886,7 @@ export default {
   "Load more": "Încarcă mai mult",
   Loading: "Se încarcă",
   "Loading dev machines...": "Se încarcă mașinile de dezvoltare...",
+  "Loading run details…": "",
   "Loading…": "Se încarcă…",
   "local dev machine project working dir": "director de lucru al proiectului mașinii de dezvoltare locale",
   "Local path the daemon runs the agent CLI in — usually the project repo on disk. Defaults to a sandbox under the runner's data dir, which is rarely what you want.":

--- a/packages/i18n/src/locales/ru/translations.ts
+++ b/packages/i18n/src/locales/ru/translations.ts
@@ -879,6 +879,7 @@ export default {
   "Load more": "Загрузить ещё",
   Loading: "Загрузка",
   "Loading dev machines...": "Загрузка машин разработки...",
+  "Loading run details…": "",
   "Loading…": "Загрузка…",
   "local dev machine project working dir": "рабочий каталог проекта на локальной машине разработчика",
   "Local path the daemon runs the agent CLI in — usually the project repo on disk. Defaults to a sandbox under the runner's data dir, which is rarely what you want.":

--- a/packages/i18n/src/locales/sk/translations.ts
+++ b/packages/i18n/src/locales/sk/translations.ts
@@ -873,6 +873,7 @@ export default {
   "Load more": "Načítať viac",
   Loading: "Načítava sa",
   "Loading dev machines...": "Načítavajú sa vývojové stroje...",
+  "Loading run details…": "",
   "Loading…": "Načítava sa…",
   "local dev machine project working dir": "pracovný adresár projektu lokálneho vývojového stroja",
   "Local path the daemon runs the agent CLI in — usually the project repo on disk. Defaults to a sandbox under the runner's data dir, which is rarely what you want.":

--- a/packages/i18n/src/locales/tr-TR/translations.ts
+++ b/packages/i18n/src/locales/tr-TR/translations.ts
@@ -870,6 +870,7 @@ export default {
   "Load more": "Daha fazla yükle",
   Loading: "Yükleniyor",
   "Loading dev machines...": "Geliştirici makineleri yükleniyor...",
+  "Loading run details…": "",
   "Loading…": "Yükleniyor…",
   "local dev machine project working dir": "yerel geliştirme makinesi proje çalışma dizini",
   "Local path the daemon runs the agent CLI in — usually the project repo on disk. Defaults to a sandbox under the runner's data dir, which is rarely what you want.":

--- a/packages/i18n/src/locales/ua/translations.ts
+++ b/packages/i18n/src/locales/ua/translations.ts
@@ -874,6 +874,7 @@ export default {
   "Load more": "Завантажити більше",
   Loading: "Завантаження",
   "Loading dev machines...": "Завантаження машин для розробки...",
+  "Loading run details…": "",
   "Loading…": "Завантаження…",
   "local dev machine project working dir": "робоча директорія проекту на локальній машині розробника",
   "Local path the daemon runs the agent CLI in — usually the project repo on disk. Defaults to a sandbox under the runner's data dir, which is rarely what you want.":

--- a/packages/i18n/src/locales/vi-VN/translations.ts
+++ b/packages/i18n/src/locales/vi-VN/translations.ts
@@ -866,6 +866,7 @@ export default {
   "Load more": "Tải thêm",
   Loading: "Đang tải",
   "Loading dev machines...": "Đang tải máy phát triển...",
+  "Loading run details…": "",
   "Loading…": "Đang tải…",
   "local dev machine project working dir": "thư mục làm việc của dự án trên máy dev cục bộ",
   "Local path the daemon runs the agent CLI in — usually the project repo on disk. Defaults to a sandbox under the runner's data dir, which is rarely what you want.":

--- a/packages/i18n/src/locales/zh-CN/translations.ts
+++ b/packages/i18n/src/locales/zh-CN/translations.ts
@@ -846,6 +846,7 @@ export default {
   "Load more": "加载更多",
   Loading: "加载中",
   "Loading dev machines...": "正在加载开发机器...",
+  "Loading run details…": "",
   "Loading…": "加载中…",
   "local dev machine project working dir": "本地开发机器项目工作目录",
   "Local path the daemon runs the agent CLI in — usually the project repo on disk. Defaults to a sandbox under the runner's data dir, which is rarely what you want.":

--- a/packages/i18n/src/locales/zh-TW/translations.ts
+++ b/packages/i18n/src/locales/zh-TW/translations.ts
@@ -845,6 +845,7 @@ export default {
   "Load more": "載入更多",
   Loading: "載入中",
   "Loading dev machines...": "正在載入開發機器...",
+  "Loading run details…": "",
   "Loading…": "載入中…",
   "local dev machine project working dir": "本機開發機器專案工作目錄",
   "Local path the daemon runs the agent CLI in — usually the project repo on disk. Defaults to a sandbox under the runner's data dir, which is rarely what you want.":


### PR DESCRIPTION
## What

Improves the UX of `/<workspace>/runners/runs`, resolving **PDASHOSS01-24**:

1. **Async detail loading** — the right-hand run-detail pane no longer makes the page wait on a fully-loaded run.
2. **Independent scrolling** — the run list (left) and run detail (right) now scroll independently instead of as one page-level container.

## How it works

- **Independent scroll.** The page is constrained to the viewport (`h-full min-h-0` flex column) and the two-pane grid gets `flex-1 min-h-0 overflow-hidden`. Each pane becomes its own `overflow-auto` scroll region. The list table header is `sticky top-0` so column labels stay visible while the list scrolls.
- **Async / non-blocking detail.** Detail already fetched async via SWR, but while a run was selected and still loading, the pane showed the misleading **"Select a run on the left."** empty state. That branch is now three-way: no selection → prompt; selected but loading → `Spinner` + **"Loading run details…"**; loaded → detail. The page never blocks on detail load.

## i18n

Registered the new `"Loading run details…"` key via `pnpm i18n:sync` — English source value plus empty placeholders for the other 18 locales (matching the project's established key-sync process).

## Files

- `apps/web/app/(all)/[workspaceSlug]/runners/runs/page.tsx` — scroll containers + three-state detail pane.
- `packages/i18n/src/locales/*/translations.ts` — new `"Loading run details…"` key across all locales.

## Testing

- `oxlint --deny-warnings` + `oxfmt --check` on the changed page and en catalog → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
