### PR TITLE
feat(assistant): encrypt BYOK keys with AWS KMS instead of Fernet

### DIFF
--- a/apps/api/pi_dash/assistant/crypto.py
+++ b/apps/api/pi_dash/assistant/crypto.py
@@ -2,53 +2,118 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # See the LICENSE file for details.
 
-"""At-rest encryption for BYOK LLM API keys.
+"""At-rest encryption for BYOK LLM API keys via AWS KMS.
 
-Uses Fernet with key rotation via ``MultiFernet`` (first key encrypts, all keys
-decrypt). ``ASSISTANT_ENCRYPTION_KEY`` is a comma-separated list of urlsafe
-base64 32-byte keys. See ``.ai_design/integrate_ai_agent/02-backend.md`` §7.
+BYOK provider keys are tiny (well under KMS's 4KB Encrypt limit), so we call
+KMS Encrypt/Decrypt directly — no envelope/data-key dance. The plaintext key
+material never leaves KMS; ``UserLLMConfig.api_key_encrypted`` stores the raw
+KMS ``CiphertextBlob``. Compared with an app-held symmetric key this removes
+the single stealable master key, gives per-decrypt CloudTrail audit, and makes
+access revocable via the key policy / IAM.
+
+Configuration:
+  - ``ASSISTANT_KMS_KEY_ID`` — the CMK (key id, ARN, or alias) used to encrypt
+    and decrypt. Unset → the assistant reports not-configured and BYOK keys
+    cannot be stored.
+  - ``AWS_REGION`` — region for the KMS client (falls back to boto3's default
+    resolution when blank).
+  - ``ASSISTANT_KMS_ENDPOINT_URL`` — optional endpoint override so a
+    KMS-compatible service (e.g. LocalStack) can back local / self-hosted
+    setups that have no real AWS account.
 """
 
 from __future__ import annotations
 
-from cryptography.fernet import Fernet, InvalidToken, MultiFernet
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
 from django.conf import settings
 
 from pi_dash.assistant.errors import AssistantNotConfigured
 
+# KMS error codes that mean "this ciphertext can't be decrypted with this key"
+# (tampered/foreign ciphertext or the wrong CMK) — a data problem, not an
+# operational one. These map to AssistantNotConfigured like Fernet's
+# InvalidToken did; everything else (AccessDenied, throttling, endpoint down)
+# is operational and propagates unchanged.
+_UNDECRYPTABLE_CODES = frozenset(
+    {"InvalidCiphertextException", "IncorrectKeyException", "NotFoundException"}
+)
 
-def _fernet() -> MultiFernet:
-    raw = getattr(settings, "ASSISTANT_ENCRYPTION_KEY", "") or ""
-    keys = [k.strip() for k in raw.split(",") if k.strip()]
-    if not keys:
+# Lazily-built, process-wide KMS client. Cached because boto3 client creation
+# is relatively expensive; the client is safe to reuse across these calls.
+_client = None
+
+
+def _key_id() -> str:
+    return (getattr(settings, "ASSISTANT_KMS_KEY_ID", "") or "").strip()
+
+
+def _require_key_id() -> str:
+    key_id = _key_id()
+    if not key_id:
         raise AssistantNotConfigured(
-            "ASSISTANT_ENCRYPTION_KEY is not set; BYOK keys cannot be stored."
+            "ASSISTANT_KMS_KEY_ID is not set; BYOK keys cannot be stored."
         )
-    try:
-        return MultiFernet([Fernet(k.encode()) for k in keys])
-    except (ValueError, TypeError) as exc:  # malformed key material
-        raise AssistantNotConfigured(f"ASSISTANT_ENCRYPTION_KEY is invalid: {exc}") from exc
+    return key_id
+
+
+def _kms():
+    global _client
+    if _client is None:
+        kwargs = {}
+        region = (getattr(settings, "AWS_REGION", "") or "").strip()
+        if region:
+            kwargs["region_name"] = region
+        endpoint = (getattr(settings, "ASSISTANT_KMS_ENDPOINT_URL", "") or "").strip()
+        if endpoint:
+            kwargs["endpoint_url"] = endpoint
+        _client = boto3.client("kms", **kwargs)
+    return _client
 
 
 def is_configured() -> bool:
-    return bool((getattr(settings, "ASSISTANT_ENCRYPTION_KEY", "") or "").strip())
+    return bool(_key_id())
 
 
 def encrypt(plaintext: str) -> bytes:
-    return _fernet().encrypt(plaintext.encode("utf-8"))
+    """Encrypt a BYOK key under the configured CMK. Returns the raw KMS
+    CiphertextBlob (stored as-is in ``api_key_encrypted``)."""
+    key_id = _require_key_id()
+    try:
+        resp = _kms().encrypt(KeyId=key_id, Plaintext=plaintext.encode("utf-8"))
+    except (BotoCoreError, ClientError) as exc:
+        raise AssistantNotConfigured(f"KMS encrypt failed: {exc}") from exc
+    return resp["CiphertextBlob"]
 
 
 def decrypt(token: bytes) -> str:
     if not token:
         return ""
+    # Pin KeyId so a ciphertext can only be decrypted by the CMK we expect
+    # (defence in depth against a swapped/foreign blob).
+    key_id = _require_key_id()
     try:
-        return _fernet().decrypt(bytes(token)).decode("utf-8")
-    except InvalidToken as exc:
-        raise AssistantNotConfigured(
-            "Stored BYOK key could not be decrypted with the current key set."
-        ) from exc
+        resp = _kms().decrypt(CiphertextBlob=bytes(token), KeyId=key_id)
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in _UNDECRYPTABLE_CODES:
+            raise AssistantNotConfigured(
+                "Stored BYOK key could not be decrypted with the configured KMS key."
+            ) from exc
+        raise
+    return resp["Plaintext"].decode("utf-8")
 
 
 def rotate(token: bytes) -> bytes:
-    """Re-encrypt a token under the primary key (used by the rotation command)."""
-    return _fernet().rotate(bytes(token))
+    """Re-encrypt a stored ciphertext under the current CMK.
+
+    KMS rotates the backing key material automatically and old ciphertext keeps
+    decrypting, so this is only needed to refresh a blob (e.g. after switching
+    CMKs). ``ReEncrypt`` does it inside KMS without exposing the plaintext.
+    """
+    key_id = _require_key_id()
+    try:
+        resp = _kms().re_encrypt(CiphertextBlob=bytes(token), DestinationKeyId=key_id)
+    except (BotoCoreError, ClientError) as exc:
+        raise AssistantNotConfigured(f"KMS re-encrypt failed: {exc}") from exc
+    return resp["CiphertextBlob"]

--- a/apps/api/pi_dash/settings/common.py
+++ b/apps/api/pi_dash/settings/common.py
@@ -210,9 +210,14 @@ REDIS_HEALTH_CHECK_INTERVAL = os.environ.get("REDIS_HEALTH_CHECK_INTERVAL", 30)
 REDIS_MAX_CONNECTIONS = os.environ.get("REDIS_MAX_CONNECTIONS")
 
 # AI Assistant — see .ai_design/integrate_ai_agent/
-# Comma-separated MultiFernet key list (urlsafe base64, 32 bytes). When unset,
-# BYOK keys cannot be stored (the config endpoint reports assistant_not_configured).
-ASSISTANT_ENCRYPTION_KEY = os.environ.get("ASSISTANT_ENCRYPTION_KEY", "")
+# BYOK keys are encrypted at rest via AWS KMS (pi_dash.assistant.crypto).
+# ASSISTANT_KMS_KEY_ID is the CMK (id / ARN / alias) used to encrypt+decrypt;
+# region comes from AWS_REGION. When unset, BYOK keys cannot be stored (the
+# config endpoint reports assistant_not_configured). ASSISTANT_KMS_ENDPOINT_URL
+# optionally points the KMS client at a compatible endpoint (e.g. LocalStack)
+# for local / self-hosted setups without a real AWS account.
+ASSISTANT_KMS_KEY_ID = os.environ.get("ASSISTANT_KMS_KEY_ID", "")
+ASSISTANT_KMS_ENDPOINT_URL = os.environ.get("ASSISTANT_KMS_ENDPOINT_URL", "")
 # SSRF guard for BYOK base_url. Off in OSS (LAN vLLM/Ollama allowed); cloud sets True.
 ASSISTANT_BLOCK_PRIVATE_URLS = os.environ.get("ASSISTANT_BLOCK_PRIVATE_URLS", "false").lower() in (
     "1",

--- a/apps/api/pi_dash/tests/contract/assistant/conftest.py
+++ b/apps/api/pi_dash/tests/contract/assistant/conftest.py
@@ -15,7 +15,7 @@ import types
 from uuid import uuid4
 
 import pytest
-from cryptography.fernet import Fernet
+from botocore.exceptions import ClientError
 from django.utils import timezone
 
 from pi_dash.assistant import crypto
@@ -158,11 +158,51 @@ def world(db):
     )
 
 
+def _kms_client_error(code: str) -> ClientError:
+    return ClientError({"Error": {"Code": code, "Message": code}}, "Decrypt")
+
+
+class FakeKMS:
+    """In-memory stand-in for the KMS client so tests round-trip BYOK crypto
+    without AWS. Ciphertext is an opaque token (never contains the plaintext);
+    decrypt verifies the caller's KeyId matches the one used to encrypt, so the
+    "wrong CMK" path raises like real KMS."""
+
+    def __init__(self):
+        self._store: dict[bytes, tuple[str, bytes]] = {}
+        self._counter = 0
+
+    def encrypt(self, KeyId, Plaintext):
+        self._counter += 1
+        token = f"kmsfake-{self._counter}".encode()
+        self._store[token] = (KeyId, Plaintext)
+        return {"CiphertextBlob": token, "KeyId": KeyId}
+
+    def decrypt(self, CiphertextBlob, KeyId=None):
+        entry = self._store.get(bytes(CiphertextBlob))
+        if entry is None:
+            raise _kms_client_error("InvalidCiphertextException")
+        stored_key, plaintext = entry
+        if KeyId is not None and KeyId != stored_key:
+            raise _kms_client_error("IncorrectKeyException")
+        return {"Plaintext": plaintext, "KeyId": stored_key}
+
+    def re_encrypt(self, CiphertextBlob, DestinationKeyId):
+        entry = self._store.get(bytes(CiphertextBlob))
+        if entry is None:
+            raise _kms_client_error("InvalidCiphertextException")
+        _, plaintext = entry
+        return self.encrypt(KeyId=DestinationKeyId, Plaintext=plaintext)
+
+
 @pytest.fixture
-def fernet_key(settings):
-    key = Fernet.generate_key().decode()
-    settings.ASSISTANT_ENCRYPTION_KEY = key
-    return key
+def kms_crypto(settings, monkeypatch):
+    """Configure KMS-backed BYOK crypto with an in-memory fake (no AWS)."""
+    key_id = "arn:aws:kms:us-west-2:000000000000:key/test-cmk"
+    settings.ASSISTANT_KMS_KEY_ID = key_id
+    settings.AWS_REGION = "us-west-2"
+    monkeypatch.setattr(crypto, "_client", FakeKMS())
+    return key_id
 
 
 def configure_llm(user, *, model="gpt-test", base_url="https://api.example.com/v1"):

--- a/apps/api/pi_dash/tests/contract/assistant/test_crypto.py
+++ b/apps/api/pi_dash/tests/contract/assistant/test_crypto.py
@@ -3,44 +3,41 @@
 # See the LICENSE file for details.
 
 import pytest
-from cryptography.fernet import Fernet
 
 from pi_dash.assistant import crypto
 from pi_dash.assistant.errors import AssistantNotConfigured
+from pi_dash.tests.contract.assistant.conftest import FakeKMS
 
 
-def test_roundtrip(settings):
-    settings.ASSISTANT_ENCRYPTION_KEY = Fernet.generate_key().decode()
+def test_roundtrip(kms_crypto):
     token = crypto.encrypt("sk-secret")
     assert token != b"sk-secret"
-    assert b"sk-secret" not in token  # not stored in plaintext
+    assert b"sk-secret" not in token  # ciphertext is opaque, no plaintext
     assert crypto.decrypt(token) == "sk-secret"
 
 
-def test_multifernet_rotation(settings):
-    old_key = Fernet.generate_key().decode()
-    new_key = Fernet.generate_key().decode()
-    settings.ASSISTANT_ENCRYPTION_KEY = old_key
+def test_reencrypt_roundtrips(kms_crypto):
     token = crypto.encrypt("sk-rotate")
-
-    # New primary key prepended; old key still present -> old token still decrypts.
-    settings.ASSISTANT_ENCRYPTION_KEY = f"{new_key},{old_key}"
-    assert crypto.decrypt(token) == "sk-rotate"
-
     rotated = crypto.rotate(token)
+    assert rotated != token
     assert crypto.decrypt(rotated) == "sk-rotate"
 
 
-def test_missing_key_raises(settings):
-    settings.ASSISTANT_ENCRYPTION_KEY = ""
+def test_missing_key_raises(settings, monkeypatch):
+    settings.ASSISTANT_KMS_KEY_ID = ""
+    monkeypatch.setattr(crypto, "_client", FakeKMS())
     assert not crypto.is_configured()
     with pytest.raises(AssistantNotConfigured):
         crypto.encrypt("x")
 
 
-def test_decrypt_with_wrong_keyset_raises(settings):
-    settings.ASSISTANT_ENCRYPTION_KEY = Fernet.generate_key().decode()
+def test_decrypt_with_wrong_key_raises(settings, kms_crypto):
     token = crypto.encrypt("sk-secret")
-    settings.ASSISTANT_ENCRYPTION_KEY = Fernet.generate_key().decode()  # different key
+    # A different CMK cannot decrypt a ciphertext minted under another key.
+    settings.ASSISTANT_KMS_KEY_ID = "arn:aws:kms:us-west-2:000000000000:key/other-cmk"
     with pytest.raises(AssistantNotConfigured):
         crypto.decrypt(token)
+
+
+def test_decrypt_empty_returns_empty(kms_crypto):
+    assert crypto.decrypt(b"") == ""

--- a/apps/api/pi_dash/tests/contract/assistant/test_endpoints.py
+++ b/apps/api/pi_dash/tests/contract/assistant/test_endpoints.py
@@ -75,7 +75,7 @@ def test_listing_threads_reaps_abandoned_empty_conversations(world):
 
 # --- messages ---
 
-def test_message_requires_llm_config(world, fernet_key):
+def test_message_requires_llm_config(world, kms_crypto):
     c = client_for(world.member)
     thread = AssistantThread.objects.create(workspace=world.ws, user=world.member)
     res = c.post(f"{base(world.ws)}/threads/{thread.id}/messages/", {"content": "hello"}, format="json")
@@ -83,7 +83,7 @@ def test_message_requires_llm_config(world, fernet_key):
     assert res.data["error"] == "llm_config_missing"
 
 
-def test_message_creates_turn_and_blocks_concurrent(world, fernet_key, mocker, django_capture_on_commit_callbacks):
+def test_message_creates_turn_and_blocks_concurrent(world, kms_crypto, mocker, django_capture_on_commit_callbacks):
     delay = mocker.patch("pi_dash.assistant.views.messages.run_assistant_turn.delay")
     configure_llm(world.member)
     c = client_for(world.member)
@@ -108,7 +108,7 @@ def test_message_creates_turn_and_blocks_concurrent(world, fernet_key, mocker, d
     delay.assert_called_once()
 
 
-def test_message_lists_in_envelope_shape(world, fernet_key, mocker):
+def test_message_lists_in_envelope_shape(world, kms_crypto, mocker):
     mocker.patch("pi_dash.assistant.views.messages.run_assistant_turn.delay")
     configure_llm(world.member)
     c = client_for(world.member)
@@ -121,7 +121,7 @@ def test_message_lists_in_envelope_shape(world, fernet_key, mocker):
     assert "content" in res.data[0]
 
 
-def test_message_list_paginates_and_tolerates_bad_params(world, fernet_key):
+def test_message_list_paginates_and_tolerates_bad_params(world, kms_crypto):
     from pi_dash.assistant.models import MessageKind
     from pi_dash.assistant.runtime import events
 
@@ -142,7 +142,7 @@ def test_message_list_paginates_and_tolerates_bad_params(world, fernet_key):
     assert len(res.data) == 3
 
 
-def test_cannot_access_other_users_thread(world, fernet_key):
+def test_cannot_access_other_users_thread(world, kms_crypto):
     other_thread = AssistantThread.objects.create(workspace=world.ws, user=world.admin)
     c = client_for(world.member)
     res = c.get(f"{base(world.ws)}/threads/{other_thread.id}/messages/")
@@ -151,7 +151,7 @@ def test_cannot_access_other_users_thread(world, fernet_key):
 
 # --- llm config ---
 
-def test_llm_config_lifecycle(world, fernet_key):
+def test_llm_config_lifecycle(world, kms_crypto):
     c = client_for(world.member)
     # unset -> 200 with has_api_key False
     res = c.get("/api/users/me/llm-config/")

--- a/apps/api/pi_dash/tests/contract/loop/conftest.py
+++ b/apps/api/pi_dash/tests/contract/loop/conftest.py
@@ -4,7 +4,7 @@
 
 """Fixtures for loop (Auto Project Management) tests.
 
-Reuses the assistant contract fixtures (``world``, ``fernet_key``,
+Reuses the assistant contract fixtures (``world``, ``kms_crypto``,
 ``configure_llm``) so the access-control matrix is identical, and adds builders
 for loop jobs / targets.
 """
@@ -19,7 +19,7 @@ from django.utils import timezone
 # Re-export the assistant fixtures so they're discoverable in this package.
 from pi_dash.tests.contract.assistant.conftest import (  # noqa: F401
     configure_llm,
-    fernet_key,
+    kms_crypto,
     world,
 )
 from pi_dash.db.models import LoopJob, LoopTarget, LoopUserPreference

--- a/apps/api/pi_dash/tests/contract/loop/test_admin_api.py
+++ b/apps/api/pi_dash/tests/contract/loop/test_admin_api.py
@@ -118,7 +118,7 @@ def test_delete_soft_deletes(world, instance_admin):
     assert not LoopJob.objects.filter(slug="del", deleted_at__isnull=True).exists()
 
 
-def test_targets_listing(world, instance_admin, fernet_key):
+def test_targets_listing(world, instance_admin, kms_crypto):
     from pi_dash.tests.contract.assistant.conftest import configure_llm
     from pi_dash.tests.contract.loop.conftest import make_target
 

--- a/apps/api/pi_dash/tests/contract/loop/test_eligibility.py
+++ b/apps/api/pi_dash/tests/contract/loop/test_eligibility.py
@@ -24,7 +24,7 @@ def _eligible(world):
     return job, make_target(job, world.ws, world.member)
 
 
-def test_eligible_target_passes(world, fernet_key):
+def test_eligible_target_passes(world, kms_crypto):
     job, target = _eligible(world)
     assert eligibility.check(target) is None
     assert list(eligibility.eligible_due_targets().values_list("id", flat=True)) == [target.id]
@@ -37,33 +37,33 @@ def test_no_llm_config_skipped(world):
     assert eligibility.eligible_due_targets().count() == 0
 
 
-def test_job_disabled_pref_skipped(world, fernet_key):
+def test_job_disabled_pref_skipped(world, kms_crypto):
     job, target = _eligible(world)
     set_pref(world.member, job, False)
     assert eligibility.check(target) == SkipReason.USER_DISABLED
     assert eligibility.eligible_due_targets().count() == 0
 
 
-def test_master_pause_skipped(world, fernet_key):
+def test_master_pause_skipped(world, kms_crypto):
     job, target = _eligible(world)
     set_pref(world.member, None, False)
     assert eligibility.check(target) == SkipReason.MASTER_PAUSED
 
 
-def test_below_min_role_skipped(world, fernet_key):
+def test_below_min_role_skipped(world, kms_crypto):
     job = make_job(min_role=20)  # admin-only
     configure_llm(world.member)  # member is role 15 < 20
     target = make_target(job, world.ws, world.member)
     assert eligibility.check(target) == SkipReason.MIN_ROLE
 
 
-def test_membership_gone_skipped(world, fernet_key):
+def test_membership_gone_skipped(world, kms_crypto):
     job, target = _eligible(world)
     WorkspaceMember.objects.filter(workspace=world.ws, member=world.member).update(is_active=False)
     assert eligibility.check(target) == SkipReason.MEMBERSHIP_GONE
 
 
-def test_master_pause_precedes_job_off(world, fernet_key):
+def test_master_pause_precedes_job_off(world, kms_crypto):
     job, target = _eligible(world)
     set_pref(world.member, None, False)  # master paused
     set_pref(world.member, job, False)  # also job-off

--- a/apps/api/pi_dash/tests/contract/loop/test_fire_dispatch.py
+++ b/apps/api/pi_dash/tests/contract/loop/test_fire_dispatch.py
@@ -28,7 +28,7 @@ from pi_dash.tests.contract.loop.conftest import make_job, make_target
 pytestmark = pytest.mark.django_db
 
 
-def test_fire_happy_path_queues_turn(world, fernet_key, mocker, django_capture_on_commit_callbacks):
+def test_fire_happy_path_queues_turn(world, kms_crypto, mocker, django_capture_on_commit_callbacks):
     delay = mocker.patch("pi_dash.loop.dispatch.run_assistant_turn.delay")
     configure_llm(world.member)
     job = make_job(prompt="close merged PR issues")
@@ -50,7 +50,7 @@ def test_fire_happy_path_queues_turn(world, fernet_key, mocker, django_capture_o
     delay.assert_called_once()
 
 
-def test_fire_skips_when_turn_active(world, fernet_key, mocker):
+def test_fire_skips_when_turn_active(world, kms_crypto, mocker):
     mocker.patch("pi_dash.loop.dispatch.run_assistant_turn.delay")
     configure_llm(world.member)
     job = make_job()
@@ -70,7 +70,7 @@ def test_fire_skips_when_turn_active(world, fernet_key, mocker):
     assert AssistantTurn.objects.filter(thread=thread).count() == 1
 
 
-def test_fire_noop_when_cursor_in_future(world, fernet_key):
+def test_fire_noop_when_cursor_in_future(world, kms_crypto):
     configure_llm(world.member)
     job = make_job()
     future = timezone.now() + datetime.timedelta(hours=1)
@@ -78,7 +78,7 @@ def test_fire_noop_when_cursor_in_future(world, fernet_key):
     assert loop_tasks.fire_loop_target(str(target.id)) is False
 
 
-def test_dispatch_rotates_full_thread(world, fernet_key, mocker, django_capture_on_commit_callbacks):
+def test_dispatch_rotates_full_thread(world, kms_crypto, mocker, django_capture_on_commit_callbacks):
     mocker.patch("pi_dash.loop.dispatch.run_assistant_turn.delay")
     settings_headroom = 30
     configure_llm(world.member)

--- a/apps/api/pi_dash/tests/contract/loop/test_scanner.py
+++ b/apps/api/pi_dash/tests/contract/loop/test_scanner.py
@@ -48,7 +48,7 @@ def test_reconcile_is_idempotent(world, settings, mocker):
     assert second == 0  # nothing new the second time
 
 
-def test_fanout_queues_only_eligible_due(world, settings, fernet_key, mocker):
+def test_fanout_queues_only_eligible_due(world, settings, kms_crypto, mocker):
     settings.LOOP_RECONCILE_EVERY_MINUTES = 99  # disable reconcile this tick
     fire = mocker.patch.object(loop_tasks, "fire_loop_target")
     job = make_job(min_role=15)
@@ -66,7 +66,7 @@ def test_fanout_queues_only_eligible_due(world, settings, fernet_key, mocker):
     assert ineligible.next_run_at > timezone.now()  # cursor advanced past now
 
 
-def test_fanout_respects_dispatch_cap(world, settings, fernet_key, mocker):
+def test_fanout_respects_dispatch_cap(world, settings, kms_crypto, mocker):
     settings.LOOP_RECONCILE_EVERY_MINUTES = 99
     settings.LOOP_MAX_DISPATCH_PER_TICK = 1
     fire = mocker.patch.object(loop_tasks, "fire_loop_target")


### PR DESCRIPTION
## What

Replaces the app-held **Fernet** master key with **AWS KMS** for at-rest encryption of BYOK provider keys.

Why: the Fernet design kept a single symmetric master key in app config (SSM/env) that is pulled into process memory to decrypt. Anyone who can read that key (SSM read, env/memory dump, a DB dump + the key) can decrypt **every** user's provider credential **offline, forever, with no trace**. With KMS:
- the plaintext key material **never leaves KMS** (HSM-backed),
- every Decrypt is **audited in CloudTrail**,
- access is **revocable** (key policy / IAM) and rate-limitable — a kill switch.

BYOK keys are well under KMS's 4KB Encrypt limit, so we call **Encrypt/Decrypt directly** (no envelope/data-key). `UserLLMConfig.api_key_encrypted` (BinaryField) stores the raw `CiphertextBlob` — **no schema change**.

## Backward compatibility

None needed — the assistant/BYOK feature is **unreleased**, so there is no stored Fernet ciphertext to migrate. Fernet is removed outright (no dual-read).

## Config

- `ASSISTANT_KMS_KEY_ID` — CMK id / ARN / alias (unset → assistant reports not-configured, BYOK disabled)
- `AWS_REGION` — KMS client region
- `ASSISTANT_KMS_ENDPOINT_URL` — optional endpoint override (e.g. LocalStack) for local / self-hosted setups without a real AWS account

`crypto.py` keeps the same public surface (`is_configured` / `encrypt` / `decrypt` / `rotate`), so the 3 call sites are unchanged.

## Tests

`crypto.py` is exercised with an in-memory **fake KMS** (no AWS in CI). The shared `fernet_key` fixture is renamed `kms_crypto` across the assistant + loop contract suites. Full assistant + loop suites pass locally (**100 passed**).

## Follow-up (infra, separate)

Cloud envs need a CMK + `ASSISTANT_KMS_KEY_ID` SSM param + `kms:Encrypt`/`kms:Decrypt` granted to the EC2 instance role, and the deploy bootstrap's required-keys updated (`ASSISTANT_ENCRYPTION_KEY` → `ASSISTANT_KMS_KEY_ID`). Being applied to test alongside this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)