### PR TITLE
PIDASH-1 change claude code's default llm to "default" instead of fable 5

### DIFF
--- a/apps/web/core/components/runners/runner-models.ts
+++ b/apps/web/core/components/runners/runner-models.ts
@@ -103,13 +103,12 @@ export const RUNNER_MODEL_OPTIONS: Record<TRunnerAgent, IRunnerModelOption[]> = 
 };
 
 /**
- * Pre-selected model option id per agent in the "Add runner" form. Claude
- * runners default to Fable 5; the others fall back to the agent's own
- * built-in model (the ``"default"`` sentinel). The id must exist in that
- * agent's `RUNNER_MODEL_OPTIONS` list.
+ * Pre-selected model option id per agent in the "Add runner" form. All agents
+ * fall back to the agent's own built-in model (the ``"default"`` sentinel).
+ * The id must exist in that agent's `RUNNER_MODEL_OPTIONS` list.
  */
 export const DEFAULT_MODEL_BY_AGENT: Record<TRunnerAgent, string> = {
-  "claude-code": "claude-fable-5",
+  "claude-code": DEFAULT_MODEL_ID,
   codex: DEFAULT_MODEL_ID,
   "cursor-agent": DEFAULT_MODEL_ID,
 };


### PR DESCRIPTION
## Summary

The "Add runner" modal pre-selected **Fable 5** as the default model for the `claude-code` agent. Anthropic has disabled Fable usage, so newly enrolled claude-code runners fail at run time with *"Claude Fable 5 is currently unavailable"* (see PIDASH-1 run failure).

This points the `claude-code` default at the existing `"default"` sentinel (`DEFAULT_MODEL_ID`), so the modal no longer pre-fills Fable 5 and new runners use Claude Code's built-in default model (no `--model` emitted).

## Changes

- `apps/web/core/components/runners/runner-models.ts`: `DEFAULT_MODEL_BY_AGENT["claude-code"]` → `DEFAULT_MODEL_ID`, plus the now-stale doc comment.

Fable 5 remains a selectable option in the dropdown — scope here is "just" the default, per the issue.

## Validation

- `add-runner-modal` vitest suite: 5/5 pass
- oxlint on the changed file: 0 warnings / 0 errors

Resolves PIDASH-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
