### PR TITLE
refactor(assistant): provider-agnostic CipherBackend seam over KMS

### DIFF
--- a/apps/api/pi_dash/assistant/crypto.py
+++ b/apps/api/pi_dash/assistant/crypto.py
@@ -2,27 +2,29 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # See the LICENSE file for details.
 
-"""At-rest encryption for BYOK LLM API keys via AWS KMS.
+"""At-rest encryption for BYOK LLM API keys.
 
-BYOK provider keys are tiny (well under KMS's 4KB Encrypt limit), so we call
-KMS Encrypt/Decrypt directly — no envelope/data-key dance. The plaintext key
-material never leaves KMS; ``UserLLMConfig.api_key_encrypted`` stores the raw
-KMS ``CiphertextBlob``. Compared with an app-held symmetric key this removes
-the single stealable master key, gives per-decrypt CloudTrail audit, and makes
-access revocable via the key policy / IAM.
+A thin, provider-agnostic seam (:class:`CipherBackend`) over a managed KMS, so
+the call sites (``encrypt`` / ``decrypt`` / ``rotate`` / ``is_configured``) stay
+the same regardless of which provider does the crypto. BYOK provider keys are
+tiny, so backends encrypt them directly (no envelope); ``encrypt`` returns the
+opaque ciphertext stored in ``UserLLMConfig.api_key_encrypted``.
 
-Configuration:
-  - ``ASSISTANT_KMS_KEY_ID`` — the CMK (key id, ARN, or alias) used to encrypt
-    and decrypt. Unset → the assistant reports not-configured and BYOK keys
-    cannot be stored.
-  - ``AWS_REGION`` — region for the KMS client (falls back to boto3's default
-    resolution when blank).
-  - ``ASSISTANT_KMS_ENDPOINT_URL`` — optional endpoint override so a
-    KMS-compatible service (e.g. LocalStack) can back local / self-hosted
-    setups that have no real AWS account.
+Only **AWS KMS** is implemented today. To add another provider (GCP KMS, Azure
+Key Vault, Vault Transit, …) implement :class:`CipherBackend`, register it in
+``_BACKENDS``, and select it with ``ASSISTANT_CRYPTO_BACKEND`` — no call-site
+changes. Whatever the provider, the goal is the same: the plaintext key
+material never lives in app config, and decrypt is auditable + revocable.
+
+Conventions for implementations:
+  - "ciphertext I can't decrypt with this key" and "not configured" both raise
+    :class:`AssistantNotConfigured`; operational failures (auth, network) are
+    left to propagate.
 """
 
 from __future__ import annotations
+
+import abc
 
 import boto3
 from botocore.exceptions import BotoCoreError, ClientError
@@ -30,90 +32,146 @@ from django.conf import settings
 
 from pi_dash.assistant.errors import AssistantNotConfigured
 
-# KMS error codes that mean "this ciphertext can't be decrypted with this key"
-# (tampered/foreign ciphertext or the wrong CMK) — a data problem, not an
-# operational one. These map to AssistantNotConfigured like Fernet's
-# InvalidToken did; everything else (AccessDenied, throttling, endpoint down)
-# is operational and propagates unchanged.
-_UNDECRYPTABLE_CODES = frozenset(
-    {"InvalidCiphertextException", "IncorrectKeyException", "NotFoundException"}
-)
 
-# Lazily-built, process-wide KMS client. Cached because boto3 client creation
-# is relatively expensive; the client is safe to reuse across these calls.
-_client = None
+class CipherBackend(abc.ABC):
+    """Encrypts/decrypts a single small secret (a BYOK provider key) at rest."""
 
+    @abc.abstractmethod
+    def is_configured(self) -> bool:
+        """Whether the backend has everything it needs to encrypt/decrypt."""
 
-def _key_id() -> str:
-    return (getattr(settings, "ASSISTANT_KMS_KEY_ID", "") or "").strip()
+    @abc.abstractmethod
+    def encrypt(self, plaintext: str) -> bytes:
+        """Encrypt ``plaintext``; returns the opaque ciphertext to store."""
 
+    @abc.abstractmethod
+    def decrypt(self, token: bytes) -> str:
+        """Decrypt a stored ciphertext back to plaintext."""
 
-def _require_key_id() -> str:
-    key_id = _key_id()
-    if not key_id:
-        raise AssistantNotConfigured(
-            "ASSISTANT_KMS_KEY_ID is not set; BYOK keys cannot be stored."
-        )
-    return key_id
+    @abc.abstractmethod
+    def rotate(self, token: bytes) -> bytes:
+        """Re-encrypt a stored ciphertext under the current key material."""
 
 
-def _kms():
-    global _client
-    if _client is None:
-        kwargs = {}
-        region = (getattr(settings, "AWS_REGION", "") or "").strip()
-        if region:
-            kwargs["region_name"] = region
-        endpoint = (getattr(settings, "ASSISTANT_KMS_ENDPOINT_URL", "") or "").strip()
-        if endpoint:
-            kwargs["endpoint_url"] = endpoint
-        _client = boto3.client("kms", **kwargs)
-    return _client
+class AwsKmsBackend(CipherBackend):
+    """AWS KMS backend — direct Encrypt/Decrypt (BYOK keys are < KMS's 4KB
+    limit, so no data-key envelope). ``api_key_encrypted`` holds the raw KMS
+    ``CiphertextBlob``.
+
+    Config: ``ASSISTANT_KMS_KEY_ID`` (CMK id/ARN/alias), ``AWS_REGION``, and an
+    optional ``ASSISTANT_KMS_ENDPOINT_URL`` (e.g. LocalStack) for local /
+    self-hosted setups without a real AWS account.
+    """
+
+    # KMS error codes meaning "this ciphertext can't be decrypted with this
+    # key" (tampered/foreign blob or wrong CMK) — a data problem → reported as
+    # AssistantNotConfigured. Everything else (AccessDenied, throttling,
+    # endpoint down) is operational and propagates.
+    _UNDECRYPTABLE_CODES = frozenset(
+        {"InvalidCiphertextException", "IncorrectKeyException", "NotFoundException"}
+    )
+
+    def __init__(self, client=None):
+        # ``client`` is injectable for tests; built lazily otherwise.
+        self._client = client
+
+    def _key_id(self) -> str:
+        return (getattr(settings, "ASSISTANT_KMS_KEY_ID", "") or "").strip()
+
+    def _require_key_id(self) -> str:
+        key_id = self._key_id()
+        if not key_id:
+            raise AssistantNotConfigured(
+                "ASSISTANT_KMS_KEY_ID is not set; BYOK keys cannot be stored."
+            )
+        return key_id
+
+    def _kms(self):
+        if self._client is None:
+            kwargs = {}
+            region = (getattr(settings, "AWS_REGION", "") or "").strip()
+            if region:
+                kwargs["region_name"] = region
+            endpoint = (getattr(settings, "ASSISTANT_KMS_ENDPOINT_URL", "") or "").strip()
+            if endpoint:
+                kwargs["endpoint_url"] = endpoint
+            self._client = boto3.client("kms", **kwargs)
+        return self._client
+
+    def is_configured(self) -> bool:
+        return bool(self._key_id())
+
+    def encrypt(self, plaintext: str) -> bytes:
+        key_id = self._require_key_id()
+        try:
+            resp = self._kms().encrypt(KeyId=key_id, Plaintext=plaintext.encode("utf-8"))
+        except (BotoCoreError, ClientError) as exc:
+            raise AssistantNotConfigured(f"KMS encrypt failed: {exc}") from exc
+        return resp["CiphertextBlob"]
+
+    def decrypt(self, token: bytes) -> str:
+        if not token:
+            return ""
+        # Pin KeyId so a ciphertext can only be decrypted by the CMK we expect.
+        key_id = self._require_key_id()
+        try:
+            resp = self._kms().decrypt(CiphertextBlob=bytes(token), KeyId=key_id)
+        except ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code", "")
+            if code in self._UNDECRYPTABLE_CODES:
+                raise AssistantNotConfigured(
+                    "Stored BYOK key could not be decrypted with the configured KMS key."
+                ) from exc
+            raise
+        return resp["Plaintext"].decode("utf-8")
+
+    def rotate(self, token: bytes) -> bytes:
+        key_id = self._require_key_id()
+        try:
+            resp = self._kms().re_encrypt(CiphertextBlob=bytes(token), DestinationKeyId=key_id)
+        except (BotoCoreError, ClientError) as exc:
+            raise AssistantNotConfigured(f"KMS re-encrypt failed: {exc}") from exc
+        return resp["CiphertextBlob"]
+
+
+# Registry of available backends, keyed by the ``ASSISTANT_CRYPTO_BACKEND``
+# value. Add a provider here once its CipherBackend is implemented.
+_BACKENDS: dict[str, type[CipherBackend]] = {
+    "aws-kms": AwsKmsBackend,
+}
+
+# Process-wide cached backend instance (its KMS client is reused across calls).
+_backend: CipherBackend | None = None
+
+
+def get_backend() -> CipherBackend:
+    global _backend
+    if _backend is None:
+        name = (getattr(settings, "ASSISTANT_CRYPTO_BACKEND", "") or "aws-kms").strip()
+        backend_cls = _BACKENDS.get(name)
+        if backend_cls is None:
+            raise AssistantNotConfigured(
+                f"unknown ASSISTANT_CRYPTO_BACKEND {name!r} "
+                f"(available: {', '.join(sorted(_BACKENDS))})"
+            )
+        _backend = backend_cls()
+    return _backend
+
+
+# --- Public API: stable, provider-agnostic; delegates to the active backend. ---
 
 
 def is_configured() -> bool:
-    return bool(_key_id())
+    return get_backend().is_configured()
 
 
 def encrypt(plaintext: str) -> bytes:
-    """Encrypt a BYOK key under the configured CMK. Returns the raw KMS
-    CiphertextBlob (stored as-is in ``api_key_encrypted``)."""
-    key_id = _require_key_id()
-    try:
-        resp = _kms().encrypt(KeyId=key_id, Plaintext=plaintext.encode("utf-8"))
-    except (BotoCoreError, ClientError) as exc:
-        raise AssistantNotConfigured(f"KMS encrypt failed: {exc}") from exc
-    return resp["CiphertextBlob"]
+    return get_backend().encrypt(plaintext)
 
 
 def decrypt(token: bytes) -> str:
-    if not token:
-        return ""
-    # Pin KeyId so a ciphertext can only be decrypted by the CMK we expect
-    # (defence in depth against a swapped/foreign blob).
-    key_id = _require_key_id()
-    try:
-        resp = _kms().decrypt(CiphertextBlob=bytes(token), KeyId=key_id)
-    except ClientError as exc:
-        code = exc.response.get("Error", {}).get("Code", "")
-        if code in _UNDECRYPTABLE_CODES:
-            raise AssistantNotConfigured(
-                "Stored BYOK key could not be decrypted with the configured KMS key."
-            ) from exc
-        raise
-    return resp["Plaintext"].decode("utf-8")
+    return get_backend().decrypt(token)
 
 
 def rotate(token: bytes) -> bytes:
-    """Re-encrypt a stored ciphertext under the current CMK.
-
-    KMS rotates the backing key material automatically and old ciphertext keeps
-    decrypting, so this is only needed to refresh a blob (e.g. after switching
-    CMKs). ``ReEncrypt`` does it inside KMS without exposing the plaintext.
-    """
-    key_id = _require_key_id()
-    try:
-        resp = _kms().re_encrypt(CiphertextBlob=bytes(token), DestinationKeyId=key_id)
-    except (BotoCoreError, ClientError) as exc:
-        raise AssistantNotConfigured(f"KMS re-encrypt failed: {exc}") from exc
-    return resp["CiphertextBlob"]
+    return get_backend().rotate(token)

--- a/apps/api/pi_dash/settings/common.py
+++ b/apps/api/pi_dash/settings/common.py
@@ -216,6 +216,10 @@ REDIS_MAX_CONNECTIONS = os.environ.get("REDIS_MAX_CONNECTIONS")
 # config endpoint reports assistant_not_configured). ASSISTANT_KMS_ENDPOINT_URL
 # optionally points the KMS client at a compatible endpoint (e.g. LocalStack)
 # for local / self-hosted setups without a real AWS account.
+# Which crypto backend encrypts BYOK keys (pi_dash.assistant.crypto). Only
+# "aws-kms" ships today; the seam exists so other providers (GCP KMS, Azure
+# Key Vault, Vault Transit) can be added without touching call sites.
+ASSISTANT_CRYPTO_BACKEND = os.environ.get("ASSISTANT_CRYPTO_BACKEND", "aws-kms")
 ASSISTANT_KMS_KEY_ID = os.environ.get("ASSISTANT_KMS_KEY_ID", "")
 ASSISTANT_KMS_ENDPOINT_URL = os.environ.get("ASSISTANT_KMS_ENDPOINT_URL", "")
 # SSRF guard for BYOK base_url. Off in OSS (LAN vLLM/Ollama allowed); cloud sets True.

--- a/apps/api/pi_dash/tests/contract/assistant/conftest.py
+++ b/apps/api/pi_dash/tests/contract/assistant/conftest.py
@@ -201,7 +201,7 @@ def kms_crypto(settings, monkeypatch):
     key_id = "arn:aws:kms:us-west-2:000000000000:key/test-cmk"
     settings.ASSISTANT_KMS_KEY_ID = key_id
     settings.AWS_REGION = "us-west-2"
-    monkeypatch.setattr(crypto, "_client", FakeKMS())
+    monkeypatch.setattr(crypto, "_backend", crypto.AwsKmsBackend(client=FakeKMS()))
     return key_id
 
 

--- a/apps/api/pi_dash/tests/contract/assistant/test_crypto.py
+++ b/apps/api/pi_dash/tests/contract/assistant/test_crypto.py
@@ -25,10 +25,17 @@ def test_reencrypt_roundtrips(kms_crypto):
 
 def test_missing_key_raises(settings, monkeypatch):
     settings.ASSISTANT_KMS_KEY_ID = ""
-    monkeypatch.setattr(crypto, "_client", FakeKMS())
+    monkeypatch.setattr(crypto, "_backend", crypto.AwsKmsBackend(client=FakeKMS()))
     assert not crypto.is_configured()
     with pytest.raises(AssistantNotConfigured):
         crypto.encrypt("x")
+
+
+def test_unknown_backend_raises(settings, monkeypatch):
+    settings.ASSISTANT_CRYPTO_BACKEND = "gcp-kms"  # not implemented
+    monkeypatch.setattr(crypto, "_backend", None)  # force re-selection
+    with pytest.raises(AssistantNotConfigured):
+        crypto.get_backend()
 
 
 def test_decrypt_with_wrong_key_raises(settings, kms_crypto):


### PR DESCRIPTION
## What
Adds a thin **`CipherBackend`** abstraction over the BYOK at-rest crypto so the encryption provider is swappable without touching call sites.

- `CipherBackend` ABC: `is_configured` / `encrypt` / `decrypt` / `rotate`.
- `AwsKmsBackend` — the **only** implementation today (the existing KMS logic, now behind the interface).
- Registry + `ASSISTANT_CRYPTO_BACKEND` setting (default `aws-kms`) selects the backend; the module-level `encrypt/decrypt/...` delegate to it (public API unchanged — the 3 call sites don't move).

## Why
Makes the KMS-only design explicit and leaves a clean extension point: adding **GCP KMS / Azure Key Vault / Vault Transit** later is just implementing the ABC + one registry line — no call-site churn. Not implementing other providers now, just the seam.

## Tests
Fake KMS client is now injected into `AwsKmsBackend`; added an unknown-backend case. Full assistant + loop suites pass (**101 passed**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)