### PR TITLE
PDASHOSS01-27 when scheduler bind is in "create issue and apply fix" mode, we should move the issue to in progress state after creation

### DIFF
--- a/apps/api/pi_dash/db/models/scheduler.py
+++ b/apps/api/pi_dash/db/models/scheduler.py
@@ -35,12 +35,9 @@ class OutcomeMode(models.TextChoices):
     across projects. The scheduler layer never creates issues or edits code
     itself — it only dispatches an agent run. ``outcome_mode`` steers that run
     by appending a work-mode directive to the dispatched prompt (see
-    ``OUTCOME_MODE_DIRECTIVES`` and ``pi_dash.bgtasks.scheduler``). The agent
-    still does the work via the same ``pidash`` CLI / git tools a user-driven
-    run uses.
-
-    A future PR unifies this into the prompt composer (one composer for issue
-    *and* scheduler runs); for now the directive is appended to the prompt.
+    ``OUTCOME_MODE_DIRECTIVES`` and ``pi_dash.prompting.context.
+    build_scheduler_task_body``). The agent still does the work via the same
+    ``pidash`` CLI / git tools a user-driven run uses.
     """
 
     CREATE_ISSUE = "create_issue", "Create issues"
@@ -72,21 +69,26 @@ OUTCOME_MODE_DIRECTIVES: dict[str, str] = {
         "describing the finding instead (same form as create-issue mode)."
     ),
     OutcomeMode.FIX_AND_REVIEW: (
-        "## Work mode: fix and open for review\n\n"
-        "For each distinct finding, do ALL of the following:\n"
+        "## Work mode: file issue and delegate fix\n\n"
+        "Do NOT modify code or open a pull request in this run — the fix is "
+        "delegated to the issue agent. For each distinct finding, do ALL of "
+        "the following:\n"
         "1. File a Pi Dash issue with the `pidash` CLI (de-dupe against existing "
         "open issues by file + root cause, as in create-issue mode), and note "
-        "the issue identifier it returns:\n"
+        "the issue identifier it returns. Write the description so an AI agent "
+        "can implement the fix without re-investigating: file path(s) and line "
+        "range, the evidence you observed, root cause, severity, a concrete "
+        "suggested fix, and how to validate it:\n"
         "    pidash issue create --project <PROJ> --title \"<short summary>\" \\\n"
-        "        --description \"<file path, line range, evidence, severity, "
-        'suggested fix>"\n'
-        "2. Implement the fix and open a pull request for human review — do NOT "
-        "merge it. Reference the issue identifier in the PR.\n"
-        "3. Move the issue straight to the review column so a human picks it up:\n"
-        "    pidash issue patch <IDENT> --state \"In Review\"\n"
-        "If a fix is risky, ambiguous, or larger than a focused change, do NOT "
-        "force it: leave the issue in its default state (do NOT move it to In "
-        "Review) and describe the blocker in the issue instead of opening a PR."
+        "        --description \"<agent-ready technical details>\"\n"
+        "2. Move the issue to In Progress — this automatically delegates it to "
+        "the coding agent, which implements the fix and opens a pull request "
+        "for human review:\n"
+        "    pidash issue patch <IDENT> --state \"In Progress\"\n"
+        "If a finding is risky, ambiguous, or larger than a focused change, "
+        "still file the issue but leave it in its default state (do NOT move "
+        "it to In Progress) and describe the open questions in the issue "
+        "description instead."
     ),
 }
 

--- a/apps/api/pi_dash/tests/unit/bg_tasks/test_scheduler_task.py
+++ b/apps/api/pi_dash/tests/unit/bg_tasks/test_scheduler_task.py
@@ -266,22 +266,26 @@ def test_fire_appends_apply_fix_directive(binding):
     assert "do NOT merge" in prompt
     # The other modes' directives must not leak in.
     assert "Work mode: create issues" not in prompt
-    assert "Work mode: fix and open for review" not in prompt
+    assert "Work mode: file issue and delegate fix" not in prompt
 
 
 @pytest.mark.unit
 def test_fire_appends_fix_and_review_directive(binding):
-    """fix_and_review files an issue, applies the fix, and moves the issue
-    straight to In Review — the directive must instruct all three steps."""
+    """fix_and_review files an agent-ready issue and moves it to In Progress —
+    the In Progress transition auto-delegates the fix to the issue agent, so
+    the scheduler run itself must NOT modify code or open a PR."""
     binding.outcome_mode = OutcomeMode.FIX_AND_REVIEW
     binding.save(update_fields=["outcome_mode"])
     fire_scheduler_binding(str(binding.pk))
     binding.refresh_from_db()
     prompt = binding.last_run.prompt
-    assert "Work mode: fix and open for review" in prompt
+    assert "Work mode: file issue and delegate fix" in prompt
     assert "pidash issue create" in prompt
-    assert "open a pull request" in prompt
-    assert 'pidash issue patch <IDENT> --state "In Review"' in prompt
+    assert "Do NOT modify code or open a pull request in this run" in prompt
+    assert 'pidash issue patch <IDENT> --state "In Progress"' in prompt
+    # The old in-run fix instruction must be gone: the issue agent, not the
+    # scheduler run, moves the issue through review.
+    assert 'pidash issue patch <IDENT> --state "In Review"' not in prompt
 
 
 @pytest.mark.unit

--- a/apps/web/core/components/project/scheduler-bindings/binding-outcome-mode-field.tsx
+++ b/apps/web/core/components/project/scheduler-bindings/binding-outcome-mode-field.tsx
@@ -25,7 +25,7 @@ const OUTCOME_MODE_OPTIONS: ReadonlyArray<{ value: SchedulerOutcomeMode; label: 
   {
     value: "fix_and_review",
     label: "Fix & open for review",
-    help: "File an issue for each finding, implement the fix, open a pull request (never merged automatically), and move the issue straight to In Review for a human.",
+    help: "File an agent-ready issue for each finding and move it to In Progress — that automatically delegates the fix to the coding agent, which opens a pull request for review (never merged automatically).",
   },
 ];
 


### PR DESCRIPTION
## Summary

Closes the gap in the scheduler-binding `fix_and_review` ("create issue and apply fix") outcome mode where the scheduler run applied fixes directly and filed disconnected issues that just sat there.

The work-mode directive (`OUTCOME_MODE_DIRECTIVES[OutcomeMode.FIX_AND_REVIEW]` in `apps/api/pi_dash/db/models/scheduler.py`) now instructs the scheduler run to:

1. **File an agent-ready issue** per finding — description must carry file path(s) and line range, observed evidence, root cause, severity, a concrete suggested fix, and validation steps, so the issue agent can implement without re-investigating.
2. **Move the issue to "In Progress"** (`pidash issue patch <IDENT> --state "In Progress"`) — this transition is a registered ticking/delegation state (`orchestration/agent_phases.py` → `handle_issue_state_transition`), so it auto-triggers the issue agent, which applies the fix and opens the PR through the standard delegated workflow. Issue and fix stay linked.
3. **Not modify code or open PRs in the scheduler run itself.** Risky/ambiguous findings are still filed but left in the default state with open questions documented, instead of being force-delegated.

Also updates the `fix_and_review` help copy in the binding modal (`binding-outcome-mode-field.tsx`) to describe the new delegation behavior, and refreshes a stale docstring pointer (`bgtasks.scheduler` → `prompting.context.build_scheduler_task_body`).

No DB migration, no API surface change: the enum value `fix_and_review` and its label are unchanged — only prompt/help text.

## Test plan

- [x] `pi_dash/tests/unit/bg_tasks/test_scheduler_task.py` — updated `test_fire_appends_fix_and_review_directive` to pin the new behavior (create → In Progress, no in-run fix, old "In Review" instruction gone); 21 tests pass
- [x] `pi_dash/tests/unit/prompting/test_scheduler_composer.py` — 5 tests pass (directive flows through `build_scheduler_task_body` unchanged)
- [x] Web type-check: no new errors from the help-text edit (pre-existing unrelated errors on main in `add-runner-modal.tsx` / `scheduler.store.ts`)
- [x] i18n: outcome-mode help strings are not present in any locale file (English source doubles as key), so the copy change strands no translations

🤖 Generated with [Claude Code](https://claude.com/claude-code)
