### PR TITLE
PDASHOSS01-25 "New work item" is not working when page is in AI Agents

### DIFF
--- a/apps/web/app/(all)/[workspaceSlug]/runners/layout.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/layout.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from "@pi-dash/i18n";
 import { RunnerService } from "@pi-dash/services";
 import type { IRunner } from "@pi-dash/types";
 import { NotAuthorizedView } from "@/components/auth-screens/not-authorized-view";
+import { ProjectsAppPowerKProvider } from "@/components/power-k/projects-app-provider";
 import { WorkspaceShell } from "@/components/workspace/workspace-shell";
 import { useUserPermissions } from "@/hooks/store/user";
 import { useWorkspace } from "@/hooks/store/use-workspace";
@@ -46,57 +47,69 @@ const RunnersLayout = observer(function RunnersLayout() {
 
   if (workspaceUserInfo && !canViewRunners) {
     return (
-      <WorkspaceShell>
-        <NotAuthorizedView section="general" className="h-auto" />
-      </WorkspaceShell>
+      <>
+        {/* Mounts the workspace command palette + shared modal hosts (incl. the
+            "New work item" create modal) — runners sits outside the (projects)
+            layout, so without this the sidebar "New work item" button is inert. */}
+        <ProjectsAppPowerKProvider />
+        <WorkspaceShell>
+          <NotAuthorizedView section="general" className="h-auto" />
+        </WorkspaceShell>
+      </>
     );
   }
 
   const base = `/${workspaceSlug}/runners`;
 
   return (
-    <WorkspaceShell>
-      <div className="flex h-full w-full overflow-hidden">
-        <aside className="w-[280px] shrink-0 border-r border-subtle bg-surface-1">
-          <div className="flex h-12 items-center border-b border-subtle px-4 text-14 font-semibold text-primary">
-            {t("AI Agents")}
-          </div>
-          <nav className="flex flex-col gap-1 p-2">
-            <NavLink
-              to={base}
-              end
-              className={({ isActive }) =>
-                `flex h-9 items-center gap-2 rounded px-2 text-13 ${
-                  isActive ? "bg-layer-1 font-medium text-primary" : "text-secondary hover:bg-layer-1"
-                }`
-              }
-            >
-              <LayoutDashboard className="size-4" />
-              <span>Overview</span>
-            </NavLink>
-            <div className="mt-2 px-2 text-11 font-medium text-tertiary uppercase">Runners</div>
-            {(runners ?? []).map((runner) => (
+    <>
+      {/* Mounts the workspace command palette + shared modal hosts (incl. the
+          "New work item" create modal) — runners sits outside the (projects)
+          layout, so without this the sidebar "New work item" button is inert. */}
+      <ProjectsAppPowerKProvider />
+      <WorkspaceShell>
+        <div className="flex h-full w-full overflow-hidden">
+          <aside className="w-[280px] shrink-0 border-r border-subtle bg-surface-1">
+            <div className="flex h-12 items-center border-b border-subtle px-4 text-14 font-semibold text-primary">
+              {t("AI Agents")}
+            </div>
+            <nav className="flex flex-col gap-1 p-2">
               <NavLink
-                key={runner.id}
-                to={`${base}/chat/${runner.id}`}
+                to={base}
+                end
                 className={({ isActive }) =>
-                  `flex min-h-11 items-center gap-2 rounded px-2 py-2 text-13 ${
+                  `flex h-9 items-center gap-2 rounded px-2 text-13 ${
                     isActive ? "bg-layer-1 font-medium text-primary" : "text-secondary hover:bg-layer-1"
                   }`
                 }
               >
-                <Bot className="size-4 shrink-0" />
-                <span className="min-w-0 flex-1 truncate">{runner.name}</span>
-                <Circle className={`size-2 fill-current ${statusColor(runner.status)}`} />
+                <LayoutDashboard className="size-4" />
+                <span>Overview</span>
               </NavLink>
-            ))}
-          </nav>
-        </aside>
-        <main className="min-w-0 flex-1 overflow-auto p-6">
-          <Outlet />
-        </main>
-      </div>
-    </WorkspaceShell>
+              <div className="mt-2 px-2 text-11 font-medium text-tertiary uppercase">Runners</div>
+              {(runners ?? []).map((runner) => (
+                <NavLink
+                  key={runner.id}
+                  to={`${base}/chat/${runner.id}`}
+                  className={({ isActive }) =>
+                    `flex min-h-11 items-center gap-2 rounded px-2 py-2 text-13 ${
+                      isActive ? "bg-layer-1 font-medium text-primary" : "text-secondary hover:bg-layer-1"
+                    }`
+                  }
+                >
+                  <Bot className="size-4 shrink-0" />
+                  <span className="min-w-0 flex-1 truncate">{runner.name}</span>
+                  <Circle className={`size-2 fill-current ${statusColor(runner.status)}`} />
+                </NavLink>
+              ))}
+            </nav>
+          </aside>
+          <main className="min-w-0 flex-1 overflow-auto p-6">
+            <Outlet />
+          </main>
+        </div>
+      </WorkspaceShell>
+    </>
   );
 });
 


### PR DESCRIPTION
## Problem

On the **AI Agents** page (`/:workspaceSlug/runners`), clicking the sidebar **"New work item"** button did nothing — the *Create new work item* modal never appeared. The button worked everywhere else.

## Root cause

The button (`SidebarQuickActions`) calls `toggleCreateIssueModal(true)`, which flips `isCreateIssueModalOpen` in the command-palette MobX store. The modal that listens to that flag — `CreateUpdateIssueModal`, rendered inside `WorkItemLevelModals` — is only mounted by **`ProjectsAppPowerKProvider`**.

Every top-level workspace section mounts that provider in its layout: `(projects)/layout.tsx`, `(settings)/layout.tsx`, `settings/profile/layout.tsx`. But the **runners** layout sits *outside* the `(projects)` route group (`apps/web/app/routes/core.ts` — `(projects)` opens at the layout on L60 and closes at L295; `runners` is registered as a sibling at L298) and mounts its own `WorkspaceShell` **without** the provider.

So on the runners route the sidebar rendered the button, the click flipped the store flag, but no modal host was listening — nothing opened. (Prompts / Schedulers / AI Dev Machines are nested *inside* `(projects)`, so they inherit the provider and were unaffected.)

## Fix

Mount `<ProjectsAppPowerKProvider />` in `apps/web/app/(all)/[workspaceSlug]/runners/layout.tsx`, on both the authorized and not-authorized return paths — mirroring the other workspace layouts. As a bonus this also restores the **Cmd+K** command palette on runners pages.

No double-mount risk: runners is a separate route subtree from `(projects)`, so the provider is never rendered twice on the same route.

## Validation

- `oxlint` on the changed file: 0 warnings / 0 errors.
- `check:types` for the changed file is clean (the repo-wide pre-existing type failures are in unrelated files — stale `@pi-dash/types` dist — and do not reference this file).
- Verified routing nesting in `routes/core.ts` confirms runners is the only sidebar-bearing workspace layout missing the provider.

Fixes PDASHOSS01-25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
