### PR TITLE
fix(web): co-locate settings-tab icons + guard missing icon (prevents React #130 white-screen)

### DIFF
--- a/apps/web/core/components/settings/profile/sidebar/item-categories.tsx
+++ b/apps/web/core/components/settings/profile/sidebar/item-categories.tsx
@@ -4,9 +4,6 @@
  * See the LICENSE file for details.
  */
 
-import type React from "react";
-import type { LucideIcon } from "lucide-react";
-import { Activity, Bell, CircleUser, KeyRound, LockIcon, RefreshCw, Settings2, Sparkles } from "lucide-react";
 import { observer } from "mobx-react";
 import { useParams } from "react-router";
 // pi dash imports
@@ -16,22 +13,10 @@ import {
   PROFILE_SETTINGS_CATEGORY_I18N_LABELS,
 } from "@pi-dash/constants";
 import { useTranslation } from "@pi-dash/i18n";
-import type { ISvgIcons } from "@pi-dash/propel/icons";
 import type { TProfileSettingsTabs } from "@pi-dash/types";
 // local imports
 import { SettingsSidebarItem } from "../../sidebar/item";
 import { ProfileSettingsSidebarWorkspaceOptions } from "./workspace-options";
-
-const ICONS: Record<TProfileSettingsTabs, LucideIcon | React.FC<ISvgIcons>> = {
-  general: CircleUser,
-  security: LockIcon,
-  activity: Activity,
-  preferences: Settings2,
-  "ai-assistant": Sparkles,
-  "auto-project-management": RefreshCw,
-  notifications: Bell,
-  "api-tokens": KeyRound,
-};
 
 type Props = {
   activeTab: TProfileSettingsTabs;
@@ -66,7 +51,7 @@ export const ProfileSettingsSidebarItemCategories = observer(function ProfileSet
                   as="button"
                   onClick={() => updateActiveTab(item.key)}
                   isActive={activeTab === item.key}
-                  icon={ICONS[item.key]}
+                  icon={item.icon}
                   label={t(item.i18n_label)}
                 />
               ))}

--- a/apps/web/core/components/settings/sidebar/item.tsx
+++ b/apps/web/core/components/settings/sidebar/item.tsx
@@ -36,7 +36,12 @@ export function SettingsSidebarItem(props: Props) {
   const content = (
     <>
       {"icon" in props ? (
-        <span className="grid size-4 shrink-0 place-items-center">{<props.icon className="size-3.5" />}</span>
+        // Guard against a missing icon: rendering `<undefined />` throws React
+        // error #130 and white-screens the whole settings area. Degrade to no
+        // icon instead.
+        <span className="grid size-4 shrink-0 place-items-center">
+          {props.icon ? <props.icon className="size-3.5" /> : null}
+        </span>
       ) : (
         props.iconNode
       )}

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -22,7 +22,8 @@
     "clean": "rm -rf .turbo && rm -rf .next && rm -rf node_modules && rm -rf dist"
   },
   "dependencies": {
-    "@pi-dash/types": "workspace:*"
+    "@pi-dash/types": "workspace:*",
+    "lucide-react": "catalog:"
   },
   "devDependencies": {
     "@pi-dash/typescript-config": "workspace:*",

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "license": "AGPL-3.0",
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",

--- a/packages/constants/src/settings/profile.ts
+++ b/packages/constants/src/settings/profile.ts
@@ -4,6 +4,17 @@
  * See the LICENSE file for details.
  */
 
+import {
+  Activity,
+  Bell,
+  CircleUser,
+  KeyRound,
+  LockIcon,
+  type LucideIcon,
+  RefreshCw,
+  Settings2,
+  Sparkles,
+} from "lucide-react";
 // pi dash imports
 import type { TProfileSettingsTabs } from "@pi-dash/types";
 
@@ -22,44 +33,57 @@ export const PROFILE_SETTINGS_CATEGORY_I18N_LABELS: Record<PROFILE_SETTINGS_CATE
   [PROFILE_SETTINGS_CATEGORY.DEVELOPER]: "Developer",
 };
 
+// The icon is co-located with each tab so the sidebar can render `item.icon`
+// directly — there is no separate key→icon lookup table that can drift out of
+// sync when a tab is added (which previously caused an undefined component →
+// React #130 crash, especially in the cloud overlay's forked sidebar).
 export const PROFILE_SETTINGS: Record<
   TProfileSettingsTabs,
   {
     key: TProfileSettingsTabs;
     i18n_label: string;
+    icon: LucideIcon;
   }
 > = {
   general: {
     key: "general",
     i18n_label: "Profile",
+    icon: CircleUser,
   },
   security: {
     key: "security",
     i18n_label: "Security",
+    icon: LockIcon,
   },
   activity: {
     key: "activity",
     i18n_label: "Activity",
+    icon: Activity,
   },
   preferences: {
     key: "preferences",
     i18n_label: "Preferences",
+    icon: Settings2,
   },
   "ai-assistant": {
     key: "ai-assistant",
     i18n_label: "AI Assistant",
+    icon: Sparkles,
   },
   "auto-project-management": {
     key: "auto-project-management",
     i18n_label: "Auto Project Management",
+    icon: RefreshCw,
   },
   notifications: {
     key: "notifications",
     i18n_label: "Notifications",
+    icon: Bell,
   },
   "api-tokens": {
     key: "api-tokens",
     i18n_label: "Personal Access Tokens",
+    icon: KeyRound,
   },
 };
 
@@ -67,7 +91,7 @@ export const PROFILE_SETTINGS_TABS: TProfileSettingsTabs[] = Object.keys(PROFILE
 
 export const GROUPED_PROFILE_SETTINGS: Record<
   PROFILE_SETTINGS_CATEGORY,
-  { key: TProfileSettingsTabs; i18n_label: string }[]
+  { key: TProfileSettingsTabs; i18n_label: string; icon: LucideIcon }[]
 > = {
   [PROFILE_SETTINGS_CATEGORY.YOUR_PROFILE]: [
     PROFILE_SETTINGS["general"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -805,6 +805,9 @@ importers:
       '@pi-dash/types':
         specifier: workspace:*
         version: link:../types
+      lucide-react:
+        specifier: 'catalog:'
+        version: 0.469.0(react@18.3.1)
     devDependencies:
       '@pi-dash/typescript-config':
         specifier: workspace:*


### PR DESCRIPTION
## Background
A cloud user hit a full white-screen ("something went wrong") whenever they opened **Settings**. Browser console: `Minified React error #130 ... got: undefined`.

Root cause: the profile-settings sidebar picked each row's icon from a **separate `ICONS[tab.key]` lookup table**, hand-synced with the tab list in `@pi-dash/constants`. The cloud overlay forks this sidebar and kept its **own** copy of that table, which **drifted** — when `ai-assistant` + `auto-project-management` tabs were added (#233/#247), the overlay's table wasn't updated, so `ICONS[key]` was `undefined` → `<SettingsSidebarItem icon={undefined}/>` → `<undefined/>` → React #130, crashing all of Settings (cloud build only; OSS dev was fine). It survived hard refresh and image rollback because it was baked into every recent build.

## Changes
1. **Co-locate the icon with each tab** in `PROFILE_SETTINGS` (`@pi-dash/constants`). The sidebar renders `item.icon` directly — there is no separate lookup table to drift, and the overlay reuses the same data instead of duplicating it. (Adds `lucide-react` as a constants dependency.)
2. **Guard `SettingsSidebarItem`**: render the icon only when defined (`{icon ? <icon/> : null}`), so a future missing icon degrades to a blank icon instead of white-screening Settings. This also protects the workspace/project settings sidebars.

## Why both
Co-location removes the drift; the guard removes the catastrophic *blast radius* if anything similar slips through (notably: this repo's `check:types` is currently red/ignored, so a `Record<Union>` missing a key won't fail the build).

## Companion change
`private-pi-dash` PR removes the overlay's now-redundant duplicate `ICONS` table and reads `item.icon`. Merge this OSS PR first (the overlay build resolves OSS main at build time).

## Verified
- `@pi-dash/constants` `build` + `check:types` pass.
- `oxlint` clean on changed web files; constants within warning budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)