### PR TITLE
fix(web): auto-reload on stale-chunk error after deploy

### DIFF
--- a/apps/web/app/entry.client.tsx
+++ b/apps/web/app/entry.client.tsx
@@ -7,6 +7,15 @@
 import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 import { HydratedRouter } from "react-router/dom";
+// utils
+import { reloadOnceForStaleChunk } from "@/app/error/chunk-reload";
+
+// Vite fires this when a dynamic import fails to load — typically a stale-deploy
+// chunk that the new build no longer serves. Recover by reloading once (guarded
+// against loops) and preventDefault so it never bubbles to the error boundary.
+window.addEventListener("vite:preloadError", (event) => {
+  if (reloadOnceForStaleChunk()) event.preventDefault();
+});
 
 startTransition(() => {
   hydrateRoot(

--- a/apps/web/app/error/chunk-reload.ts
+++ b/apps/web/app/error/chunk-reload.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+/**
+ * Recovery for stale-deploy chunk errors.
+ *
+ * A new release swaps the bundle's content-hashed chunks, but a user may still
+ * hold a pre-deploy index.html (cached tab, kept-open session). A lazy() import
+ * then requests a chunk the new build no longer serves, which throws. Reloading
+ * once pulls the current index + assets and resolves it.
+ */
+
+// A stale-deploy failure. Vite/Rollup and each browser word this differently,
+// and a CSS preload failure has its own wording — match them all.
+export function isChunkLoadError(error: unknown): boolean {
+  const err = error as { name?: string; message?: string } | null;
+  const message = err?.message ?? "";
+  return (
+    err?.name === "ChunkLoadError" ||
+    /failed to fetch dynamically imported module/i.test(message) ||
+    /error loading dynamically imported module/i.test(message) ||
+    /importing a module script failed/i.test(message) ||
+    /unable to preload css/i.test(message)
+  );
+}
+
+// Only reload once per short window so a genuinely-missing asset (build/CDN
+// gap, not just stale) falls through instead of looping.
+const RELOAD_GUARD_KEY = "pi-dash:chunk-reload-at";
+const RELOAD_GUARD_MS = 10_000;
+
+/**
+ * Reload once to recover from a stale-deploy chunk error.
+ *
+ * Returns `true` if a reload was triggered (the page is about to navigate away),
+ * or `false` if we reloaded too recently — the caller should then surface the
+ * real error instead of looping.
+ */
+export function reloadOnceForStaleChunk(): boolean {
+  try {
+    const last = Number(sessionStorage.getItem(RELOAD_GUARD_KEY) ?? 0);
+    if (Date.now() - last <= RELOAD_GUARD_MS) return false;
+    sessionStorage.setItem(RELOAD_GUARD_KEY, String(Date.now()));
+  } catch {
+    // sessionStorage unavailable (private mode / disabled). Reload anyway: the
+    // common case (stale index, working storage) is fully guarded above; this
+    // path only loops for the rare combination of storage-off AND a truly
+    // missing asset, which one reload still resolves in the normal sub-case.
+  }
+  window.location.reload();
+  return true;
+}

--- a/apps/web/app/error/index.tsx
+++ b/apps/web/app/error/index.tsx
@@ -7,28 +7,11 @@
 import { useEffect, useState } from "react";
 // hooks
 import { useAppRouter } from "@/hooks/use-app-router";
+// utils
+import { isChunkLoadError, reloadOnceForStaleChunk } from "./chunk-reload";
 // layouts
 import { DevErrorComponent } from "./dev";
 import { ProdErrorComponent } from "./prod";
-
-// A stale-deploy failure: the user's cached index.html references a hashed
-// chunk the new build no longer serves, so a lazy() import 404s. Vite/Rollup
-// and each browser word this differently.
-function isChunkLoadError(error: unknown): boolean {
-  const err = error as { name?: string; message?: string } | null;
-  const message = err?.message ?? "";
-  return (
-    err?.name === "ChunkLoadError" ||
-    /failed to fetch dynamically imported module/i.test(message) ||
-    /error loading dynamically imported module/i.test(message) ||
-    /importing a module script failed/i.test(message)
-  );
-}
-
-// Only reload once per short window so a genuinely-missing asset (build/CDN
-// gap, not just stale) falls through to the error screen instead of looping.
-const RELOAD_GUARD_KEY = "pi-dash:chunk-reload-at";
-const RELOAD_GUARD_MS = 10_000;
 
 const handleReload = () => window.location.reload();
 
@@ -37,20 +20,16 @@ export function CustomErrorComponent({ error }: { error: unknown }) {
   const router = useAppRouter();
   // Recover from stale-deploy chunk errors by reloading once. Start in the
   // recovering state so we don't flash the maintenance screen before reloading.
+  // (The vite:preloadError listener in entry.client usually catches these first;
+  // this boundary is the fallback for chunk errors that slip past it.)
   const [recovering, setRecovering] = useState(() => isChunkLoadError(error));
 
   const handleGoHome = () => router.push("/");
 
   useEffect(() => {
     if (!isChunkLoadError(error)) return;
-    const last = Number(sessionStorage.getItem(RELOAD_GUARD_KEY) ?? 0);
-    if (Date.now() - last > RELOAD_GUARD_MS) {
-      sessionStorage.setItem(RELOAD_GUARD_KEY, String(Date.now()));
-      window.location.reload();
-    } else {
-      // Already tried recently — the asset is likely gone, show the real error.
-      setRecovering(false);
-    }
+    // If we reloaded too recently, the asset is likely gone — show the real error.
+    if (!reloadOnceForStaleChunk()) setRecovering(false);
   }, [error]);
 
   if (import.meta.env.DEV) {

--- a/apps/web/app/error/index.tsx
+++ b/apps/web/app/error/index.tsx
@@ -4,22 +4,61 @@
  * See the LICENSE file for details.
  */
 
+import { useEffect, useState } from "react";
 // hooks
 import { useAppRouter } from "@/hooks/use-app-router";
 // layouts
 import { DevErrorComponent } from "./dev";
 import { ProdErrorComponent } from "./prod";
 
+// A stale-deploy failure: the user's cached index.html references a hashed
+// chunk the new build no longer serves, so a lazy() import 404s. Vite/Rollup
+// and each browser word this differently.
+function isChunkLoadError(error: unknown): boolean {
+  const err = error as { name?: string; message?: string } | null;
+  const message = err?.message ?? "";
+  return (
+    err?.name === "ChunkLoadError" ||
+    /failed to fetch dynamically imported module/i.test(message) ||
+    /error loading dynamically imported module/i.test(message) ||
+    /importing a module script failed/i.test(message)
+  );
+}
+
+// Only reload once per short window so a genuinely-missing asset (build/CDN
+// gap, not just stale) falls through to the error screen instead of looping.
+const RELOAD_GUARD_KEY = "pi-dash:chunk-reload-at";
+const RELOAD_GUARD_MS = 10_000;
+
+const handleReload = () => window.location.reload();
+
 export function CustomErrorComponent({ error }: { error: unknown }) {
   // router
   const router = useAppRouter();
+  // Recover from stale-deploy chunk errors by reloading once. Start in the
+  // recovering state so we don't flash the maintenance screen before reloading.
+  const [recovering, setRecovering] = useState(() => isChunkLoadError(error));
 
   const handleGoHome = () => router.push("/");
-  const handleReload = () => window.location.reload();
+
+  useEffect(() => {
+    if (!isChunkLoadError(error)) return;
+    const last = Number(sessionStorage.getItem(RELOAD_GUARD_KEY) ?? 0);
+    if (Date.now() - last > RELOAD_GUARD_MS) {
+      sessionStorage.setItem(RELOAD_GUARD_KEY, String(Date.now()));
+      window.location.reload();
+    } else {
+      // Already tried recently — the asset is likely gone, show the real error.
+      setRecovering(false);
+    }
+  }, [error]);
 
   if (import.meta.env.DEV) {
     return <DevErrorComponent error={error} onGoHome={handleGoHome} onReload={handleReload} />;
   }
+
+  // About to reload; render nothing rather than the maintenance screen.
+  if (recovering) return null;
 
   return <ProdErrorComponent onGoHome={handleGoHome} />;
 }


### PR DESCRIPTION
## What

When a new web release is deployed, the bundle's hashed JS chunks are swapped, but users may still be holding a **pre-deploy `index.html`** (cached tab, kept-open session). Navigating to a `lazy()` route then requests a chunk filename the new build no longer serves → **404** → the error is thrown into the route `ErrorBoundary`, which shows the full "🚧 Looks like something went wrong" maintenance screen even though the app and API are perfectly healthy.

This is exactly what surfaced on the test instance at `/settings/profile/ai-assistant` after the `v2026.6.14.1` deploy: the server logs showed every API call and (after reload) every asset returning `200` — the only failure was a stale lazy chunk.

## Change

`CustomErrorComponent` (the renderer behind the root route `ErrorBoundary`) now detects the stale-chunk error class and **reloads once** to fetch the current `index.html` + assets, instead of rendering the maintenance screen.

- Detection covers Vite/Rollup + per-browser wordings (`ChunkLoadError`, "failed to fetch dynamically imported module", "error loading dynamically imported module", "importing a module script failed").
- A short `sessionStorage` guard window means a *genuinely* missing asset (real build/CDN gap, not just stale) falls through to the error screen instead of looping.
- Single point of fix: every `lazy()` route in the app throws into this same boundary, so this covers the whole class, not just the assistant settings tab.
- **Dev is untouched** — `DevErrorComponent` still shows the full stack, so real render bugs aren't masked.

A genuine non-stale render crash inside a chunk is *not* auto-reloaded (the module loaded, then threw — not a chunk-*load* error), so real bugs still surface. Intended.

## Test plan

- [x] `oxlint` clean on the changed file
- [ ] Manual: with a logged-in session, simulate by throwing a `ChunkLoadError` from a lazy route → page reloads once instead of showing the maintenance screen; throw it twice rapidly → falls through to the error screen (no loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)