### PR TITLE
PDASHOSS01-26 explain what runner is

### DIFF
--- a/apps/web/app/(all)/[workspaceSlug]/runners/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/page.tsx
@@ -118,7 +118,7 @@ const RunnersListPage = observer(function RunnersListPage() {
                     <div className="font-medium">{t("How to add a runner")}</div>
                     <div className="whitespace-pre-line text-secondary">
                       {t(
-                        '1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.'
+                        'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.'
                       )}
                     </div>
                   </div>

--- a/packages/i18n/src/locales/cs/translations.ts
+++ b/packages/i18n/src/locales/cs/translations.ts
@@ -50,8 +50,6 @@ export default {
   "1 day": "1 den",
   "1 month ago": "před 1 měsícem",
   "1 week": "1 týden",
-  '1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    '1. Klikněte na "Přidat runner", vyberte projekt + pod a vygenerujte příkaz CLI.\n2. Na stroji, který bude hostit runner, spusťte zobrazený příkaz `pidash runner add`. Pokud host ještě není přihlášen, CLI nejprve spustí `pidash auth login`.\n3. Démon zaregistruje runner a ten se zde zobrazí jako online.\n\nPředpoklad: agent CLI (codex / claude) musí být již nainstalován na hostitelském stroji.',
   "10,000-feet view of all active cycles.": "Pohled z výšky 10 000 stop na všechny aktivní cykly.",
   "2 weeks": "2 týdny",
   "3 days": "3 dny",
@@ -60,6 +58,8 @@ export default {
     "Řádek na straně cloudu, který představuje jednu instanci agenta vázanou na projekt (a volitelně na pod). Spuštěním `pidash runner add` na přihlášeném stroji se vytvoří řádek a tento stroj se naváže jako hostitel. Jeden stroj může hostit mnoho runnerů.",
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "Dlouho běžící proces na pozadí, který udržuje WebSocket relaci s Pi Dash cloudem, odesílá práci nakonfigurovanému agentovi a streamuje zpět schválení a heartbeaty. Jeden démon na stroj.",
+  'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
+    "",
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "Schopnost číst, zapisovat, upravovat a mazat entity v rámci projektů, cyklů a modulů",
   Accept: "Přijmout",

--- a/packages/i18n/src/locales/cs/translations.ts
+++ b/packages/i18n/src/locales/cs/translations.ts
@@ -59,7 +59,7 @@ export default {
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "Dlouho běžící proces na pozadí, který udržuje WebSocket relaci s Pi Dash cloudem, odesílá práci nakonfigurovanému agentovi a streamuje zpět schválení a heartbeaty. Jeden démon na stroj.",
   'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    "",
+    'Runner je instance AI agenta, která pracuje na zadaném projektu.\n\n1. Klikněte na "Přidat runner", vyberte projekt + pod a vygenerujte příkaz CLI.\n2. Na stroji, který bude hostit runner, spusťte zobrazený příkaz `pidash runner add`. Pokud host ještě není přihlášen, CLI nejprve spustí `pidash auth login`.\n3. Démon zaregistruje runner a ten se zde zobrazí jako online.\n\nPředpoklad: agent CLI (codex / claude) musí být již nainstalován na hostitelském stroji.',
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "Schopnost číst, zapisovat, upravovat a mazat entity v rámci projektů, cyklů a modulů",
   Accept: "Přijmout",

--- a/packages/i18n/src/locales/de/translations.ts
+++ b/packages/i18n/src/locales/de/translations.ts
@@ -59,7 +59,7 @@ export default {
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "Ein langlebiger Hintergrundprozess, der die WebSocket-Sitzung mit der Pi Dash Cloud aufrechterhält, Arbeit an den konfigurierten Agenten verteilt und Genehmigungen + Heartbeats zurückstreamt. Ein Daemon pro Rechner.",
   'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    "",
+    'Ein Runner ist eine KI-Agent-Instanz, die an einem bestimmten Projekt arbeitet.\n\n1. Klicken Sie auf "Add runner", wählen Sie ein Projekt + Pod und generieren Sie den CLI-Befehl.\n2. Führen Sie auf dem Rechner, der den Runner hosten wird, den angezeigten Befehl `pidash runner add` aus. Wenn der Host noch nicht angemeldet ist, startet die CLI zuerst `pidash auth login`.\n3. Der Daemon registriert den Runner und er wird hier als online angezeigt.\n\nVoraussetzung: Die Agent-CLI (codex / claude) muss bereits auf dem Host installiert sein.',
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "Fähigkeit, Entitäten in Projekten, Zyklen und Modulen zu lesen, zu schreiben, zu bearbeiten und zu löschen",
   Accept: "Akzeptieren",

--- a/packages/i18n/src/locales/de/translations.ts
+++ b/packages/i18n/src/locales/de/translations.ts
@@ -50,8 +50,6 @@ export default {
   "1 day": "1 Tag",
   "1 month ago": "vor 1 Monat",
   "1 week": "1 Woche",
-  '1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    '1. Klicken Sie auf "Add runner", wählen Sie ein Projekt + Pod und generieren Sie den CLI-Befehl.\n2. Führen Sie auf dem Rechner, der den Runner hosten wird, den angezeigten Befehl `pidash runner add` aus. Wenn der Host noch nicht angemeldet ist, startet die CLI zuerst `pidash auth login`.\n3. Der Daemon registriert den Runner und er wird hier als online angezeigt.\n\nVoraussetzung: Die Agent-CLI (codex / claude) muss bereits auf dem Host installiert sein.',
   "10,000-feet view of all active cycles.": "10.000-Fuß-Ansicht aller aktiven Zyklen.",
   "2 weeks": "2 Wochen",
   "3 days": "3 Tage",
@@ -60,6 +58,8 @@ export default {
     "Eine cloudseitige Zeile, die eine an ein Projekt (und optional einen Pod) gebundene Agenteninstanz darstellt. Das Ausführen von `pidash runner add` auf einem angemeldeten Rechner erstellt die Zeile und bindet diesen Rechner als Host. Ein Rechner kann viele Runner hosten.",
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "Ein langlebiger Hintergrundprozess, der die WebSocket-Sitzung mit der Pi Dash Cloud aufrechterhält, Arbeit an den konfigurierten Agenten verteilt und Genehmigungen + Heartbeats zurückstreamt. Ein Daemon pro Rechner.",
+  'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
+    "",
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "Fähigkeit, Entitäten in Projekten, Zyklen und Modulen zu lesen, zu schreiben, zu bearbeiten und zu löschen",
   Accept: "Akzeptieren",

--- a/packages/i18n/src/locales/en/translations.ts
+++ b/packages/i18n/src/locales/en/translations.ts
@@ -49,8 +49,6 @@ export default {
   "1 day": "1 day",
   "1 month ago": "1 month ago",
   "1 week": "1 week",
-  '1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    '1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.',
   "10,000-feet view of all active cycles.": "10,000-feet view of all active cycles.",
   "2 weeks": "2 weeks",
   "3 days": "3 days",
@@ -59,6 +57,8 @@ export default {
     "A cloud-side row that represents one agent instance bound to a project (and optionally a pod). Running `pidash runner add` on a logged-in machine creates the row and binds that machine as the host. A machine can host many runners.",
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.",
+  'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
+    'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.',
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "Ability to read, write, edit, and delete entities inside projects, cycles, and modules",
   Accept: "Accept",

--- a/packages/i18n/src/locales/es/translations.ts
+++ b/packages/i18n/src/locales/es/translations.ts
@@ -59,7 +59,7 @@ export default {
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "Un proceso de fondo de larga duración que mantiene la sesión WebSocket con Pi Dash cloud, envía trabajo al agente configurado y transmite aprobaciones + latidos de vuelta. Un daemon por máquina.",
   'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    "",
+    'Un runner es una instancia de agente de IA que trabaja en un proyecto determinado.\n\n1. Haz clic en "Add runner", selecciona un proyecto + pod y genera el comando CLI.\n2. En la máquina que alojará el runner, ejecuta el comando `pidash runner add` mostrado. Si el host aún no ha iniciado sesión, la CLI inicia `pidash auth login` primero.\n3. El daemon registra el runner y aparece en línea aquí.\n\nRequisito previo: la CLI del agente (codex / claude) ya debe estar instalada en el host.',
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "Capacidad para leer, escribir, editar y eliminar entidades dentro de proyectos, ciclos y módulos",
   Accept: "Aceptar",

--- a/packages/i18n/src/locales/es/translations.ts
+++ b/packages/i18n/src/locales/es/translations.ts
@@ -50,8 +50,6 @@ export default {
   "1 day": "1 día",
   "1 month ago": "Hace 1 mes",
   "1 week": "1 semana",
-  '1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    '1. Haz clic en "Add runner", selecciona un proyecto + pod y genera el comando CLI.\n2. En la máquina que alojará el runner, ejecuta el comando `pidash runner add` mostrado. Si el host aún no ha iniciado sesión, la CLI inicia `pidash auth login` primero.\n3. El daemon registra el runner y aparece en línea aquí.\n\nRequisito previo: la CLI del agente (codex / claude) ya debe estar instalada en el host.',
   "10,000-feet view of all active cycles.": "Vista general de todos los ciclos activos.",
   "2 weeks": "2 semanas",
   "3 days": "3 días",
@@ -60,6 +58,8 @@ export default {
     "Una fila del lado de la nube que representa una instancia de agente vinculada a un proyecto (y opcionalmente a un pod). Ejecutar `pidash runner add` en una máquina con sesión iniciada crea la fila y vincula esa máquina como host. Una máquina puede alojar muchos runners.",
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "Un proceso de fondo de larga duración que mantiene la sesión WebSocket con Pi Dash cloud, envía trabajo al agente configurado y transmite aprobaciones + latidos de vuelta. Un daemon por máquina.",
+  'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
+    "",
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "Capacidad para leer, escribir, editar y eliminar entidades dentro de proyectos, ciclos y módulos",
   Accept: "Aceptar",

--- a/packages/i18n/src/locales/fr/translations.ts
+++ b/packages/i18n/src/locales/fr/translations.ts
@@ -60,7 +60,7 @@ export default {
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "Un processus d'arrière-plan de longue durée qui maintient la session WebSocket avec le cloud Pi Dash, distribue le travail à l'agent configuré et renvoie les approbations et les battements de cœur. Un démon par machine.",
   'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    "",
+    "Un runner est une instance d'agent IA qui travaille sur un projet donné.\n\n1. Cliquez sur \"Ajouter un runner\", choisissez un projet + un pod et générez la commande CLI.\n2. Sur la machine qui hébergera le runner, exécutez la commande `pidash runner add` affichée. Si l'hôte n'est pas encore connecté, le CLI lance d'abord `pidash auth login`.\n3. Le démon enregistre le runner et il apparaît en ligne ici.\n\nPrérequis : le CLI de l'agent (codex / claude) doit déjà être installé sur l'hôte.",
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "Capacité de lire, écrire, modifier et supprimer des entités dans les projets, cycles et modules",
   Accept: "Accepter",

--- a/packages/i18n/src/locales/fr/translations.ts
+++ b/packages/i18n/src/locales/fr/translations.ts
@@ -51,8 +51,6 @@ export default {
   "1 day": "1 jour",
   "1 month ago": "il y a 1 mois",
   "1 week": "1 semaine",
-  '1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    "1. Cliquez sur \"Ajouter un runner\", choisissez un projet + un pod et générez la commande CLI.\n2. Sur la machine qui hébergera le runner, exécutez la commande `pidash runner add` affichée. Si l'hôte n'est pas encore connecté, le CLI lance d'abord `pidash auth login`.\n3. Le démon enregistre le runner et il apparaît en ligne ici.\n\nPrérequis : le CLI de l'agent (codex / claude) doit déjà être installé sur l'hôte.",
   "10,000-feet view of all active cycles.": "Vue d'ensemble de tous les cycles actifs.",
   "2 weeks": "2 semaines",
   "3 days": "3 jours",
@@ -61,6 +59,8 @@ export default {
     "Une ligne côté cloud qui représente une instance d'agent liée à un projet (et éventuellement à un pod). L'exécution de `pidash runner add` sur une machine connectée crée la ligne et lie cette machine en tant qu'hôte. Une machine peut héberger plusieurs runners.",
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "Un processus d'arrière-plan de longue durée qui maintient la session WebSocket avec le cloud Pi Dash, distribue le travail à l'agent configuré et renvoie les approbations et les battements de cœur. Un démon par machine.",
+  'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
+    "",
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "Capacité de lire, écrire, modifier et supprimer des entités dans les projets, cycles et modules",
   Accept: "Accepter",

--- a/packages/i18n/src/locales/id/translations.ts
+++ b/packages/i18n/src/locales/id/translations.ts
@@ -57,7 +57,7 @@ export default {
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "Proses latar belakang yang berjalan lama yang mempertahankan sesi WebSocket dengan cloud Pi Dash, mengirimkan pekerjaan ke agen yang dikonfigurasi, dan mengalirkan persetujuan + detak jantung kembali. Satu daemon per mesin.",
   'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    "",
+    'Runner adalah instans agen AI yang mengerjakan suatu proyek tertentu.\n\n1. Klik "Tambah runner", pilih proyek + pod dan buat perintah CLI.\n2. Pada mesin yang akan menjadi host runner, jalankan perintah `pidash runner add` yang ditampilkan. Jika host belum masuk, CLI akan memulai `pidash auth login` terlebih dahulu.\n3. Daemon mendaftarkan runner dan akan muncul online di sini.\n\nPrasyarat: CLI agen (codex / claude) harus sudah terinstal di host.',
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "Kemampuan untuk membaca, menulis, mengedit, dan menghapus entitas di dalam proyek, siklus, dan modul",
   Accept: "Terima",

--- a/packages/i18n/src/locales/id/translations.ts
+++ b/packages/i18n/src/locales/id/translations.ts
@@ -48,8 +48,6 @@ export default {
   "1 day": "1 hari",
   "1 month ago": "1 bulan yang lalu",
   "1 week": "1 minggu",
-  '1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    '1. Klik "Tambah runner", pilih proyek + pod dan buat perintah CLI.\n2. Pada mesin yang akan menjadi host runner, jalankan perintah `pidash runner add` yang ditampilkan. Jika host belum masuk, CLI akan memulai `pidash auth login` terlebih dahulu.\n3. Daemon mendaftarkan runner dan akan muncul online di sini.\n\nPrasyarat: CLI agen (codex / claude) harus sudah terinstal di host.',
   "10,000-feet view of all active cycles.": "Pandangan menyeluruh dari semua siklus aktif.",
   "2 weeks": "2 minggu",
   "3 days": "3 hari",
@@ -58,6 +56,8 @@ export default {
     "Baris sisi cloud yang mewakili satu instance agen yang terikat pada proyek (dan opsional pod). Menjalankan `pidash runner add` pada mesin yang sudah masuk akan membuat baris tersebut dan mengikat mesin itu sebagai host. Sebuah mesin dapat menjadi host bagi banyak runner.",
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "Proses latar belakang yang berjalan lama yang mempertahankan sesi WebSocket dengan cloud Pi Dash, mengirimkan pekerjaan ke agen yang dikonfigurasi, dan mengalirkan persetujuan + detak jantung kembali. Satu daemon per mesin.",
+  'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
+    "",
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "Kemampuan untuk membaca, menulis, mengedit, dan menghapus entitas di dalam proyek, siklus, dan modul",
   Accept: "Terima",

--- a/packages/i18n/src/locales/it/translations.ts
+++ b/packages/i18n/src/locales/it/translations.ts
@@ -51,8 +51,6 @@ export default {
   "1 day": "1 giorno",
   "1 month ago": "1 mese fa",
   "1 week": "1 settimana",
-  '1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    "1. Clicca su \"Add runner\", scegli un progetto + pod e genera il comando CLI.\n2. Sulla macchina che ospiterà il runner, esegui il comando `pidash runner add` visualizzato. Se l'host non ha ancora effettuato l'accesso, la CLI avvia prima `pidash auth login`.\n3. Il demone registra il runner e lo mostra online qui.\n\nPrerequisito: la CLI dell'agente (codex / claude) deve essere già installata sull'host.",
   "10,000-feet view of all active cycles.": "Vista a 10.000 piedi di tutti i cicli attivi.",
   "2 weeks": "2 settimane",
   "3 days": "3 giorni",
@@ -61,6 +59,8 @@ export default {
     "Una riga lato cloud che rappresenta un'istanza dell'agente legata a un progetto (e opzionalmente a un pod). Eseguire `pidash runner add` su una macchina connessa crea la riga e associa quella macchina come host. Una macchina può ospitare molti runner.",
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "Un processo in background a lunga esecuzione che mantiene la sessione WebSocket con Pi Dash cloud, invia lavoro all'agente configurato e trasmette approvazioni + heartbeat. Un demone per macchina.",
+  'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
+    "",
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "Capacità di leggere, scrivere, modificare ed eliminare entità all'interno di progetti, cicli e moduli",
   Accept: "Accetta",

--- a/packages/i18n/src/locales/it/translations.ts
+++ b/packages/i18n/src/locales/it/translations.ts
@@ -60,7 +60,7 @@ export default {
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "Un processo in background a lunga esecuzione che mantiene la sessione WebSocket con Pi Dash cloud, invia lavoro all'agente configurato e trasmette approvazioni + heartbeat. Un demone per macchina.",
   'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    "",
+    "Un runner è un'istanza di agente IA che lavora su un progetto specifico.\n\n1. Clicca su \"Add runner\", scegli un progetto + pod e genera il comando CLI.\n2. Sulla macchina che ospiterà il runner, esegui il comando `pidash runner add` visualizzato. Se l'host non ha ancora effettuato l'accesso, la CLI avvia prima `pidash auth login`.\n3. Il demone registra il runner e lo mostra online qui.\n\nPrerequisito: la CLI dell'agente (codex / claude) deve essere già installata sull'host.",
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "Capacità di leggere, scrivere, modificare ed eliminare entità all'interno di progetti, cicli e moduli",
   Accept: "Accetta",

--- a/packages/i18n/src/locales/ja/translations.ts
+++ b/packages/i18n/src/locales/ja/translations.ts
@@ -58,7 +58,7 @@ export default {
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "Pi Dash クラウドとのWebSocketセッションを維持し、設定されたエージェントに作業をディスパッチし、承認とハートビートをストリーミングする長時間実行のバックグラウンドプロセス。マシンごとに1つのデーモン。",
   'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    "",
+    "ランナーは、特定のプロジェクトで作業する AI エージェントのインスタンスです。\n\n1. 「ランナーを追加」をクリックし、プロジェクトとポッドを選択してCLIコマンドを生成します。\n2. ランナーをホストするマシンで、表示された `pidash runner add` コマンドを実行します。ホストがまだログインしていない場合、CLIは最初に `pidash auth login` を開始します。\n3. デーモンがランナーを登録し、ここでオンラインとして表示されます。\n\n前提条件: エージェントCLI（codex / claude）がホストに既にインストールされている必要があります。",
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "プロジェクト、サイクル、モジュール内のエンティティの読み取り、書き込み、編集、削除の機能",
   Accept: "承認",

--- a/packages/i18n/src/locales/ja/translations.ts
+++ b/packages/i18n/src/locales/ja/translations.ts
@@ -49,8 +49,6 @@ export default {
   "1 day": "1日",
   "1 month ago": "1ヶ月前",
   "1 week": "1週間",
-  '1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    "1. 「ランナーを追加」をクリックし、プロジェクトとポッドを選択してCLIコマンドを生成します。\n2. ランナーをホストするマシンで、表示された `pidash runner add` コマンドを実行します。ホストがまだログインしていない場合、CLIは最初に `pidash auth login` を開始します。\n3. デーモンがランナーを登録し、ここでオンラインとして表示されます。\n\n前提条件: エージェントCLI（codex / claude）がホストに既にインストールされている必要があります。",
   "10,000-feet view of all active cycles.": "すべてのアクティブなサイクルの俯瞰図。",
   "2 weeks": "2週間",
   "3 days": "3日",
@@ -59,6 +57,8 @@ export default {
     "プロジェクト（およびオプションでポッド）にバインドされた1つのエージェントインスタンスを表すクラウド側の行。ログインしたマシンで `pidash runner add` を実行すると、行が作成され、そのマシンがホストとしてバインドされます。1台のマシンで複数のランナーをホストできます。",
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "Pi Dash クラウドとのWebSocketセッションを維持し、設定されたエージェントに作業をディスパッチし、承認とハートビートをストリーミングする長時間実行のバックグラウンドプロセス。マシンごとに1つのデーモン。",
+  'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
+    "",
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "プロジェクト、サイクル、モジュール内のエンティティの読み取り、書き込み、編集、削除の機能",
   Accept: "承認",

--- a/packages/i18n/src/locales/ko/translations.ts
+++ b/packages/i18n/src/locales/ko/translations.ts
@@ -48,8 +48,6 @@ export default {
   "1 day": "1일",
   "1 month ago": "1개월 전",
   "1 week": "1주",
-  '1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    '1. "Add runner"를 클릭하고 프로젝트 + 포드를 선택한 후 CLI 명령어를 생성합니다.\n2. 러너를 호스팅할 머신에서 표시된 `pidash runner add` 명령어를 실행합니다. 호스트가 아직 로그인하지 않은 경우 CLI가 먼저 `pidash auth login`을 시작합니다.\n3. 데몬이 러너를 등록하고 여기에 온라인으로 표시됩니다.\n\n전제 조건: 에이전트 CLI(codex / claude)가 호스트에 이미 설치되어 있어야 합니다.',
   "10,000-feet view of all active cycles.": "모든 활성 사이클의 개괄적인 보기.",
   "2 weeks": "2주",
   "3 days": "3일",
@@ -58,6 +56,8 @@ export default {
     "프로젝트(및 선택적으로 포드)에 바인딩된 하나의 에이전트 인스턴스를 나타내는 클라우드 측 행입니다. 로그인된 머신에서 `pidash runner add`를 실행하면 행이 생성되고 해당 머신이 호스트로 바인딩됩니다. 하나의 머신은 여러 러너를 호스팅할 수 있습니다.",
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "Pi Dash 클라우드와의 WebSocket 세션을 유지하고, 구성된 에이전트에 작업을 전달하며, 승인 및 하트비트를 다시 스트리밍하는 장기 실행 백그라운드 프로세스입니다. 머신당 하나의 데몬.",
+  'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
+    "",
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "프로젝트, 사이클 및 모듈 내의 엔터티를 읽고, 쓰고, 편집하고, 삭제할 수 있는 기능",
   Accept: "수락",

--- a/packages/i18n/src/locales/ko/translations.ts
+++ b/packages/i18n/src/locales/ko/translations.ts
@@ -57,7 +57,7 @@ export default {
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "Pi Dash 클라우드와의 WebSocket 세션을 유지하고, 구성된 에이전트에 작업을 전달하며, 승인 및 하트비트를 다시 스트리밍하는 장기 실행 백그라운드 프로세스입니다. 머신당 하나의 데몬.",
   'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    "",
+    '러너는 특정 프로젝트에서 작업하는 AI 에이전트 인스턴스입니다.\n\n1. "Add runner"를 클릭하고 프로젝트 + 포드를 선택한 후 CLI 명령어를 생성합니다.\n2. 러너를 호스팅할 머신에서 표시된 `pidash runner add` 명령어를 실행합니다. 호스트가 아직 로그인하지 않은 경우 CLI가 먼저 `pidash auth login`을 시작합니다.\n3. 데몬이 러너를 등록하고 여기에 온라인으로 표시됩니다.\n\n전제 조건: 에이전트 CLI(codex / claude)가 호스트에 이미 설치되어 있어야 합니다.',
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "프로젝트, 사이클 및 모듈 내의 엔터티를 읽고, 쓰고, 편집하고, 삭제할 수 있는 기능",
   Accept: "수락",

--- a/packages/i18n/src/locales/pl/translations.ts
+++ b/packages/i18n/src/locales/pl/translations.ts
@@ -49,8 +49,6 @@ export default {
   "1 day": "1 dzień",
   "1 month ago": "1 miesiąc temu",
   "1 week": "1 tydzień",
-  '1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    '1. Kliknij "Add runner", wybierz projekt + pod i wygeneruj polecenie CLI.\n2. Na maszynie, która będzie hostować runnera, uruchom wyświetlone polecenie `pidash runner add`. Jeśli host nie jest jeszcze zalogowany, CLI najpierw uruchamia `pidash auth login`.\n3. Demon rejestruje runnera i pojawia się on tutaj jako online.\n\nWymaganie wstępne: agent CLI (codex / claude) musi być już zainstalowany na hoście.',
   "10,000-feet view of all active cycles.": "Widok z lotu ptaka wszystkich aktywnych cykli.",
   "2 weeks": "2 tygodnie",
   "3 days": "3 dni",
@@ -59,6 +57,8 @@ export default {
     "Wiersz po stronie chmury reprezentujący jedną instancję agenta powiązaną z projektem (i opcjonalnie podem). Uruchomienie `pidash runner add` na zalogowanej maszynie tworzy wiersz i wiąże tę maszynę jako hosta. Jedna maszyna może hostować wielu runnerów.",
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "Długotrwały proces w tle, który utrzymuje sesję WebSocket z chmurą Pi Dash, wysyła pracę do skonfigurowanego agenta i strumieniuje zatwierdzenia + sygnały aktywności z powrotem. Jeden demon na maszynę.",
+  'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
+    "",
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "Możliwość odczytu, zapisu, edycji i usuwania encji w projektach, cyklach i modułach",
   Accept: "Akceptuj",

--- a/packages/i18n/src/locales/pl/translations.ts
+++ b/packages/i18n/src/locales/pl/translations.ts
@@ -58,7 +58,7 @@ export default {
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "Długotrwały proces w tle, który utrzymuje sesję WebSocket z chmurą Pi Dash, wysyła pracę do skonfigurowanego agenta i strumieniuje zatwierdzenia + sygnały aktywności z powrotem. Jeden demon na maszynę.",
   'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    "",
+    'Runner to instancja agenta AI pracująca nad danym projektem.\n\n1. Kliknij "Add runner", wybierz projekt + pod i wygeneruj polecenie CLI.\n2. Na maszynie, która będzie hostować runnera, uruchom wyświetlone polecenie `pidash runner add`. Jeśli host nie jest jeszcze zalogowany, CLI najpierw uruchamia `pidash auth login`.\n3. Demon rejestruje runnera i pojawia się on tutaj jako online.\n\nWymaganie wstępne: agent CLI (codex / claude) musi być już zainstalowany na hoście.',
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "Możliwość odczytu, zapisu, edycji i usuwania encji w projektach, cyklach i modułach",
   Accept: "Akceptuj",

--- a/packages/i18n/src/locales/pt-BR/translations.ts
+++ b/packages/i18n/src/locales/pt-BR/translations.ts
@@ -59,7 +59,7 @@ export default {
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "Um processo de segundo plano de longa duração que mantém a sessão WebSocket com a nuvem Pi Dash, despacha trabalho para o agente configurado e transmite aprovações + heartbeats de volta. Um daemon por máquina.",
   'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    "",
+    'Um runner é uma instância de agente de IA que trabalha em um projeto específico.\n\n1. Clique em "Adicionar runner", escolha um projeto + pod e gere o comando CLI.\n2. Na máquina que hospedará o runner, execute o comando `pidash runner add` exibido. Se o host ainda não estiver logado, a CLI inicia `pidash auth login` primeiro.\n3. O daemon registra o runner e ele aparece online aqui.\n\nPré-requisito: a CLI do agente (codex / claude) já deve estar instalada no host.',
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "Capacidade de ler, escrever, editar e excluir entidades dentro de projetos, ciclos e módulos",
   Accept: "Aceitar",

--- a/packages/i18n/src/locales/pt-BR/translations.ts
+++ b/packages/i18n/src/locales/pt-BR/translations.ts
@@ -50,8 +50,6 @@ export default {
   "1 day": "1 dia",
   "1 month ago": "1 mês atrás",
   "1 week": "1 semana",
-  '1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    '1. Clique em "Adicionar runner", escolha um projeto + pod e gere o comando CLI.\n2. Na máquina que hospedará o runner, execute o comando `pidash runner add` exibido. Se o host ainda não estiver logado, a CLI inicia `pidash auth login` primeiro.\n3. O daemon registra o runner e ele aparece online aqui.\n\nPré-requisito: a CLI do agente (codex / claude) já deve estar instalada no host.',
   "10,000-feet view of all active cycles.": "Visão geral de todos os ciclos ativos.",
   "2 weeks": "2 semanas",
   "3 days": "3 dias",
@@ -60,6 +58,8 @@ export default {
     "Uma linha do lado da nuvem que representa uma instância de agente vinculada a um projeto (e opcionalmente a um pod). Executar `pidash runner add` em uma máquina logada cria a linha e vincula essa máquina como host. Uma máquina pode hospedar muitos runners.",
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "Um processo de segundo plano de longa duração que mantém a sessão WebSocket com a nuvem Pi Dash, despacha trabalho para o agente configurado e transmite aprovações + heartbeats de volta. Um daemon por máquina.",
+  'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
+    "",
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "Capacidade de ler, escrever, editar e excluir entidades dentro de projetos, ciclos e módulos",
   Accept: "Aceitar",

--- a/packages/i18n/src/locales/ro/translations.ts
+++ b/packages/i18n/src/locales/ro/translations.ts
@@ -59,7 +59,7 @@ export default {
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "Un proces de fundal de lungă durată care menține sesiunea WebSocket cu cloud-ul Pi Dash, trimite lucrări agentului configurat și transmite înapoi aprobări + bătăi de inimă (heartbeats). Un daemon per mașină.",
   'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    "",
+    'Un runner este o instanță de agent AI care lucrează la un anumit proiect.\n\n1. Faceți clic pe "Add runner", alegeți un proiect + pod și generați comanda CLI.\n2. Pe mașina care va găzdui runner-ul, rulați comanda `pidash runner add` afișată. Dacă gazda nu este încă autentificată, CLI-ul pornește mai întâi `pidash auth login`.\n3. Daemon-ul înregistrează runner-ul și acesta apare online aici.\n\nCondiție prealabilă: agentul CLI (codex / claude) trebuie să fie deja instalat pe gazdă.',
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "Abilitatea de a citi, scrie, edita și șterge entități în cadrul proiectelor, ciclurilor și modulelor",
   Accept: "Acceptă",

--- a/packages/i18n/src/locales/ro/translations.ts
+++ b/packages/i18n/src/locales/ro/translations.ts
@@ -50,8 +50,6 @@ export default {
   "1 day": "1 zi",
   "1 month ago": "acum o lună",
   "1 week": "1 săptămână",
-  '1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    '1. Faceți clic pe "Add runner", alegeți un proiect + pod și generați comanda CLI.\n2. Pe mașina care va găzdui runner-ul, rulați comanda `pidash runner add` afișată. Dacă gazda nu este încă autentificată, CLI-ul pornește mai întâi `pidash auth login`.\n3. Daemon-ul înregistrează runner-ul și acesta apare online aici.\n\nCondiție prealabilă: agentul CLI (codex / claude) trebuie să fie deja instalat pe gazdă.',
   "10,000-feet view of all active cycles.": "Vedere de ansamblu (la 10.000 de picioare) a tuturor ciclurilor active.",
   "2 weeks": "2 săptămâni",
   "3 days": "3 zile",
@@ -60,6 +58,8 @@ export default {
     "Un rând din partea cloud care reprezintă o instanță de agent legată de un proiect (și opțional de un pod). Executarea comenzii `pidash runner add` pe o mașină autentificată creează rândul și leagă acea mașină ca gazdă. O mașină poate găzdui mai mulți runneri.",
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "Un proces de fundal de lungă durată care menține sesiunea WebSocket cu cloud-ul Pi Dash, trimite lucrări agentului configurat și transmite înapoi aprobări + bătăi de inimă (heartbeats). Un daemon per mașină.",
+  'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
+    "",
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "Abilitatea de a citi, scrie, edita și șterge entități în cadrul proiectelor, ciclurilor și modulelor",
   Accept: "Acceptă",

--- a/packages/i18n/src/locales/ru/translations.ts
+++ b/packages/i18n/src/locales/ru/translations.ts
@@ -61,7 +61,7 @@ export default {
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "Долго работающий фоновый процесс, который поддерживает сессию WebSocket с Pi Dash cloud, отправляет работу настроенному агенту и передаёт обратно подтверждения + сигналы пульса. Один демон на машину.",
   'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    "",
+    "Раннер — это экземпляр ИИ-агента, работающий над заданным проектом.\n\n1. Нажмите «Add runner», выберите проект + под и сгенерируйте команду CLI.\n2. На машине, которая будет хостить раннер, выполните отображаемую команду `pidash runner add`. Если хост ещё не вошёл в систему, CLI сначала запускает `pidash auth login`.\n3. Демон регистрирует раннер, и он отображается как онлайн здесь.\n\nПредварительное условие: агент CLI (codex / claude) уже должен быть установлен на хосте.",
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "Возможность читать, записывать, редактировать и удалять сущности внутри проектов, циклов и модулей",
   Accept: "Принять",

--- a/packages/i18n/src/locales/ru/translations.ts
+++ b/packages/i18n/src/locales/ru/translations.ts
@@ -52,8 +52,6 @@ export default {
   "1 day": "1 день",
   "1 month ago": "1 месяц назад",
   "1 week": "1 неделя",
-  '1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    "1. Нажмите «Add runner», выберите проект + под и сгенерируйте команду CLI.\n2. На машине, которая будет хостить раннер, выполните отображаемую команду `pidash runner add`. Если хост ещё не вошёл в систему, CLI сначала запускает `pidash auth login`.\n3. Демон регистрирует раннер, и он отображается как онлайн здесь.\n\nПредварительное условие: агент CLI (codex / claude) уже должен быть установлен на хосте.",
   "10,000-feet view of all active cycles.": "Обзор всех активных циклов с высоты 10 000 футов.",
   "2 weeks": "2 недели",
   "3 days": "3 дня",
@@ -62,6 +60,8 @@ export default {
     "Облачная строка, представляющая один экземпляр агента, привязанный к проекту (и, опционально, к поду). Выполнение `pidash runner add` на авторизованной машине создаёт строку и привязывает эту машину как хост. Одна машина может хостить много раннеров.",
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "Долго работающий фоновый процесс, который поддерживает сессию WebSocket с Pi Dash cloud, отправляет работу настроенному агенту и передаёт обратно подтверждения + сигналы пульса. Один демон на машину.",
+  'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
+    "",
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "Возможность читать, записывать, редактировать и удалять сущности внутри проектов, циклов и модулей",
   Accept: "Принять",

--- a/packages/i18n/src/locales/sk/translations.ts
+++ b/packages/i18n/src/locales/sk/translations.ts
@@ -59,7 +59,7 @@ export default {
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "Dlho bežiaci proces na pozadí, ktorý udržiava WebSocket reláciu s Pi Dash cloudom, odosiela prácu nakonfigurovanému agentovi a streamuje späť schválenia a heartbeaty. Jeden daemon na stroj.",
   'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    "",
+    "Runner je inštancia AI agenta, ktorá pracuje na zadanom projekte.\n\n1. Kliknite na „Add runner“, vyberte projekt + pod a vygenerujte príkaz CLI.\n2. Na stroji, ktorý bude hostiť runner, spustite zobrazený príkaz `pidash runner add`. Ak hostiteľ ešte nie je prihlásený, CLI najprv spustí `pidash auth login`.\n3. Daemon zaregistruje runner a ten sa tu zobrazí ako online.\n\nPredpoklad: agent CLI (codex / claude) musí byť už nainštalovaný na hostiteľovi.",
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "Schopnosť čítať, zapisovať, upravovať a mazať entity v rámci projektov, cyklov a modulov",
   Accept: "Prijať",

--- a/packages/i18n/src/locales/sk/translations.ts
+++ b/packages/i18n/src/locales/sk/translations.ts
@@ -50,8 +50,6 @@ export default {
   "1 day": "1 deň",
   "1 month ago": "pred 1 mesiacom",
   "1 week": "1 týždeň",
-  '1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    "1. Kliknite na „Add runner“, vyberte projekt + pod a vygenerujte príkaz CLI.\n2. Na stroji, ktorý bude hostiť runner, spustite zobrazený príkaz `pidash runner add`. Ak hostiteľ ešte nie je prihlásený, CLI najprv spustí `pidash auth login`.\n3. Daemon zaregistruje runner a ten sa tu zobrazí ako online.\n\nPredpoklad: agent CLI (codex / claude) musí byť už nainštalovaný na hostiteľovi.",
   "10,000-feet view of all active cycles.": "Pohľad z výšky 10 000 stôp na všetky aktívne cykly.",
   "2 weeks": "2 týždne",
   "3 days": "3 dni",
@@ -60,6 +58,8 @@ export default {
     "Riadok na strane cloudu, ktorý predstavuje jednu inštanciu agenta viazanú na projekt (a voliteľne na pod). Spustením `pidash runner add` na prihlásenom stroji sa vytvorí riadok a tento stroj sa viaže ako hostiteľ. Jeden stroj môže hostiť viacero runnerov.",
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "Dlho bežiaci proces na pozadí, ktorý udržiava WebSocket reláciu s Pi Dash cloudom, odosiela prácu nakonfigurovanému agentovi a streamuje späť schválenia a heartbeaty. Jeden daemon na stroj.",
+  'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
+    "",
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "Schopnosť čítať, zapisovať, upravovať a mazať entity v rámci projektov, cyklov a modulov",
   Accept: "Prijať",

--- a/packages/i18n/src/locales/tr-TR/translations.ts
+++ b/packages/i18n/src/locales/tr-TR/translations.ts
@@ -58,7 +58,7 @@ export default {
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "Pi Dash bulutu ile WebSocket oturumunu sürdüren, yapılandırılmış aracıya iş gönderen ve onaylar + kalp atışlarını geri akıtan uzun süreli bir arka plan işlemi. Makine başına bir daemon.",
   'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    "",
+    "Runner, belirli bir proje üzerinde çalışan bir yapay zekâ aracı örneğidir.\n\n1. \"Runner Ekle\"ye tıklayın, bir proje + pod seçin ve CLI komutunu oluşturun.\n2. Runner'ı barındıracak makinede, görüntülenen `pidash runner add` komutunu çalıştırın. Ana bilgisayar henüz oturum açmamışsa, CLI önce `pidash auth login` başlatır.\n3. Daemon runner'ı kaydeder ve burada çevrimiçi olarak gösterilir.\n\nÖn koşul: aracı CLI'si (codex / claude) ana bilgisayara zaten yüklenmiş olmalıdır.",
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "Projeler, döngüler ve modüller içindeki varlıkları okuma, yazma, düzenleme ve silme yeteneği",
   Accept: "Kabul Et",

--- a/packages/i18n/src/locales/tr-TR/translations.ts
+++ b/packages/i18n/src/locales/tr-TR/translations.ts
@@ -49,8 +49,6 @@ export default {
   "1 day": "1 gün",
   "1 month ago": "1 ay önce",
   "1 week": "1 hafta",
-  '1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    "1. \"Runner Ekle\"ye tıklayın, bir proje + pod seçin ve CLI komutunu oluşturun.\n2. Runner'ı barındıracak makinede, görüntülenen `pidash runner add` komutunu çalıştırın. Ana bilgisayar henüz oturum açmamışsa, CLI önce `pidash auth login` başlatır.\n3. Daemon runner'ı kaydeder ve burada çevrimiçi olarak gösterilir.\n\nÖn koşul: aracı CLI'si (codex / claude) ana bilgisayara zaten yüklenmiş olmalıdır.",
   "10,000-feet view of all active cycles.": "Tüm aktif döngülerin 10.000 fitlik görünümü.",
   "2 weeks": "2 hafta",
   "3 days": "3 gün",
@@ -59,6 +57,8 @@ export default {
     "Bir projeye (ve isteğe bağlı olarak bir pod'a) bağlı bir aracı örneğini temsil eden bulut tarafı satırı. Oturum açmış bir makinede `pidash runner add` çalıştırmak satırı oluşturur ve o makineyi ana bilgisayar olarak bağlar. Bir makine birçok runner'ı barındırabilir.",
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "Pi Dash bulutu ile WebSocket oturumunu sürdüren, yapılandırılmış aracıya iş gönderen ve onaylar + kalp atışlarını geri akıtan uzun süreli bir arka plan işlemi. Makine başına bir daemon.",
+  'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
+    "",
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "Projeler, döngüler ve modüller içindeki varlıkları okuma, yazma, düzenleme ve silme yeteneği",
   Accept: "Kabul Et",

--- a/packages/i18n/src/locales/ua/translations.ts
+++ b/packages/i18n/src/locales/ua/translations.ts
@@ -60,7 +60,7 @@ export default {
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "Довготривалий фоновий процес, який підтримує сеанс WebSocket з Pi Dash cloud, надсилає роботу налаштованому агенту та передає назад схвалення + пульс. Один демон на машину.",
   'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    "",
+    'Раннер — це екземпляр ШІ-агента, що працює над заданим проєктом.\n\n1. Натисніть "Add runner", виберіть проєкт + под і згенеруйте команду CLI.\n2. На машині, яка буде хостом для раннера, виконайте показану команду `pidash runner add`. Якщо хост ще не авторизований, CLI спочатку запускає `pidash auth login`.\n3. Демон реєструє раннер, і він з\'являється тут як онлайн.\n\nПередумова: агент CLI (codex / claude) вже має бути встановлений на хості.',
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "Можливість читати, записувати, редагувати та видаляти сутності в проєктах, циклах і модулях.",
   Accept: "Прийняти",

--- a/packages/i18n/src/locales/ua/translations.ts
+++ b/packages/i18n/src/locales/ua/translations.ts
@@ -51,8 +51,6 @@ export default {
   "1 day": "1 день",
   "1 month ago": "1 місяць тому",
   "1 week": "1 тиждень",
-  '1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    '1. Натисніть "Add runner", виберіть проєкт + под і згенеруйте команду CLI.\n2. На машині, яка буде хостом для раннера, виконайте показану команду `pidash runner add`. Якщо хост ще не авторизований, CLI спочатку запускає `pidash auth login`.\n3. Демон реєструє раннер, і він з\'являється тут як онлайн.\n\nПередумова: агент CLI (codex / claude) вже має бути встановлений на хості.',
   "10,000-feet view of all active cycles.": "10 000-футовий огляд усіх активних циклів.",
   "2 weeks": "2 тижні",
   "3 days": "3 дні",
@@ -61,6 +59,8 @@ export default {
     "Хмарний рядок, який представляє один екземпляр агента, прив'язаний до проєкту (і, за бажанням, до пода). Виконання `pidash runner add` на авторизованій машині створює рядок і прив'язує цю машину як хост. Одна машина може розміщувати багато раннерів.",
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "Довготривалий фоновий процес, який підтримує сеанс WebSocket з Pi Dash cloud, надсилає роботу налаштованому агенту та передає назад схвалення + пульс. Один демон на машину.",
+  'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
+    "",
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "Можливість читати, записувати, редагувати та видаляти сутності в проєктах, циклах і модулях.",
   Accept: "Прийняти",

--- a/packages/i18n/src/locales/vi-VN/translations.ts
+++ b/packages/i18n/src/locales/vi-VN/translations.ts
@@ -58,7 +58,7 @@ export default {
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "Một tiến trình nền chạy lâu dài duy trì phiên WebSocket với đám mây Pi Dash, phân phối công việc cho agent đã cấu hình và truyền phê duyệt + tín hiệu nhịp tim trở lại. Một daemon cho mỗi máy.",
   'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    "",
+    'Runner là một thực thể tác nhân AI làm việc trên một dự án cụ thể.\n\n1. Nhấp "Add runner", chọn một dự án + pod và tạo lệnh CLI.\n2. Trên máy sẽ lưu trữ runner, chạy lệnh `pidash runner add` được hiển thị. Nếu máy chủ chưa đăng nhập, CLI sẽ bắt đầu `pidash auth login` trước.\n3. Daemon đăng ký runner và nó hiển thị trực tuyến ở đây.\n\nĐiều kiện tiên quyết: CLI agent (codex / claude) phải được cài đặt trên máy chủ.',
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "Khả năng đọc, ghi, chỉnh sửa và xóa các thực thể trong dự án, chu kỳ và mô-đun",
   Accept: "Chấp nhận",

--- a/packages/i18n/src/locales/vi-VN/translations.ts
+++ b/packages/i18n/src/locales/vi-VN/translations.ts
@@ -49,8 +49,6 @@ export default {
   "1 day": "1 ngày",
   "1 month ago": "1 tháng trước",
   "1 week": "1 tuần",
-  '1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    '1. Nhấp "Add runner", chọn một dự án + pod và tạo lệnh CLI.\n2. Trên máy sẽ lưu trữ runner, chạy lệnh `pidash runner add` được hiển thị. Nếu máy chủ chưa đăng nhập, CLI sẽ bắt đầu `pidash auth login` trước.\n3. Daemon đăng ký runner và nó hiển thị trực tuyến ở đây.\n\nĐiều kiện tiên quyết: CLI agent (codex / claude) phải được cài đặt trên máy chủ.',
   "10,000-feet view of all active cycles.": "Tổng quan cấp cao về tất cả các chu kỳ đang hoạt động.",
   "2 weeks": "2 tuần",
   "3 days": "3 ngày",
@@ -59,6 +57,8 @@ export default {
     "Một hàng phía đám mây đại diện cho một phiên bản agent được liên kết với một dự án (và tùy chọn một pod). Chạy `pidash runner add` trên máy đã đăng nhập sẽ tạo hàng và liên kết máy đó làm máy chủ. Một máy có thể lưu trữ nhiều runner.",
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "Một tiến trình nền chạy lâu dài duy trì phiên WebSocket với đám mây Pi Dash, phân phối công việc cho agent đã cấu hình và truyền phê duyệt + tín hiệu nhịp tim trở lại. Một daemon cho mỗi máy.",
+  'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
+    "",
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "Khả năng đọc, ghi, chỉnh sửa và xóa các thực thể trong dự án, chu kỳ và mô-đun",
   Accept: "Chấp nhận",

--- a/packages/i18n/src/locales/zh-CN/translations.ts
+++ b/packages/i18n/src/locales/zh-CN/translations.ts
@@ -57,7 +57,7 @@ export default {
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "一个长期运行的后台进程，维护与 Pi Dash 云的 WebSocket 会话，将工作分派给配置的代理，并流式返回审批和心跳。每台机器一个守护进程。",
   'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    "",
+    "运行器是在指定项目上工作的 AI 代理实例。\n\n1. 点击“添加运行器”，选择一个项目 + pod 并生成 CLI 命令。\n2. 在将托管运行器的机器上，运行显示的 `pidash runner add` 命令。如果主机尚未登录，CLI 会先启动 `pidash auth login`。\n3. 守护进程注册运行器，并在此处显示为在线。\n\n前提条件：代理 CLI（codex / claude）必须已安装在主机上。",
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "在项目、周期和模块内读取、写入、编辑和删除实体的能力",
   Accept: "接受",

--- a/packages/i18n/src/locales/zh-CN/translations.ts
+++ b/packages/i18n/src/locales/zh-CN/translations.ts
@@ -48,8 +48,6 @@ export default {
   "1 day": "1 天",
   "1 month ago": "1个月前",
   "1 week": "1周",
-  '1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    "1. 点击“添加运行器”，选择一个项目 + pod 并生成 CLI 命令。\n2. 在将托管运行器的机器上，运行显示的 `pidash runner add` 命令。如果主机尚未登录，CLI 会先启动 `pidash auth login`。\n3. 守护进程注册运行器，并在此处显示为在线。\n\n前提条件：代理 CLI（codex / claude）必须已安装在主机上。",
   "10,000-feet view of all active cycles.": "所有活跃周期的鸟瞰图。",
   "2 weeks": "2周",
   "3 days": "3天",
@@ -58,6 +56,8 @@ export default {
     "一个云端的行，代表绑定到项目（以及可选的 pod）的一个代理实例。在已登录的机器上运行 `pidash runner add` 会创建该行并将该机器绑定为主机。一台机器可以托管多个运行器。",
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "一个长期运行的后台进程，维护与 Pi Dash 云的 WebSocket 会话，将工作分派给配置的代理，并流式返回审批和心跳。每台机器一个守护进程。",
+  'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
+    "",
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "在项目、周期和模块内读取、写入、编辑和删除实体的能力",
   Accept: "接受",

--- a/packages/i18n/src/locales/zh-TW/translations.ts
+++ b/packages/i18n/src/locales/zh-TW/translations.ts
@@ -48,8 +48,6 @@ export default {
   "1 day": "1 天",
   "1 month ago": "1 個月前",
   "1 week": "1 週",
-  '1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    "1. 點擊「新增執行器」，選擇專案 + Pod 並產生 CLI 指令。\n2. 在將託管執行器的機器上，執行顯示的 `pidash runner add` 指令。如果主機尚未登入，CLI 會先啟動 `pidash auth login`。\n3. 守護程序會註冊執行器，並在此處顯示為上線狀態。\n\n先決條件：代理 CLI（codex / claude）必須已安裝在主機上。",
   "10,000-feet view of all active cycles.": "所有進行中週期的鳥瞰圖。",
   "2 weeks": "2 週",
   "3 days": "3 天",
@@ -58,6 +56,8 @@ export default {
     "一個雲端端的列，代表一個繫結到專案（以及可選的 Pod）的代理執行個體。在已登入的機器上執行 `pidash runner add` 會建立該列，並將該機器繫結為主機。一台機器可以託管多個執行器。",
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "一個長時間執行的背景程序，負責維護與 Pi Dash 雲端的 WebSocket 連線，將工作分派給已設定的代理，並串流回核准與心跳訊號。每台機器一個守護程序。",
+  'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
+    "",
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "能夠讀取、寫入、編輯和刪除專案、週期和模組內的實體",
   Accept: "接受",

--- a/packages/i18n/src/locales/zh-TW/translations.ts
+++ b/packages/i18n/src/locales/zh-TW/translations.ts
@@ -57,7 +57,7 @@ export default {
   "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.":
     "一個長時間執行的背景程序，負責維護與 Pi Dash 雲端的 WebSocket 連線，將工作分派給已設定的代理，並串流回核准與心跳訊號。每台機器一個守護程序。",
   'A runner is an AI agent instance working on a given project.\n\n1. Click "Add runner", pick a project + pod and generate the CLI command.\n2. On the machine that will host the runner, run the displayed `pidash runner add` command. If the host is not logged in yet, the CLI starts `pidash auth login` first.\n3. The daemon registers the runner and it shows online here.\n\nPrerequisite: the agent CLI (codex / claude) must already be installed on the host.':
-    "",
+    "執行器是在指定專案上運作的 AI 代理執行個體。\n\n1. 點擊「新增執行器」，選擇專案 + Pod 並產生 CLI 指令。\n2. 在將託管執行器的機器上，執行顯示的 `pidash runner add` 指令。如果主機尚未登入，CLI 會先啟動 `pidash auth login`。\n3. 守護程序會註冊執行器，並在此處顯示為上線狀態。\n\n先決條件：代理 CLI（codex / claude）必須已安裝在主機上。",
   "Ability to read, write, edit, and delete entities inside projects, cycles, and modules":
     "能夠讀取、寫入、編輯和刪除專案、週期和模組內的實體",
   Accept: "接受",


### PR DESCRIPTION
## What

Adds a one-sentence definition to the start of the "How to add a runner" tooltip so it explains what a runner *is* before listing the how-to steps:

> A runner is an AI agent instance working on a given project.

followed by the existing numbered steps, unchanged.

## Why

PDASHOSS01-26 — the tooltip jumped straight into how to add a runner without first saying what a runner is. The leading sentence gives newcomers context before the steps.

## Changes

- `apps/web/app/(all)/[workspaceSlug]/runners/page.tsx` — prepend the definition sentence to the tooltip body string.
- `packages/i18n/src/locales/*/translations.ts` — re-ran `pnpm i18n:sync` to register the new message id. Non-English locales fall back to English until refilled with `pnpm i18n:translate`.

## Validation

- `pnpm i18n:sync` ran clean.
- `npx oxlint` on the touched component → 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
