### PR TITLE
PDASHOSS01-23 there is UI issue in Install scheduler

### DIFF
--- a/apps/web/core/components/project/scheduler-bindings/binding-schedule-fields.tsx
+++ b/apps/web/core/components/project/scheduler-bindings/binding-schedule-fields.tsx
@@ -109,7 +109,7 @@ export function BindingScheduleFields<T extends FieldValues>({
             <TextArea
               {...field}
               id={`field-${String(rruleName)}`}
-              rows={2}
+              className="min-h-[56px] text-13"
               placeholder="FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR;BYHOUR=9;BYMINUTE=0"
               hasError={!!rruleErr}
             />
@@ -133,7 +133,7 @@ export function BindingScheduleFields<T extends FieldValues>({
             <TextArea
               {...field}
               id={`field-${String(extraContextName)}`}
-              rows={4}
+              className="min-h-[96px] text-13"
               placeholder={t("Notes specific to this project…")}
             />
           )}


### PR DESCRIPTION
## Problem

On the scheduler install/edit modals (`/…/schedulers/list`), the **Recurrence (RRULE)** and **Project context (optional)** fields rendered too short — content was clipped and users had to scroll inside the field to read the bottom half.

## Root cause

Both textareas were sized with bare `rows={2}` / `rows={4}` and **no `min-h` floor**. The shared `useAutoResizeTextArea` hook overrides `rows` by setting an inline `style.height` from `scrollHeight`. When that measurement comes in short — e.g. web-font reflow after first paint, or the edit modal mounting before `reset()` populates the fields — there is no floor to catch it, and the `no-scrollbar` class on `TextArea` hides the resulting overflow scrollbar. Net effect: clipped text with hidden scroll.

Every other `TextArea` in the app (project description `min-h-[102px]`, scheduler description `min-h-[60px]`, scheduler prompt `min-h-[180px]`) avoids this by using a `min-h-[...]` floor plus an explicit `text-13` line-height, and never `rows`. These two fields had simply deviated from that pattern.

## Fix

Replace `rows={2}` / `rows={4}` with `className="min-h-[56px] text-13"` and `className="min-h-[96px] text-13"`, matching the established textarea pattern. The min-height keeps the parity with the previous default heights while giving auto-resize a floor so content is never clipped.

## Validation

- `oxlint` clean on the changed file.
- `check:types` introduces no new errors (47 pre-existing errors on `main` are unaffected — none in the touched file).
- Change is CSS-only on two textareas; no behavioral/logic changes.

## Follow-up (out of scope)

`useAutoResizeTextArea` could be hardened to re-measure on `document.fonts.ready` and compensate for border-box, so future `rows`-only textareas don't regress. Left for separate triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
