### PR TITLE
feat(loop): Auto Project Management — periodic assistant jobs

### DIFF
--- a/.ai_design/loop_project_management/design.md
+++ b/.ai_design/loop_project_management/design.md
@@ -1,0 +1,666 @@
+# Loop (Auto Project Management) — Design
+
+**Status:** Draft
+**Date:** 2026-06-12
+**Scope:** MVP. Instance-defined "loop jobs" (prompt + timer) that periodically run each user's **AI assistant** against each workspace they belong to, performing routine issue management on their behalf. Backend (catalog + Beat + dispatch through the existing assistant runtime), a user-facing enable/disable surface in `apps/web` settings, and a job-management page in `apps/admin`.
+
+**Naming rule:** "Loop" is the internal/code name only. Every user-visible string says **"Auto Project Management"** (settings section, descriptions, API route segment `auto-pm`). Writes the loop makes are attributed exactly like the assistant's: comments carry `speaker_label="Pi Dash AI"`. Only the instance-admin UI (`apps/admin`) may use the word "Loop".
+
+---
+
+## 1. Problem
+
+PR #233 shipped a native AI assistant (`apps/api/pi_dash/assistant/`): a chat agent that can search, read, create, update, and comment on the user's issues, running under the user's identity, the user's BYOK LLM key, and the user's workspace/project permissions. But it only acts when the user types at it.
+
+A large class of project-management work is _routine_: "close issues whose PR merged", "flag stale issues", "nudge unassigned work". Users shouldn't have to ask for these every day — the platform should run them automatically and the user should simply benefit from the result.
+
+We want a **loop**: a set of instance-defined jobs (prompt + timer), authored by the instance operator (AI Republic on Pi Dash Cloud), that periodically execute through each user's assistant in each workspace they belong to.
+
+## 2. Decisions already made (settled in discussion — do not re-litigate)
+
+1. **A loop run executes _as the user_.** Same identity, same BYOK `UserLLMConfig`, same role/membership enforcement as a chat turn. What the user can do, the loop can do; what the user can't, the loop can't. There is **no** service account, no system actor, no permission bypass of any kind.
+2. **The unit of execution is the membership edge.** userA∈ws1, userB∈ws1, userA∈ws2 → three independent loops. There is no workspace-level or delegate execution, ever.
+3. **Jobs are instance-level and opaque in operation.** The operator defines jobs in the admin platform; they auto-apply to every membership edge. Users cannot create/edit jobs, change prompts, or change timers.
+4. **Users can enable/disable.** An "Auto Project Management" section in user settings lists the jobs with on/off toggles (default **on**) plus a master pause. Toggle only — no editing.
+5. **Quiet failure is fine.** A job a user lacks permission for (e.g. an admin-only job running under a member account) silently does less or nothing. In-run permission errors are already surfaced to the model as retryable tool errors (`ToolPermissionError(ModelRetry)`, `assistant/tools/_scoping.py:30`), so the agent skips what it can't touch and continues — "different loops perform according to user's authorities" falls out for free.
+6. **Loop ≠ Scheduler.** The Project Scheduler dispatches `AgentRun`s to external runner pods, is workspace-authored, and is installed per-project. The loop dispatches **assistant turns** on in-process Celery workers, is instance-authored, and applies per membership edge with zero installation.
+
+## 3. Goals
+
+- **Zero-setup benefit.** A new builtin job lights up for every eligible user with no action on their part (and no backfill — see §6.3 `LoopUserPreference` defaults).
+- **Total reuse of the assistant runtime.** A loop run _is_ an `AssistantTurn` in a hidden `AssistantThread`. No parallel agent, no parallel permission layer, no parallel finalization/usage/error machinery. `run_assistant_turn` (`assistant/tasks.py:380`) is called **unchanged**.
+- **Implicit consent on OSS.** Loop runs spend the user's own BYOK key, so eligibility requires a working `UserLLMConfig` — "has configured the assistant" is the opt-in. On Cloud, the existing `pi_dash.ee.assistant.model_provider` seam supplies platform keys and the gate becomes a plan decision, not a code path (§7.8).
+- **Operator observability.** The admin platform can see, per job, what ran, what was skipped and why, what it cost (`AssistantTurn.usage`), and what it did.
+- **Honest attribution.** Issue writes carry `created_via="loop"`; comments show as "Pi Dash AI" acting under the user's account, so a user can always tell why an issue moved.
+
+## 4. Non-Goals (MVP)
+
+- **No user-authored jobs**, no per-user prompt/interval overrides, no per-workspace user preferences (the toggle is per user, global).
+- **No visible transcript.** Loop threads are hidden from the assistant UI. Flipping the filter later is the "show me what it did" feature — no migration needed.
+- **No event-driven jobs** — timers only.
+- **No retry policy.** A failed run waits for the next tick (`AssistantTurn.error_code` records why).
+- **No cross-run coordination.** Two members' loops touching the same shared issue converge by data, not locks: list-tools return only issues still needing the action, so the second run is a cheap no-op. Residual duplicate comments are a prompt-quality problem, as with the scheduler (§3 of its design).
+- **No notification/digest of loop actions.** Users discover results in the issue activity itself.
+
+## 5. Relationship to existing systems
+
+|                   | Project Scheduler                       | Assistant (chat)                 | **Loop (this design)**                |
+| ----------------- | --------------------------------------- | -------------------------------- | ------------------------------------- |
+| Definition author | Workspace admin                         | n/a (user types a message)       | **Instance operator** (`apps/admin`)  |
+| Bound to          | Project, via `SchedulerBinding` install | (workspace, user) thread         | **Membership edge** (job × ws × user) |
+| Executes via      | `AgentRun` → external runner pod        | `run_assistant_turn` Celery task | **Same `run_assistant_turn` task**    |
+| Identity          | `binding.actor`                         | `thread.user`                    | `thread.user` (the member)            |
+| LLM credentials   | Runner's own (Codex session)            | User BYOK / cloud seam           | User BYOK / cloud seam                |
+| User setup        | Install per project                     | Configure LLM, open chat         | **None** (toggle to opt out)          |
+| Cadence           | Per-install RRULE bundle                | On demand                        | Per-job RRULE bundle                  |
+
+All three coexist. The loop reuses the scheduler's _scheduling_ idioms (Beat scanner, SFU claim, RRULE helpers in `pi_dash/bgtasks/_rrule.py`) and the assistant's _execution_ path; it adds no third runtime.
+
+## 6. Schema
+
+**File placement** mirrors the scheduler exactly: models in `pi_dash/db/models/loop.py` (exported from `db/models/__init__.py`), Beat tasks in `pi_dash/bgtasks/loop.py`, app-level logic (builtins, eligibility, dispatch, views) in `pi_dash/loop/` as a plain package — no new `INSTALLED_APPS` entry, no app-local migrations. The two migrations land in `db` and `assistant` respectively.
+
+All three models extend `BaseModel` (`pi_dash/db/models/base.py` — audit fields + soft delete), which is why every unique constraint below is conditional on `deleted_at__isnull=True` (same tombstone-collision reasoning as scheduler design §5).
+
+### 6.1 `LoopJob` — the instance catalog entry
+
+```python
+# pi_dash/db/models/loop.py
+from __future__ import annotations
+
+from django.conf import settings
+from django.db import models
+
+from .base import BaseModel
+
+# Reuse the scheduler's operator-error cap so admin surfaces stay consistent.
+from .scheduler import LAST_ERROR_MAX_LEN  # noqa: F401  (re-exported for bgtasks)
+
+
+class LoopJob(BaseModel):
+    slug = models.CharField(max_length=64)                 # e.g. "auto-close-merged"
+    name = models.CharField(max_length=255)                # admin-facing
+    public_name = models.CharField(max_length=255)         # user-facing; never contains "loop"
+    public_description = models.TextField(blank=True)      # shown on the settings toggle card
+    prompt = models.TextField()                            # becomes the turn's user message verbatim
+    min_role = models.PositiveSmallIntegerField(default=15)  # ROLE_CHOICES (db/models/workspace.py:19)
+    enabled = models.BooleanField(default=True)             # per-job kill switch (admin)
+    is_builtin = models.BooleanField(default=True)          # seeded in-tree; admin-created rows use False
+
+    # Timer — same RRULE bundle subset as SchedulerBinding, evaluated by
+    # pi_dash/bgtasks/_rrule.next_fire_from_rrule (which treats rdates/exdates
+    # as optional, so adding them later is non-breaking). rrule may NOT be
+    # empty here: a single-shot loop job is meaningless.
+    dtstart = models.DateTimeField()
+    rrule = models.CharField(max_length=255)                # e.g. "FREQ=DAILY;BYHOUR=3;BYMINUTE=0"
+    tzid = models.CharField(max_length=64, default="UTC")
+
+    class Meta:
+        db_table = "loop_jobs"
+        ordering = ("-created_at",)
+        constraints = [
+            models.UniqueConstraint(
+                fields=["slug"],
+                condition=models.Q(deleted_at__isnull=True),
+                name="loop_job_unique_slug_when_active",
+            ),
+        ]
+```
+
+Validation at the API layer (§9.2): `validate_rrule_string(rrule)` (`bgtasks/_rrule.py:218`) plus a loop-specific floor — reject `FREQ=MINUTELY` and `FREQ=HOURLY` with `INTERVAL < 1` hour equivalent; loop jobs fire LLM runs per membership edge, so the minimum cadence is **hourly** (`_validate_loop_rrule` in `pi_dash/loop/admin_views.py`, returns 400 `{"error": "rrule_too_frequent"}`).
+
+### 6.2 `LoopTarget` — the membership-edge cursor
+
+```python
+class LoopTarget(BaseModel):
+    job = models.ForeignKey("db.LoopJob", on_delete=models.CASCADE, related_name="targets")
+    workspace = models.ForeignKey("db.Workspace", on_delete=models.CASCADE, related_name="loop_targets")
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="loop_targets")
+
+    # The hidden conversation this target's runs land in. Recreated on
+    # rotation (§7.6); SET_NULL so deleting a thread can't kill the cursor.
+    thread = models.ForeignKey(
+        "assistant.AssistantThread", on_delete=models.SET_NULL,
+        null=True, blank=True, related_name="+",
+    )
+
+    next_run_at = models.DateTimeField(null=True, blank=True)   # NULL = newly created, stagger pending
+    last_run = models.ForeignKey(
+        "assistant.AssistantTurn", on_delete=models.SET_NULL,
+        null=True, blank=True, related_name="+",
+    )
+    # Sparse skip diagnostics — overwritten in place, never accreted (a
+    # row-per-skip log at edge × job × day scale would dwarf every other table).
+    last_skipped_at = models.DateTimeField(null=True, blank=True)
+    last_skip_reason = models.CharField(max_length=64, blank=True, default="")
+
+    class Meta:
+        db_table = "loop_targets"
+        ordering = ("-created_at",)
+        constraints = [
+            models.UniqueConstraint(
+                fields=["job", "workspace", "user"],
+                condition=models.Q(deleted_at__isnull=True),
+                name="loop_target_unique_edge_when_active",
+            ),
+        ]
+        indexes = [models.Index(fields=["next_run_at"], name="loop_target_due_idx")]
+```
+
+Skip reasons (string enum, defined as `SkipReason(models.TextChoices)` in the same file):
+
+| value                | set by         | meaning                                         |
+| -------------------- | -------------- | ----------------------------------------------- |
+| `user_disabled`      | scanner / fire | `LoopUserPreference(job, enabled=False)` exists |
+| `master_paused`      | scanner / fire | master-pause preference row exists              |
+| `min_role`           | scanner / fire | membership role < `job.min_role`                |
+| `llm_config_missing` | scanner / fire | no usable LLM credentials (§7.8 seam)           |
+| `membership_gone`    | scanner / fire | no active `WorkspaceMember` row for the edge    |
+| `turn_active`        | fire           | previous run still in flight on the thread      |
+| `dispatch_error`     | fire           | unexpected exception creating the turn (logged) |
+
+There is **no `LoopRun` model.** The run _is_ the `AssistantTurn` — status, `usage`, `model_used`, `error_code`, timestamps are already there (`assistant/models.py:63-96`), and the transcript (what the agent actually did, tool calls included) is the thread's `AssistantMessage` rows. Admin run-history reads turns through `LoopTarget.thread`. Duplicating any of that onto a loop-side model repeats the mistake the scheduler design explicitly avoided (its §5 note on not mirroring `AgentRun.status`).
+
+### 6.3 `LoopUserPreference` — the user's toggles
+
+```python
+class LoopUserPreference(BaseModel):
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="loop_preferences")
+    # NULL job = the master "pause all Auto Project Management" switch.
+    job = models.ForeignKey("db.LoopJob", on_delete=models.CASCADE, null=True, blank=True,
+                            related_name="user_preferences")
+    enabled = models.BooleanField(default=True)
+
+    class Meta:
+        db_table = "loop_user_preferences"
+        ordering = ("-created_at",)
+        constraints = [
+            models.UniqueConstraint(
+                fields=["user", "job"],
+                condition=models.Q(deleted_at__isnull=True),
+                name="loop_pref_unique_user_job_when_active",
+            ),
+            models.UniqueConstraint(
+                fields=["user"],
+                condition=models.Q(job__isnull=True, deleted_at__isnull=True),
+                name="loop_pref_unique_user_master_when_active",
+            ),
+        ]
+```
+
+**Absence of a row means enabled.** This is what makes new builtin jobs light up for everyone with zero backfill (decision §2.4 + goal §3.1). Only opt-outs are stored; the toggle endpoints upsert (`update_or_create`) rather than insert.
+
+### 6.4 `AssistantThread.kind` — hiding loop threads
+
+```python
+# Added to AssistantThread (apps/api/pi_dash/assistant/models.py:22)
+class ThreadKind(models.TextChoices):
+    CHAT = "chat", "Chat"
+    LOOP = "loop", "Loop"
+
+kind = models.CharField(max_length=16, choices=ThreadKind.choices, default=ThreadKind.CHAT)
+```
+
+`AssistantThreadListCreateEndpoint.get` (`assistant/views/threads.py:22`) adds `kind=ThreadKind.CHAT` to its filter. That is the _entire_ opacity mechanism. The other thread/message/SSE endpoints stay as-is: they are already owner-scoped (`owned_thread`, `views/_base.py:31`), so a user inspecting their own loop thread by ID leaks nothing — it's their own agent's work. POST `/threads/` always creates `kind="chat"` (the field is not serializer-writable).
+
+### 6.5 Migrations
+
+1. **`db`** — `00XX_loop_mvp.py`: creates `loop_jobs`, `loop_targets`, `loop_user_preferences`; data-migration step seeds the builtin job (§8.1) with `enabled=False` (rollout §13). The seed imports prompt text from `pi_dash/loop/builtins.py` (module is Django-free, like `_rrule.py`, so the migration can import it).
+2. **`assistant`** — `0002_thread_kind.py`: additive `kind` column with default; no backfill (existing rows are chat threads by definition).
+
+Test DBs run with `--reuse-db --nomigrations`; CI and the local container need one `--create-db` run after this lands (same as PR #233's migration).
+
+## 7. Execution
+
+### 7.1 Beat entry
+
+```python
+# apps/api/pi_dash/celery.py — next to "scan-due-scheduler-bindings" (celery.py:118)
+"scan-due-loop-targets": {
+    "task": "pi_dash.bgtasks.loop.scan_due_targets",
+    "schedule": crontab(minute="*"),
+},
+```
+
+Singleton-Beat caveat is inherited from the scheduler (`bgtasks/scheduler.py:22`): double Beat doubles scan rate but SFU claims keep correctness.
+
+### 7.2 Scanner — `pi_dash/bgtasks/loop.py::scan_due_targets`
+
+```python
+@shared_task(name="pi_dash.bgtasks.loop.scan_due_targets")
+def scan_due_targets() -> int:
+    if not getattr(settings, "LOOP_ENABLED", True):
+        return 0
+    now = timezone.now()
+    _reconcile_targets(now)                      # (a) — internally throttled
+    return _fan_out_due(now)                     # (b)
+```
+
+**(a) Reconcile** — create missing `LoopTarget` rows for every (enabled job × active membership edge). Runs only when `now.minute % 15 == 0` (cheap throttle; a new member waits ≤15 min for a cursor, and their first fire is next occurrence + stagger anyway):
+
+```python
+def _reconcile_targets(now) -> None:
+    if now.minute % LOOP_RECONCILE_EVERY_MINUTES != 0:
+        return
+    for job in LoopJob.objects.filter(enabled=True, deleted_at__isnull=True):
+        existing = LoopTarget.objects.filter(
+            job=job, deleted_at__isnull=True,
+            workspace_id=OuterRef("workspace_id"), user_id=OuterRef("member_id"),
+        )
+        edges = (
+            WorkspaceMember.objects
+            .filter(is_active=True, member__is_active=True, deleted_at__isnull=True)
+            .annotate(has_target=Exists(existing))
+            .filter(has_target=False)
+            .values_list("workspace_id", "member_id")
+        )
+        nxt = next_fire_from_rrule(dtstart=job.dtstart, rrule_str=job.rrule, tzid=job.tzid, now=now)
+        if nxt is None:
+            continue  # bad RRULE; admin API validation should make this unreachable
+        LoopTarget.objects.bulk_create(
+            [
+                LoopTarget(job=job, workspace_id=ws, user_id=uid,
+                           next_run_at=nxt + _stagger(job.id, ws, uid))
+                for ws, uid in edges.iterator(chunk_size=1000)
+            ],
+            ignore_conflicts=True,   # races with concurrent scans collapse on the conditional unique
+            batch_size=500,
+        )
+```
+
+New targets get `next_run_at = next fire + stagger`, **not** NULL-meaning-due — a freshly eligible user waits for the next scheduled occurrence rather than triggering a burst the minute a job is created. Membership _removal_ is handled at fire time (`membership_gone`), not by reconcile — no `WorkspaceMember` signal wiring in MVP.
+
+**(b) Fan out** — claim due target IDs, pre-filtered by eligibility so no Celery task is queued for a target that would only skip:
+
+```python
+def _fan_out_due(now) -> int:
+    due = eligibility.eligible_due_targets(now)          # §7.8 — returns a queryset of ids
+    ids = list(due.order_by("next_run_at")[:LOOP_MAX_DISPATCH_PER_TICK].values_list("id", flat=True))
+    for target_id in ids:
+        fire_loop_target.delay(str(target_id))
+    _advance_ineligible_due(now)                          # see below
+    return len(ids)
+```
+
+Targets that are **due but ineligible** must still have their cursor advanced, or they would be re-examined every minute forever. `_advance_ineligible_due` runs one bulk pass per skip-reason class (each is a queryset difference of `due_targets - eligible`, annotated per reason), setting `next_run_at` to the job's next occurrence + stagger and stamping `last_skipped_at=now`, `last_skip_reason=<reason>` via `bulk_update` in batches. Because RRULE evaluation is per-job, group the updates by `job_id` and compute `next_fire_from_rrule` once per job per tick. Over-cap eligible targets (beyond `LOOP_MAX_DISPATCH_PER_TICK`) are _not_ advanced — they stay due and drain on subsequent ticks (backpressure by design).
+
+### 7.3 Stagger
+
+A daily job naively fires every eligible edge in the same minute — a thundering herd of N×M LLM calls. Each target's fire time gets a deterministic offset (no `random` in scheduling paths — reproducible tests, stable per edge):
+
+```python
+from zlib import crc32
+
+def _stagger(job_id, workspace_id, user_id) -> timedelta:
+    window = max(1, int(getattr(settings, "LOOP_STAGGER_WINDOW_MINUTES", 60)))
+    seed = f"{job_id}:{workspace_id}:{user_id}".encode()
+    return timedelta(minutes=crc32(seed) % window)
+```
+
+Default window 60 minutes spreads a 1000-edge instance to ~17 dispatches/minute. The stagger is applied every time `next_run_at` is advanced (reconcile, fire, ineligible-advance), so a given edge always fires at the same offset within its job's window.
+
+### 7.4 Per-target fire — `pi_dash/bgtasks/loop.py::fire_loop_target`
+
+Follows the scheduler's claim shape (`bgtasks/scheduler.py:144`) but with **no rollback phase**: dispatch here is local row creation inside the same database, not a remote pod match that can transiently fail. If Phase 2 raises, the cursor stays advanced, the exception is logged, and `last_skip_reason="dispatch_error"` is recorded — next occurrence retries naturally.
+
+```python
+@shared_task(name="pi_dash.bgtasks.loop.fire_loop_target", bind=True, max_retries=0)
+def fire_loop_target(self, target_id: str) -> bool:
+    if not getattr(settings, "LOOP_ENABLED", True):
+        return False
+
+    # ----- Phase 1: claim under SFU, re-check eligibility, advance cursor -----
+    with transaction.atomic():
+        target = (
+            LoopTarget.objects.select_for_update(of=("self",))
+            .select_related("job", "workspace", "user")
+            .filter(pk=target_id, deleted_at__isnull=True)
+            .first()
+        )
+        if target is None:
+            return False
+        now = timezone.now()
+        if target.next_run_at is not None and target.next_run_at > now:
+            return False                      # raced the scanner; another fire already claimed
+        job = target.job
+        nxt = next_fire_from_rrule(dtstart=job.dtstart, rrule_str=job.rrule, tzid=job.tzid, now=now)
+        target.next_run_at = (nxt + _stagger(job.id, target.workspace_id, target.user_id)) if nxt else None
+
+        skip = eligibility.check(target)      # §7.8 — None | SkipReason value
+        if skip is not None:
+            target.last_skipped_at = now
+            target.last_skip_reason = skip
+            target.save(update_fields=["next_run_at", "last_skipped_at", "last_skip_reason", "updated_at"])
+            return False
+        target.save(update_fields=["next_run_at", "updated_at"])
+
+    # ----- Phase 2: dispatch a turn (own transaction; mirrors the message POST) -----
+    return dispatch.dispatch_loop_turn(target_id)
+```
+
+### 7.5 Dispatch — `pi_dash/loop/dispatch.py::dispatch_loop_turn`
+
+Mirrors the chat message POST handler (`assistant/views/messages.py:84-104`) minus HTTP, plus thread management. Reuses `events.create_message` (`assistant/runtime/events.py`) so `seq` allocation and SSE event rows behave identically to chat.
+
+```python
+def dispatch_loop_turn(target_id: str) -> bool:
+    with transaction.atomic():
+        target = (
+            LoopTarget.objects.select_for_update(of=("self",))
+            .select_related("job", "workspace", "user")
+            .get(pk=target_id)
+        )
+        thread = _ensure_thread(target)                    # get-or-create + rotation, below
+
+        locked = AssistantThread.objects.select_for_update().get(pk=thread.pk)
+        if locked.active_turn_id is not None:
+            # Previous run still in flight — skip, don't queue (scheduler §9.1 policy).
+            # The stale-turn sweep (assistant/tasks.py:389) guarantees this clears
+            # even after a worker crash, so a target can never wedge permanently.
+            target.last_skipped_at = timezone.now()
+            target.last_skip_reason = SkipReason.TURN_ACTIVE
+            target.save(update_fields=["last_skipped_at", "last_skip_reason", "updated_at"])
+            return False
+
+        turn = AssistantTurn.objects.create(thread=locked, status=TurnStatus.QUEUED)
+        user_msg = events.create_message(
+            locked, MessageKind.USER, turn=turn,
+            display_content=target.job.prompt, status=MessageStatus.COMPLETED,
+        )
+        turn.user_message = user_msg
+        turn.save(update_fields=["user_message"])
+        locked.active_turn = turn
+        locked.save(update_fields=["active_turn", "updated_at"])
+
+        target.last_run = turn
+        target.last_skip_reason = ""
+        target.save(update_fields=["last_run", "last_skip_reason", "updated_at"])
+
+    transaction.on_commit(lambda tid=str(turn.id): run_assistant_turn.delay(tid))
+    return True
+```
+
+`_ensure_thread(target)`:
+
+1. If `target.thread_id` is set and the thread row exists with `kind="loop"`, count its messages; if `count < MAX_THREAD_MESSAGES - LOOP_ROTATION_HEADROOM` (`assistant/errors.py:93` minus headroom, default 200−30), return it.
+2. Otherwise create `AssistantThread(workspace=target.workspace, user=target.user, kind=ThreadKind.LOOP, title=target.job.public_name, is_archived=False)`, archive the old thread (`is_archived=True`) if any, point `target.thread` at the new one, return it. Rotation resets the run's memory (§7.7) — acceptable; job prompts must not _depend_ on memory for correctness, only benefit from it.
+
+Note the chat-side guards that do **not** apply here: no LLM-config 422 pre-check (eligibility already covered it; if the key is deleted between claim and run, `_run_turn` fails the turn with `llm_config_missing` — correct and visible to the admin), no throttle (Beat is the rate limiter), no `MAX_THREAD_MESSAGES` 409 (rotation makes it unreachable), no auto-title.
+
+### 7.6 What runs — stock assistant machinery, end to end
+
+From `run_assistant_turn.delay(turn_id)` onward, **nothing is loop-specific**: `_load_context` (`tasks.py:70`) resolves user/deps from the thread; `resolve_model_for_user` (imported from `pi_dash.ee.assistant.model_provider`, `tasks.py:290`) resolves credentials; `UsageLimits(request_limit=25, tool_calls_limit=20)` (`tasks.py:313`) bounds per-run cost; soft/hard time limits (`ASSISTANT_TURN_SOFT_LIMIT/HARD_LIMIT`) bound wall clock; `_complete_turn`/`_fail_turn` finalize and clear `active_turn`; the stale-turn sweep recovers crashes.
+
+### 7.7 Loop-mode runtime seam (the only assistant changes)
+
+Three small, mode-gated changes:
+
+**(a) `AssistantDeps.mode`** (`runtime/deps.py:20`): add field `mode: str = "chat"` (values `"chat" | "loop"`) and a derived property:
+
+```python
+@property
+def created_via(self) -> str:
+    return "assistant" if self.mode == "chat" else "loop"
+```
+
+`_load_context` (`tasks.py:70`) sets `mode=thread.kind` when building deps.
+
+**(b) Unattended instructions** (`runtime/instructions.py`): append a block in `dynamic_instructions(ctx)` when `deps.mode == "loop"` — this composes with `BASE_INSTRUCTIONS` rather than replacing it, so all standing rules (investigate-first, untrusted-content tags, error handling) still apply. Rule 3 of `BASE_INSTRUCTIONS` ("ask before bulk changes") is overridden explicitly because there is nobody to ask:
+
+```python
+LOOP_INSTRUCTIONS = """\
+## Unattended mode
+You are running as a scheduled maintenance task. No human reads your reply \
+live, and nobody can answer questions — never ask; when a judgement is \
+ambiguous, skip that item instead of guessing. Perform only the actions your \
+task instructions explicitly call for. Never delete anything. The bulk-change \
+confirmation rule does not apply, but act on at most {LOOP_MAX_WRITES} items \
+per run; if more qualify, handle the oldest and note the remainder in your \
+summary. End with a short plain-text summary of every action you took, or \
+"No action needed."
+"""
+```
+
+(`LOOP_MAX_WRITES` formatted from settings, default 10 — a per-run blast-radius cap enforced by instruction; the hard backstop remains `tool_calls_limit=20`.)
+
+**(c) Attribution**: `tools/issues.py:182` changes `created_via="assistant"` → `created_via=ctx.deps.created_via` (same in `update_issue`'s activity-tracking call if it passes an origin). Comments are untouched: `speaker_label="Pi Dash AI"` already says the right thing to users (naming rule).
+
+**(d) History budget**: `load_history` (`runtime/history.py:27`) currently reads `ASSISTANT_HISTORY_MAX_TURNS` (default 40). It gains a kind-aware cap — loop threads replay history too (memory: "yesterday I closed #42") but at a tighter default because it's a daily token cost:
+
+```python
+setting = "ASSISTANT_LOOP_HISTORY_MAX_TURNS" if thread.kind == "loop" else "ASSISTANT_HISTORY_MAX_TURNS"
+default = 5 if thread.kind == "loop" else 40
+max_turns = max(1, int(getattr(settings, setting, default)))
+```
+
+### 7.8 Eligibility — one seam, used by scanner and fire
+
+`pi_dash/loop/eligibility.py` is the single place "may this edge run this job now?" is answered, in two forms (queryset for bulk pre-filter, per-row for the fire-time re-check). It is also the **Cloud seam**: the BYOK credential check is one overridable function, mirroring how `resolve_model_for_user` lives behind `pi_dash.ee.assistant.model_provider`.
+
+```python
+# pi_dash/loop/eligibility.py
+def llm_available_q() -> Exists:
+    """Exists() subquery: does OuterRef('user_id') have usable LLM credentials?
+
+    CE: a UserLLMConfig with a key. The ee/cloud overlay replaces this to also
+    admit plan-entitled users with platform keys."""
+    return Exists(UserLLMConfig.objects.filter(
+        user_id=OuterRef("user_id"), api_key_encrypted__isnull=False,
+    ))
+
+def eligible_due_targets(now) -> QuerySet[LoopTarget]:
+    return (
+        LoopTarget.objects
+        .filter(deleted_at__isnull=True, job__enabled=True, job__deleted_at__isnull=True)
+        .filter(Q(next_run_at__lte=now) | Q(next_run_at__isnull=True))
+        .annotate(
+            _member=Exists(WorkspaceMember.objects.filter(
+                workspace_id=OuterRef("workspace_id"), member_id=OuterRef("user_id"),
+                is_active=True, deleted_at__isnull=True, role__gte=OuterRef("job__min_role"),
+            )),
+            _job_off=Exists(LoopUserPreference.objects.filter(
+                user_id=OuterRef("user_id"), job_id=OuterRef("job_id"),
+                enabled=False, deleted_at__isnull=True,
+            )),
+            _paused=Exists(LoopUserPreference.objects.filter(
+                user_id=OuterRef("user_id"), job__isnull=True,
+                enabled=False, deleted_at__isnull=True,
+            )),
+            _llm=llm_available_q(),
+        )
+        .filter(_member=True, _job_off=False, _paused=False, _llm=True)
+    )
+
+def check(target) -> Optional[str]:
+    """Fire-time re-check of one claimed target. Returns a SkipReason value or None.
+    Same predicates as eligible_due_targets, evaluated freshest-wins under the
+    caller's SFU — preferences/membership/config may have changed since the scan."""
+```
+
+`check` evaluates the predicates in fixed order (`master_paused`, `user_disabled`, `membership_gone`/`min_role`, `llm_config_missing`) so the recorded skip reason is deterministic.
+
+## 8. Builtin job and the PR-status tool
+
+### 8.1 The seeded job (`pi_dash/loop/builtins.py`)
+
+```python
+BUILTIN_LOOP_JOBS = [
+    BuiltinLoopJob(
+        slug="auto-close-merged",
+        name="Auto-close merged-PR issues",
+        public_name="Close issues when their PR merges",
+        public_description=(
+            "Checks your projects once a day and marks an issue Done when the "
+            "pull request that implements it has been merged."
+        ),
+        min_role=15,
+        rrule="FREQ=DAILY;BYHOUR=3;BYMINUTE=0",   # dtstart = seed-migration time, tzid UTC
+        prompt=(
+            "Review open issues in the projects you can access, oldest first. "
+            "An issue is a candidate when it references a pull request — in its "
+            "links, description, or comments. For each candidate, call "
+            "get_pull_request_status on the PR URL. If — and only if — the tool "
+            "reports state \"merged\", move the issue to a state in its "
+            "project's \"completed\" state group (use list_states to find one) "
+            "and add a one-line comment naming the merged PR. If merge state is "
+            "\"unknown\" or the issue's state is already in the completed group, "
+            "leave it untouched. Do not create or delete anything."
+        ),
+    ),
+]
+```
+
+The module is Django-free (dataclass + list) so the seed migration imports it directly, like `_rrule.py`. The data migration upserts by `slug` (idempotent re-runs) with `enabled=False` per §13.
+
+### 8.2 New assistant tool — `get_pull_request_status`
+
+Nothing in the DB materializes PR merge state: `Issue.git_work_branch` is a branch name (`db/models/issue.py:171`), `IssueLink` is a free-form URL (`issue.py:444`), and the GitHub integration syncs issues/comments, not PRs (`db/models/integration/github.py`). The agent therefore gets one new read-only tool, in `pi_dash/assistant/tools/github.py`, registered by adding the module to the import list in `tools/__init__.py:11`. Registered for chat and loop alike — "is the PR for this issue merged?" is a useful chat question too.
+
+```python
+@assistant.tool
+def get_pull_request_status(ctx: RunContext[AssistantDeps], url: str) -> dict:
+    """Check whether a GitHub pull request is merged. Accepts a full PR URL."""
+```
+
+Implementation contract:
+
+1. **Parse**: `^https://github\.com/(?P<owner>[\w.-]+)/(?P<repo>[\w.-]+)/pull/(?P<num>\d+)`. Non-matching input → `{"state": "unknown", "reason": "unsupported_url"}` (no exception — the prompt treats `unknown` as "don't act").
+2. **SSRF**: the URL is regex-pinned to `https://github.com/`, and the _API_ call goes to the constant host `https://api.github.com`, so `ssrf.is_blocked` (`assistant/ssrf.py:25`) is consulted only for consistency with `ASSISTANT_BLOCK_PRIVATE_URLS` policy on the constructed API URL. No redirect following (`follow_redirects=False`).
+3. **Credentials**: best-effort token lookup — a `GithubRepositorySync` joined through the user's member projects in this workspace (reuse `_scoping.member_projects(ctx.deps)`) whose repository matches `owner/repo`; if found, use its `credentials["access_token"]` as `Authorization: Bearer`. Otherwise call unauthenticated (public repos; 60 req/h/IP).
+4. **Call**: `GET https://api.github.com/repos/{owner}/{repo}/pulls/{num}` via `httpx` (already a runtime dependency), `timeout=10s`. Map: HTTP 200 → `{"state": "merged"|"closed"|"open", "title", "merged_at"}` (merged when `merged_at` non-null, else `closed_at` non-null → closed); 404/403/451 → `unknown` with `reason` (`not_found`, `rate_limited`, `blocked`); network/timeout errors → `unknown`/`network_error`. The tool **never raises** — `unknown` is a normal answer the builtin prompt is written around.
+5. **Budget**: a per-run counter on deps (`deps.pr_lookups`, cap `LOOP_PR_LOOKUPS_PER_RUN`, default 15, enforced for both modes); past the cap, return `unknown`/`budget_exhausted`. Prevents one run from burning the unauthenticated rate limit for the whole host IP.
+6. **Sync tool**: plain `def` (pydantic-ai runs sync tools in a threadpool, same as the existing tools), so `httpx.Client`, not the async client.
+
+## 9. API
+
+### 9.1 User settings — `pi_dash/loop/views.py`, routed from `pi_dash/loop/urls.py`, included in `pi_dash/urls.py` as `path("api/", include("pi_dash.loop.urls"))` (next to the assistant include, `urls.py:19`)
+
+All three endpoints: plain `BaseAPIView` subclasses, authenticated user only, **no workspace role check** (these are the user's own preferences; route segment is `auto-pm` per the naming rule).
+
+```
+GET   /api/users/me/auto-pm/
+PATCH /api/users/me/auto-pm/
+PATCH /api/users/me/auto-pm/jobs/<slug>/
+```
+
+**GET** response (jobs = `LoopJob.objects.filter(enabled=True, deleted_at__isnull=True)`; `interval_label` derived server-side from the RRULE FREQ — `"daily"`, `"weekly"`, `"hourly"` — so the client never parses RRULEs):
+
+```json
+{
+  "enabled": true,
+  "jobs": [
+    {
+      "slug": "auto-close-merged",
+      "name": "Close issues when their PR merges",
+      "description": "Checks your projects once a day and marks an issue Done when the pull request that implements it has been merged.",
+      "interval_label": "daily",
+      "enabled": true
+    }
+  ]
+}
+```
+
+`name`/`description` map from `public_name`/`public_description`. The serializer **whitelists exactly these five keys** — `prompt`, `min_role`, internal `name`, and anything saying "loop" must never serialize here (contract-tested, §12).
+
+**PATCH /auto-pm/** body `{"enabled": false}` → upserts the master row: `LoopUserPreference.objects.update_or_create(user=request.user, job=None, deleted_at__isnull=True, defaults={"enabled": False})`. Any key other than `enabled`, or a non-bool → 400 `{"error": "invalid_payload"}`. Response: the GET shape.
+
+**PATCH /auto-pm/jobs/<slug>/** — same contract per job; unknown/disabled slug → 404 `{"error": "not_found"}`.
+
+### 9.2 Instance admin — `pi_dash/loop/admin_views.py`, routed via `path("loop/", include("pi_dash.loop.admin_urls"))` added to `pi_dash/license/urls.py` (mounted under `/api/instances/`, `pi_dash/urls.py:21`)
+
+All endpoints `permission_classes = [InstanceAdminPermission]` (`license/api/permissions/instance.py:12`), following the existing `license/api/views/` conventions.
+
+```
+GET  POST          /api/instances/loop/jobs/
+GET  PATCH DELETE  /api/instances/loop/jobs/<uuid:pk>/
+GET                /api/instances/loop/jobs/<uuid:pk>/targets/
+```
+
+Job serializer (full fields — this is the operator surface): `id, slug, name, public_name, public_description, prompt, min_role, enabled, is_builtin, dtstart, rrule, tzid, created_at, updated_at` + read-only annotations `target_count`, `last_24h: {completed, failed, skipped}` (three conditional `Count` aggregates over targets/turns). Writes validate: slug format (`^[a-z0-9-]{1,64}$`), `min_role ∈ {5, 15, 20}`, RRULE via `validate_rrule_string` + the hourly floor (§6.1) → 400 with `{"error": "invalid_rrule", "detail": ...}`. `is_builtin` is read-only; DELETE soft-deletes (targets cascade via the async soft-delete machinery, same as scheduler bindings).
+
+Targets listing (paginated, default 50/page; filterable `?skip_reason=&workspace=&status=`): per row `workspace_slug, user_email, next_run_at, last_skipped_at, last_skip_reason`, and from `last_run` (select_related): `status, error_code, model_used, usage.total_tokens, completed_at`. This is the operator's answer to "is this thing working and what does it cost" — no separate run-history endpoint in MVP.
+
+## 10. Frontend
+
+### 10.A `apps/web` — profile settings: "Auto Project Management"
+
+Follows the AI-assistant settings page pattern exactly (it is the adjacent feature):
+
+| piece            | file                                                                                                                                                                                                                                                                                                                                                                                                       |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Types            | `packages/types/src/auto-pm.ts` — `IAutoPMJob { slug; name; description; interval_label; enabled }`, `IAutoPMSettings { enabled; jobs: IAutoPMJob[] }`; star-exported from `packages/types/src/index.ts`                                                                                                                                                                                                   |
+| Service          | `packages/services/src/auto-pm/auto-pm.service.ts` — `class AutoPMService extends APIService` (ctor pattern as `assistant.service.ts:15`); methods `getSettings(): Promise<IAutoPMSettings>` → GET `/api/users/me/auto-pm/`; `setMasterEnabled(enabled: boolean)` → PATCH; `setJobEnabled(slug: string, enabled: boolean)` → PATCH `/api/users/me/auto-pm/jobs/${slug}/`; exported from the services index |
+| Page component   | `apps/web/core/components/settings/profile/content/pages/auto-project-management.tsx` — `useSWR("auto-pm-settings", () => service.getSettings())`, optimistic `mutate` on toggle, `setToast` on failure (mirror `ai-assistant.tsx`)                                                                                                                                                                        |
+| Tab registration | `packages/constants/src/settings/profile.ts` — add key `"auto-project-management"` to `TProfileSettingsTabs`, `PROFILE_SETTINGS` (`i18n_label: "Auto Project Management"`), and `GROUPED_PROFILE_SETTINGS[YOUR_PROFILE]` directly after `"ai-assistant"`; add an icon to the sidebar `ICONS` map (`item-categories.tsx`) — `Repeat` or `RefreshCw` from lucide                                             |
+| Route wiring     | the existing `[profileTabId]` page switch (`apps/web/app/(all)/settings/profile/[profileTabId]/page.tsx`) gains the `"auto-project-management"` → `<AutoProjectManagementSettings />` case                                                                                                                                                                                                                 |
+
+Page layout: heading + explainer paragraph ("Pi Dash AI can do routine project upkeep for you automatically. It acts with your permissions and only in workspaces you belong to."), master toggle row ("Pause all"), then one card per job — `name`, `description`, cadence chip from `interval_label`, toggle. Toggles disabled (with hint) while the master switch is off. When `jobs` is empty, render nothing but the heading + "Nothing is scheduled on this instance yet." All strings via `useTranslation()` keys under `auto_pm.*`, added to **every** locale in `packages/i18n/src/locales/<lang>/` (English placeholder where untranslated, per the parity rule).
+
+If the user has no LLM config, show an inline callout linking to the AI Assistant tab: "Auto Project Management uses your AI Assistant connection — set it up first." (`has_api_key` known from the existing `assistant-llm-config` SWR key.)
+
+### 10.B `apps/admin` — "Loop" page
+
+Mirrors the AI instance-settings page structure (`apps/admin/app/(all)/(dashboard)/ai/page.tsx` + `form.tsx`):
+
+- Route: `apps/admin/app/(all)/(dashboard)/loop/page.tsx` (list) and `loop/[jobId]/page.tsx` (detail).
+- Sidebar: add to `use-sidebar-menu/core.ts` — `loop: { Icon: Repeat, name: "Loop", description: "Scheduled AI project management jobs.", href: "/loop/" }`.
+- Service: `packages/services/src/instance/loop.service.ts` — `InstanceLoopService extends APIService` with `list/create/update/destroy` for `/api/instances/loop/jobs/` and `listTargets(jobId, params)`.
+- List page: table (name, slug, RRULE, min_role, enabled toggle PATCHing inline, builtin badge, 24h completed/failed/skipped counts) + "New job" modal (all writable fields; prompt as monospace textarea; RRULE as text input — server 400 surfaces inline, same plain-text-input choice as scheduler design §8.C).
+- Detail page: the job form + the targets table (columns from §9.2) with skip-reason filter chips.
+
+## 11. Settings
+
+```python
+# pi_dash/settings/common.py — one block next to the ASSISTANT_* keys (common.py:215)
+LOOP_ENABLED = os.environ.get("LOOP_ENABLED", "true").lower() == "true"
+LOOP_STAGGER_WINDOW_MINUTES = int(os.environ.get("LOOP_STAGGER_WINDOW_MINUTES", 60))
+LOOP_MAX_DISPATCH_PER_TICK = int(os.environ.get("LOOP_MAX_DISPATCH_PER_TICK", 100))
+LOOP_RECONCILE_EVERY_MINUTES = int(os.environ.get("LOOP_RECONCILE_EVERY_MINUTES", 15))
+LOOP_ROTATION_HEADROOM = int(os.environ.get("LOOP_ROTATION_HEADROOM", 30))
+LOOP_MAX_WRITES = int(os.environ.get("LOOP_MAX_WRITES", 10))
+LOOP_PR_LOOKUPS_PER_RUN = int(os.environ.get("LOOP_PR_LOOKUPS_PER_RUN", 15))
+ASSISTANT_LOOP_HISTORY_MAX_TURNS = int(os.environ.get("ASSISTANT_LOOP_HISTORY_MAX_TURNS", 5))
+```
+
+Per-run cost is bounded by the assistant's own machinery: `UsageLimits(request_limit=25, tool_calls_limit=20)` (`tasks.py:313`), `ASSISTANT_TURN_SOFT_LIMIT/HARD_LIMIT`, and usage recorded per turn. The eligibility chain means **zero tokens are ever spent** for users who never configured an LLM key, disabled the feature, or lack the job's role.
+
+## 12. Testing
+
+Contract tests in `pi_dash/tests/contract/loop/` (pattern of `tests/contract/assistant/`, reusing its `world` fixture); RRULE/stagger unit tests beside `tests/unit/scheduler/`.
+
+| file                                       | asserts                                                                                                                                                                                                                                                                                                                                                                                    |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `test_models.py`                           | conditional uniques (re-create after soft delete works; duplicate active edge rejected); master-pref unique                                                                                                                                                                                                                                                                                |
+| `test_eligibility.py`                      | each predicate flips eligibility exactly once: pref-off, master pause, role < min_role, no LLM key, inactive membership; `check()` returns the right `SkipReason` in the documented precedence order                                                                                                                                                                                       |
+| `test_scanner.py`                          | reconcile creates targets only for missing active edges, idempotent under double-run; new targets get future `next_run_at` (no immediate burst); fan-out queues only eligible-due ids, respects `LOOP_MAX_DISPATCH_PER_TICK` ordering by `next_run_at`; ineligible-due rows get cursor advanced + reason stamped; `LOOP_ENABLED=False` short-circuits                                      |
+| `test_fire_dispatch.py`                    | happy path: turn + user message (content == job.prompt) created, `thread.active_turn` set, `run_assistant_turn.delay` queued on commit (mocked, `django_capture_on_commit_callbacks`), `target.last_run` set; `turn_active` skip leaves no new turn; raced `next_run_at > now` no-ops; rotation: thread at `200 - headroom` messages → new thread, old archived, `target.thread` repointed |
+| `test_runtime_seam.py`                     | `deps.mode` set from `thread.kind`; loop threads get `LOOP_INSTRUCTIONS` appended, chat threads don't; `created_via="loop"` on issues created under a loop turn; history cap honors `ASSISTANT_LOOP_HISTORY_MAX_TURNS` for loop threads only (extends `test_history.py`)                                                                                                                   |
+| `test_thread_visibility.py`                | thread list excludes `kind="loop"`; owner GET by id still works; POST always creates chat                                                                                                                                                                                                                                                                                                  |
+| `test_user_api.py`                         | GET shape (exact key whitelist — fails if `prompt`/`min_role` ever serialize); master + per-job PATCH round-trip and precedence; invalid payload 400; unknown slug 404; guest-in-every-workspace user can still toggle (no role gate)                                                                                                                                                      |
+| `test_admin_api.py`                        | non-instance-admin 401/403; CRUD round-trip; RRULE validation 400s (`FREQ=MINUTELY` rejected); `is_builtin` immutable; targets listing fields + filters                                                                                                                                                                                                                                    |
+| `test_github_tool.py` (unit, mocked httpx) | merged / open / closed mapping; non-GitHub URL → `unsupported_url`; 403 → `rate_limited`; timeout → `network_error`; per-run lookup budget; credentials picked from an accessible project's sync, not from inaccessible ones                                                                                                                                                               |
+
+Local run uses the baked-image workflow (docker cp + `pip install -r requirements/test.txt`); schema changes here require one `--create-db` run.
+
+## 13. Rollout
+
+- All changes are additive (3 new tables, 1 defaulted column on `assistant_thread`, new settings with safe defaults). Deploy order is free; Beat picks up the new entry on restart.
+- Seed migration creates the builtin job **`enabled=False`**. Combined with absence-means-enabled preferences, flipping it on in `apps/admin` is the launch act — do it on the dogfooding instance first, watch the targets table for a day (skip-reason distribution, token usage, failure rate), then enable on production.
+- Kill switches, outermost-in: `LOOP_ENABLED` env → per-job `enabled` (admin) → per-user master pause → per-user per-job toggle.
+
+## 14. Open questions (resolve before merge)
+
+1. **PR-state auth fallback.** When no `GithubRepositorySync` credentials exist, is unauthenticated GitHub API acceptable (60 req/h/IP), or should the tool return `unknown` unless credentials exist? Recommend: try unauthenticated, treat 403 as `unknown`/`rate_limited`; the prompt's "only act when clearly established" makes `unknown` safe, and `LOOP_PR_LOOKUPS_PER_RUN` bounds the burn.
+2. **Guest jobs.** `min_role` default is 15; do we ever want guest-eligible jobs? Schema supports 5, MVP ships none. Recommend: defer.
+3. **`update_issue` orchestration side-effect.** `update_issue` may dispatch an orchestration run on state transition (`tools/issues.py`, `update_issue` → `handle_issue_state_transition`). Moving an issue to a completed-group state from a loop run should be inert there, but verify during PR 2 that the transition hook doesn't fire coding runs for completed-group moves; if it can, gate it on `deps.mode`.
+4. **Cloud plan gating.** Lives behind `eligibility.llm_available_q()` + `resolve_model_for_user` (both `ee`-overridable); whether the plan check is a queryset join or a model-provider refusal is a private-pi-dash decision. This design guarantees the seam only.
+
+## 15. Future work (explicitly not MVP)
+
+- Surface loop threads in the assistant UI ("see what Auto PM did"), per-edge activity digest.
+- Per-workspace user preference overrides; workspace-admin opt-out for a whole workspace.
+- Event-driven jobs (on PR merge webhook, on issue stale) — likely a different trigger feeding the same `LoopTarget` dispatch path.
+- User-authored jobs (where loop and scheduler authoring may converge into one catalog UX).
+- More builtins: stale-issue triage, unassigned-work nudge, duplicate detection.
+- A `merged_at`-materializing PR sync (would let the builtin drop its live API calls entirely).
+- `rdates`/`exdates` on `LoopJob` if operators ever need calendar exceptions.

--- a/.ai_design/loop_project_management/tasks.md
+++ b/.ai_design/loop_project_management/tasks.md
@@ -1,0 +1,76 @@
+# Loop (Auto Project Management) — Implementation Tasks
+
+This file turns `design.md` into a concrete MVP implementation checklist.
+
+Related docs:
+
+- `design.md`
+- `.ai_design/project_scheduler/design.md` (scheduling idioms reused here)
+- `.ai_design/integrate_ai_agent/` (assistant runtime this builds on)
+
+## Suggested rollout
+
+### PR 1 — Schema and seeding (design §6)
+
+Goal: land all database changes with no runtime behavior change.
+
+- `pi_dash/db/models/loop.py`: `LoopJob`, `LoopTarget` (+ `SkipReason`), `LoopUserPreference` per §6.1–6.3; export from `db/models/__init__.py`
+- `assistant` migration `0002_thread_kind.py`: `ThreadKind` choices + `kind` column (§6.4)
+- `kind=CHAT` filter in `AssistantThreadListCreateEndpoint.get` (`assistant/views/threads.py:22`) — behaviorally inert until loop threads exist, so it belongs here
+- `pi_dash/loop/builtins.py` (Django-free, §8.1) + `db` migration creating tables and upserting the builtin job with `enabled=False` (§13)
+- tests: `test_models.py`, `test_thread_visibility.py` (§12)
+- note: CI/local test DBs need one `--create-db` run after this lands
+
+### PR 2 — Loop-mode runtime seam (design §7.7)
+
+Goal: the assistant runtime understands unattended turns; nothing dispatches them yet.
+
+- `AssistantDeps.mode` + `created_via` property (`runtime/deps.py:20`); `mode=thread.kind` in `_load_context` (`assistant/tasks.py:70`)
+- `LOOP_INSTRUCTIONS` block in `dynamic_instructions` (`runtime/instructions.py:52`), formatted with `LOOP_MAX_WRITES`
+- `created_via=ctx.deps.created_via` in `tools/issues.py:182` (and the update path)
+- kind-aware history cap in `runtime/history.py:27` + `ASSISTANT_LOOP_HISTORY_MAX_TURNS` setting
+- resolve open question §14.3 (orchestration side-effect of completed-group transitions under loop mode)
+- tests: `test_runtime_seam.py` (§12)
+
+### PR 3 — Eligibility, scanner, fire, dispatch (design §7.1–7.6, §7.8)
+
+Goal: due targets dispatch real assistant turns end-to-end.
+
+- `pi_dash/loop/eligibility.py`: `llm_available_q()` (ee-overridable), `eligible_due_targets(now)`, `check(target)` with deterministic reason precedence (§7.8)
+- `pi_dash/loop/dispatch.py`: `dispatch_loop_turn` + `_ensure_thread` rotation (§7.5)
+- `pi_dash/bgtasks/loop.py`: `scan_due_targets` (`_reconcile_targets` throttled, `_fan_out_due`, `_advance_ineligible_due`) and `fire_loop_target` (§7.2–7.4); `_stagger` helper (§7.3)
+- `scan-due-loop-targets` Beat entry (`pi_dash/celery.py`, next to line 118)
+- settings block (§11): `LOOP_ENABLED`, `LOOP_STAGGER_WINDOW_MINUTES`, `LOOP_MAX_DISPATCH_PER_TICK`, `LOOP_RECONCILE_EVERY_MINUTES`, `LOOP_ROTATION_HEADROOM`, `LOOP_MAX_WRITES`
+- tests: `test_eligibility.py`, `test_scanner.py`, `test_fire_dispatch.py` (§12)
+
+### PR 4 — `get_pull_request_status` tool (design §8.2)
+
+Goal: the builtin job can actually establish merge state.
+
+- `pi_dash/assistant/tools/github.py` per the §8.2 contract (parse → creds via `_scoping.member_projects` → httpx → never-raise mapping → per-run budget); register in `tools/__init__.py:11`
+- `LOOP_PR_LOOKUPS_PER_RUN` setting
+- tests: `test_github_tool.py` (§12, mocked httpx)
+
+### PR 5 — User settings API + web UI (design §9.1, §10.A)
+
+Goal: users can see and toggle "Auto Project Management".
+
+- `pi_dash/loop/views.py` + `pi_dash/loop/urls.py`; include in `pi_dash/urls.py` (`path("api/", include("pi_dash.loop.urls"))`)
+- GET/PATCH contracts per §9.1 — five-key whitelist, `interval_label` derived server-side, `enabled`-only PATCH
+- `packages/types/src/auto-pm.ts`, `packages/services/src/auto-pm/auto-pm.service.ts`, page component `auto-project-management.tsx`, tab registration in `packages/constants/src/settings/profile.ts` + sidebar icon, route case in `[profileTabId]/page.tsx` (§10.A table)
+- i18n keys `auto_pm.*` in every locale
+- tests: `test_user_api.py` (§12)
+
+### PR 6 — Instance admin API + admin UI (design §9.2, §10.B)
+
+Goal: the operator can manage jobs and observe targets.
+
+- `pi_dash/loop/admin_views.py` + `admin_urls.py`; `path("loop/", include(...))` in `pi_dash/license/urls.py`; `InstanceAdminPermission` throughout
+- job serializer + RRULE validation incl. hourly floor (§6.1, §9.2); targets listing with filters
+- `apps/admin` `loop/` pages + sidebar entry + `InstanceLoopService` (§10.B)
+- tests: `test_admin_api.py` (§12)
+- launch act: flip the seeded job to enabled on the dogfooding instance, watch the targets table per §13, then production
+
+## Out of scope (tracked in design §15)
+
+- visible loop transcripts, digests, per-workspace preferences, event-driven jobs, user-authored jobs, additional builtins, PR-state materialization, rdates/exdates

--- a/apps/admin/app/(all)/(dashboard)/loop/detail.tsx
+++ b/apps/admin/app/(all)/(dashboard)/loop/detail.tsx
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useState } from "react";
+import { observer } from "mobx-react";
+import { useNavigate, useParams } from "react-router";
+import useSWR from "swr";
+import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
+import { InstanceLoopService } from "@pi-dash/services";
+import type { ILoopJob, ILoopTargetsPage } from "@pi-dash/types";
+import { Button, Loader } from "@pi-dash/ui";
+// components
+import { PageWrapper } from "@/components/common/page-wrapper";
+// local
+import { LoopJobFormModal } from "./form-modal";
+
+const service = new InstanceLoopService();
+
+const SKIP_REASONS = [
+  "",
+  "user_disabled",
+  "master_paused",
+  "min_role",
+  "llm_config_missing",
+  "membership_gone",
+  "turn_active",
+  "dispatch_error",
+];
+
+const InstanceLoopDetailPage = observer(function InstanceLoopDetailPage() {
+  const { jobId } = useParams<{ jobId: string }>();
+  const navigate = useNavigate();
+  const [editing, setEditing] = useState(false);
+  const [skipFilter, setSkipFilter] = useState("");
+
+  const { data: job, mutate } = useSWR<ILoopJob>(jobId ? ["INSTANCE_LOOP_JOB", jobId] : null, () =>
+    service.retrieve(jobId!)
+  );
+  const { data: targets } = useSWR<ILoopTargetsPage>(jobId ? ["INSTANCE_LOOP_TARGETS", jobId, skipFilter] : null, () =>
+    service.listTargets(jobId!, skipFilter ? { skip_reason: skipFilter } : {})
+  );
+
+  const remove = async () => {
+    if (!job) return;
+    try {
+      await service.destroy(job.id);
+      setToast({ type: TOAST_TYPE.SUCCESS, title: "Deleted", message: "Loop job deleted." });
+      navigate("/loop/");
+    } catch {
+      setToast({ type: TOAST_TYPE.ERROR, title: "Delete failed", message: "Could not delete the job." });
+    }
+  };
+
+  if (!job) {
+    return (
+      <PageWrapper header={{ title: "Loop job", description: "" }}>
+        <Loader className="space-y-4">
+          <Loader.Item height="48px" />
+          <Loader.Item height="120px" />
+        </Loader>
+      </PageWrapper>
+    );
+  }
+
+  return (
+    <PageWrapper
+      header={{
+        title: job.name,
+        description: job.public_description || "Loop job detail",
+        actions: (
+          <div className="flex gap-2">
+            <Button variant="neutral-primary" onClick={() => setEditing(true)}>
+              Edit
+            </Button>
+            <Button variant="link-danger" onClick={remove}>
+              Delete
+            </Button>
+          </div>
+        ),
+      }}
+    >
+      <div className="mx-4 space-y-6">
+        {job.stats && (
+          <div className="grid grid-cols-4 gap-3">
+            <Stat label="Targets" value={job.stats.target_count} />
+            <Stat label="Completed (24h)" value={job.stats.completed} />
+            <Stat label="Failed (24h)" value={job.stats.failed} />
+            <Stat label="Skipped (24h)" value={job.stats.skipped} />
+          </div>
+        )}
+
+        <div className="flex items-center gap-2">
+          <span className="text-12 text-secondary">Skip reason</span>
+          <select
+            className="rounded-md border border-subtle bg-surface-1 px-2 py-1 text-12"
+            value={skipFilter}
+            onChange={(e) => setSkipFilter(e.target.value)}
+          >
+            {SKIP_REASONS.map((r) => (
+              <option key={r} value={r}>
+                {r || "all"}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="overflow-hidden rounded-md border border-subtle">
+          <table className="w-full text-body-sm-regular">
+            <thead className="bg-surface-2 text-secondary">
+              <tr>
+                <th className="px-3 py-2 text-left font-medium">Workspace</th>
+                <th className="px-3 py-2 text-left font-medium">User</th>
+                <th className="px-3 py-2 text-left font-medium">Next run</th>
+                <th className="px-3 py-2 text-left font-medium">Last run</th>
+                <th className="px-3 py-2 text-left font-medium">Tokens</th>
+                <th className="px-3 py-2 text-left font-medium">Last skip</th>
+              </tr>
+            </thead>
+            <tbody>
+              {(targets?.results ?? []).map((t) => (
+                <tr key={t.id} className="border-t border-subtle">
+                  <td className="px-3 py-2">{t.workspace_slug}</td>
+                  <td className="px-3 py-2">{t.user_email}</td>
+                  <td className="px-3 py-2 text-12 text-secondary">
+                    {t.next_run_at ? new Date(t.next_run_at).toLocaleString() : "—"}
+                  </td>
+                  <td className="px-3 py-2 text-12">{t.last_run ? t.last_run.status : "—"}</td>
+                  <td className="px-3 py-2 text-12 text-secondary">{t.last_run?.total_tokens ?? "—"}</td>
+                  <td className="px-3 py-2 text-12 text-secondary">{t.last_skip_reason || "—"}</td>
+                </tr>
+              ))}
+              {targets && targets.results.length === 0 && (
+                <tr>
+                  <td colSpan={6} className="px-3 py-4 text-center text-12 text-secondary">
+                    No targets yet.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {editing && (
+        <LoopJobFormModal
+          job={job}
+          onClose={() => setEditing(false)}
+          onSaved={() => {
+            setEditing(false);
+            void mutate();
+          }}
+        />
+      )}
+    </PageWrapper>
+  );
+});
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-md border border-subtle bg-surface-1 px-4 py-3">
+      <div className="text-h5-semibold text-primary">{value}</div>
+      <div className="text-12 text-secondary">{label}</div>
+    </div>
+  );
+}
+
+export const meta = () => [{ title: "Loop Job - God Mode" }];
+
+export default InstanceLoopDetailPage;

--- a/apps/admin/app/(all)/(dashboard)/loop/form-modal.tsx
+++ b/apps/admin/app/(all)/(dashboard)/loop/form-modal.tsx
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useState } from "react";
+import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
+import { InstanceLoopService } from "@pi-dash/services";
+import type { ILoopJob, ILoopJobInput } from "@pi-dash/types";
+import { Button, EModalWidth, ModalCore } from "@pi-dash/ui";
+
+const service = new InstanceLoopService();
+
+type Props = {
+  job?: ILoopJob;
+  onClose: () => void;
+  onSaved: (job: ILoopJob) => void;
+};
+
+const FIELD = "rounded-md border border-subtle bg-surface-1 px-3 py-2 text-body-sm-regular";
+
+export function LoopJobFormModal({ job, onClose, onSaved }: Props) {
+  const editing = !!job;
+  const [slug, setSlug] = useState(job?.slug ?? "");
+  const [name, setName] = useState(job?.name ?? "");
+  const [publicName, setPublicName] = useState(job?.public_name ?? "");
+  const [publicDescription, setPublicDescription] = useState(job?.public_description ?? "");
+  const [prompt, setPrompt] = useState(job?.prompt ?? "");
+  const [minRole, setMinRole] = useState(job?.min_role ?? 15);
+  const [rrule, setRrule] = useState(job?.rrule ?? "FREQ=DAILY;BYHOUR=3;BYMINUTE=0");
+  const [tzid, setTzid] = useState(job?.tzid ?? "UTC");
+  const [saving, setSaving] = useState(false);
+
+  const save = async () => {
+    setSaving(true);
+    const payload: ILoopJobInput = {
+      slug,
+      name,
+      public_name: publicName,
+      public_description: publicDescription,
+      prompt,
+      min_role: minRole,
+      rrule,
+      tzid,
+    };
+    try {
+      const result = editing ? await service.update(job!.id, payload) : await service.create(payload);
+      setToast({ type: TOAST_TYPE.SUCCESS, title: "Saved", message: "Loop job saved." });
+      onSaved(result);
+    } catch (e: unknown) {
+      const err = e as { error?: string; detail?: string } | null;
+      setToast({
+        type: TOAST_TYPE.ERROR,
+        title: "Save failed",
+        message: err?.detail || err?.error || "Check the fields and try again.",
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <ModalCore isOpen handleClose={onClose} width={EModalWidth.XXL}>
+      <div className="flex max-h-[85vh] flex-col gap-3 overflow-y-auto p-5">
+        <h3 className="text-h6-semibold text-primary">{editing ? "Edit job" : "New job"}</h3>
+
+        <label className="flex flex-col gap-1 text-12 text-secondary">
+          Slug
+          <input
+            className={FIELD}
+            value={slug}
+            onChange={(e) => setSlug(e.target.value)}
+            placeholder="auto-close-merged"
+            disabled={editing && job?.is_builtin}
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-12 text-secondary">
+          Admin name
+          <input className={FIELD} value={name} onChange={(e) => setName(e.target.value)} />
+        </label>
+        <label className="flex flex-col gap-1 text-12 text-secondary">
+          User-facing name
+          <input className={FIELD} value={publicName} onChange={(e) => setPublicName(e.target.value)} />
+        </label>
+        <label className="flex flex-col gap-1 text-12 text-secondary">
+          User-facing description
+          <textarea
+            className={FIELD}
+            rows={2}
+            value={publicDescription}
+            onChange={(e) => setPublicDescription(e.target.value)}
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-12 text-secondary">
+          Prompt
+          <textarea
+            className={`${FIELD} font-mono`}
+            rows={6}
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+          />
+        </label>
+        <div className="grid grid-cols-2 gap-3">
+          <label className="flex flex-col gap-1 text-12 text-secondary">
+            Min role
+            <select className={FIELD} value={minRole} onChange={(e) => setMinRole(Number(e.target.value))}>
+              <option value={5}>Guest</option>
+              <option value={15}>Member</option>
+              <option value={20}>Admin</option>
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-12 text-secondary">
+            Timezone
+            <input className={FIELD} value={tzid} onChange={(e) => setTzid(e.target.value)} />
+          </label>
+        </div>
+        <label className="flex flex-col gap-1 text-12 text-secondary">
+          Recurrence (RRULE — hourly or slower)
+          <input
+            className={`${FIELD} font-mono`}
+            value={rrule}
+            onChange={(e) => setRrule(e.target.value)}
+            placeholder="FREQ=DAILY;BYHOUR=3;BYMINUTE=0"
+          />
+        </label>
+
+        <div className="mt-2 flex justify-end gap-2">
+          <Button variant="neutral-primary" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            onClick={save}
+            loading={saving}
+            disabled={!slug.trim() || !name.trim() || !publicName.trim() || !prompt.trim()}
+          >
+            Save
+          </Button>
+        </div>
+      </div>
+    </ModalCore>
+  );
+}

--- a/apps/admin/app/(all)/(dashboard)/loop/page.tsx
+++ b/apps/admin/app/(all)/(dashboard)/loop/page.tsx
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useState } from "react";
+import { observer } from "mobx-react";
+import { Link } from "react-router";
+import useSWR from "swr";
+import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
+import { InstanceLoopService } from "@pi-dash/services";
+import type { ILoopJob } from "@pi-dash/types";
+import { Button, Loader, ToggleSwitch } from "@pi-dash/ui";
+// components
+import { PageWrapper } from "@/components/common/page-wrapper";
+// local
+import { LoopJobFormModal } from "./form-modal";
+
+const service = new InstanceLoopService();
+
+const InstanceLoopPage = observer(function InstanceLoopPage() {
+  const { data: jobs, mutate, isLoading } = useSWR<ILoopJob[]>("INSTANCE_LOOP_JOBS", () => service.list());
+  const [creating, setCreating] = useState(false);
+
+  const toggleEnabled = async (job: ILoopJob, enabled: boolean) => {
+    void mutate((prev) => prev?.map((j) => (j.id === job.id ? { ...j, enabled } : j)), false);
+    try {
+      await service.update(job.id, { enabled });
+      void mutate();
+    } catch {
+      setToast({ type: TOAST_TYPE.ERROR, title: "Update failed", message: "Could not change the job state." });
+      void mutate();
+    }
+  };
+
+  return (
+    <PageWrapper
+      header={{
+        title: "Loop — Auto Project Management",
+        description:
+          "Scheduled AI jobs that run as each user to manage their issues. Users see these as “Auto Project Management”.",
+        actions: <Button onClick={() => setCreating(true)}>New job</Button>,
+      }}
+    >
+      {isLoading || !jobs ? (
+        <Loader className="space-y-4">
+          <Loader.Item height="48px" />
+          <Loader.Item height="48px" />
+        </Loader>
+      ) : jobs.length === 0 ? (
+        <p className="px-4 text-body-sm-regular text-secondary">No jobs yet. Create one to get started.</p>
+      ) : (
+        <div className="mx-4 overflow-hidden rounded-md border border-subtle">
+          <table className="w-full text-body-sm-regular">
+            <thead className="bg-surface-2 text-secondary">
+              <tr>
+                <th className="px-3 py-2 text-left font-medium">Name</th>
+                <th className="px-3 py-2 text-left font-medium">Slug</th>
+                <th className="px-3 py-2 text-left font-medium">Recurrence</th>
+                <th className="px-3 py-2 text-left font-medium">Min role</th>
+                <th className="px-3 py-2 text-left font-medium">Builtin</th>
+                <th className="px-3 py-2 text-left font-medium">Enabled</th>
+              </tr>
+            </thead>
+            <tbody>
+              {jobs.map((job) => (
+                <tr key={job.id} className="border-t border-subtle">
+                  <td className="px-3 py-2">
+                    <Link to={`/loop/${job.id}`} className="text-primary underline-offset-2 hover:underline">
+                      {job.name}
+                    </Link>
+                  </td>
+                  <td className="font-mono px-3 py-2 text-12 text-secondary">{job.slug}</td>
+                  <td className="font-mono px-3 py-2 text-12 text-secondary">{job.rrule}</td>
+                  <td className="px-3 py-2">{ROLE_LABELS[job.min_role] ?? job.min_role}</td>
+                  <td className="px-3 py-2">{job.is_builtin ? "Yes" : "No"}</td>
+                  <td className="px-3 py-2">
+                    <ToggleSwitch value={job.enabled} onChange={(v) => toggleEnabled(job, v)} size="sm" />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {creating && (
+        <LoopJobFormModal
+          onClose={() => setCreating(false)}
+          onSaved={() => {
+            setCreating(false);
+            void mutate();
+          }}
+        />
+      )}
+    </PageWrapper>
+  );
+});
+
+export const ROLE_LABELS: Record<number, string> = { 20: "Admin", 15: "Member", 5: "Guest" };
+
+export const meta = () => [{ title: "Loop Settings - God Mode" }];
+
+export default InstanceLoopPage;

--- a/apps/admin/app/routes.ts
+++ b/apps/admin/app/routes.ts
@@ -20,6 +20,8 @@ export default [
     route("authentication/google", "./(all)/(dashboard)/authentication/google/page.tsx"),
     route("authentication/gitea", "./(all)/(dashboard)/authentication/gitea/page.tsx"),
     route("ai", "./(all)/(dashboard)/ai/page.tsx"),
+    route("loop", "./(all)/(dashboard)/loop/page.tsx"),
+    route("loop/:jobId", "./(all)/(dashboard)/loop/detail.tsx"),
     route("image", "./(all)/(dashboard)/image/page.tsx"),
   ]),
   // Catch-all route for 404 handling - must be last

--- a/apps/admin/hooks/use-sidebar-menu/core.ts
+++ b/apps/admin/hooks/use-sidebar-menu/core.ts
@@ -4,13 +4,13 @@
  * See the LICENSE file for details.
  */
 
-import { Image, BrainCog, Cog, Mail } from "lucide-react";
+import { Image, BrainCog, Cog, Mail, RefreshCw } from "lucide-react";
 // pi dash imports
 import { LockIcon, WorkspaceIcon } from "@pi-dash/propel/icons";
 // types
 import type { TSidebarMenuItem } from "./types";
 
-export type TCoreSidebarMenuKey = "general" | "email" | "workspace" | "authentication" | "ai" | "image";
+export type TCoreSidebarMenuKey = "general" | "email" | "workspace" | "authentication" | "ai" | "loop" | "image";
 
 export const coreSidebarMenuLinks: Record<TCoreSidebarMenuKey, TSidebarMenuItem> = {
   general: {
@@ -42,6 +42,12 @@ export const coreSidebarMenuLinks: Record<TCoreSidebarMenuKey, TSidebarMenuItem>
     name: "Artificial intelligence",
     description: "Configure your OpenAI creds.",
     href: `/ai/`,
+  },
+  loop: {
+    Icon: RefreshCw,
+    name: "Loop",
+    description: "Scheduled AI project management jobs.",
+    href: `/loop/`,
   },
   image: {
     Icon: Image,

--- a/apps/admin/hooks/use-sidebar-menu/index.ts
+++ b/apps/admin/hooks/use-sidebar-menu/index.ts
@@ -15,6 +15,7 @@ export function useSidebarMenu(): TSidebarMenuItem[] {
     coreSidebarMenuLinks.authentication,
     coreSidebarMenuLinks.workspace,
     coreSidebarMenuLinks.ai,
+    coreSidebarMenuLinks.loop,
     coreSidebarMenuLinks.image,
   ];
 }

--- a/apps/api/pi_dash/assistant/migrations/0002_assistantthread_kind.py
+++ b/apps/api/pi_dash/assistant/migrations/0002_assistantthread_kind.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Add ``AssistantThread.kind`` (chat | loop).
+
+Additive, defaulted column. Existing rows are chat threads by definition, so no
+backfill is needed. Loop (Auto Project Management) run threads carry
+``kind="loop"`` and are hidden from the assistant thread list. See
+``.ai_design/loop_project_management/design.md`` §6.4.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("assistant", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="assistantthread",
+            name="kind",
+            field=models.CharField(
+                choices=[("chat", "Chat"), ("loop", "Loop")],
+                default="chat",
+                max_length=16,
+            ),
+        ),
+    ]

--- a/apps/api/pi_dash/assistant/models.py
+++ b/apps/api/pi_dash/assistant/models.py
@@ -19,6 +19,11 @@ from django.conf import settings
 from django.db import models
 
 
+class ThreadKind(models.TextChoices):
+    CHAT = "chat", "Chat"
+    LOOP = "loop", "Loop"
+
+
 class AssistantThread(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     workspace = models.ForeignKey(
@@ -28,6 +33,9 @@ class AssistantThread(models.Model):
         settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="assistant_threads"
     )
     title = models.CharField(max_length=255, blank=True, default="")
+    # "chat" = user-driven conversation (visible in the assistant UI);
+    # "loop" = Auto Project Management run thread (hidden from the thread list).
+    kind = models.CharField(max_length=16, choices=ThreadKind.choices, default=ThreadKind.CHAT)
     is_archived = models.BooleanField(default=False)
     # The single in-flight turn for this thread (one-active-turn flag). Nullable
     # FK rather than a bool so cancellation/sweep have a handle on the turn.

--- a/apps/api/pi_dash/assistant/runtime/deps.py
+++ b/apps/api/pi_dash/assistant/runtime/deps.py
@@ -13,7 +13,18 @@ See ``.ai_design/integrate_ai_agent/02-backend.md`` §2.
 from __future__ import annotations
 
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+
+
+@dataclass
+class RunBudget:
+    """Mutable per-run counters. Lives on the (frozen) deps via default_factory
+    so each run gets a fresh budget without touching every construction site.
+    Tools mutate it in place — frozen only forbids reassigning the field, not
+    mutating the object it points to.
+    """
+
+    pr_lookups: int = 0
 
 
 @dataclass(frozen=True)
@@ -26,3 +37,12 @@ class AssistantDeps:
     workspace_role: int  # 20 admin / 15 member / 5 guest
     thread_id: uuid.UUID
     turn_id: uuid.UUID
+    # "chat" = user-driven turn; "loop" = unattended Auto Project Management run.
+    # Derived from the thread's kind in _load_context.
+    mode: str = "chat"
+    budget: RunBudget = field(default_factory=RunBudget)
+
+    @property
+    def created_via(self) -> str:
+        """The ``Issue.created_via`` marker for writes made in this run."""
+        return "assistant" if self.mode == "chat" else "loop"

--- a/apps/api/pi_dash/assistant/runtime/deps.py
+++ b/apps/api/pi_dash/assistant/runtime/deps.py
@@ -40,7 +40,10 @@ class AssistantDeps:
     # "chat" = user-driven turn; "loop" = unattended Auto Project Management run.
     # Derived from the thread's kind in _load_context.
     mode: str = "chat"
-    budget: RunBudget = field(default_factory=RunBudget)
+    # Per-run mutable counters. compare=False keeps them out of __eq__/__hash__
+    # so the frozen deps stays hashable and two runs with identical identity
+    # compare equal regardless of how much budget each has spent.
+    budget: RunBudget = field(default_factory=RunBudget, compare=False)
 
     @property
     def created_via(self) -> str:

--- a/apps/api/pi_dash/assistant/runtime/history.py
+++ b/apps/api/pi_dash/assistant/runtime/history.py
@@ -28,7 +28,13 @@ def load_history(thread: AssistantThread) -> list:
     """Return the prior ``list[ModelMessage]`` for this thread (most recent completed turns)."""
     from pydantic_ai.messages import ModelMessagesTypeAdapter
 
-    max_turns = max(1, int(getattr(settings, "ASSISTANT_HISTORY_MAX_TURNS", 40)))
+    # Loop (Auto Project Management) threads replay history too — memory like
+    # "yesterday I closed #42" — but at a tighter default since it's a daily
+    # token cost. See ``.ai_design/loop_project_management/design.md`` §7.7.
+    if getattr(thread, "kind", "chat") == "loop":
+        max_turns = max(1, int(getattr(settings, "ASSISTANT_LOOP_HISTORY_MAX_TURNS", 5)))
+    else:
+        max_turns = max(1, int(getattr(settings, "ASSISTANT_HISTORY_MAX_TURNS", 40)))
     messages: list = []
     blobs = list(
         thread.turns.filter(status=TurnStatus.COMPLETED, model_messages__isnull=False)

--- a/apps/api/pi_dash/assistant/runtime/instructions.py
+++ b/apps/api/pi_dash/assistant/runtime/instructions.py
@@ -11,6 +11,7 @@ model behaviour. See ``.ai_design/integrate_ai_agent/02-backend.md`` §2.1.
 
 from __future__ import annotations
 
+from django.conf import settings
 from django.utils import timezone
 
 from pi_dash.core.permissions import ROLE_MEMBER
@@ -49,6 +50,23 @@ offer dispatch_coding_run instead of attempting it yourself.
 """
 
 
+# Appended (not substituted) when a turn runs unattended on a loop thread. The
+# base rules still apply; this overrides only rule 3 (ask-before-bulk — there is
+# nobody to ask) and adds the unattended contract. See
+# ``.ai_design/loop_project_management/design.md`` §7.7.
+LOOP_INSTRUCTIONS = """\
+## Unattended mode
+You are running as a scheduled maintenance task. No human reads your reply \
+live, and nobody can answer questions — never ask; when a judgement is \
+ambiguous, skip that item instead of guessing. Perform only the actions your \
+task instructions explicitly call for. Never delete anything. The \
+bulk-change confirmation rule does not apply, but act on at most {max_writes} \
+items per run; if more qualify, handle the oldest and note the remainder in \
+your summary. End with a short plain-text summary of every action you took, \
+or "No action needed."
+"""
+
+
 def dynamic_instructions(ctx) -> str:
     """Per-run context appended to the base instructions (derived from deps)."""
     deps = ctx.deps
@@ -62,4 +80,7 @@ def dynamic_instructions(ctx) -> str:
         lines.append(
             "This user's role cannot create or modify issues; offer read-only help."
         )
+    if getattr(deps, "mode", "chat") == "loop":
+        max_writes = int(getattr(settings, "LOOP_MAX_WRITES", 10))
+        lines.append(LOOP_INSTRUCTIONS.format(max_writes=max_writes))
     return "\n".join(lines)

--- a/apps/api/pi_dash/assistant/tasks.py
+++ b/apps/api/pi_dash/assistant/tasks.py
@@ -88,7 +88,7 @@ def _load_context(turn_id):
         workspace_role=int(role),
         thread_id=thread.id,
         turn_id=turn.id,
-        mode=thread.kind,
+        mode=getattr(thread, "kind", "chat"),
     )
     return _Ctx(thread=thread, turn=turn, user=user, user_text=user_text, deps=deps)
 

--- a/apps/api/pi_dash/assistant/tasks.py
+++ b/apps/api/pi_dash/assistant/tasks.py
@@ -88,6 +88,7 @@ def _load_context(turn_id):
         workspace_role=int(role),
         thread_id=thread.id,
         turn_id=turn.id,
+        mode=thread.kind,
     )
     return _Ctx(thread=thread, turn=turn, user=user, user_text=user_text, deps=deps)
 

--- a/apps/api/pi_dash/assistant/tools/__init__.py
+++ b/apps/api/pi_dash/assistant/tools/__init__.py
@@ -8,6 +8,6 @@ Each tool module decorates its functions with ``@assistant.tool`` at import
 time, so importing the package (done in ``AssistantConfig.ready``) wires them up.
 """
 
-from pi_dash.assistant.tools import comments, issues, projects, runs  # noqa: F401
+from pi_dash.assistant.tools import comments, github, issues, projects, runs  # noqa: F401
 
-__all__ = ["projects", "issues", "comments", "runs"]
+__all__ = ["projects", "issues", "comments", "runs", "github"]

--- a/apps/api/pi_dash/assistant/tools/github.py
+++ b/apps/api/pi_dash/assistant/tools/github.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""GitHub read tool — pull-request merge status.
+
+Nothing in the DB materializes PR merge state (issue links are free-form URLs,
+the GitHub integration syncs issues/comments not PRs), so the agent checks
+merge state live. This tool **never raises**: ``state="unknown"`` is a normal
+answer the loop's auto-close prompt is written around ("only act when clearly
+established"). Available to chat and loop runs alike. See
+``.ai_design/loop_project_management/design.md`` §8.2.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+from django.conf import settings
+from pydantic_ai import RunContext
+
+from pi_dash.assistant import ssrf
+from pi_dash.assistant.runtime.agent import assistant
+from pi_dash.assistant.runtime.deps import AssistantDeps
+from pi_dash.assistant.tools import _scoping
+
+logger = logging.getLogger(__name__)
+
+_PR_URL_RE = re.compile(
+    r"^https://github\.com/(?P<owner>[\w.-]+)/(?P<repo>[\w.-]+)/pull/(?P<num>\d+)"
+)
+_API_HOST = "https://api.github.com"
+_TIMEOUT_S = 10
+
+
+def _unknown(reason: str) -> dict:
+    return {"state": "unknown", "reason": reason}
+
+
+def _find_token(deps: AssistantDeps, owner: str, repo: str) -> str | None:
+    """Best-effort access token from a GithubRepositorySync on a project the
+    user can access whose repository matches ``owner/repo``. Returns None when
+    none is found (the call then proceeds unauthenticated)."""
+    from pi_dash.db.models import GithubRepositorySync
+
+    sync = (
+        GithubRepositorySync.objects.filter(
+            project__in=_scoping.member_projects(deps),
+            repository__owner__iexact=owner,
+            repository__name__iexact=repo,
+        )
+        .order_by("-created_at")
+        .first()
+    )
+    if sync is None:
+        return None
+    creds = sync.credentials or {}
+    token = creds.get("access_token") or creds.get("token")
+    return token or None
+
+
+@assistant.tool
+def get_pull_request_status(ctx: RunContext[AssistantDeps], url: str) -> dict:
+    """Check whether a GitHub pull request is merged.
+
+    Pass a full PR URL like ``https://github.com/owner/repo/pull/123``. Returns
+    ``{"state": "merged"|"open"|"closed"|"unknown", ...}``. A non-GitHub or
+    unparseable URL, a rate limit, or a network error all return ``unknown`` —
+    treat ``unknown`` as "could not establish; do not act".
+    """
+    deps = ctx.deps
+
+    # Per-run budget — protects the unauthenticated GitHub rate limit.
+    cap = int(getattr(settings, "LOOP_PR_LOOKUPS_PER_RUN", 15))
+    if deps.budget.pr_lookups >= cap:
+        return _unknown("budget_exhausted")
+    deps.budget.pr_lookups += 1
+
+    match = _PR_URL_RE.match((url or "").strip())
+    if match is None:
+        return _unknown("unsupported_url")
+    owner, repo, num = match.group("owner"), match.group("repo"), match.group("num")
+
+    api_url = f"{_API_HOST}/repos/{owner}/{repo}/pulls/{num}"
+    if ssrf.is_blocked(api_url):
+        return _unknown("blocked")
+
+    headers = {"Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28"}
+    token = _find_token(deps, owner, repo)
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    import httpx
+
+    try:
+        with httpx.Client(timeout=_TIMEOUT_S, follow_redirects=False) as client:
+            resp = client.get(api_url, headers=headers)
+    except Exception:  # noqa: BLE001 — any transport failure is just "unknown"
+        logger.warning("get_pull_request_status: network error for %s/%s#%s", owner, repo, num)
+        return _unknown("network_error")
+
+    if resp.status_code == 404:
+        return _unknown("not_found")
+    if resp.status_code in (403, 429):
+        return _unknown("rate_limited")
+    if resp.status_code == 451:
+        return _unknown("blocked")
+    if resp.status_code != 200:
+        return _unknown(f"http_{resp.status_code}")
+
+    try:
+        data = resp.json()
+    except Exception:  # noqa: BLE001
+        return _unknown("bad_response")
+
+    if data.get("merged") or data.get("merged_at"):
+        state = "merged"
+    elif data.get("state") == "closed":
+        state = "closed"
+    else:
+        state = "open"
+    return {
+        "state": state,
+        "title": data.get("title"),
+        "merged_at": data.get("merged_at"),
+        "url": f"https://github.com/{owner}/{repo}/pull/{num}",
+    }

--- a/apps/api/pi_dash/assistant/tools/issues.py
+++ b/apps/api/pi_dash/assistant/tools/issues.py
@@ -179,7 +179,7 @@ def create_issue(
             project=project,
             workspace=project.workspace,
             created_by=user,
-            created_via="assistant",
+            created_via=deps.created_via,
         )
 
     _results.record_write(

--- a/apps/api/pi_dash/assistant/views/threads.py
+++ b/apps/api/pi_dash/assistant/views/threads.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from rest_framework import status
 from rest_framework.response import Response
 
-from pi_dash.assistant.models import AssistantThread
+from pi_dash.assistant.models import AssistantThread, ThreadKind
 from pi_dash.assistant.serializers import AssistantThreadSerializer
 from pi_dash.assistant.tasks import cancel_key
 from pi_dash.assistant.views._base import AssistantBaseView
@@ -19,8 +19,11 @@ class AssistantThreadListCreateEndpoint(AssistantBaseView):
         denied = self.require_member(request, slug)
         if denied:
             return denied
+        # Only chat threads surface in the assistant UI; loop (Auto Project
+        # Management) threads are hidden — that filter is the entire opacity
+        # mechanism (design §6.4).
         threads = AssistantThread.objects.filter(
-            user=request.user, workspace__slug=slug, is_archived=False
+            user=request.user, workspace__slug=slug, is_archived=False, kind=ThreadKind.CHAT
         ).order_by("-updated_at")[:50]
         return Response(AssistantThreadSerializer(threads, many=True).data)
 

--- a/apps/api/pi_dash/bgtasks/loop.py
+++ b/apps/api/pi_dash/bgtasks/loop.py
@@ -1,0 +1,223 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Loop (Auto Project Management) — Beat scanner and per-target fire.
+
+The scanner (:func:`scan_due_targets`) runs once a minute under Celery Beat and
+does two things: reconcile (create missing targets for new membership edges,
+throttled) and fan out (queue :func:`fire_loop_target` for every eligible due
+target). ``fire_loop_target`` claims one target under SFU, re-checks eligibility
+freshest-wins, advances the cursor, and hands off to
+:func:`pi_dash.loop.dispatch.dispatch_loop_turn`.
+
+Unlike the scheduler there is **no rollback phase**: dispatch here is local row
+creation, not a remote pod match that can transiently fail. See
+``.ai_design/loop_project_management/design.md`` §7.1–7.4.
+
+**Beat must run as a singleton** — multiple Beat schedulers double the scan
+rate. The atomic SFU claim keeps fan-out race-safe regardless.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+from zlib import crc32
+
+from celery import shared_task
+from django.conf import settings
+from django.db.models import Exists, OuterRef
+from django.utils import timezone
+
+from pi_dash.bgtasks._rrule import next_fire_from_rrule
+from pi_dash.db.models import LoopJob, LoopTarget, WorkspaceMember
+from pi_dash.loop import dispatch, eligibility
+
+logger = logging.getLogger("pi_dash.worker")
+
+
+def _is_enabled() -> bool:
+    return getattr(settings, "LOOP_ENABLED", True)
+
+
+def _stagger(job_id, workspace_id, user_id) -> timedelta:
+    """Deterministic per-edge offset within the stagger window (no randomness in
+    scheduling paths → reproducible tests, stable per edge)."""
+    window = max(1, int(getattr(settings, "LOOP_STAGGER_WINDOW_MINUTES", 60)))
+    seed = f"{job_id}:{workspace_id}:{user_id}".encode()
+    return timedelta(minutes=crc32(seed) % window)
+
+
+def _next_fire_for_job(job: LoopJob, *, now=None):
+    return next_fire_from_rrule(
+        dtstart=job.dtstart, rrule_str=job.rrule or "", tzid=job.tzid or "UTC", now=now
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Scanner
+# --------------------------------------------------------------------------- #
+
+def _reconcile_targets(now) -> int:
+    """Create missing ``LoopTarget`` rows for (enabled job × active edge).
+
+    Throttled to once per ``LOOP_RECONCILE_EVERY_MINUTES`` — a new member waits
+    at most that long for a cursor, and their first fire is next occurrence +
+    stagger regardless. Returns the number of targets created.
+    """
+    every = max(1, int(getattr(settings, "LOOP_RECONCILE_EVERY_MINUTES", 15)))
+    if now.minute % every != 0:
+        return 0
+
+    created = 0
+    for job in LoopJob.objects.filter(enabled=True, deleted_at__isnull=True):
+        nxt = _next_fire_for_job(job, now=now)
+        if nxt is None:
+            # Bad RRULE — admin API validation should make this unreachable.
+            logger.warning("loop.reconcile: job=%s has unusable rrule=%r", job.slug, job.rrule)
+            continue
+        has_target = LoopTarget.objects.filter(
+            job=job,
+            deleted_at__isnull=True,
+            workspace_id=OuterRef("workspace_id"),
+            user_id=OuterRef("member_id"),
+        )
+        edges = (
+            WorkspaceMember.objects.filter(
+                is_active=True, member__is_active=True, deleted_at__isnull=True
+            )
+            .annotate(_has=Exists(has_target))
+            .filter(_has=False)
+            .values_list("workspace_id", "member_id")
+        )
+        batch = [
+            LoopTarget(
+                job=job,
+                workspace_id=ws,
+                user_id=uid,
+                next_run_at=nxt + _stagger(job.id, ws, uid),
+            )
+            for ws, uid in edges.iterator(chunk_size=1000)
+        ]
+        if batch:
+            LoopTarget.objects.bulk_create(batch, ignore_conflicts=True, batch_size=500)
+            created += len(batch)
+    if created:
+        logger.info("loop.reconcile: created %d targets", created)
+    return created
+
+
+def _advance_ineligible_due(now) -> int:
+    """Advance the cursor for due-but-ineligible targets so they aren't
+    re-examined every minute. One bulk pass, cursor recomputed once per job.
+    Returns the number advanced.
+    """
+    eligible_ids = set(eligibility.eligible_due_targets(now).values_list("id", flat=True))
+    due = (
+        eligibility.due_targets(now)
+        .select_related("job")
+        .exclude(id__in=eligible_ids)
+    )
+    # Compute each job's next fire once.
+    next_by_job: dict = {}
+    to_update = []
+    for target in due.iterator(chunk_size=1000):
+        job = target.job
+        if job.id not in next_by_job:
+            next_by_job[job.id] = _next_fire_for_job(job, now=now)
+        nxt = next_by_job[job.id]
+        reason = eligibility.check(target)
+        target.next_run_at = (
+            nxt + _stagger(job.id, target.workspace_id, target.user_id) if nxt else None
+        )
+        target.last_skipped_at = now
+        target.last_skip_reason = reason or ""
+        to_update.append(target)
+    if to_update:
+        LoopTarget.objects.bulk_update(
+            to_update,
+            ["next_run_at", "last_skipped_at", "last_skip_reason", "updated_at"],
+            batch_size=500,
+        )
+    return len(to_update)
+
+
+@shared_task(name="pi_dash.bgtasks.loop.scan_due_targets")
+def scan_due_targets() -> int:
+    """Reconcile, then fan out ``fire_loop_target`` for eligible due targets.
+
+    Returns the number of fan-outs (for logging / tests).
+    """
+    if not _is_enabled():
+        return 0
+
+    now = timezone.now()
+    _reconcile_targets(now)
+
+    cap = max(1, int(getattr(settings, "LOOP_MAX_DISPATCH_PER_TICK", 100)))
+    ids = list(
+        eligibility.eligible_due_targets(now)
+        .order_by("next_run_at")
+        .values_list("id", flat=True)[:cap]
+    )
+    for target_id in ids:
+        fire_loop_target.delay(str(target_id))
+
+    # Targets that are due but ineligible still need their cursor advanced, or
+    # they'd be re-scanned every minute forever. (Over-cap *eligible* targets
+    # are intentionally left due — backpressure; they drain next tick.)
+    _advance_ineligible_due(now)
+
+    if ids:
+        logger.info("loop.scan: dispatched %d fire_loop_target tasks", len(ids))
+    return len(ids)
+
+
+# --------------------------------------------------------------------------- #
+# Per-target fire
+# --------------------------------------------------------------------------- #
+
+@shared_task(name="pi_dash.bgtasks.loop.fire_loop_target", bind=True, max_retries=0)
+def fire_loop_target(self, target_id: str) -> bool:
+    """Claim one target under SFU, re-check eligibility, advance the cursor, and
+    dispatch a turn. Returns ``True`` if a turn was queued.
+    """
+    if not _is_enabled():
+        return False
+
+    from django.db import transaction
+
+    # ----- Phase 1: claim, re-check eligibility, advance cursor -----
+    with transaction.atomic():
+        target = (
+            LoopTarget.objects.select_for_update(of=("self",))
+            .select_related("job", "workspace", "user")
+            .filter(pk=target_id, deleted_at__isnull=True)
+            .first()
+        )
+        if target is None:
+            return False
+        now = timezone.now()
+        # Future cursor = raced the scanner; another fire already claimed.
+        if target.next_run_at is not None and target.next_run_at > now:
+            return False
+
+        job = target.job
+        nxt = _next_fire_for_job(job, now=now)
+        target.next_run_at = (
+            nxt + _stagger(job.id, target.workspace_id, target.user_id) if nxt else None
+        )
+
+        skip = eligibility.check(target)
+        if skip is not None:
+            target.last_skipped_at = now
+            target.last_skip_reason = skip
+            target.save(
+                update_fields=["next_run_at", "last_skipped_at", "last_skip_reason", "updated_at"]
+            )
+            return False
+        target.save(update_fields=["next_run_at", "updated_at"])
+
+    # ----- Phase 2: dispatch a turn (own transaction; no rollback) -----
+    return dispatch.dispatch_loop_turn(str(target_id))

--- a/apps/api/pi_dash/bgtasks/loop.py
+++ b/apps/api/pi_dash/bgtasks/loop.py
@@ -108,12 +108,14 @@ def _reconcile_targets(now) -> int:
     return created
 
 
-def _advance_ineligible_due(now) -> int:
+def _advance_ineligible_due(now, eligible_ids) -> int:
     """Advance the cursor for due-but-ineligible targets so they aren't
     re-examined every minute. One bulk pass, cursor recomputed once per job.
+
+    ``eligible_ids`` is the set already computed by the scanner, so the eligible
+    queryset (4 annotated subqueries) is evaluated once per tick, not twice.
     Returns the number advanced.
     """
-    eligible_ids = set(eligibility.eligible_due_targets(now).values_list("id", flat=True))
     due = (
         eligibility.due_targets(now)
         .select_related("job")
@@ -156,18 +158,19 @@ def scan_due_targets() -> int:
     _reconcile_targets(now)
 
     cap = max(1, int(getattr(settings, "LOOP_MAX_DISPATCH_PER_TICK", 100)))
-    ids = list(
-        eligibility.eligible_due_targets(now)
-        .order_by("next_run_at")
-        .values_list("id", flat=True)[:cap]
+    # Evaluate the eligible set once; cap the dispatch slice in Python and reuse
+    # the full set to exclude eligibles from the ineligible-advance pass.
+    eligible_ids = list(
+        eligibility.eligible_due_targets(now).order_by("next_run_at").values_list("id", flat=True)
     )
+    ids = eligible_ids[:cap]
     for target_id in ids:
         fire_loop_target.delay(str(target_id))
 
     # Targets that are due but ineligible still need their cursor advanced, or
     # they'd be re-scanned every minute forever. (Over-cap *eligible* targets
     # are intentionally left due — backpressure; they drain next tick.)
-    _advance_ineligible_due(now)
+    _advance_ineligible_due(now, set(eligible_ids))
 
     if ids:
         logger.info("loop.scan: dispatched %d fire_loop_target tasks", len(ids))

--- a/apps/api/pi_dash/celery.py
+++ b/apps/api/pi_dash/celery.py
@@ -119,6 +119,12 @@ app.conf.beat_schedule = {
         "task": "pi_dash.bgtasks.scheduler.scan_due_bindings",
         "schedule": crontab(minute="*"),
     },
+    # Loop (Auto Project Management) scanner — see
+    # .ai_design/loop_project_management/design.md §7.1.
+    "scan-due-loop-targets": {
+        "task": "pi_dash.bgtasks.loop.scan_due_targets",
+        "schedule": crontab(minute="*"),
+    },
 }
 
 

--- a/apps/api/pi_dash/db/migrations/0149_loop_mvp.py
+++ b/apps/api/pi_dash/db/migrations/0149_loop_mvp.py
@@ -1,0 +1,304 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Loop (Auto Project Management) — MVP schema + builtin seed.
+
+Creates:
+  - ``LoopJob`` — instance-level (prompt + timer) catalog entries. Conditional
+    unique on ``slug`` filtered to ``deleted_at IS NULL``.
+  - ``LoopTarget`` — per-membership-edge cursor (job × workspace × user) with a
+    nullable FK to the hidden ``assistant.AssistantThread`` and to the last
+    ``assistant.AssistantTurn`` (the run *is* the turn — no LoopRun model).
+  - ``LoopUserPreference`` — a user's per-job opt-out (or master pause when
+    ``job`` is NULL). Absence of a row = enabled.
+
+Seeds the one MVP builtin job (``auto-close-merged``) ``enabled=False`` — the
+operator flips it on from apps/admin after a smoke test (design §13).
+
+See ``.ai_design/loop_project_management/design.md`` §6, §8.1.
+"""
+
+import uuid
+
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+def seed_builtin_jobs(apps, schema_editor):
+    from pi_dash.loop.builtins import BUILTIN_LOOP_JOBS
+
+    LoopJob = apps.get_model("db", "LoopJob")
+    now = __import__("django.utils.timezone", fromlist=["now"]).now()
+    for spec in BUILTIN_LOOP_JOBS:
+        LoopJob.objects.update_or_create(
+            slug=spec.slug,
+            deleted_at__isnull=True,
+            defaults={
+                "name": spec.name,
+                "public_name": spec.public_name,
+                "public_description": spec.public_description,
+                "prompt": spec.prompt,
+                "min_role": spec.min_role,
+                "enabled": False,  # operator enables after smoke test (design §13)
+                "is_builtin": True,
+                "dtstart": now,
+                "rrule": spec.rrule,
+                "tzid": spec.tzid,
+            },
+        )
+
+
+def unseed_builtin_jobs(apps, schema_editor):
+    from pi_dash.loop.builtins import BUILTIN_LOOP_JOBS
+
+    LoopJob = apps.get_model("db", "LoopJob")
+    LoopJob.objects.filter(slug__in=[s.slug for s in BUILTIN_LOOP_JOBS]).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("db", "0148_issue_created_via"),
+        ("assistant", "0002_assistantthread_kind"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="LoopJob",
+            fields=[
+                ("created_at", models.DateTimeField(auto_now_add=True, verbose_name="Created At")),
+                ("updated_at", models.DateTimeField(auto_now=True, verbose_name="Last Modified At")),
+                ("deleted_at", models.DateTimeField(blank=True, null=True, verbose_name="Deleted At")),
+                ("id", models.UUIDField(db_index=True, default=uuid.uuid4, editable=False, primary_key=True, serialize=False, unique=True)),
+                ("slug", models.CharField(max_length=64)),
+                ("name", models.CharField(max_length=255)),
+                ("public_name", models.CharField(max_length=255)),
+                ("public_description", models.TextField(blank=True, default="")),
+                ("prompt", models.TextField()),
+                ("min_role", models.PositiveSmallIntegerField(default=15)),
+                ("enabled", models.BooleanField(default=True)),
+                ("is_builtin", models.BooleanField(default=True)),
+                ("dtstart", models.DateTimeField()),
+                ("rrule", models.CharField(max_length=255)),
+                ("tzid", models.CharField(default="UTC", max_length=64)),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="loopjob_created_by",
+                        to=settings.AUTH_USER_MODEL,
+                        verbose_name="Created By",
+                    ),
+                ),
+                (
+                    "updated_by",
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="loopjob_updated_by",
+                        to=settings.AUTH_USER_MODEL,
+                        verbose_name="Last Modified By",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Loop Job",
+                "verbose_name_plural": "Loop Jobs",
+                "db_table": "loop_jobs",
+                "ordering": ("-created_at",),
+            },
+        ),
+        migrations.CreateModel(
+            name="LoopTarget",
+            fields=[
+                ("created_at", models.DateTimeField(auto_now_add=True, verbose_name="Created At")),
+                ("updated_at", models.DateTimeField(auto_now=True, verbose_name="Last Modified At")),
+                ("deleted_at", models.DateTimeField(blank=True, null=True, verbose_name="Deleted At")),
+                ("id", models.UUIDField(db_index=True, default=uuid.uuid4, editable=False, primary_key=True, serialize=False, unique=True)),
+                ("next_run_at", models.DateTimeField(blank=True, null=True)),
+                ("last_skipped_at", models.DateTimeField(blank=True, null=True)),
+                (
+                    "last_skip_reason",
+                    models.CharField(
+                        blank=True,
+                        choices=[
+                            ("user_disabled", "User disabled this job"),
+                            ("master_paused", "User paused all Auto PM"),
+                            ("min_role", "Below the job's minimum role"),
+                            ("llm_config_missing", "No usable LLM credentials"),
+                            ("membership_gone", "No active workspace membership"),
+                            ("turn_active", "Previous run still in flight"),
+                            ("dispatch_error", "Unexpected error creating the turn"),
+                        ],
+                        default="",
+                        max_length=64,
+                    ),
+                ),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="looptarget_created_by",
+                        to=settings.AUTH_USER_MODEL,
+                        verbose_name="Created By",
+                    ),
+                ),
+                (
+                    "updated_by",
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="looptarget_updated_by",
+                        to=settings.AUTH_USER_MODEL,
+                        verbose_name="Last Modified By",
+                    ),
+                ),
+                (
+                    "job",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="targets",
+                        to="db.loopjob",
+                    ),
+                ),
+                (
+                    "workspace",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="loop_targets",
+                        to="db.workspace",
+                    ),
+                ),
+                (
+                    "user",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="loop_targets",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "thread",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to="assistant.assistantthread",
+                    ),
+                ),
+                (
+                    "last_run",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to="assistant.assistantturn",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Loop Target",
+                "verbose_name_plural": "Loop Targets",
+                "db_table": "loop_targets",
+                "ordering": ("-created_at",),
+            },
+        ),
+        migrations.CreateModel(
+            name="LoopUserPreference",
+            fields=[
+                ("created_at", models.DateTimeField(auto_now_add=True, verbose_name="Created At")),
+                ("updated_at", models.DateTimeField(auto_now=True, verbose_name="Last Modified At")),
+                ("deleted_at", models.DateTimeField(blank=True, null=True, verbose_name="Deleted At")),
+                ("id", models.UUIDField(db_index=True, default=uuid.uuid4, editable=False, primary_key=True, serialize=False, unique=True)),
+                ("enabled", models.BooleanField(default=True)),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="loopuserpreference_created_by",
+                        to=settings.AUTH_USER_MODEL,
+                        verbose_name="Created By",
+                    ),
+                ),
+                (
+                    "updated_by",
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="loopuserpreference_updated_by",
+                        to=settings.AUTH_USER_MODEL,
+                        verbose_name="Last Modified By",
+                    ),
+                ),
+                (
+                    "user",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="loop_preferences",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "job",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="user_preferences",
+                        to="db.loopjob",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Loop User Preference",
+                "verbose_name_plural": "Loop User Preferences",
+                "db_table": "loop_user_preferences",
+                "ordering": ("-created_at",),
+            },
+        ),
+        migrations.AddConstraint(
+            model_name="loopjob",
+            constraint=models.UniqueConstraint(
+                fields=("slug",),
+                condition=models.Q(deleted_at__isnull=True),
+                name="loop_job_unique_slug_when_active",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="looptarget",
+            constraint=models.UniqueConstraint(
+                fields=("job", "workspace", "user"),
+                condition=models.Q(deleted_at__isnull=True),
+                name="loop_target_unique_edge_when_active",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="looptarget",
+            index=models.Index(fields=("next_run_at",), name="loop_target_due_idx"),
+        ),
+        migrations.AddConstraint(
+            model_name="loopuserpreference",
+            constraint=models.UniqueConstraint(
+                fields=("user", "job"),
+                condition=models.Q(deleted_at__isnull=True),
+                name="loop_pref_unique_user_job_when_active",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="loopuserpreference",
+            constraint=models.UniqueConstraint(
+                fields=("user",),
+                condition=models.Q(job__isnull=True, deleted_at__isnull=True),
+                name="loop_pref_unique_user_master_when_active",
+            ),
+        ),
+        migrations.RunPython(seed_builtin_jobs, unseed_builtin_jobs),
+    ]

--- a/apps/api/pi_dash/db/models/__init__.py
+++ b/apps/api/pi_dash/db/models/__init__.py
@@ -94,3 +94,5 @@ from .description import Description, DescriptionVersion
 from .issue_agent_ticker import IssueAgentTicker
 
 from .scheduler import Scheduler, SchedulerBinding, SchedulerSource
+
+from .loop import LoopJob, LoopTarget, LoopUserPreference, SkipReason

--- a/apps/api/pi_dash/db/models/loop.py
+++ b/apps/api/pi_dash/db/models/loop.py
@@ -1,0 +1,183 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Loop (Auto Project Management) — instance-defined periodic assistant jobs.
+
+A ``LoopJob`` is an instance-level (prompt + timer) authored by the operator.
+A ``LoopTarget`` is the per-membership-edge cursor (job × workspace × user) that
+the Beat scanner advances and fires; each fire dispatches a normal
+``AssistantTurn`` in a hidden ``kind="loop"`` thread, running as the user with
+the user's permissions and credentials. ``LoopUserPreference`` records a user's
+opt-outs (absence of a row = enabled).
+
+See ``.ai_design/loop_project_management/design.md`` §6.
+"""
+
+from __future__ import annotations
+
+from django.conf import settings
+from django.db import models
+
+from .base import BaseModel
+
+
+class SkipReason(models.TextChoices):
+    """Why a due target was skipped instead of dispatched.
+
+    Stored sparsely on :attr:`LoopTarget.last_skip_reason` (overwritten in
+    place, never accreted as a log). See design §6.2.
+    """
+
+    USER_DISABLED = "user_disabled", "User disabled this job"
+    MASTER_PAUSED = "master_paused", "User paused all Auto PM"
+    MIN_ROLE = "min_role", "Below the job's minimum role"
+    LLM_CONFIG_MISSING = "llm_config_missing", "No usable LLM credentials"
+    MEMBERSHIP_GONE = "membership_gone", "No active workspace membership"
+    TURN_ACTIVE = "turn_active", "Previous run still in flight"
+    DISPATCH_ERROR = "dispatch_error", "Unexpected error creating the turn"
+
+
+class LoopJob(BaseModel):
+    """An instance catalog entry: a prompt + a recurrence.
+
+    Instance-scoped (no workspace FK), so the operator defines a job once and it
+    auto-applies to every membership edge via reconcile (design §7.2). The
+    user-facing ``public_*`` fields never contain the word "loop"; ``name`` is
+    the admin-facing label.
+    """
+
+    slug = models.CharField(max_length=64)
+    name = models.CharField(max_length=255)
+    public_name = models.CharField(max_length=255)
+    public_description = models.TextField(blank=True, default="")
+    prompt = models.TextField()
+    # ROLE_CHOICES from db/models/workspace.py: 20 admin / 15 member / 5 guest.
+    min_role = models.PositiveSmallIntegerField(default=15)
+    enabled = models.BooleanField(default=True)
+    is_builtin = models.BooleanField(default=True)
+
+    # Timer — the same RRULE bundle subset as SchedulerBinding, evaluated by
+    # pi_dash/bgtasks/_rrule.next_fire_from_rrule. ``rrule`` may not be empty:
+    # a single-shot loop job is meaningless.
+    dtstart = models.DateTimeField()
+    rrule = models.CharField(max_length=255)
+    tzid = models.CharField(max_length=64, default="UTC")
+
+    class Meta:
+        db_table = "loop_jobs"
+        verbose_name = "Loop Job"
+        verbose_name_plural = "Loop Jobs"
+        ordering = ("-created_at",)
+        constraints = [
+            models.UniqueConstraint(
+                fields=["slug"],
+                condition=models.Q(deleted_at__isnull=True),
+                name="loop_job_unique_slug_when_active",
+            ),
+        ]
+
+    def __str__(self) -> str:
+        return f"LoopJob({self.slug})"
+
+
+class LoopTarget(BaseModel):
+    """The cursor for one (job × workspace × user) membership edge.
+
+    There is intentionally NO ``LoopRun`` model — the run *is* the
+    ``AssistantTurn`` referenced by :attr:`last_run`; status, usage, errors, and
+    the full transcript live there. See design §6.2.
+    """
+
+    job = models.ForeignKey("db.LoopJob", on_delete=models.CASCADE, related_name="targets")
+    workspace = models.ForeignKey(
+        "db.Workspace", on_delete=models.CASCADE, related_name="loop_targets"
+    )
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="loop_targets"
+    )
+
+    # The hidden conversation this target's runs land in. Recreated on rotation
+    # (design §7.5); SET_NULL so deleting a thread can't kill the cursor.
+    thread = models.ForeignKey(
+        "assistant.AssistantThread",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="+",
+    )
+
+    # NULL = newly created, stagger pending (treated as due by the scanner).
+    next_run_at = models.DateTimeField(null=True, blank=True)
+    last_run = models.ForeignKey(
+        "assistant.AssistantTurn",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="+",
+    )
+    # Sparse skip diagnostics — overwritten in place, never accreted.
+    last_skipped_at = models.DateTimeField(null=True, blank=True)
+    last_skip_reason = models.CharField(
+        max_length=64, choices=SkipReason.choices, blank=True, default=""
+    )
+
+    class Meta:
+        db_table = "loop_targets"
+        verbose_name = "Loop Target"
+        verbose_name_plural = "Loop Targets"
+        ordering = ("-created_at",)
+        constraints = [
+            models.UniqueConstraint(
+                fields=["job", "workspace", "user"],
+                condition=models.Q(deleted_at__isnull=True),
+                name="loop_target_unique_edge_when_active",
+            ),
+        ]
+        indexes = [models.Index(fields=["next_run_at"], name="loop_target_due_idx")]
+
+    def __str__(self) -> str:
+        return f"LoopTarget(job={self.job_id}, ws={self.workspace_id}, user={self.user_id})"
+
+
+class LoopUserPreference(BaseModel):
+    """A user's opt-out for a job (or the master "pause all" switch when
+    ``job`` is NULL). Absence of a row means enabled — only opt-outs are stored,
+    which is what makes new builtin jobs light up with zero backfill (design
+    §6.3).
+    """
+
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="loop_preferences"
+    )
+    # NULL job = the master "pause all Auto Project Management" switch.
+    job = models.ForeignKey(
+        "db.LoopJob",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="user_preferences",
+    )
+    enabled = models.BooleanField(default=True)
+
+    class Meta:
+        db_table = "loop_user_preferences"
+        verbose_name = "Loop User Preference"
+        verbose_name_plural = "Loop User Preferences"
+        ordering = ("-created_at",)
+        constraints = [
+            models.UniqueConstraint(
+                fields=["user", "job"],
+                condition=models.Q(deleted_at__isnull=True),
+                name="loop_pref_unique_user_job_when_active",
+            ),
+            models.UniqueConstraint(
+                fields=["user"],
+                condition=models.Q(job__isnull=True, deleted_at__isnull=True),
+                name="loop_pref_unique_user_master_when_active",
+            ),
+        ]
+
+    def __str__(self) -> str:
+        scope = self.job_id or "master"
+        return f"LoopUserPreference(user={self.user_id}, job={scope}, enabled={self.enabled})"

--- a/apps/api/pi_dash/license/urls.py
+++ b/apps/api/pi_dash/license/urls.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # See the LICENSE file for details.
 
-from django.urls import path
+from django.urls import include, path
 
 from pi_dash.license.api.views import (
     EmailCredentialCheckEndpoint,
@@ -71,4 +71,7 @@ urlpatterns = [
         name="instance-workspace-availability",
     ),
     path("workspaces/", InstanceWorkSpaceEndpoint.as_view(), name="instance-workspace"),
+    # Loop (Auto Project Management) admin — see
+    # .ai_design/loop_project_management/design.md §9.2.
+    path("loop/", include("pi_dash.loop.admin_urls")),
 ]

--- a/apps/api/pi_dash/loop/__init__.py
+++ b/apps/api/pi_dash/loop/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Loop (Auto Project Management) — periodic assistant jobs.
+
+This package holds the loop's eligibility, dispatch, builtins, and HTTP views.
+Models live in ``pi_dash/db/models/loop.py`` and Beat tasks in
+``pi_dash/bgtasks/loop.py`` (mirroring the scheduler's layout), so there is no
+separate Django app / no ``INSTALLED_APPS`` entry.
+
+See ``.ai_design/loop_project_management/design.md``.
+"""

--- a/apps/api/pi_dash/loop/admin_urls.py
+++ b/apps/api/pi_dash/loop/admin_urls.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+from django.urls import path
+
+from pi_dash.loop.admin_views import (
+    LoopJobDetailEndpoint,
+    LoopJobListCreateEndpoint,
+    LoopJobTargetsEndpoint,
+)
+
+# Mounted under /api/instances/loop/ (see license/urls.py).
+urlpatterns = [
+    path("jobs/", LoopJobListCreateEndpoint.as_view(), name="loop-jobs"),
+    path("jobs/<uuid:pk>/", LoopJobDetailEndpoint.as_view(), name="loop-job-detail"),
+    path("jobs/<uuid:pk>/targets/", LoopJobTargetsEndpoint.as_view(), name="loop-job-targets"),
+]

--- a/apps/api/pi_dash/loop/admin_views.py
+++ b/apps/api/pi_dash/loop/admin_views.py
@@ -1,0 +1,234 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Instance-admin endpoints for managing loop jobs and observing targets.
+
+All behind :class:`InstanceAdminPermission`. The admin surface exposes the full
+job (prompt, min_role, RRULE) — unlike the user surface (§9.1). See design §9.2.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import timedelta
+
+from django.db.models import Count, Q
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.response import Response
+
+from pi_dash.app.views.base import BaseAPIView
+from pi_dash.assistant.models import TurnStatus
+from pi_dash.bgtasks._rrule import RRuleValidationError, validate_rrule_string
+from pi_dash.db.models import LoopJob, LoopTarget, SkipReason
+from pi_dash.license.api.permissions import InstanceAdminPermission
+
+_SLUG_RE = re.compile(r"^[a-z0-9-]{1,64}$")
+_VALID_ROLES = {5, 15, 20}
+_WRITABLE = {
+    "slug",
+    "name",
+    "public_name",
+    "public_description",
+    "prompt",
+    "min_role",
+    "enabled",
+    "dtstart",
+    "rrule",
+    "tzid",
+}
+
+
+def _job_payload(job: LoopJob) -> dict:
+    return {
+        "id": str(job.id),
+        "slug": job.slug,
+        "name": job.name,
+        "public_name": job.public_name,
+        "public_description": job.public_description,
+        "prompt": job.prompt,
+        "min_role": job.min_role,
+        "enabled": job.enabled,
+        "is_builtin": job.is_builtin,
+        "dtstart": job.dtstart.isoformat() if job.dtstart else None,
+        "rrule": job.rrule,
+        "tzid": job.tzid,
+        "created_at": job.created_at.isoformat() if job.created_at else None,
+        "updated_at": job.updated_at.isoformat() if job.updated_at else None,
+    }
+
+
+def _hourly_floor_ok(rrule: str) -> bool:
+    """Reject sub-hourly cadences — loop jobs fire an LLM run per membership
+    edge, so the minimum sensible cadence is hourly (design §6.1)."""
+    freq = ""
+    for part in (rrule or "").split(";"):
+        if part.startswith("FREQ="):
+            freq = part[len("FREQ="):].upper()
+    return freq not in ("SECONDLY", "MINUTELY")
+
+
+def _validate_writes(data: dict, *, partial: bool) -> tuple[dict, Response | None]:
+    """Validate and coerce a job write payload."""
+    cleaned: dict = {}
+    for key, value in data.items():
+        if key not in _WRITABLE:
+            continue  # ignore read-only / unknown keys (is_builtin, id, ...)
+        cleaned[key] = value
+
+    if "slug" in cleaned and not _SLUG_RE.match(str(cleaned["slug"])):
+        return {}, Response({"error": "invalid_slug"}, status=status.HTTP_400_BAD_REQUEST)
+    if "min_role" in cleaned and int(cleaned["min_role"]) not in _VALID_ROLES:
+        return {}, Response({"error": "invalid_min_role"}, status=status.HTTP_400_BAD_REQUEST)
+    if "rrule" in cleaned:
+        rrule = str(cleaned["rrule"])
+        if not rrule:
+            return {}, Response(
+                {"error": "invalid_rrule", "detail": "rrule is required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        try:
+            validate_rrule_string(rrule)
+        except RRuleValidationError as exc:
+            return {}, Response({"error": "invalid_rrule", "detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+        if not _hourly_floor_ok(rrule):
+            return {}, Response({"error": "rrule_too_frequent"}, status=status.HTTP_400_BAD_REQUEST)
+
+    if not partial:
+        required = {"slug", "name", "public_name", "prompt", "rrule"}
+        missing = required - set(cleaned.keys())
+        if missing:
+            return {}, Response(
+                {"error": "missing_fields", "detail": sorted(missing)}, status=status.HTTP_400_BAD_REQUEST
+            )
+    return cleaned, None
+
+
+class LoopJobListCreateEndpoint(BaseAPIView):
+    permission_classes = [InstanceAdminPermission]
+
+    def get(self, request):
+        jobs = LoopJob.objects.filter(deleted_at__isnull=True).order_by("-created_at")
+        return Response([_job_payload(j) for j in jobs])
+
+    def post(self, request):
+        cleaned, err = _validate_writes(request.data if isinstance(request.data, dict) else {}, partial=False)
+        if err is not None:
+            return err
+        if LoopJob.objects.filter(slug=cleaned["slug"], deleted_at__isnull=True).exists():
+            return Response({"error": "slug_taken"}, status=status.HTTP_409_CONFLICT)
+        if "dtstart" not in cleaned:
+            cleaned["dtstart"] = timezone.now()
+        job = LoopJob.objects.create(is_builtin=False, **cleaned)
+        return Response(_job_payload(job), status=status.HTTP_201_CREATED)
+
+
+class LoopJobDetailEndpoint(BaseAPIView):
+    permission_classes = [InstanceAdminPermission]
+
+    def get(self, request, pk):
+        job = LoopJob.objects.filter(pk=pk, deleted_at__isnull=True).first()
+        if job is None:
+            return Response({"error": "not_found"}, status=status.HTTP_404_NOT_FOUND)
+        payload = _job_payload(job)
+        # 24h run rollup from the job's targets' last runs.
+        since = timezone.now() - timedelta(hours=24)
+        agg = LoopTarget.objects.filter(job=job, deleted_at__isnull=True).aggregate(
+            target_count=Count("id"),
+            completed=Count(
+                "last_run",
+                filter=Q(last_run__status=TurnStatus.COMPLETED, last_run__completed_at__gte=since),
+            ),
+            failed=Count(
+                "last_run",
+                filter=Q(last_run__status=TurnStatus.FAILED, last_run__completed_at__gte=since),
+            ),
+            skipped=Count("id", filter=Q(last_skipped_at__gte=since)),
+        )
+        payload["stats"] = agg
+        return Response(payload)
+
+    def patch(self, request, pk):
+        job = LoopJob.objects.filter(pk=pk, deleted_at__isnull=True).first()
+        if job is None:
+            return Response({"error": "not_found"}, status=status.HTTP_404_NOT_FOUND)
+        cleaned, err = _validate_writes(request.data if isinstance(request.data, dict) else {}, partial=True)
+        if err is not None:
+            return err
+        if "slug" in cleaned and cleaned["slug"] != job.slug and (
+            LoopJob.objects.filter(slug=cleaned["slug"], deleted_at__isnull=True).exclude(pk=job.pk).exists()
+        ):
+            return Response({"error": "slug_taken"}, status=status.HTTP_409_CONFLICT)
+        for key, value in cleaned.items():
+            setattr(job, key, value)
+        job.save()
+        return Response(_job_payload(job))
+
+    def delete(self, request, pk):
+        job = LoopJob.objects.filter(pk=pk, deleted_at__isnull=True).first()
+        if job is None:
+            return Response({"error": "not_found"}, status=status.HTTP_404_NOT_FOUND)
+        job.delete()  # soft delete; cascades to targets via SoftDeleteModel
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class LoopJobTargetsEndpoint(BaseAPIView):
+    permission_classes = [InstanceAdminPermission]
+
+    def get(self, request, pk):
+        job = LoopJob.objects.filter(pk=pk, deleted_at__isnull=True).first()
+        if job is None:
+            return Response({"error": "not_found"}, status=status.HTTP_404_NOT_FOUND)
+        qs = (
+            LoopTarget.objects.filter(job=job, deleted_at__isnull=True)
+            .select_related("workspace", "user", "last_run")
+            .order_by("-updated_at")
+        )
+        skip_reason = request.query_params.get("skip_reason")
+        if skip_reason in SkipReason.values:
+            qs = qs.filter(last_skip_reason=skip_reason)
+        workspace = request.query_params.get("workspace")
+        if workspace:
+            qs = qs.filter(workspace__slug=workspace)
+        run_status = request.query_params.get("status")
+        if run_status in TurnStatus.values:
+            qs = qs.filter(last_run__status=run_status)
+
+        try:
+            page = max(1, int(request.query_params.get("page", 1)))
+        except (TypeError, ValueError):
+            page = 1
+        per = 50
+        start = (page - 1) * per
+        rows = list(qs[start : start + per])
+        return Response(
+            {
+                "page": page,
+                "results": [self._row(t) for t in rows],
+            }
+        )
+
+    @staticmethod
+    def _row(t: LoopTarget) -> dict:
+        run = t.last_run
+        usage = (run.usage or {}) if run else {}
+        return {
+            "id": str(t.id),
+            "workspace_slug": t.workspace.slug if t.workspace_id else None,
+            "user_email": t.user.email if t.user_id else None,
+            "next_run_at": t.next_run_at.isoformat() if t.next_run_at else None,
+            "last_skipped_at": t.last_skipped_at.isoformat() if t.last_skipped_at else None,
+            "last_skip_reason": t.last_skip_reason,
+            "last_run": (
+                {
+                    "status": run.status,
+                    "error_code": run.error_code,
+                    "model_used": run.model_used,
+                    "total_tokens": usage.get("total_tokens"),
+                    "completed_at": run.completed_at.isoformat() if run.completed_at else None,
+                }
+                if run
+                else None
+            ),
+        }

--- a/apps/api/pi_dash/loop/builtins.py
+++ b/apps/api/pi_dash/loop/builtins.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Builtin loop jobs, seeded by migration.
+
+This module is intentionally Django-free (a dataclass + a list) so the seed
+data migration can import it without the apps registry — same pattern as
+``pi_dash/bgtasks/_rrule.py``. See design §8.1.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class BuiltinLoopJob:
+    slug: str
+    name: str
+    public_name: str
+    public_description: str
+    prompt: str
+    min_role: int
+    rrule: str
+    tzid: str = "UTC"
+
+
+AUTO_CLOSE_MERGED_PROMPT = (
+    "Review open issues in the projects you can access, oldest first. "
+    "An issue is a candidate when it references a pull request — in its "
+    "links, description, or comments. For each candidate, call "
+    "get_pull_request_status on the PR URL. If — and only if — the tool "
+    'reports state "merged", move the issue to a state in its project\'s '
+    '"completed" state group (use list_states to find one) and add a '
+    "one-line comment naming the merged PR. If merge state is "
+    '"unknown" or the issue\'s state is already in the completed group, '
+    "leave it untouched. Do not create or delete anything."
+)
+
+
+#: The MVP catalog. Exactly one builtin to validate the wiring end to end;
+#: more ship later as code with no schema change. Seeded ``enabled=False`` by
+#: the migration (design §13) — the operator flips it on from apps/admin after
+#: a smoke test.
+BUILTIN_LOOP_JOBS: list[BuiltinLoopJob] = [
+    BuiltinLoopJob(
+        slug="auto-close-merged",
+        name="Auto-close merged-PR issues",
+        public_name="Close issues when their PR merges",
+        public_description=(
+            "Checks your projects once a day and marks an issue Done when the "
+            "pull request that implements it has been merged."
+        ),
+        prompt=AUTO_CLOSE_MERGED_PROMPT,
+        min_role=15,  # Member
+        rrule="FREQ=DAILY;BYHOUR=3;BYMINUTE=0",
+    ),
+]

--- a/apps/api/pi_dash/loop/dispatch.py
+++ b/apps/api/pi_dash/loop/dispatch.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Loop dispatch — turn one claimed, eligible target into an assistant turn.
+
+Mirrors the chat message POST handler (``assistant/views/messages.py``) minus
+HTTP, plus hidden-thread management with rotation. From
+``run_assistant_turn.delay`` onward, nothing is loop-specific — the stock
+assistant runtime resolves the user, credentials, history, limits, and
+finalization. See ``.ai_design/loop_project_management/design.md`` §7.5.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from django.conf import settings
+from django.db import transaction
+from django.utils import timezone
+
+from pi_dash.assistant.errors import MAX_THREAD_MESSAGES
+from pi_dash.assistant.models import (
+    AssistantMessage,
+    AssistantThread,
+    AssistantTurn,
+    MessageKind,
+    MessageStatus,
+    ThreadKind,
+    TurnStatus,
+)
+from pi_dash.assistant.runtime import events
+from pi_dash.assistant.tasks import run_assistant_turn
+from pi_dash.db.models import LoopTarget, SkipReason
+
+logger = logging.getLogger("pi_dash.worker")
+
+
+def _ensure_thread(target: LoopTarget) -> AssistantThread:
+    """Return a usable hidden loop thread for this target, rotating when the
+    current one is near the per-thread message cap.
+
+    Rotation resets the run's cross-run memory — acceptable, because job prompts
+    must not depend on memory for correctness, only benefit from it.
+    """
+    headroom = int(getattr(settings, "LOOP_ROTATION_HEADROOM", 30))
+    threshold = max(1, MAX_THREAD_MESSAGES - headroom)
+
+    current = None
+    if target.thread_id is not None:
+        current = (
+            AssistantThread.objects.filter(pk=target.thread_id, kind=ThreadKind.LOOP).first()
+        )
+    if current is not None:
+        count = AssistantMessage.objects.filter(thread=current).count()
+        if count < threshold:
+            return current
+
+    # Create a fresh thread; archive the old one (kept for admin history).
+    fresh = AssistantThread.objects.create(
+        workspace=target.workspace,
+        user=target.user,
+        kind=ThreadKind.LOOP,
+        title=target.job.public_name[:255],
+        is_archived=False,
+    )
+    if current is not None:
+        AssistantThread.objects.filter(pk=current.pk).update(is_archived=True, updated_at=timezone.now())
+    LoopTarget.objects.filter(pk=target.pk).update(thread=fresh, updated_at=timezone.now())
+    target.thread = fresh
+    return fresh
+
+
+def dispatch_loop_turn(target_id: str) -> bool:
+    """Create the hidden-thread turn for ``target_id`` and queue execution.
+
+    Returns ``True`` when a turn was queued, ``False`` when skipped (a previous
+    run is still in flight) or on an unexpected dispatch error.
+    """
+    try:
+        with transaction.atomic():
+            target = (
+                LoopTarget.objects.select_for_update(of=("self",))
+                .select_related("job", "workspace", "user")
+                .get(pk=target_id)
+            )
+            thread = _ensure_thread(target)
+
+            locked = AssistantThread.objects.select_for_update().get(pk=thread.pk)
+            if locked.active_turn_id is not None:
+                # Previous run still in flight — skip, don't queue (same policy
+                # as the scheduler). The assistant stale-turn sweep guarantees
+                # active_turn eventually clears even after a worker crash, so a
+                # target can never wedge permanently.
+                LoopTarget.objects.filter(pk=target.pk).update(
+                    last_skipped_at=timezone.now(),
+                    last_skip_reason=SkipReason.TURN_ACTIVE,
+                    updated_at=timezone.now(),
+                )
+                return False
+
+            turn = AssistantTurn.objects.create(thread=locked, status=TurnStatus.QUEUED)
+            user_msg = events.create_message(
+                locked,
+                MessageKind.USER,
+                turn=turn,
+                display_content=target.job.prompt,
+                status=MessageStatus.COMPLETED,
+            )
+            turn.user_message = user_msg
+            turn.save(update_fields=["user_message"])
+            locked.active_turn = turn
+            locked.save(update_fields=["active_turn", "updated_at"])
+
+            LoopTarget.objects.filter(pk=target.pk).update(
+                last_run=turn, last_skip_reason="", updated_at=timezone.now()
+            )
+
+        transaction.on_commit(lambda tid=str(turn.id): run_assistant_turn.delay(tid))
+        logger.info("loop.dispatch: queued turn=%s target=%s", turn.id, target_id)
+        return True
+    except LoopTarget.DoesNotExist:
+        return False
+    except Exception:  # noqa: BLE001 — record and move on; next occurrence retries
+        logger.exception("loop.dispatch: unexpected error for target=%s", target_id)
+        LoopTarget.objects.filter(pk=target_id).update(
+            last_skipped_at=timezone.now(),
+            last_skip_reason=SkipReason.DISPATCH_ERROR,
+            updated_at=timezone.now(),
+        )
+        return False

--- a/apps/api/pi_dash/loop/eligibility.py
+++ b/apps/api/pi_dash/loop/eligibility.py
@@ -1,0 +1,143 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Loop eligibility — the single place "may this edge run this job now?" is
+answered, in two forms: a queryset pre-filter for the scanner's bulk fan-out
+and a per-row re-check for the fire task (freshest-wins under SFU).
+
+This module is also the **Cloud seam**: the BYOK credential check is one
+overridable function (:func:`llm_available_q`), mirroring how
+``resolve_model_for_user`` lives behind ``pi_dash.ee.assistant.model_provider``.
+The cloud overlay replaces it to also admit plan-entitled users with platform
+keys. See ``.ai_design/loop_project_management/design.md`` §7.8.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from django.db.models import Exists, OuterRef, Q, QuerySet
+from django.utils import timezone
+
+from pi_dash.assistant.models import UserLLMConfig
+from pi_dash.db.models import LoopTarget, LoopUserPreference, SkipReason, WorkspaceMember
+
+
+def llm_available_q() -> Exists:
+    """``Exists`` subquery: does ``OuterRef('user_id')`` have usable LLM creds?
+
+    CE: a ``UserLLMConfig`` row with a stored key. Overridden in the cloud
+    overlay to also admit plan-entitled users.
+    """
+    return Exists(
+        UserLLMConfig.objects.filter(
+            user_id=OuterRef("user_id"), api_key_encrypted__isnull=False
+        )
+    )
+
+
+def _member_q() -> Exists:
+    return Exists(
+        WorkspaceMember.objects.filter(
+            workspace_id=OuterRef("workspace_id"),
+            member_id=OuterRef("user_id"),
+            is_active=True,
+            deleted_at__isnull=True,
+            role__gte=OuterRef("job__min_role"),
+        )
+    )
+
+
+def _job_off_q() -> Exists:
+    return Exists(
+        LoopUserPreference.objects.filter(
+            user_id=OuterRef("user_id"),
+            job_id=OuterRef("job_id"),
+            enabled=False,
+            deleted_at__isnull=True,
+        )
+    )
+
+
+def _master_paused_q() -> Exists:
+    return Exists(
+        LoopUserPreference.objects.filter(
+            user_id=OuterRef("user_id"),
+            job__isnull=True,
+            enabled=False,
+            deleted_at__isnull=True,
+        )
+    )
+
+
+def due_targets(now=None) -> QuerySet:
+    """All targets whose cursor is due (or NULL = newly created), for enabled,
+    non-deleted jobs. Does NOT apply eligibility — used by the scanner to
+    compute both the eligible set and the ineligible-to-advance set."""
+    now = now or timezone.now()
+    return (
+        LoopTarget.objects.filter(
+            deleted_at__isnull=True,
+            job__enabled=True,
+            job__deleted_at__isnull=True,
+        )
+        .filter(Q(next_run_at__lte=now) | Q(next_run_at__isnull=True))
+    )
+
+
+def eligible_due_targets(now=None) -> QuerySet:
+    """Due targets that pass every eligibility predicate — safe to dispatch."""
+    return (
+        due_targets(now)
+        .annotate(
+            _member=_member_q(),
+            _job_off=_job_off_q(),
+            _paused=_master_paused_q(),
+            _llm=llm_available_q(),
+        )
+        .filter(_member=True, _job_off=False, _paused=False, _llm=True)
+    )
+
+
+def check(target: LoopTarget) -> Optional[str]:
+    """Fire-time re-check of one claimed target.
+
+    Returns a :class:`SkipReason` value, or ``None`` when the target is eligible.
+    Predicates are evaluated in a fixed precedence order so the recorded skip
+    reason is deterministic: master pause → job opt-out → membership/role →
+    LLM credentials.
+    """
+    user_id = target.user_id
+
+    if LoopUserPreference.objects.filter(
+        user_id=user_id, job__isnull=True, enabled=False, deleted_at__isnull=True
+    ).exists():
+        return SkipReason.MASTER_PAUSED
+
+    if LoopUserPreference.objects.filter(
+        user_id=user_id, job_id=target.job_id, enabled=False, deleted_at__isnull=True
+    ).exists():
+        return SkipReason.USER_DISABLED
+
+    membership = (
+        WorkspaceMember.objects.filter(
+            workspace_id=target.workspace_id,
+            member_id=user_id,
+            is_active=True,
+            deleted_at__isnull=True,
+        )
+        .values_list("role", flat=True)
+        .first()
+    )
+    if membership is None:
+        return SkipReason.MEMBERSHIP_GONE
+    if membership < target.job.min_role:
+        return SkipReason.MIN_ROLE
+
+    if not UserLLMConfig.objects.filter(
+        user_id=user_id, api_key_encrypted__isnull=False
+    ).exists():
+        return SkipReason.LLM_CONFIG_MISSING
+
+    return None

--- a/apps/api/pi_dash/loop/eligibility.py
+++ b/apps/api/pi_dash/loop/eligibility.py
@@ -24,17 +24,31 @@ from pi_dash.assistant.models import UserLLMConfig
 from pi_dash.db.models import LoopTarget, LoopUserPreference, SkipReason, WorkspaceMember
 
 
-def llm_available_q() -> Exists:
-    """``Exists`` subquery: does ``OuterRef('user_id')`` have usable LLM creds?
+def _usable_llm_filter() -> dict:
+    """Single source of truth for "this user has usable LLM credentials".
 
-    CE: a ``UserLLMConfig`` row with a stored key. Overridden in the cloud
-    overlay to also admit plan-entitled users.
+    CE: a ``UserLLMConfig`` row with a stored key. The cloud overlay widens
+    this (or overrides :func:`llm_available_q` / :func:`user_has_llm` together)
+    to also admit plan-entitled users. Keeping the filter in one place is what
+    guarantees the scanner pre-filter and the fire-time re-check can't diverge.
     """
+    return {"api_key_encrypted__isnull": False}
+
+
+def llm_available_q() -> Exists:
+    """``Exists`` subquery: does ``OuterRef('user_id')`` have usable LLM creds?"""
     return Exists(
-        UserLLMConfig.objects.filter(
-            user_id=OuterRef("user_id"), api_key_encrypted__isnull=False
-        )
+        UserLLMConfig.objects.filter(user_id=OuterRef("user_id"), **_usable_llm_filter())
     )
+
+
+def user_has_llm(user_id) -> bool:
+    """Row-level form of :func:`llm_available_q` for the fire-time re-check.
+
+    Shares ``_usable_llm_filter`` with the queryset form so the scanner and the
+    per-target ``check`` always agree on who has credentials.
+    """
+    return UserLLMConfig.objects.filter(user_id=user_id, **_usable_llm_filter()).exists()
 
 
 def _member_q() -> Exists:
@@ -135,9 +149,7 @@ def check(target: LoopTarget) -> Optional[str]:
     if membership < target.job.min_role:
         return SkipReason.MIN_ROLE
 
-    if not UserLLMConfig.objects.filter(
-        user_id=user_id, api_key_encrypted__isnull=False
-    ).exists():
+    if not user_has_llm(user_id):
         return SkipReason.LLM_CONFIG_MISSING
 
     return None

--- a/apps/api/pi_dash/loop/serializers.py
+++ b/apps/api/pi_dash/loop/serializers.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Loop serialization helpers — user-facing and admin-facing shapes.
+
+The user-facing shape (:func:`public_job_payload`) is a deliberate **whitelist**:
+``prompt``, ``min_role``, the admin ``name``, and anything that says "loop" must
+never reach a normal user. See design §9.1.
+"""
+
+from __future__ import annotations
+
+from pi_dash.db.models import LoopJob
+
+_FREQ_LABELS = {
+    "MINUTELY": "every few minutes",
+    "HOURLY": "hourly",
+    "DAILY": "daily",
+    "WEEKLY": "weekly",
+    "MONTHLY": "monthly",
+    "YEARLY": "yearly",
+}
+
+
+def interval_label(rrule: str) -> str:
+    """Plain-language cadence from an RRULE FREQ, so the client never parses
+    RRULEs. Falls back to "periodically" for anything unrecognized."""
+    for part in (rrule or "").split(";"):
+        if part.startswith("FREQ="):
+            return _FREQ_LABELS.get(part[len("FREQ="):].upper(), "periodically")
+    return "periodically"
+
+
+def public_job_payload(job: LoopJob, *, enabled: bool) -> dict:
+    """User-facing job card. Whitelisted keys only."""
+    return {
+        "slug": job.slug,
+        "name": job.public_name,
+        "description": job.public_description,
+        "interval_label": interval_label(job.rrule),
+        "enabled": enabled,
+    }

--- a/apps/api/pi_dash/loop/urls.py
+++ b/apps/api/pi_dash/loop/urls.py
@@ -1,0 +1,12 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+from django.urls import path
+
+from pi_dash.loop.views import AutoPMJobEndpoint, AutoPMSettingsEndpoint
+
+urlpatterns = [
+    path("users/me/auto-pm/", AutoPMSettingsEndpoint.as_view(), name="auto-pm-settings"),
+    path("users/me/auto-pm/jobs/<str:slug>/", AutoPMJobEndpoint.as_view(), name="auto-pm-job"),
+]

--- a/apps/api/pi_dash/loop/views.py
+++ b/apps/api/pi_dash/loop/views.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""User-facing "Auto Project Management" settings endpoints.
+
+A user can see the instance's enabled jobs and toggle each on/off (plus a master
+pause). Absence of a preference row = enabled. These are the user's own
+preferences, so there is no workspace-role gate. The route segment is
+``auto-pm`` and the payload never exposes prompts or the word "loop". See
+design §9.1.
+"""
+
+from __future__ import annotations
+
+from rest_framework import status
+from rest_framework.response import Response
+
+from pi_dash.app.views.base import BaseAPIView
+from pi_dash.db.models import LoopJob, LoopUserPreference
+from pi_dash.loop.serializers import public_job_payload
+
+
+def _master_enabled(user) -> bool:
+    pref = (
+        LoopUserPreference.objects.filter(user=user, job__isnull=True, deleted_at__isnull=True)
+        .values_list("enabled", flat=True)
+        .first()
+    )
+    return True if pref is None else bool(pref)
+
+
+def _job_enabled_map(user) -> dict:
+    """slug-keyed effective enabled state for every enabled job."""
+    off_job_ids = set(
+        LoopUserPreference.objects.filter(
+            user=user, job__isnull=False, enabled=False, deleted_at__isnull=True
+        ).values_list("job_id", flat=True)
+    )
+    return off_job_ids
+
+
+def _settings_payload(user) -> dict:
+    off_job_ids = _job_enabled_map(user)
+    jobs = LoopJob.objects.filter(enabled=True, deleted_at__isnull=True).order_by("public_name")
+    return {
+        "enabled": _master_enabled(user),
+        "jobs": [public_job_payload(j, enabled=j.id not in off_job_ids) for j in jobs],
+    }
+
+
+def _read_enabled(request) -> tuple[bool | None, Response | None]:
+    """Extract a single boolean ``enabled`` from the request body, or an error
+    response. Rejects any other key so the contract is toggle-only."""
+    data = request.data if isinstance(request.data, dict) else {}
+    if set(data.keys()) - {"enabled"} or "enabled" not in data:
+        return None, Response({"error": "invalid_payload"}, status=status.HTTP_400_BAD_REQUEST)
+    value = data.get("enabled")
+    if not isinstance(value, bool):
+        return None, Response({"error": "invalid_payload"}, status=status.HTTP_400_BAD_REQUEST)
+    return value, None
+
+
+class AutoPMSettingsEndpoint(BaseAPIView):
+    """GET the user's Auto PM settings; PATCH the master pause switch."""
+
+    def get(self, request):
+        return Response(_settings_payload(request.user))
+
+    def patch(self, request):
+        enabled, err = _read_enabled(request)
+        if err is not None:
+            return err
+        LoopUserPreference.objects.update_or_create(
+            user=request.user,
+            job=None,
+            deleted_at__isnull=True,
+            defaults={"enabled": enabled},
+        )
+        return Response(_settings_payload(request.user))
+
+
+class AutoPMJobEndpoint(BaseAPIView):
+    """PATCH a single job's on/off state for the requesting user."""
+
+    def patch(self, request, slug):
+        job = LoopJob.objects.filter(slug=slug, enabled=True, deleted_at__isnull=True).first()
+        if job is None:
+            return Response({"error": "not_found"}, status=status.HTTP_404_NOT_FOUND)
+        enabled, err = _read_enabled(request)
+        if err is not None:
+            return err
+        LoopUserPreference.objects.update_or_create(
+            user=request.user,
+            job=job,
+            deleted_at__isnull=True,
+            defaults={"enabled": enabled},
+        )
+        return Response(_settings_payload(request.user))

--- a/apps/api/pi_dash/settings/common.py
+++ b/apps/api/pi_dash/settings/common.py
@@ -226,6 +226,30 @@ ASSISTANT_TURN_HARD_LIMIT = int(os.environ.get("ASSISTANT_TURN_HARD_LIMIT", 330)
 # in the UI is unaffected — only what the model sees is truncated.
 ASSISTANT_HISTORY_MAX_TURNS = int(os.environ.get("ASSISTANT_HISTORY_MAX_TURNS", 40))
 
+# Loop (Auto Project Management) — periodic assistant jobs.
+# See .ai_design/loop_project_management/design.md §11.
+# Instance kill switch: when false, the scanner and fire tasks short-circuit.
+LOOP_ENABLED = os.environ.get("LOOP_ENABLED", "true").lower() in ("1", "true", "yes")
+# Deterministic per-edge fire offset window (minutes) so a daily job doesn't
+# fire every membership edge in the same minute.
+LOOP_STAGGER_WINDOW_MINUTES = int(os.environ.get("LOOP_STAGGER_WINDOW_MINUTES", 60))
+# Backpressure: at most this many targets dispatched per scanner tick; the rest
+# stay due and drain on later ticks.
+LOOP_MAX_DISPATCH_PER_TICK = int(os.environ.get("LOOP_MAX_DISPATCH_PER_TICK", 100))
+# Reconcile (create missing targets for new membership edges) runs only when
+# minute % this == 0 — cheap throttle vs. the per-minute due scan.
+LOOP_RECONCILE_EVERY_MINUTES = int(os.environ.get("LOOP_RECONCILE_EVERY_MINUTES", 15))
+# Rotate to a fresh hidden thread when within this many messages of the cap.
+LOOP_ROTATION_HEADROOM = int(os.environ.get("LOOP_ROTATION_HEADROOM", 30))
+# Per-run blast-radius cap, enforced by instruction (hard backstop is the
+# assistant's tool_calls_limit).
+LOOP_MAX_WRITES = int(os.environ.get("LOOP_MAX_WRITES", 10))
+# Per-run cap on get_pull_request_status calls (protects the unauthenticated
+# GitHub rate limit for the host IP).
+LOOP_PR_LOOKUPS_PER_RUN = int(os.environ.get("LOOP_PR_LOOKUPS_PER_RUN", 15))
+# Completed loop turns replayed as history — tighter than chat (daily cost).
+ASSISTANT_LOOP_HISTORY_MAX_TURNS = int(os.environ.get("ASSISTANT_LOOP_HISTORY_MAX_TURNS", 5))
+
 if REDIS_SSL:
     CACHES = {
         "default": {

--- a/apps/api/pi_dash/tests/contract/loop/conftest.py
+++ b/apps/api/pi_dash/tests/contract/loop/conftest.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Fixtures for loop (Auto Project Management) tests.
+
+Reuses the assistant contract fixtures (``world``, ``fernet_key``,
+``configure_llm``) so the access-control matrix is identical, and adds builders
+for loop jobs / targets.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+from django.utils import timezone
+
+# Re-export the assistant fixtures so they're discoverable in this package.
+from pi_dash.tests.contract.assistant.conftest import (  # noqa: F401
+    configure_llm,
+    fernet_key,
+    world,
+)
+from pi_dash.db.models import LoopJob, LoopTarget, LoopUserPreference
+
+
+def make_job(
+    *,
+    slug="auto-close-merged",
+    name="Auto-close",
+    public_name="Close merged",
+    prompt="do the thing",
+    min_role=15,
+    enabled=True,
+    is_builtin=True,
+    rrule="FREQ=DAILY;BYHOUR=3;BYMINUTE=0",
+    dtstart=None,
+) -> LoopJob:
+    return LoopJob.objects.create(
+        slug=slug,
+        name=name,
+        public_name=public_name,
+        public_description="desc",
+        prompt=prompt,
+        min_role=min_role,
+        enabled=enabled,
+        is_builtin=is_builtin,
+        rrule=rrule,
+        tzid="UTC",
+        dtstart=dtstart or (timezone.now() - datetime.timedelta(days=1)),
+    )
+
+
+def make_target(job, workspace, user, *, next_run_at="due", thread=None) -> LoopTarget:
+    if next_run_at == "due":
+        next_run_at = timezone.now() - datetime.timedelta(minutes=1)
+    return LoopTarget.objects.create(
+        job=job, workspace=workspace, user=user, next_run_at=next_run_at, thread=thread
+    )
+
+
+def set_pref(user, job, enabled) -> LoopUserPreference:
+    return LoopUserPreference.objects.create(user=user, job=job, enabled=enabled)
+
+
+@pytest.fixture
+def job(db):
+    return make_job()

--- a/apps/api/pi_dash/tests/contract/loop/test_admin_api.py
+++ b/apps/api/pi_dash/tests/contract/loop/test_admin_api.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Instance-admin loop API — permission gate, CRUD, RRULE validation."""
+
+from __future__ import annotations
+
+import pytest
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from pi_dash.db.models import LoopJob
+from pi_dash.license.models import Instance, InstanceAdmin
+from pi_dash.tests.contract.loop.conftest import make_job
+
+pytestmark = pytest.mark.django_db
+
+JOBS_URL = "/api/instances/loop/jobs/"
+
+
+@pytest.fixture
+def instance_admin(world):
+    instance = Instance.objects.create(
+        instance_name="test",
+        instance_id="i1",
+        current_version="1.0.0",
+        last_checked_at=timezone.now(),
+    )
+    InstanceAdmin.objects.create(instance=instance, user=world.admin, role=20, is_verified=True)
+    return world.admin
+
+
+def _client(user):
+    c = APIClient()
+    c.force_authenticate(user=user)
+    return c
+
+
+def test_non_admin_blocked(world):
+    c = _client(world.member)
+    assert c.get(JOBS_URL).status_code == 403
+
+
+def test_admin_can_list(world, instance_admin):
+    make_job(slug="j1")
+    c = _client(instance_admin)
+    res = c.get(JOBS_URL)
+    assert res.status_code == 200
+    assert any(j["slug"] == "j1" for j in res.data)
+    # Admin surface exposes the full job, including the prompt.
+    assert "prompt" in res.data[0]
+
+
+def test_create_job(world, instance_admin):
+    c = _client(instance_admin)
+    res = c.post(
+        JOBS_URL,
+        {
+            "slug": "new-job",
+            "name": "New",
+            "public_name": "New public",
+            "public_description": "d",
+            "prompt": "do it",
+            "min_role": 15,
+            "rrule": "FREQ=DAILY;BYHOUR=2",
+            "tzid": "UTC",
+        },
+        format="json",
+    )
+    assert res.status_code == 201
+    assert res.data["is_builtin"] is False
+    assert LoopJob.objects.filter(slug="new-job").exists()
+
+
+def test_create_rejects_subhourly_rrule(world, instance_admin):
+    c = _client(instance_admin)
+    res = c.post(
+        JOBS_URL,
+        {
+            "slug": "fast",
+            "name": "Fast",
+            "public_name": "Fast",
+            "prompt": "p",
+            "rrule": "FREQ=MINUTELY",
+        },
+        format="json",
+    )
+    assert res.status_code == 400
+    assert res.data["error"] == "rrule_too_frequent"
+
+
+def test_create_rejects_bad_slug(world, instance_admin):
+    c = _client(instance_admin)
+    res = c.post(
+        JOBS_URL,
+        {"slug": "Bad Slug", "name": "n", "public_name": "n", "prompt": "p", "rrule": "FREQ=DAILY"},
+        format="json",
+    )
+    assert res.status_code == 400
+    assert res.data["error"] == "invalid_slug"
+
+
+def test_patch_cannot_change_is_builtin(world, instance_admin):
+    job = make_job(slug="b", is_builtin=True)
+    c = _client(instance_admin)
+    res = c.patch(f"{JOBS_URL}{job.id}/", {"is_builtin": False, "enabled": False}, format="json")
+    assert res.status_code == 200
+    job.refresh_from_db()
+    assert job.is_builtin is True  # immutable
+    assert job.enabled is False
+
+
+def test_delete_soft_deletes(world, instance_admin):
+    job = make_job(slug="del")
+    c = _client(instance_admin)
+    assert c.delete(f"{JOBS_URL}{job.id}/").status_code == 204
+    assert not LoopJob.objects.filter(slug="del", deleted_at__isnull=True).exists()
+
+
+def test_targets_listing(world, instance_admin, fernet_key):
+    from pi_dash.tests.contract.assistant.conftest import configure_llm
+    from pi_dash.tests.contract.loop.conftest import make_target
+
+    job = make_job(slug="t")
+    configure_llm(world.member)
+    make_target(job, world.ws, world.member)
+    c = _client(instance_admin)
+    res = c.get(f"{JOBS_URL}{job.id}/targets/")
+    assert res.status_code == 200
+    assert len(res.data["results"]) == 1
+    assert res.data["results"][0]["workspace_slug"] == world.ws.slug

--- a/apps/api/pi_dash/tests/contract/loop/test_eligibility.py
+++ b/apps/api/pi_dash/tests/contract/loop/test_eligibility.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Eligibility — each predicate flips eligibility exactly once, with a
+deterministic skip reason and precedence."""
+
+from __future__ import annotations
+
+import pytest
+
+from pi_dash.db.models import SkipReason, WorkspaceMember
+from pi_dash.loop import eligibility
+from pi_dash.tests.contract.assistant.conftest import configure_llm
+from pi_dash.tests.contract.loop.conftest import make_job, make_target, set_pref
+
+pytestmark = pytest.mark.django_db
+
+
+def _eligible(world):
+    """A target whose user has a working LLM config and member role."""
+    job = make_job(min_role=15)
+    configure_llm(world.member)
+    return job, make_target(job, world.ws, world.member)
+
+
+def test_eligible_target_passes(world, fernet_key):
+    job, target = _eligible(world)
+    assert eligibility.check(target) is None
+    assert list(eligibility.eligible_due_targets().values_list("id", flat=True)) == [target.id]
+
+
+def test_no_llm_config_skipped(world):
+    job = make_job()
+    target = make_target(job, world.ws, world.member)  # no configure_llm
+    assert eligibility.check(target) == SkipReason.LLM_CONFIG_MISSING
+    assert eligibility.eligible_due_targets().count() == 0
+
+
+def test_job_disabled_pref_skipped(world, fernet_key):
+    job, target = _eligible(world)
+    set_pref(world.member, job, False)
+    assert eligibility.check(target) == SkipReason.USER_DISABLED
+    assert eligibility.eligible_due_targets().count() == 0
+
+
+def test_master_pause_skipped(world, fernet_key):
+    job, target = _eligible(world)
+    set_pref(world.member, None, False)
+    assert eligibility.check(target) == SkipReason.MASTER_PAUSED
+
+
+def test_below_min_role_skipped(world, fernet_key):
+    job = make_job(min_role=20)  # admin-only
+    configure_llm(world.member)  # member is role 15 < 20
+    target = make_target(job, world.ws, world.member)
+    assert eligibility.check(target) == SkipReason.MIN_ROLE
+
+
+def test_membership_gone_skipped(world, fernet_key):
+    job, target = _eligible(world)
+    WorkspaceMember.objects.filter(workspace=world.ws, member=world.member).update(is_active=False)
+    assert eligibility.check(target) == SkipReason.MEMBERSHIP_GONE
+
+
+def test_master_pause_precedes_job_off(world, fernet_key):
+    job, target = _eligible(world)
+    set_pref(world.member, None, False)  # master paused
+    set_pref(world.member, job, False)  # also job-off
+    # Master pause is checked first.
+    assert eligibility.check(target) == SkipReason.MASTER_PAUSED

--- a/apps/api/pi_dash/tests/contract/loop/test_fire_dispatch.py
+++ b/apps/api/pi_dash/tests/contract/loop/test_fire_dispatch.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Fire + dispatch — happy path queues a turn, turn_active skips, rotation."""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+from django.utils import timezone
+
+from pi_dash.assistant.errors import MAX_THREAD_MESSAGES
+from pi_dash.assistant.models import (
+    AssistantMessage,
+    AssistantThread,
+    AssistantTurn,
+    MessageKind,
+    ThreadKind,
+    TurnStatus,
+)
+from pi_dash.bgtasks import loop as loop_tasks
+from pi_dash.db.models import SkipReason
+from pi_dash.tests.contract.assistant.conftest import configure_llm
+from pi_dash.tests.contract.loop.conftest import make_job, make_target
+
+pytestmark = pytest.mark.django_db
+
+
+def test_fire_happy_path_queues_turn(world, fernet_key, mocker, django_capture_on_commit_callbacks):
+    delay = mocker.patch("pi_dash.loop.dispatch.run_assistant_turn.delay")
+    configure_llm(world.member)
+    job = make_job(prompt="close merged PR issues")
+    target = make_target(job, world.ws, world.member)
+
+    with django_capture_on_commit_callbacks(execute=True):
+        assert loop_tasks.fire_loop_target(str(target.id)) is True
+
+    target.refresh_from_db()
+    # A hidden loop thread was created and carries the active turn.
+    thread = target.thread
+    assert thread is not None
+    assert thread.kind == ThreadKind.LOOP
+    assert thread.active_turn_id is not None
+    # The user message is the job prompt verbatim.
+    msg = AssistantMessage.objects.get(thread=thread, kind=MessageKind.USER)
+    assert msg.display_content == "close merged PR issues"
+    assert target.last_run_id == thread.active_turn_id
+    delay.assert_called_once()
+
+
+def test_fire_skips_when_turn_active(world, fernet_key, mocker):
+    mocker.patch("pi_dash.loop.dispatch.run_assistant_turn.delay")
+    configure_llm(world.member)
+    job = make_job()
+    # Pre-create a loop thread with an in-flight turn.
+    thread = AssistantThread.objects.create(
+        workspace=world.ws, user=world.member, kind=ThreadKind.LOOP
+    )
+    turn = AssistantTurn.objects.create(thread=thread, status=TurnStatus.RUNNING)
+    thread.active_turn = turn
+    thread.save(update_fields=["active_turn"])
+    target = make_target(job, world.ws, world.member, thread=thread)
+
+    assert loop_tasks.fire_loop_target(str(target.id)) is False
+    target.refresh_from_db()
+    assert target.last_skip_reason == SkipReason.TURN_ACTIVE
+    # No second turn was created.
+    assert AssistantTurn.objects.filter(thread=thread).count() == 1
+
+
+def test_fire_noop_when_cursor_in_future(world, fernet_key):
+    configure_llm(world.member)
+    job = make_job()
+    future = timezone.now() + datetime.timedelta(hours=1)
+    target = make_target(job, world.ws, world.member, next_run_at=future)
+    assert loop_tasks.fire_loop_target(str(target.id)) is False
+
+
+def test_dispatch_rotates_full_thread(world, fernet_key, mocker, django_capture_on_commit_callbacks):
+    mocker.patch("pi_dash.loop.dispatch.run_assistant_turn.delay")
+    settings_headroom = 30
+    configure_llm(world.member)
+    job = make_job()
+    old_thread = AssistantThread.objects.create(
+        workspace=world.ws, user=world.member, kind=ThreadKind.LOOP
+    )
+    # Fill the thread past the rotation threshold.
+    full_count = MAX_THREAD_MESSAGES - settings_headroom + 1
+    AssistantMessage.objects.bulk_create(
+        [
+            AssistantMessage(thread=old_thread, seq=i, kind=MessageKind.ASSISTANT, display_content="x")
+            for i in range(full_count)
+        ]
+    )
+    target = make_target(job, world.ws, world.member, thread=old_thread)
+
+    with django_capture_on_commit_callbacks(execute=True):
+        loop_tasks.fire_loop_target(str(target.id))
+
+    target.refresh_from_db()
+    assert target.thread_id != old_thread.id  # rotated to a fresh thread
+    old_thread.refresh_from_db()
+    assert old_thread.is_archived is True

--- a/apps/api/pi_dash/tests/contract/loop/test_github_tool.py
+++ b/apps/api/pi_dash/tests/contract/loop/test_github_tool.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""get_pull_request_status — URL parsing, status mapping, budget, never raises."""
+
+from __future__ import annotations
+
+import pytest
+
+from pi_dash.assistant.tools import github
+from pi_dash.tests.contract.assistant.conftest import fake_ctx, make_deps
+
+pytestmark = pytest.mark.django_db
+
+
+class _Resp:
+    def __init__(self, status_code, payload=None):
+        self.status_code = status_code
+        self._payload = payload or {}
+
+    def json(self):
+        return self._payload
+
+
+class _Client:
+    def __init__(self, resp):
+        self._resp = resp
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def get(self, url, headers=None):
+        return self._resp
+
+
+def _patch_httpx(mocker, resp):
+    mocker.patch("httpx.Client", return_value=_Client(resp))
+
+
+def _ctx(world):
+    return fake_ctx(make_deps(world.member, world.ws, 15))
+
+
+def test_merged(world, mocker):
+    _patch_httpx(mocker, _Resp(200, {"merged": True, "merged_at": "2026-01-01T00:00:00Z", "title": "Fix"}))
+    out = github.get_pull_request_status(_ctx(world), "https://github.com/o/r/pull/5")
+    assert out["state"] == "merged"
+    assert out["title"] == "Fix"
+
+
+def test_open(world, mocker):
+    _patch_httpx(mocker, _Resp(200, {"merged": False, "state": "open", "title": "WIP"}))
+    out = github.get_pull_request_status(_ctx(world), "https://github.com/o/r/pull/5")
+    assert out["state"] == "open"
+
+
+def test_closed_unmerged(world, mocker):
+    _patch_httpx(mocker, _Resp(200, {"merged": False, "merged_at": None, "state": "closed"}))
+    out = github.get_pull_request_status(_ctx(world), "https://github.com/o/r/pull/5")
+    assert out["state"] == "closed"
+
+
+def test_non_github_url(world, mocker):
+    spy = mocker.patch("httpx.Client")
+    out = github.get_pull_request_status(_ctx(world), "https://gitlab.com/o/r/merge_requests/1")
+    assert out == {"state": "unknown", "reason": "unsupported_url"}
+    spy.assert_not_called()  # no network for an unparseable URL
+
+
+def test_rate_limited(world, mocker):
+    _patch_httpx(mocker, _Resp(403))
+    out = github.get_pull_request_status(_ctx(world), "https://github.com/o/r/pull/5")
+    assert out == {"state": "unknown", "reason": "rate_limited"}
+
+
+def test_not_found(world, mocker):
+    _patch_httpx(mocker, _Resp(404))
+    out = github.get_pull_request_status(_ctx(world), "https://github.com/o/r/pull/5")
+    assert out["reason"] == "not_found"
+
+
+def test_network_error_never_raises(world, mocker):
+    mocker.patch("httpx.Client", side_effect=RuntimeError("boom"))
+    out = github.get_pull_request_status(_ctx(world), "https://github.com/o/r/pull/5")
+    assert out == {"state": "unknown", "reason": "network_error"}
+
+
+def test_per_run_budget(world, mocker, settings):
+    settings.LOOP_PR_LOOKUPS_PER_RUN = 2
+    _patch_httpx(mocker, _Resp(200, {"merged": True, "merged_at": "x"}))
+    ctx = _ctx(world)
+    assert github.get_pull_request_status(ctx, "https://github.com/o/r/pull/1")["state"] == "merged"
+    assert github.get_pull_request_status(ctx, "https://github.com/o/r/pull/2")["state"] == "merged"
+    # Third call exceeds the budget.
+    out = github.get_pull_request_status(ctx, "https://github.com/o/r/pull/3")
+    assert out == {"state": "unknown", "reason": "budget_exhausted"}

--- a/apps/api/pi_dash/tests/contract/loop/test_models.py
+++ b/apps/api/pi_dash/tests/contract/loop/test_models.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Loop model constraints — conditional uniques survive soft-delete."""
+
+from __future__ import annotations
+
+import pytest
+from django.db import IntegrityError, transaction
+
+from pi_dash.db.models import LoopUserPreference
+from pi_dash.tests.contract.loop.conftest import make_job, make_target, set_pref
+
+pytestmark = pytest.mark.django_db
+
+
+def test_job_slug_unique_when_active():
+    make_job(slug="dup")
+    with pytest.raises(IntegrityError):
+        with transaction.atomic():
+            make_job(slug="dup")
+
+
+def test_job_slug_reusable_after_soft_delete():
+    j = make_job(slug="reuse")
+    j.delete()  # soft delete sets deleted_at
+    # A new active row with the same slug is allowed (tombstone excluded).
+    again = make_job(slug="reuse")
+    assert again.pk != j.pk
+
+
+def test_target_edge_unique_when_active(world):
+    j = make_job()
+    make_target(j, world.ws, world.member)
+    with pytest.raises(IntegrityError):
+        with transaction.atomic():
+            make_target(j, world.ws, world.member)
+
+
+def test_master_pref_unique_per_user(world):
+    LoopUserPreference.objects.create(user=world.member, job=None, enabled=False)
+    with pytest.raises(IntegrityError):
+        with transaction.atomic():
+            LoopUserPreference.objects.create(user=world.member, job=None, enabled=True)
+
+
+def test_job_pref_unique_per_user_job(world):
+    j = make_job()
+    set_pref(world.member, j, False)
+    with pytest.raises(IntegrityError):
+        with transaction.atomic():
+            set_pref(world.member, j, True)

--- a/apps/api/pi_dash/tests/contract/loop/test_runtime_seam.py
+++ b/apps/api/pi_dash/tests/contract/loop/test_runtime_seam.py
@@ -33,6 +33,18 @@ def test_created_via_depends_on_mode(world):
     assert loop.created_via == "loop"
 
 
+def test_deps_hashable_and_budget_excluded_from_identity(world):
+    # The frozen deps must stay hashable despite carrying a mutable budget, and
+    # two runs with the same identity must compare/hash equal regardless of how
+    # much budget each has spent (budget is compare=False).
+    a = make_deps(world.member, world.ws, 15, thread_id=world.ws.id, turn_id=world.ws.id)
+    b = make_deps(world.member, world.ws, 15, thread_id=world.ws.id, turn_id=world.ws.id)
+    b.budget.pr_lookups = 9
+    assert hash(a) == hash(b)
+    assert a == b
+    assert len({a, b}) == 1
+
+
 def test_loop_instructions_only_in_loop_mode(world):
     chat = make_deps(world.member, world.ws, 15)
     loop = AssistantDeps(**{**chat.__dict__, "mode": "loop"})

--- a/apps/api/pi_dash/tests/contract/loop/test_runtime_seam.py
+++ b/apps/api/pi_dash/tests/contract/loop/test_runtime_seam.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Loop-mode runtime seam — mode propagation, unattended instructions,
+created_via attribution, kind-aware history cap."""
+
+from __future__ import annotations
+
+import datetime
+import types
+
+import pytest
+from django.utils import timezone
+
+from pi_dash.assistant.models import AssistantThread, AssistantTurn, ThreadKind, TurnStatus
+from pi_dash.assistant.runtime import history
+from pi_dash.assistant.runtime.deps import AssistantDeps
+from pi_dash.assistant.runtime.instructions import dynamic_instructions
+from pi_dash.tests.contract.assistant.conftest import make_deps
+
+pytestmark = pytest.mark.django_db
+
+
+def _ctx(deps):
+    return types.SimpleNamespace(deps=deps)
+
+
+def test_created_via_depends_on_mode(world):
+    chat = make_deps(world.member, world.ws, 15)
+    loop = AssistantDeps(**{**chat.__dict__, "mode": "loop"})
+    assert chat.created_via == "assistant"
+    assert loop.created_via == "loop"
+
+
+def test_loop_instructions_only_in_loop_mode(world):
+    chat = make_deps(world.member, world.ws, 15)
+    loop = AssistantDeps(**{**chat.__dict__, "mode": "loop"})
+    assert "Unattended mode" not in dynamic_instructions(_ctx(chat))
+    assert "Unattended mode" in dynamic_instructions(_ctx(loop))
+
+
+def _deps_with_real_thread(world, *, mode, kind):
+    thread = AssistantThread.objects.create(workspace=world.ws, user=world.member, kind=kind)
+    turn = AssistantTurn.objects.create(thread=thread, status=TurnStatus.RUNNING)
+    base = make_deps(world.member, world.ws, 15, thread_id=thread.id, turn_id=turn.id)
+    return AssistantDeps(**{**base.__dict__, "mode": mode})
+
+
+def test_create_issue_marks_created_via_loop(world):
+    from pi_dash.assistant.tools import issues as issue_tools
+    from pi_dash.db.models import Issue
+
+    deps = _deps_with_real_thread(world, mode="loop", kind=ThreadKind.LOOP)
+    result = issue_tools.create_issue(
+        _ctx(deps), project_id=str(world.proj_a.id), name="From the loop"
+    )
+    issue = Issue.objects.get(id=result["id"])
+    assert issue.created_via == "loop"
+
+
+def test_create_issue_marks_created_via_assistant_in_chat(world):
+    from pi_dash.assistant.tools import issues as issue_tools
+    from pi_dash.db.models import Issue
+
+    deps = _deps_with_real_thread(world, mode="chat", kind=ThreadKind.CHAT)
+    result = issue_tools.create_issue(
+        _ctx(deps), project_id=str(world.proj_a.id), name="From chat"
+    )
+    issue = Issue.objects.get(id=result["id"])
+    assert issue.created_via == "assistant"
+
+
+def test_loop_history_cap(world, settings, mocker):
+    settings.ASSISTANT_LOOP_HISTORY_MAX_TURNS = 2
+    settings.ASSISTANT_HISTORY_MAX_TURNS = 40
+    # Pass stored blobs through verbatim so the test controls their shape.
+    mocker.patch(
+        "pydantic_ai.messages.ModelMessagesTypeAdapter.validate_python",
+        side_effect=lambda blob: blob,
+    )
+    thread = AssistantThread.objects.create(
+        workspace=world.ws, user=world.member, kind=ThreadKind.LOOP
+    )
+    t0 = timezone.now() - datetime.timedelta(minutes=10)
+    for i in range(4):
+        turn = AssistantTurn.objects.create(
+            thread=thread, status=TurnStatus.COMPLETED, model_messages=[{"i": i}]
+        )
+        AssistantTurn.objects.filter(pk=turn.pk).update(
+            created_at=t0 + datetime.timedelta(minutes=i)
+        )
+
+    out = history.load_history(thread)
+    # Only the newest 2 turns replayed (loop cap, not the chat cap of 40).
+    assert out == [{"i": 2}, {"i": 3}]
+
+
+def test_chat_history_uses_chat_cap(world, settings, mocker):
+    settings.ASSISTANT_LOOP_HISTORY_MAX_TURNS = 2
+    settings.ASSISTANT_HISTORY_MAX_TURNS = 40
+    mocker.patch(
+        "pydantic_ai.messages.ModelMessagesTypeAdapter.validate_python",
+        side_effect=lambda blob: blob,
+    )
+    thread = AssistantThread.objects.create(
+        workspace=world.ws, user=world.member, kind=ThreadKind.CHAT
+    )
+    t0 = timezone.now() - datetime.timedelta(minutes=10)
+    for i in range(4):
+        turn = AssistantTurn.objects.create(
+            thread=thread, status=TurnStatus.COMPLETED, model_messages=[{"i": i}]
+        )
+        AssistantTurn.objects.filter(pk=turn.pk).update(
+            created_at=t0 + datetime.timedelta(minutes=i)
+        )
+    # Chat cap (40) keeps all 4.
+    assert len(history.load_history(thread)) == 4

--- a/apps/api/pi_dash/tests/contract/loop/test_scanner.py
+++ b/apps/api/pi_dash/tests/contract/loop/test_scanner.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Scanner — reconcile creates targets, fan-out queues only eligible, ineligible
+cursors get advanced, kill switch short-circuits."""
+
+from __future__ import annotations
+
+
+import pytest
+from django.utils import timezone
+
+from pi_dash.bgtasks import loop as loop_tasks
+from pi_dash.db.models import LoopTarget, SkipReason
+from pi_dash.tests.contract.assistant.conftest import configure_llm
+from pi_dash.tests.contract.loop.conftest import make_job, make_target
+
+pytestmark = pytest.mark.django_db
+
+
+def test_kill_switch_short_circuits(world, settings):
+    settings.LOOP_ENABLED = False
+    assert loop_tasks.scan_due_targets() == 0
+
+
+def test_reconcile_creates_targets_for_active_edges(world, settings, mocker):
+    # Force reconcile to run regardless of wall-clock minute.
+    settings.LOOP_RECONCILE_EVERY_MINUTES = 1
+    mocker.patch.object(loop_tasks, "fire_loop_target")
+    job = make_job(min_role=5)  # guest-eligible so every edge qualifies
+    now = timezone.now().replace(second=0, microsecond=0)
+    created = loop_tasks._reconcile_targets(now)
+    # world has 4 active members in ws + 1 in other_ws = 5 edges.
+    assert created == LoopTarget.objects.filter(job=job).count()
+    assert created >= 5
+    # New targets are scheduled for the FUTURE (no immediate burst).
+    assert LoopTarget.objects.filter(job=job, next_run_at__lte=now).count() == 0
+
+
+def test_reconcile_is_idempotent(world, settings, mocker):
+    settings.LOOP_RECONCILE_EVERY_MINUTES = 1
+    make_job(min_role=5)
+    now = timezone.now().replace(second=0, microsecond=0)
+    first = loop_tasks._reconcile_targets(now)
+    second = loop_tasks._reconcile_targets(now)
+    assert first >= 5
+    assert second == 0  # nothing new the second time
+
+
+def test_fanout_queues_only_eligible_due(world, settings, fernet_key, mocker):
+    settings.LOOP_RECONCILE_EVERY_MINUTES = 99  # disable reconcile this tick
+    fire = mocker.patch.object(loop_tasks, "fire_loop_target")
+    job = make_job(min_role=15)
+    configure_llm(world.member)
+    eligible = make_target(job, world.ws, world.member)
+    # guest has no LLM config and is below min_role → ineligible, must be advanced not queued.
+    ineligible = make_target(job, world.ws, world.guest)
+
+    n = loop_tasks.scan_due_targets()
+    assert n == 1
+    fire.delay.assert_called_once_with(str(eligible.id))
+
+    ineligible.refresh_from_db()
+    assert ineligible.last_skip_reason in {SkipReason.MIN_ROLE, SkipReason.LLM_CONFIG_MISSING}
+    assert ineligible.next_run_at > timezone.now()  # cursor advanced past now
+
+
+def test_fanout_respects_dispatch_cap(world, settings, fernet_key, mocker):
+    settings.LOOP_RECONCILE_EVERY_MINUTES = 99
+    settings.LOOP_MAX_DISPATCH_PER_TICK = 1
+    fire = mocker.patch.object(loop_tasks, "fire_loop_target")
+    job = make_job(min_role=15)
+    for u in (world.member, world.outsider):
+        configure_llm(u)
+        make_target(job, world.ws, u)
+    n = loop_tasks.scan_due_targets()
+    assert n == 1
+    assert fire.delay.call_count == 1

--- a/apps/api/pi_dash/tests/contract/loop/test_thread_visibility.py
+++ b/apps/api/pi_dash/tests/contract/loop/test_thread_visibility.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Loop threads are hidden from the assistant thread list but still
+owner-accessible by id; new threads are always chat."""
+
+from __future__ import annotations
+
+import pytest
+from rest_framework.test import APIClient
+
+from pi_dash.assistant.models import AssistantThread, ThreadKind
+
+pytestmark = pytest.mark.django_db
+
+
+def _client(user):
+    c = APIClient()
+    c.force_authenticate(user=user)
+    return c
+
+
+def test_thread_list_excludes_loop_threads(world):
+    AssistantThread.objects.create(workspace=world.ws, user=world.member, kind=ThreadKind.CHAT, title="chat")
+    AssistantThread.objects.create(workspace=world.ws, user=world.member, kind=ThreadKind.LOOP, title="loop")
+    c = _client(world.member)
+    res = c.get(f"/api/workspaces/{world.ws.slug}/assistant/threads/")
+    assert res.status_code == 200
+    titles = {t["title"] for t in res.data}
+    assert "chat" in titles
+    assert "loop" not in titles
+
+
+def test_thread_create_is_always_chat(world):
+    c = _client(world.member)
+    res = c.post(
+        f"/api/workspaces/{world.ws.slug}/assistant/threads/",
+        {"title": "hi", "kind": "loop"},  # kind is ignored
+        format="json",
+    )
+    assert res.status_code == 201
+    thread = AssistantThread.objects.get(id=res.data["id"])
+    assert thread.kind == ThreadKind.CHAT
+
+
+def test_owner_can_read_own_loop_thread_messages(world):
+    loop_thread = AssistantThread.objects.create(
+        workspace=world.ws, user=world.member, kind=ThreadKind.LOOP
+    )
+    c = _client(world.member)
+    res = c.get(f"/api/workspaces/{world.ws.slug}/assistant/threads/{loop_thread.id}/messages/")
+    assert res.status_code == 200

--- a/apps/api/pi_dash/tests/contract/loop/test_user_api.py
+++ b/apps/api/pi_dash/tests/contract/loop/test_user_api.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""User-facing Auto PM settings API — whitelist shape, toggles, precedence."""
+
+from __future__ import annotations
+
+import pytest
+from rest_framework.test import APIClient
+
+from pi_dash.db.models import LoopUserPreference
+from pi_dash.tests.contract.loop.conftest import make_job
+
+pytestmark = pytest.mark.django_db
+
+SETTINGS_URL = "/api/users/me/auto-pm/"
+
+
+def _client(user):
+    c = APIClient()
+    c.force_authenticate(user=user)
+    return c
+
+
+def test_get_shape_whitelists_keys(world):
+    make_job(slug="j1", public_name="Job One", prompt="SECRET PROMPT", min_role=20)
+    c = _client(world.member)
+    res = c.get(SETTINGS_URL)
+    assert res.status_code == 200
+    assert res.data["enabled"] is True
+    job = res.data["jobs"][0]
+    assert set(job.keys()) == {"slug", "name", "description", "interval_label", "enabled"}
+    # The prompt / admin name / min_role must never leak.
+    assert "SECRET" not in str(res.data)
+    assert "min_role" not in job
+    assert job["name"] == "Job One"  # public_name, not admin name
+
+
+def test_disabled_jobs_excluded(world):
+    make_job(slug="on", enabled=True)
+    make_job(slug="off", enabled=False)
+    c = _client(world.member)
+    res = c.get(SETTINGS_URL)
+    slugs = {j["slug"] for j in res.data["jobs"]}
+    assert slugs == {"on"}
+
+
+def test_master_pause_toggle(world):
+    make_job(slug="j1")
+    c = _client(world.member)
+    res = c.patch(SETTINGS_URL, {"enabled": False}, format="json")
+    assert res.status_code == 200
+    assert res.data["enabled"] is False
+    assert LoopUserPreference.objects.filter(user=world.member, job__isnull=True, enabled=False).exists()
+
+
+def test_per_job_toggle(world):
+    make_job(slug="j1")
+    c = _client(world.member)
+    res = c.patch(f"{SETTINGS_URL}jobs/j1/", {"enabled": False}, format="json")
+    assert res.status_code == 200
+    job = next(j for j in res.data["jobs"] if j["slug"] == "j1")
+    assert job["enabled"] is False
+    # Toggling again flips it back (upsert, not duplicate rows).
+    res = c.patch(f"{SETTINGS_URL}jobs/j1/", {"enabled": True}, format="json")
+    job = next(j for j in res.data["jobs"] if j["slug"] == "j1")
+    assert job["enabled"] is True
+    assert LoopUserPreference.objects.filter(user=world.member, job__slug="j1").count() == 1
+
+
+def test_invalid_payload_rejected(world):
+    make_job(slug="j1")
+    c = _client(world.member)
+    assert c.patch(SETTINGS_URL, {"enabled": "yes"}, format="json").status_code == 400
+    assert c.patch(SETTINGS_URL, {"foo": True}, format="json").status_code == 400
+
+
+def test_unknown_job_404(world):
+    c = _client(world.member)
+    assert c.patch(f"{SETTINGS_URL}jobs/nope/", {"enabled": False}, format="json").status_code == 404
+
+
+def test_guest_can_still_toggle(world):
+    # No workspace-role gate — preferences are the user's own.
+    make_job(slug="j1")
+    c = _client(world.guest)
+    assert c.get(SETTINGS_URL).status_code == 200
+    assert c.patch(f"{SETTINGS_URL}jobs/j1/", {"enabled": False}, format="json").status_code == 200

--- a/apps/api/pi_dash/urls.py
+++ b/apps/api/pi_dash/urls.py
@@ -17,6 +17,7 @@ handler404 = "pi_dash.app.views.error_404.custom_404_view"
 urlpatterns = [
     path("api/", include("pi_dash.app.urls")),
     path("api/", include("pi_dash.assistant.urls")),
+    path("api/", include("pi_dash.loop.urls")),
     path("api/public/", include("pi_dash.space.urls")),
     path("api/instances/", include("pi_dash.license.urls")),
     path("api/runners/", include("pi_dash.runner.web_urls")),

--- a/apps/web/core/components/settings/profile/content/pages/auto-project-management.tsx
+++ b/apps/web/core/components/settings/profile/content/pages/auto-project-management.tsx
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { observer } from "mobx-react";
+import useSWR from "swr";
+// pi dash imports
+import { useTranslation } from "@pi-dash/i18n";
+import { setToast, TOAST_TYPE } from "@pi-dash/propel/toast";
+import { AutoPMService } from "@pi-dash/services";
+import type { IAutoPMJob, IAutoPMSettings } from "@pi-dash/types";
+import { ToggleSwitch } from "@pi-dash/ui";
+
+const service = new AutoPMService();
+
+export const AutoProjectManagementSettings = observer(function AutoProjectManagementSettings() {
+  const { t } = useTranslation();
+  const { data, mutate, isLoading } = useSWR<IAutoPMSettings>("auto-pm-settings", () => service.getSettings());
+
+  const masterEnabled = data?.enabled ?? true;
+  const jobs = data?.jobs ?? [];
+
+  const onError = (message?: string) =>
+    setToast({ type: TOAST_TYPE.ERROR, title: t("Something went wrong"), message: message || t("Please try again.") });
+
+  const toggleMaster = async (next: boolean) => {
+    // Optimistic: flip immediately, revalidate from the server response.
+    void mutate({ enabled: next, jobs }, false);
+    try {
+      const fresh = await service.setMasterEnabled(next);
+      void mutate(fresh, false);
+    } catch (e: unknown) {
+      const err = e as { error?: string } | null;
+      onError(err?.error);
+      void mutate();
+    }
+  };
+
+  const toggleJob = async (job: IAutoPMJob, next: boolean) => {
+    void mutate(
+      { enabled: masterEnabled, jobs: jobs.map((j) => (j.slug === job.slug ? { ...j, enabled: next } : j)) },
+      false
+    );
+    try {
+      const fresh = await service.setJobEnabled(job.slug, next);
+      void mutate(fresh, false);
+    } catch (e: unknown) {
+      const err = e as { error?: string } | null;
+      onError(err?.error);
+      void mutate();
+    }
+  };
+
+  return (
+    <div className="flex max-w-xl flex-col gap-5">
+      <div>
+        <h3 className="text-16 font-semibold text-primary">{t("Auto Project Management")}</h3>
+        <p className="mt-1 text-13 text-secondary">
+          {t(
+            "Pi Dash AI can do routine project upkeep for you automatically. It acts with your permissions and only in workspaces you belong to."
+          )}
+        </p>
+      </div>
+
+      {!isLoading && jobs.length === 0 ? (
+        <p className="text-13 text-secondary">{t("Nothing is scheduled on this instance yet.")}</p>
+      ) : (
+        <>
+          <div className="flex items-center justify-between rounded-md border border-subtle bg-surface-1 px-4 py-3">
+            <div>
+              <div className="text-14 font-medium text-primary">{t("Pause all Auto Project Management")}</div>
+              <div className="text-12 text-secondary">{t("Turn everything off without changing individual jobs.")}</div>
+            </div>
+            <ToggleSwitch value={!masterEnabled} onChange={(paused) => toggleMaster(!paused)} size="sm" />
+          </div>
+
+          <div className="flex flex-col gap-3">
+            {jobs.map((job) => (
+              <div
+                key={job.slug}
+                className="flex items-start justify-between gap-4 rounded-md border border-subtle bg-surface-1 px-4 py-3"
+              >
+                <div className="flex flex-col gap-0.5">
+                  <div className="flex items-center gap-2">
+                    <span className="text-14 font-medium text-primary">{job.name}</span>
+                    <span className="rounded bg-surface-2 px-1.5 py-0.5 text-11 text-secondary capitalize">
+                      {t(job.interval_label)}
+                    </span>
+                  </div>
+                  <span className="text-12 text-secondary">{job.description}</span>
+                </div>
+                <ToggleSwitch
+                  value={job.enabled}
+                  onChange={(next) => toggleJob(job, next)}
+                  disabled={!masterEnabled}
+                  size="sm"
+                />
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+});

--- a/apps/web/core/components/settings/profile/content/pages/index.ts
+++ b/apps/web/core/components/settings/profile/content/pages/index.ts
@@ -12,6 +12,9 @@ export const PROFILE_SETTINGS_PAGES_MAP: Record<TProfileSettingsTabs, React.Lazy
   general: lazy(() => import("./general").then((m) => ({ default: m.GeneralProfileSettings }))),
   preferences: lazy(() => import("./preferences").then((m) => ({ default: m.PreferencesProfileSettings }))),
   "ai-assistant": lazy(() => import("./ai-assistant").then((m) => ({ default: m.AIAssistantProfileSettings }))),
+  "auto-project-management": lazy(() =>
+    import("./auto-project-management").then((m) => ({ default: m.AutoProjectManagementSettings }))
+  ),
   notifications: lazy(() => import("./notifications").then((m) => ({ default: m.NotificationsProfileSettings }))),
   security: lazy(() => import("./security").then((m) => ({ default: m.SecurityProfileSettings }))),
   activity: lazy(() => import("./activity").then((m) => ({ default: m.ActivityProfileSettings }))),

--- a/apps/web/core/components/settings/profile/sidebar/item-categories.tsx
+++ b/apps/web/core/components/settings/profile/sidebar/item-categories.tsx
@@ -6,7 +6,7 @@
 
 import type React from "react";
 import type { LucideIcon } from "lucide-react";
-import { Activity, Bell, CircleUser, KeyRound, LockIcon, Settings2, Sparkles } from "lucide-react";
+import { Activity, Bell, CircleUser, KeyRound, LockIcon, RefreshCw, Settings2, Sparkles } from "lucide-react";
 import { observer } from "mobx-react";
 import { useParams } from "react-router";
 // pi dash imports
@@ -28,6 +28,7 @@ const ICONS: Record<TProfileSettingsTabs, LucideIcon | React.FC<ISvgIcons>> = {
   activity: Activity,
   preferences: Settings2,
   "ai-assistant": Sparkles,
+  "auto-project-management": RefreshCw,
   notifications: Bell,
   "api-tokens": KeyRound,
 };

--- a/packages/constants/src/settings/profile.ts
+++ b/packages/constants/src/settings/profile.ts
@@ -49,6 +49,10 @@ export const PROFILE_SETTINGS: Record<
     key: "ai-assistant",
     i18n_label: "AI Assistant",
   },
+  "auto-project-management": {
+    key: "auto-project-management",
+    i18n_label: "Auto Project Management",
+  },
   notifications: {
     key: "notifications",
     i18n_label: "Notifications",
@@ -69,6 +73,7 @@ export const GROUPED_PROFILE_SETTINGS: Record<
     PROFILE_SETTINGS["general"],
     PROFILE_SETTINGS["preferences"],
     PROFILE_SETTINGS["ai-assistant"],
+    PROFILE_SETTINGS["auto-project-management"],
     PROFILE_SETTINGS["notifications"],
     PROFILE_SETTINGS["security"],
     PROFILE_SETTINGS["activity"],

--- a/packages/services/src/auto-pm/auto-pm.service.ts
+++ b/packages/services/src/auto-pm/auto-pm.service.ts
@@ -1,0 +1,39 @@
+// Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// See the LICENSE file for details.
+
+import { API_BASE_URL } from "@pi-dash/constants";
+import type { IAutoPMSettings } from "@pi-dash/types";
+import { APIService } from "../api.service";
+
+// "Auto Project Management" client (internally: loop). Read the instance's
+// enabled jobs and toggle each on/off; the master switch pauses all of them.
+export class AutoPMService extends APIService {
+  constructor(BASE_URL?: string) {
+    super(BASE_URL || API_BASE_URL);
+  }
+
+  async getSettings(): Promise<IAutoPMSettings> {
+    return this.get(`/api/users/me/auto-pm/`)
+      .then((res) => res?.data)
+      .catch((err) => {
+        throw err?.response?.data;
+      });
+  }
+
+  async setMasterEnabled(enabled: boolean): Promise<IAutoPMSettings> {
+    return this.patch(`/api/users/me/auto-pm/`, { enabled })
+      .then((res) => res?.data)
+      .catch((err) => {
+        throw err?.response?.data;
+      });
+  }
+
+  async setJobEnabled(slug: string, enabled: boolean): Promise<IAutoPMSettings> {
+    return this.patch(`/api/users/me/auto-pm/jobs/${slug}/`, { enabled })
+      .then((res) => res?.data)
+      .catch((err) => {
+        throw err?.response?.data;
+      });
+  }
+}

--- a/packages/services/src/auto-pm/index.ts
+++ b/packages/services/src/auto-pm/index.ts
@@ -1,0 +1,5 @@
+// Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// See the LICENSE file for details.
+
+export * from "./auto-pm.service";

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -6,6 +6,7 @@
 
 export * from "./ai";
 export * from "./assistant";
+export * from "./auto-pm";
 export * from "./developer";
 export * from "./auth";
 export * from "./cycle";

--- a/packages/services/src/instance/index.ts
+++ b/packages/services/src/instance/index.ts
@@ -5,3 +5,4 @@
  */
 
 export * from "./instance.service";
+export * from "./loop.service";

--- a/packages/services/src/instance/loop.service.ts
+++ b/packages/services/src/instance/loop.service.ts
@@ -1,0 +1,66 @@
+// Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// See the LICENSE file for details.
+
+import { API_BASE_URL } from "@pi-dash/constants";
+import type { ILoopJob, ILoopJobInput, ILoopTargetsPage } from "@pi-dash/types";
+import { APIService } from "../api.service";
+
+// Instance-admin client for managing loop ("Auto Project Management") jobs and
+// observing their per-edge targets. Behind InstanceAdminPermission server-side.
+export class InstanceLoopService extends APIService {
+  constructor() {
+    super(API_BASE_URL);
+  }
+
+  async list(): Promise<ILoopJob[]> {
+    return this.get("/api/instances/loop/jobs/")
+      .then((res) => res?.data)
+      .catch((err) => {
+        throw err?.response?.data;
+      });
+  }
+
+  async retrieve(jobId: string): Promise<ILoopJob> {
+    return this.get(`/api/instances/loop/jobs/${jobId}/`)
+      .then((res) => res?.data)
+      .catch((err) => {
+        throw err?.response?.data;
+      });
+  }
+
+  async create(data: ILoopJobInput): Promise<ILoopJob> {
+    return this.post("/api/instances/loop/jobs/", data)
+      .then((res) => res?.data)
+      .catch((err) => {
+        throw err?.response?.data;
+      });
+  }
+
+  async update(jobId: string, data: ILoopJobInput): Promise<ILoopJob> {
+    return this.patch(`/api/instances/loop/jobs/${jobId}/`, data)
+      .then((res) => res?.data)
+      .catch((err) => {
+        throw err?.response?.data;
+      });
+  }
+
+  async destroy(jobId: string): Promise<void> {
+    return this.delete(`/api/instances/loop/jobs/${jobId}/`)
+      .then((res) => res?.data)
+      .catch((err) => {
+        throw err?.response?.data;
+      });
+  }
+
+  async listTargets(
+    jobId: string,
+    params: { page?: number; skip_reason?: string; status?: string } = {}
+  ): Promise<ILoopTargetsPage> {
+    return this.get(`/api/instances/loop/jobs/${jobId}/targets/`, { params })
+      .then((res) => res?.data)
+      .catch((err) => {
+        throw err?.response?.data;
+      });
+  }
+}

--- a/packages/types/src/auto-pm.ts
+++ b/packages/types/src/auto-pm.ts
@@ -1,0 +1,72 @@
+// Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// See the LICENSE file for details.
+
+// "Auto Project Management" (internally: loop). User-facing shapes only — the
+// prompt, interval RRULE, and admin metadata are never exposed here.
+
+export interface IAutoPMJob {
+  slug: string;
+  name: string;
+  description: string;
+  interval_label: string;
+  enabled: boolean;
+}
+
+export interface IAutoPMSettings {
+  enabled: boolean;
+  jobs: IAutoPMJob[];
+}
+
+// --- Instance-admin ("Loop") shapes — operator-only, full job fields. ---
+
+export interface ILoopJob {
+  id: string;
+  slug: string;
+  name: string;
+  public_name: string;
+  public_description: string;
+  prompt: string;
+  min_role: number;
+  enabled: boolean;
+  is_builtin: boolean;
+  dtstart: string | null;
+  rrule: string;
+  tzid: string;
+  created_at: string | null;
+  updated_at: string | null;
+  stats?: {
+    target_count: number;
+    completed: number;
+    failed: number;
+    skipped: number;
+  };
+}
+
+export type ILoopJobInput = Partial<
+  Pick<
+    ILoopJob,
+    "slug" | "name" | "public_name" | "public_description" | "prompt" | "min_role" | "enabled" | "rrule" | "tzid"
+  >
+>;
+
+export interface ILoopTargetRow {
+  id: string;
+  workspace_slug: string | null;
+  user_email: string | null;
+  next_run_at: string | null;
+  last_skipped_at: string | null;
+  last_skip_reason: string;
+  last_run: {
+    status: string;
+    error_code: string;
+    model_used: string;
+    total_tokens: number | null;
+    completed_at: string | null;
+  } | null;
+}
+
+export interface ILoopTargetsPage {
+  page: number;
+  results: ILoopTargetRow[];
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -10,6 +10,7 @@ export * from "./assistant";
 export * from "./analytics";
 export * from "./api_token";
 export * from "./auth";
+export * from "./auto-pm";
 export * from "./calendar";
 export * from "./charts";
 export * from "./command-palette";

--- a/packages/types/src/settings.ts
+++ b/packages/types/src/settings.ts
@@ -12,6 +12,7 @@ export type TProfileSettingsTabs =
   | "general"
   | "preferences"
   | "ai-assistant"
+  | "auto-project-management"
   | "activity"
   | "notifications"
   | "security"


### PR DESCRIPTION
## Summary

Introduces **"loop"** (user-facing name: **Auto Project Management**): instance-defined jobs (prompt + timer) that periodically run each user's AI assistant against each workspace they belong to, performing routine issue management on their behalf.

A loop run **is an `AssistantTurn`** in a hidden thread — it executes *as the user*, with the user's BYOK credentials and exact permissions. What the user can do, the loop can do; nothing more. There is no service account, no permission bypass, and no second runtime: `run_assistant_turn` is reused unchanged.

The unit of execution is the **membership edge** (job × workspace × user): `userA∈ws1`, `userB∈ws1`, `userA∈ws2` → three independent loops. Jobs are authored in the admin platform and opaque in operation; users get a settings section to enable/disable each (default on).

Design doc: `.ai_design/loop_project_management/`

## What's included

**Backend**
- `LoopJob` / `LoopTarget` / `LoopUserPreference` models + migration; the one MVP builtin ("close issues when their PR merges") is seeded **disabled** for a controlled rollout.
- `AssistantThread.kind` hides loop threads from the assistant UI (the entire opacity mechanism).
- Loop-mode runtime seam: `AssistantDeps.mode`, unattended instructions, `created_via="loop"` attribution, tighter loop history cap. **Zero changes to the assistant's permission layer.**
- `eligibility.py` (one `ee`-overridable seam for cloud plan-gating), Beat scanner (reconcile + deterministic stagger + eligible-only fan-out), per-target fire (SFU claim, no rollback), dispatch with hidden-thread rotation.
- `get_pull_request_status` tool — never raises; `unknown` is a safe answer the builtin prompt is written around.
- User API `/api/users/me/auto-pm/` (whitelisted shape, toggle-only) and instance-admin API `/api/instances/loop/` (full CRUD + targets, hourly RRULE floor).

**Frontend**
- `apps/web` profile settings → **Auto Project Management** (master pause + per-job toggles).
- `apps/admin` → **Loop** page (job list/CRUD + per-edge targets table).

## Key design decisions

- **No `LoopRun` model** — the run *is* the `AssistantTurn` (status, usage, transcript already there); skips recorded sparsely on the target.
- **Default-on via absence-of-row** preferences → new builtins light up with zero backfill; rollout seeds the builtin disabled so enabling is a deliberate admin act.
- **Stagger + reconcile throttle** avoid a thundering herd across membership edges.
- **No user-visible string says "loop."**

## Testing

- **53** new loop contract/unit tests (models, eligibility, scanner, fire/dispatch, runtime seam, thread visibility, user API, admin API, PR tool) — all green.
- Existing **44** assistant tests still pass (shared runtime touched).
- Migrations validated against a live Postgres; ruff + oxlint (`--deny-warnings`) + tsc clean on changed files.

## Rollout note

Builtin job ships **disabled**. Because preferences default-on, flipping it enabled in `apps/admin` is the launch act — recommend doing so on a dogfooding instance first and watching the targets table (skip-reason distribution, token usage, failure rate) before production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)