### PR TITLE
[codex] Implement GitHub App foundation

### DIFF
--- a/.ai_design/github_deep_integration/design.md
+++ b/.ai_design/github_deep_integration/design.md
@@ -71,9 +71,31 @@ Removing them requires a different foundation: a GitHub App.
 
 - **No runner/autonomous-PR work.** Layer 2 is sketched (§12) but not designed
   here. It is gated on Layer 1 shipping first.
-- **No GitHub Enterprise Server host support.** `github.com` (and GitHub-hosted
-  Enterprise Cloud) only, matching the current parser
-  (`parse_github_repo_url`). EGS on a custom host is a later, additive change.
+- **No GitHub Enterprise _Server_ (GHES) support.** First, a distinction this
+  doc otherwise invites readers to confuse: self-hosted **Pi Dash** talking to
+  `github.com` **is** supported (the "self-hosted single-org" mode in §11). What
+  is deferred is self-hosted **GitHub** — a GHES box on a customer host like
+  `github.acme-corp.internal`. We support `github.com` and GitHub-hosted
+  Enterprise **Cloud** (also `github.com`-hosted), matching the current parser
+  (`parse_github_repo_url`) and the `GITHUB_API_BASE` constant in
+  `utils/github_client.py`.
+
+  GHES is deferred — not because it's hard, but because it's pure host-URL
+  configurability that **changes nothing in the architecture**: the App model,
+  token minting, webhooks, and sync logic are identical; only the API base
+  (`https://<host>/api/v3`), App-registration endpoints, and webhook origin
+  differ. That's exactly what makes it a safe, additive later change. Deferring
+  avoids (a) doubling the verification matrix against a license-gated GHES
+  instance during the foundational build, (b) the narrower-than-it-looks network
+  topology (GHES usually lives inside a corporate network — only the self-hosted
+  Pi-Dash-plus-GHES-same-network combination is reachable), and (c) the ongoing
+  cost of feature-gating by GHES version, which lags `github.com`.
+
+  **To keep the later add cheap, Layer 1 must centralize the API base URL** —
+  resolve every call's host through one place (extend `GITHUB_API_BASE` into a
+  per-installation host field) instead of scattering `https://api.github.com`
+  literals. Done now, GHES becomes a config change later, not a refactor.
+
 - **No removal of PAT.** PAT stays as a fallback and for the migration window.
 - **No GitLab/Bitbucket.** Provider abstraction is noted as a seam but not built.
 - **No frontend visual design.** UI surfaces are enumerated (what data appears
@@ -159,8 +181,15 @@ A small service module — proposed `utils/github_app_auth.py` — owns:
 - New write methods land here regardless of token source:
   `close_pull_request`, `merge_pull_request`, `update_issue_state`,
   `request_review`, `get_pull_request`, `list_check_runs`, etc.
+- **Centralize the API base URL.** `GITHUB_API_BASE` is currently a module-level
+  constant pointing at `https://api.github.com`. Make the host an instance
+  property resolved through one place (defaulting to `github.com`) rather than a
+  hard-coded literal scattered across calls. Layer 1 only ever resolves it to
+  `github.com`, but doing this now is what makes GHES (§3) a config change later
+  instead of a refactor.
 
-This keeps a single REST surface; PAT vs App is just credential provenance.
+This keeps a single REST surface; PAT vs App is just credential provenance, and
+host is just configuration.
 
 ### 6.4 Where credentials live (both deployment modes)
 

--- a/.ai_design/github_deep_integration/design.md
+++ b/.ai_design/github_deep_integration/design.md
@@ -66,7 +66,7 @@ not change how issues or comments sync yet.
 - **Reuse existing infrastructure.** `WorkspaceIntegration` for per-tenant
   install state, `InstanceConfiguration` for per-instance App secrets, the
   `encrypt_data`/`decrypt_data` Fernet utilities, and the `GithubClient` shape.
-  No new secret store, no new queue.
+  No new secret store, no new queue in this foundation.
 - **Preserve PAT sync exactly as-is.** Existing PAT bindings and the 4-hour
   issue/comment polling loop keep working. App adoption must not clobber the
   PAT config or silently switch a repo to a new sync path.
@@ -248,6 +248,12 @@ GithubAppInstallation (per workspace — durable App installation state)
 
 The App **secret** is always instance-level; the **installation** is always
 workspace-level. This split is what makes both deployment modes the same code.
+For the current implementation, `InstanceConfiguration` is the single source of
+truth for these six App config values in hosted and self-hosted deployments.
+Hosted Pi Dash Cloud may later move the operational source of truth to AWS SSM /
+Secrets Manager via the private deployment repo, but that requires a separate
+configuration-source design (see §11.1). This foundation must not mix DB and
+secret-manager precedence rules.
 
 **⚠️ App secrets must NOT be served by the existing config endpoint.** Today
 `InstanceConfigurationEndpoint.get` returns _all_ rows
@@ -404,8 +410,7 @@ the `sha256=` prefix — compare prefixed-to-prefixed (or strip it from both); a
 missing/empty header must reject, not pass. (b) `raw_body` must be the exact
 bytes GitHub sent — capture it _before_ DRF parses/re-serializes the request
 (any re-encode breaks the digest). Reject on mismatch with `401` before any
-parsing. Resolve `webhook_secret` from `InstanceConfiguration` (self-hosted) or
-the single hosted App secret.
+parsing. Resolve `webhook_secret` from `InstanceConfiguration`.
 
 ### 7.3 Persist-then-process bounded lifecycle events
 
@@ -578,7 +583,7 @@ comment.
 
 - **One** GitHub App, registered by Pi Dash, owned by the vendor org.
 - App id / private key / webhook secret live in the hosted instance's
-  `InstanceConfiguration` (or env) — set once.
+  `InstanceConfiguration` — set once.
 - Each customer org **installs** the App from a Pi-Dash-created install session
   (§6.5). The verified installation callback creates/updates the workspace's
   `GithubAppInstallation`; the raw `installation` webhook alone never creates the
@@ -602,6 +607,27 @@ The **only** differences are _who registers the App_ and _which origin receives
 webhooks_. Storage, token minting, verified install binding, lifecycle handlers,
 and connection checks are identical — both read App secrets from
 `InstanceConfiguration` and installs from `WorkspaceIntegration`.
+
+### 11.1 Future design — hosted secret manager
+
+Pi Dash Cloud operations may eventually want AWS SSM Parameter Store or Secrets
+Manager as the source of truth for hosted App credentials because rotation and
+audit are easier there than direct DB writes. That should be designed as a
+separate deployment/configuration change, not as an implicit precedence patch in
+the App integration code.
+
+That future design must decide:
+
+- Whether SSM values are injected as environment variables, synchronized into
+  `InstanceConfiguration`, or referenced by key from `InstanceConfiguration`.
+- Which source wins during migration and how stale DB values are detected or
+  removed.
+- How secret rotation is performed without webhook/client-secret downtime.
+- How admin UI redaction behaves when the value is externally managed.
+- How self-hosted instances continue to use the DB-backed config path.
+
+Until that design exists, the current foundation keeps all six App config values
+in `InstanceConfiguration`.
 
 ## 12. Future runner / autonomous PRs (deferred)
 

--- a/.ai_design/github_deep_integration/design.md
+++ b/.ai_design/github_deep_integration/design.md
@@ -1,12 +1,13 @@
-# GitHub Deep Integration — Design
+# GitHub App Enablement — Design
 
-**Status:** Draft (design only — no implementation in this PR)
+**Status:** Implementation started — foundation slice
 **Date:** 2026-06-16
-**Scope:** The foundation and Layer-1 plan for moving Pi Dash from a one-way,
-PAT-polled GitHub mirror to a real-time, bidirectional integration built on a
-**GitHub App**. Targets **both** hosted multi-tenant and self-hosted
-single-org deployments. The runner/autonomous-coding phase (Layer 2) is
-sketched at the end but deliberately deferred.
+**Scope:** Foundation only: enable Pi Dash as a **GitHub App**, let a signed-in
+user install it from profile settings, safely bind that installation to an
+explicit Pi Dash workspace where the user is an admin, and verify the connection
+end to end. Targets **both** hosted multi-tenant and self-hosted single-org Pi
+Dash deployments. **No automatic issue/comment/PR sync ships in this design**;
+sync behavior is deliberately deferred to a separate future design.
 
 ---
 
@@ -26,7 +27,7 @@ Today Pi Dash connects to GitHub in three shallow ways:
   one-shot "completed in Pi Dash" comment
   (`post_completion_comment`, triggered by `bgtasks/github_signals.py`).
 
-This is enough to mirror issues, but it cannot support the real goal:
+This is enough to mirror issues, but it cannot support the long-term goal:
 
 > Make Pi Dash a layer on top of GitHub that boosts software-development
 > efficiency — the developer's whole loop (plan → code → review → ship) lives in
@@ -45,32 +46,48 @@ The current model has four hard ceilings:
    comment. State, PR actions, and checks do not flow at all.
 
 All four are properties of the **PAT auth model**, not of any one feature.
-Removing them requires a different foundation: a GitHub App.
+Removing them eventually requires a different foundation: a GitHub App. This
+design only builds that foundation and proves that the connection works; it does
+not change how issues or comments sync yet.
 
 ## 2. Goals
 
-- **Adopt a GitHub App as the data-plane credential.** Webhook-driven,
-  bot-identity, per-installation, granularly scoped. PAT becomes a legacy
-  fallback, not the primary path.
-- **Real-time, bidirectional Layer-1 sync.** Issues _and_ PRs, with state
-  mapping both ways, driven by webhooks with a polling reconciler as a safety net.
+- **Adopt a GitHub App installation as a workspace credential.** Bot identity,
+  per-installation scope, admin-approved repository access. PAT remains the
+  active data-sync credential until a later sync design replaces it.
+- **Install and verify end to end.** A signed-in Pi Dash user can install the App
+  from their profile settings, Pi Dash safely binds the GitHub installation to an
+  explicit workspace where that user is an admin, mints an installation token,
+  verifies repository access, and reports a clear connected/error status in the
+  UI.
 - **Work in both deployment modes.** Hosted multi-tenant (one App, many
   installations) and self-hosted single-org (each instance registers its own
   App). Same code paths; configuration differs.
 - **Reuse existing infrastructure.** `WorkspaceIntegration` for per-tenant
   install state, `InstanceConfiguration` for per-instance App secrets, the
-  `encrypt_data`/`decrypt_data` Fernet utilities, the Celery/Beat machinery, and
-  the `GithubClient` shape. No new secret store, no new queue.
-- **Clean migration from PAT.** Existing PAT bindings keep working until their
-  workspace adopts the App; no forced cutover, no data loss.
-- **Lay groundwork for Layer 2.** The data model (issue ↔ PR linkage, bot
-  identity, write scopes) must be the same one the runner will later use to open
-  PRs autonomously.
+  `encrypt_data`/`decrypt_data` Fernet utilities, and the `GithubClient` shape.
+  No new secret store, no new queue.
+- **Preserve PAT sync exactly as-is.** Existing PAT bindings and the 4-hour
+  issue/comment polling loop keep working. App adoption must not clobber the
+  PAT config or silently switch a repo to a new sync path.
+- **Lay groundwork without committing sync policy.** Store enough installation
+  metadata and webhook-delivery evidence that a later, more conservative sync
+  design can build on it without redesigning auth.
 
 ## 3. Non-Goals (this design)
 
-- **No runner/autonomous-PR work.** Layer 2 is sketched (§12) but not designed
-  here. It is gated on Layer 1 shipping first.
+- **No automatic issue/comment sync changes.** The existing PAT-backed 4-hour
+  poll remains the only issue/comment sync path. GitHub App webhooks for
+  `issues` and `issue_comment` are ignored/skipped in this design.
+- **No PR/check/review sync.** PR awareness, check status, review state, and
+  issue-to-PR linkage are deferred to a new future design.
+- **No bidirectional state writes.** Pi Dash does not close GitHub issues/PRs,
+  assign GitHub issues, or publish statuses/checks in this design.
+- **No reconciler changes.** Do not demote or rename the existing 4-hour
+  `github-issue-sync-every-4h` task yet; its cadence remains a PAT-sync concern.
+- **No runner/autonomous-PR work.** Runner-created branches, draft PR creation,
+  and run-completion integration are deferred until after a sync/PR design
+  exists.
 - **No GitHub Enterprise _Server_ (GHES) support.** First, a distinction this
   doc otherwise invites readers to confuse: self-hosted **Pi Dash** talking to
   `github.com` **is** supported (the "self-hosted single-org" mode in §11). What
@@ -81,8 +98,8 @@ Removing them requires a different foundation: a GitHub App.
   `utils/github_client.py`.
 
   GHES is deferred — not because it's hard, but because it's pure host-URL
-  configurability that **changes nothing in the architecture**: the App model,
-  token minting, webhooks, and sync logic are identical; only the API base
+  configurability that **changes nothing in the App architecture**: the App
+  model, token minting, and webhook verification are identical; only the API base
   (`https://<host>/api/v3`), App-registration endpoints, and webhook origin
   differ. That's exactly what makes it a safe, additive later change. Deferring
   avoids (a) doubling the verification matrix against a license-gated GHES
@@ -91,7 +108,7 @@ Removing them requires a different foundation: a GitHub App.
   Pi-Dash-plus-GHES-same-network combination is reachable), and (c) the ongoing
   cost of feature-gating by GHES version, which lags `github.com`.
 
-  **To keep the later add cheap, Layer 1 must centralize the API base URL** —
+  **To keep the later add cheap, this foundation must centralize the API base URL** —
   resolve every call's host through one place (extend `GITHUB_API_BASE` into a
   per-installation host field) instead of scattering `https://api.github.com`
   literals. Done now, GHES becomes a config change later, not a refactor.
@@ -100,28 +117,29 @@ Removing them requires a different foundation: a GitHub App.
 - **No GitLab/Bitbucket.** Provider abstraction is noted as a seam but not built.
 - **No frontend visual design.** UI surfaces are enumerated (what data appears
   where) but pixel/interaction design is out of scope.
-- **No CI-check authoring.** We _read_ check/review status (Phase 2); Pi Dash
-  does not _publish_ its own commit statuses or checks in this design.
+- **No CI-check authoring or reading.** CI/check/review handling belongs to the
+  deferred PR design.
 
 ## 4. Background — what we build on
 
 This design slots into existing systems rather than replacing them. The key
 anchors (verified in code):
 
-| System                        | Where                                                                                                                                         | What we reuse                                                                                             |
-| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| Per-tenant integration row    | `WorkspaceIntegration` (`db/models/integration/base.py`) — `config`/`metadata` JSON, `unique_together = [workspace, integration]`             | Store the App **installation** state per workspace here, mirroring how PAT is stored today.               |
-| Per-instance config + secrets | `InstanceConfiguration` (`license/models/instance.py`), `get_configuration_value()` (`license/utils/instance_value.py`), admin PATCH endpoint | Store the App **id / private key / webhook secret** here (encrypted), exactly like `EMAIL_HOST_PASSWORD`. |
-| Encryption                    | `license/utils/encryption.py` — Fernet key derived from `SECRET_KEY` via PBKDF2                                                               | Encrypt the App private key and webhook secret at rest.                                                   |
-| REST client                   | `utils/github_client.py` — PAT-auth, paginated, typed errors                                                                                  | Generalize to accept _any_ bearer token (PAT **or** installation token).                                  |
-| Sync tasks + Beat             | `bgtasks/github_sync_task.py`, `celery.py` beat `github-issue-sync-every-4h`                                                                  | Keep the full-scan task as the **reconciler**; demote cadence; add webhook-driven incremental path.       |
-| State-transition hook         | `bgtasks/github_signals.py` (pre/post-save on `Issue`)                                                                                        | Extend the same hook pattern to push Pi Dash → GitHub state changes.                                      |
-| Outbound webhooks             | `db/models/webhook.py`, `bgtasks/webhook_task.py` — HMAC-SHA256 signing                                                                       | Reuse the **HMAC verification pattern** (inverted) for _inbound_ GitHub webhooks.                         |
+| System                        | Where                                                                                                                                         | What we reuse                                                                                                                  |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Per-tenant integration row    | `WorkspaceIntegration` (`db/models/integration/base.py`) — `config`/`metadata` JSON, `unique_together = [workspace, integration]`             | Keep the workspace/provider container and legacy PAT config; anchor the App install with a one-to-one `GithubAppInstallation`. |
+| Per-instance config + secrets | `InstanceConfiguration` (`license/models/instance.py`), `get_configuration_value()` (`license/utils/instance_value.py`), admin PATCH endpoint | Store the App **id / private key / webhook secret** here, but with a write-only/redacted secret serializer (§6.4).             |
+| Encryption                    | `license/utils/encryption.py` — Fernet key derived from `SECRET_KEY` via PBKDF2                                                               | Encrypt the App private key and webhook secret at rest.                                                                        |
+| REST client                   | `utils/github_client.py` — PAT-auth, paginated, typed errors                                                                                  | Generalize enough to mint/use an installation token for connection verification.                                               |
+| Sync tasks + Beat             | `bgtasks/github_sync_task.py`, `celery.py` beat `github-issue-sync-every-4h`                                                                  | Leave unchanged. PAT polling remains the only issue/comment sync path for now.                                                 |
+| State-transition hook         | `bgtasks/github_signals.py` (pre/post-save on `Issue`)                                                                                        | Leave unchanged. No new Pi Dash → GitHub state writes in this design.                                                          |
+| Outbound webhooks             | `db/models/webhook.py`, `bgtasks/webhook_task.py` — HMAC-SHA256 signing                                                                       | Reuse the **HMAC verification pattern** (inverted) for _inbound_ GitHub webhooks.                                              |
 
 **Critical gap:** there is **no inbound webhook receiver anywhere** in the
 codebase today. The existing webhook system is outbound-only. Building a
-verified inbound receiver is the single biggest net-new piece of infrastructure
-in this design (§7).
+verified inbound receiver is still required for GitHub App installation lifecycle
+events, but this design only processes install/repository-selection events; it
+does not process issue/comment/PR events.
 
 ## 5. Why a GitHub App (vs PAT / OAuth)
 
@@ -135,9 +153,11 @@ in this design (§7).
 | Survives staff change | no                         | no               | **yes (org-owned install)**                 |
 | Install/uninstall UX  | paste a token              | per-user consent | **admin installs on selected repos**        |
 
-The decisive factor is **webhooks**: real-time and bidirectional sync are
-impossible on polling. Everything else (identity, scopes, rate limits) is why
-this is also the right home for the eventual runner phase.
+The decisive factor for this design is **installation identity**: the workspace
+connection belongs to a GitHub App installation, not to the human who pasted a
+PAT. Webhooks matter here only for App lifecycle events (`ping`,
+`installation`, `installation_repositories`). Issue/comment/PR webhooks are
+future sync inputs, not part of this implementation.
 
 ## 6. Auth architecture
 
@@ -150,11 +170,15 @@ A GitHub App authenticates in three escalating forms; we need all three:
    App-level endpoints below.
 2. **Installation token** — minted by `POST /app/installations/{id}/access_tokens`
    using the App JWT. Scoped to one installation, expires in **1 hour**, carries
-   the granted permissions on the granted repos. **This is the token the data
-   plane uses** for all REST calls (issues, PRs, comments, checks).
-3. **User-to-server token** (optional) — OAuth-on-the-App, to act _as the
-   logged-in user_ for attribution-sensitive writes. Deferred; the bot identity
-   is sufficient for Layer 1.
+   the granted permissions on the granted repos. In this design it is used only
+   for connection verification and repository-access checks; future sync designs
+   may use it as the data-plane token.
+3. **User-to-server token** — OAuth-on-the-App. In this foundation it is used
+   only during setup binding verification, because GitHub explicitly warns that
+   the installation callback's `installation_id` can be spoofed. Pi Dash uses this token
+   ephemerally to confirm the installing GitHub user can access the returned
+   installation, then discards it. Long-lived user tokens and attribution-sensitive
+   writes are out of scope.
 
 ### 6.2 Token-minting service (new)
 
@@ -174,22 +198,23 @@ A small service module — proposed `utils/github_app_auth.py` — owns:
 `GithubClient` currently takes a raw `token` and hard-codes
 `Authorization: Bearer {token}`. The change is minimal and backward-compatible:
 
-- Keep the `token=` constructor for PAT callers (the reconciler, legacy paths).
+- Keep the `token=` constructor for current PAT sync callers.
 - Add a classmethod `for_installation(installation_id)` that pulls a fresh
   installation token from §6.2 and constructs the client. Internally identical
   REST surface — the only difference is **where the bearer comes from**.
-- New write methods land here regardless of token source:
-  `close_pull_request`, `merge_pull_request`, `update_issue_state`,
-  `request_review`, `get_pull_request`, `list_check_runs`, etc.
+- Add read-only connection-check methods needed by the install flow, e.g.
+  `get_installation`, `list_installation_repositories`, and `get_repo`.
+  Write methods (`close_pull_request`, `merge_pull_request`,
+  `update_issue_state`, `request_review`, etc.) are deferred.
 - **Centralize the API base URL.** `GITHUB_API_BASE` is currently a module-level
   constant pointing at `https://api.github.com`. Make the host an instance
   property resolved through one place (defaulting to `github.com`) rather than a
-  hard-coded literal scattered across calls. Layer 1 only ever resolves it to
+  hard-coded literal scattered across calls. This design only resolves it to
   `github.com`, but doing this now is what makes GHES (§3) a config change later
   instead of a refactor.
 
-This keeps a single REST surface; PAT vs App is just credential provenance, and
-host is just configuration.
+This keeps one REST wrapper; current PAT sync keeps using its existing token
+path, while the App path is exercised only by install verification.
 
 ### 6.4 Where credentials live (both deployment modes)
 
@@ -197,23 +222,153 @@ host is just configuration.
 InstanceConfiguration (per deployment, encrypted via Fernet)
   ├─ GITHUB_APP_ID            (plaintext)
   ├─ GITHUB_APP_SLUG          (plaintext; for install URLs)
-  ├─ GITHUB_APP_PRIVATE_KEY   (is_encrypted=True)
-  ├─ GITHUB_APP_WEBHOOK_SECRET(is_encrypted=True)
-  └─ GITHUB_APP_CLIENT_ID/SECRET (is_encrypted; only if user-to-server used)
+  ├─ GITHUB_APP_PRIVATE_KEY   (is_encrypted=True, WRITE-ONLY — see below)
+  ├─ GITHUB_APP_WEBHOOK_SECRET(is_encrypted=True, WRITE-ONLY)
+  └─ GITHUB_APP_CLIENT_ID/SECRET (is_encrypted, WRITE-ONLY; setup verification only)
 
-WorkspaceIntegration.config (per workspace — the *installation*, not the App)
+WorkspaceIntegration.config (per workspace/provider — legacy PAT credential only)
   {
-    "auth_type": "github_app",
-    "installation_id": 12345678,
-    "account_login": "acme-corp",
-    "repository_selection": "selected" | "all",
-    "installed_at": "...",
-    "suspended_at": null
+    "auth_type": "pat",
+    "token": "<fernet-ciphertext>", # legacy / fallback — preserved, not clobbered
+    "github_user_login": "...",
+    "verified_at": "..."
   }
+
+GithubAppInstallation (per workspace — durable App installation state)
+  workspace_integration -> OneToOneField(WorkspaceIntegration)
+  installation_id       -> BigIntegerField(unique=True, db_index=True)
+  account_login         -> CharField
+  account_type          -> CharField      # User | Organization
+  repository_selection  -> CharField      # all | selected
+  repository_count      -> IntegerField
+  permissions           -> JSONField
+  events                -> JSONField
+  installed_at, suspended_at, verified_at, last_checked_at, last_check_error
 ```
 
 The App **secret** is always instance-level; the **installation** is always
 workspace-level. This split is what makes both deployment modes the same code.
+
+**⚠️ App secrets must NOT be served by the existing config endpoint.** Today
+`InstanceConfigurationEndpoint.get` returns _all_ rows
+(`license/api/views/configuration.py:37`) and
+`InstanceConfigurationSerializer.to_representation` _decrypts_ every
+`is_encrypted` value on read (`license/api/serializers/configuration.py:18`).
+That path already exposes `EMAIL_HOST_PASSWORD` in plaintext to any instance
+admin (and caches it for 2h) — so the §14 "treat it like `EMAIL_HOST_PASSWORD`"
+framing is exactly backwards: that _is_ the leak. `GITHUB_APP_PRIVATE_KEY` /
+`GITHUB_APP_WEBHOOK_SECRET` must be **write-only**: accept on PATCH, never
+return on GET. Required change — exclude these keys from the generic serializer
+(or give them a redacted `to_representation` that emits a `"set" / "unset"`
+sentinel instead of the value). This is a current-scope prerequisite, not a polish
+item.
+
+### 6.4.1 PAT and App credentials must coexist
+
+There is exactly **one** `WorkspaceIntegration` row per `(workspace, "github")`
+(`db/models/integration/base.py:56`), and today's sync resolves the credential
+**only** from `config["token"]` (`bgtasks/github_sync_task.py:53`). The App
+installation state therefore belongs in a sibling `GithubAppInstallation` row,
+not as a replacement for the PAT config. Two rules fix this:
+
+1. **Never clobber.** App adoption creates/updates `GithubAppInstallation` and
+   **leaves any existing PAT config intact**. Do not migrate or reshape today's
+   flat `config["token"]` PAT storage in this foundation.
+2. **Do not change sync credential selection yet.** `_resolve_token`
+   (`github_sync_task.py:53`) continues to read the PAT path for the existing
+   polling sync. The App installation token is used only by connection
+   verification in this design.
+
+A future sync design can introduce per-binding credential selection: prefer the
+App installation if the repo is covered by it, else fall back to the PAT. That
+resolver is deliberately not part of this implementation so installing the App
+cannot unexpectedly change how any repo syncs.
+
+### 6.5 Installation handshake and workspace binding
+
+An `installation` webhook by itself is **not enough** to bind a GitHub
+installation to a Pi Dash workspace. GitHub's installation callback includes an
+`installation_id`, but that query parameter is user-controllable from Pi Dash's
+point of view; treating it as proof would let a spoofed callback bind the wrong
+installation to a workspace. Hosted multi-tenant therefore needs an explicit
+install session:
+
+1. A user opens **Profile Settings -> Integrations**, chooses the target Pi Dash
+   workspace, and clicks "Install GitHub App". The target workspace selector only
+   lists workspaces where the user has admin permission.
+2. Pi Dash creates a `GithubAppInstallSession` row with
+   `workspace_id`, `actor_id`, a random `state`/nonce, `expires_at`, and
+   `status="started"`.
+3. Pi Dash sends the user to
+   `https://github.com/apps/{app_slug}/installations/new?state=<nonce>`.
+   The GitHub App registration must enable **Request user authorization (OAuth)
+   during installation** and use Pi Dash's callback URL:
+   `/api/integrations/github/app/callback/`. GitHub then returns `state`,
+   `installation_id`, and `code` to that callback.
+4. The callback requires the same user's normal Pi Dash session, validates the
+   `state` row, and re-checks that the actor is still a workspace admin for the
+   stored `workspace_id`.
+5. Pi Dash treats the callback `installation_id` as untrusted until GitHub proves
+   it belongs to the installing GitHub user:
+   - generate an ephemeral GitHub App user-to-server token for the callback user;
+   - call the user-installation endpoint and confirm the returned installation set
+     contains the callback `installation_id`;
+   - discard the user token immediately after this verification.
+6. After user-installation verification passes, use the App JWT to fetch the
+   installation from GitHub and verify the returned account/repository selection.
+7. Only after that verification does Pi Dash create/update the workspace's
+   `GithubAppInstallation` row, linked to its `WorkspaceIntegration`, and mark
+   the install session `completed`.
+
+Identity rule: Pi Dash and GitHub identities are deliberately not matched by
+email address. The Pi Dash user must be signed in and authorized as an admin of
+the selected Pi Dash workspace; the GitHub user must be able to access the
+returned GitHub App installation. Those are two separate authorization checks.
+It is valid for `user.email` in Pi Dash to differ from the installing GitHub
+account email/login.
+
+Webhook timing is deliberately decoupled from this binding flow. GitHub may
+deliver the `installation.created` webhook before the callback completes. In
+that case the receiver persists the delivery and marks it `skipped`, because no
+verified `installation_id -> workspace` mapping exists yet. It **does not create
+or attach** a `WorkspaceIntegration` row.
+After the installation callback completes, subsequent installation events route by the
+verified `installation_id -> workspace` mapping in our database.
+
+The existing `WorkspaceIntegration` model requires `actor` and `api_token` FKs.
+For App installs, use the installing admin as `actor` and create the same
+inactive APIToken shim used by the PAT connect path; if a future background-only
+repair path must create the row, it must first resolve a deterministic workspace
+system actor instead of leaving those FKs implicit.
+
+### 6.5.1 Install-session expiry and purge
+
+`GithubAppInstallSession` is a short-lived CSRF/workspace-binding proof, not a
+durable integration record. The durable record is `GithubAppInstallation`, linked
+to the workspace's `WorkspaceIntegration`.
+
+Rules:
+
+- Set `expires_at = created_at + 15 minutes` when the install session is created.
+- The installation callback must reject an expired session, mark it `expired`, and never
+  create/update `GithubAppInstallation`.
+- Use **lazy cleanup only** for the foundation; do not add a Celery Beat fallback
+  yet. Run a best-effort, bounded purge from the install-session start endpoint
+  and the installation callback:
+  - mark any `started` session with `expires_at < now()` as `expired`;
+  - hard-delete terminal sessions (`completed`, `expired`, `failed`) older than
+    7 days;
+  - log updated/deleted counts by status;
+  - catch and log cleanup failures without failing the user-facing install flow.
+- The lazy purge must be idempotent. If one request fails midway, the remaining
+  rows still match the same status/timestamp predicates, so the next install
+  start or callback can pick them up.
+- Add indexes for `state` (unique), `status`, and `expires_at` so callback lookup
+  and cleanup do not scan the table.
+
+Do **not** purge `GithubAppInstallation` or `WorkspaceIntegration` as part of this
+task. Uninstall/suspend lifecycle events update the durable install state; they
+are not install-session cleanup.
 
 ## 7. Inbound webhook receiver (new infrastructure)
 
@@ -222,10 +377,10 @@ discipline: verify at the edge, persist, ack fast, process async.
 
 ### 7.1 Endpoint
 
-A single public endpoint on the **external API** surface
-(`pi_dash.api`, mounted `/api/v1/`), e.g.
-`POST /api/v1/integrations/github/webhook/`. It must be **unauthenticated by
-`X-Api-Key`** (GitHub won't send one) and instead authenticated by **signature**.
+A single public endpoint on the authenticated app API mount:
+`POST /api/integrations/github/app/webhook/`. The endpoint itself must be
+unauthenticated by the normal Pi Dash session/API-key mechanisms (GitHub won't
+send either) and instead authenticated by **signature**.
 
 ### 7.2 Verification (reuse the HMAC pattern, inverted)
 
@@ -235,43 +390,52 @@ raw body, keyed by the App's webhook secret. The outbound webhook code
 construction; we invert it:
 
 ```python
-expected = hmac.new(webhook_secret.encode(), raw_body, hashlib.sha256).hexdigest()
-hmac.compare_digest(expected, received_sig)   # constant-time
+# GitHub sends the header as "sha256=<hexdigest>" and signs the RAW body bytes.
+# Build our digest with the same prefix and compare the full strings — do NOT
+# compare a bare hexdigest against the prefixed header.
+received = request.headers.get("X-Hub-Signature-256", "")
+expected = "sha256=" + hmac.new(webhook_secret.encode(), raw_body, hashlib.sha256).hexdigest()
+if not received or not hmac.compare_digest(expected, received):  # constant-time
+    reject_401()
 ```
 
-Reject on mismatch with `401` before any parsing. Resolve `webhook_secret` from
-`InstanceConfiguration` (self-hosted) or the single hosted App secret.
+Two correctness traps to call out for the implementer: (a) the header carries
+the `sha256=` prefix — compare prefixed-to-prefixed (or strip it from both); a
+missing/empty header must reject, not pass. (b) `raw_body` must be the exact
+bytes GitHub sent — capture it _before_ DRF parses/re-serializes the request
+(any re-encode breaks the digest). Reject on mismatch with `401` before any
+parsing. Resolve `webhook_secret` from `InstanceConfiguration` (self-hosted) or
+the single hosted App secret.
 
-### 7.3 Persist-then-process
+### 7.3 Persist-then-process bounded lifecycle events
 
 1. Verify signature on the **raw** body (must read body before DRF parses it).
 2. Persist a `GithubWebhookDelivery` row (dedupe on `X-GitHub-Delivery` UUID —
    GitHub retries deliveries; we must be idempotent).
-3. Enqueue `process_github_webhook.delay(delivery_id)` and return `202`
-   immediately. GitHub enforces a ~10s delivery timeout; never process inline.
-4. The Celery task routes by `X-GitHub-Event` (`pull_request`, `issues`,
-   `issue_comment`, `check_suite`, `pull_request_review`,
-   `installation`, `installation_repositories`) to a handler.
+3. Process only the bounded lifecycle events inline in the request:
+   `ping`, `installation`, and `installation_repositories`; return `202` after
+   status is recorded. Do **not** add a Celery task for this foundation.
+4. Any other delivery is persisted and marked `skipped` with no side effects.
 
 ### 7.4 Handler routing
 
-| Event                                    | Action                                                                                 |
-| ---------------------------------------- | -------------------------------------------------------------------------------------- |
-| `installation` (created/deleted/suspend) | Create/disable the workspace `WorkspaceIntegration` install record; mint/evict tokens. |
-| `installation_repositories`              | Update which repos a binding may cover.                                                |
-| `issues`                                 | Upsert the issue mirror **incrementally** (replaces a full poll for that issue).       |
-| `issue_comment`                          | Upsert/delete the mirrored comment.                                                    |
-| `pull_request`                           | Upsert the PR mirror; map PR state → linked issue state (§9).                          |
-| `pull_request_review`                    | Update review status on the linked issue.                                              |
-| `check_suite` / `check_run`              | Update CI status on the linked PR/issue.                                               |
+| Event                                    | Action                                                                                                                              |
+| ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `ping`                                   | Mark the App/webhook connection as reachable; useful for setup diagnostics.                                                         |
+| `installation` (created/deleted/suspend) | If a verified binding exists, enable/disable install state and evict tokens. If no binding exists yet, mark the delivery `skipped`. |
+| `installation_repositories`              | Update install metadata/repository count for connection status only.                                                                |
+| anything else                            | Mark `skipped`; issue/comment/PR/check sync is out of scope.                                                                        |
 
-Handlers are the **incremental** counterpart to today's full scan. The full scan
-survives as the reconciler (§10).
+The GitHub App should subscribe only to the lifecycle events above for this
+implementation. If GitHub sends another event anyway, Pi Dash stores enough
+delivery evidence for debugging and returns `202`, but it does not mutate issues,
+comments, PR records, or project state.
 
 ## 8. Data model changes
 
-New rows; existing GitHub models (`GithubRepository`, `GithubRepositorySync`,
-`GithubIssueSync`, `GithubCommentSync`) are unchanged in shape, only joined to.
+Current-scope rows; existing GitHub sync models (`GithubRepository`,
+`GithubRepositorySync`, `GithubIssueSync`, `GithubCommentSync`) are unchanged
+and continue to serve only the PAT-backed polling sync.
 
 ```
 GithubWebhookDelivery (new)
@@ -283,75 +447,130 @@ GithubWebhookDelivery (new)
   status       (received | processed | failed | skipped)
   received_at, processed_at, error
 
-GithubPullRequestSync (new — the missing issue↔PR link)
-  repository_sync (FK GithubRepositorySync)
-  issue        (FK Issue, null)         # the linked Pi Dash issue, if any
-  repo_pr_number (int)
-  github_pr_id (bigint)
-  pr_url       (url)
-  head_ref, base_ref (str)
-  state        (open | draft | merged | closed)
-  review_state (str, null)              # approved / changes_requested / ...
-  check_state  (str, null)              # success / failure / pending
-  metadata     (JSON)                   # last_synced_sha, linkage_source, ...
-  unique_together = [repository_sync, repo_pr_number]
+GithubAppInstallation (new)
+  workspace_integration -> OneToOneField(WorkspaceIntegration)
+  installation_id       -> BigIntegerField(unique=True, db_index=True)
+  account_login         -> CharField
+  account_type          -> CharField      # User | Organization
+  repository_selection  -> CharField      # all | selected
+  repository_count      -> PositiveIntegerField(default=0)
+  permissions           -> JSONField(default=dict)
+  events                -> JSONField(default=list)
+  installed_at          -> DateTimeField(null=True)
+  suspended_at          -> DateTimeField(null=True)
+  verified_at           -> DateTimeField(null=True)
+  last_checked_at       -> DateTimeField(null=True)
+  last_check_error      -> TextField(blank=True)
+  indexes               (installation_id unique, workspace_integration unique)
+
+GithubAppInstallSession (new)
+  state       (str, unique)      # random setup nonce; never trust installation_id alone
+  workspace   (FK Workspace)
+  actor       (FK User)          # installing admin
+  installation_id (bigint, null)
+  account_login   (str, blank)
+  status      (started | completed | expired | failed)
+  expires_at, completed_at, error
+  indexes     (state unique, status, expires_at)
 ```
 
-**Linkage discovery** (how an issue finds its PR), in priority order:
+`GithubAppInstallation` carries the current connection status:
 
-1. PR body / title references (`closes #N`, `fixes #N`) → map `#N` to the
-   mirrored `GithubIssueSync.repo_issue_id`.
-2. Branch naming convention (e.g. `pi-dash/<issue-identifier>`), which is also
-   exactly what the runner will produce in Layer 2 (`Assign.git_work_branch`
-   already exists in the runner protocol).
-3. Manual link (paste a PR URL on the issue) — always-available fallback.
+```json
+{
+  "installation_id": 12345678,
+  "account_login": "acme-corp",
+  "repository_selection": "selected",
+  "repository_count": 12,
+  "installed_at": "...",
+  "verified_at": "...",
+  "last_checked_at": "...",
+  "last_check_error": "",
+  "suspended_at": null
+}
+```
 
-## 9. Bidirectional state mapping (Layer 1)
+No `GithubPullRequestSync`, `GithubOutboundOperation`, or issue-linkage tables
+ship in this design. Those belong to the future sync/PR design.
 
-State sync is **policy**, and surprising automation is worse than none — so
-every reverse (Pi Dash → GitHub) mapping is **opt-in per project**.
+## 9. End-to-end connection verification
 
-**GitHub → Pi Dash** (inbound webhook → issue state, via the existing
-`State.group` vocabulary `backlog/unstarted/started/review/completed/cancelled`):
+The success criterion for this design is not "issues sync in real time." It is:
+a user can install the App from profile settings, Pi Dash can prove it has a
+valid installation credential for the selected workspace, and the UI can show
+whether the connection is healthy.
 
-| GitHub event                       | Pi Dash effect (default)                              |
-| ---------------------------------- | ----------------------------------------------------- |
-| PR opened linked to issue          | issue → `started`                                     |
-| PR marked ready / review requested | issue → `review`                                      |
-| PR merged                          | issue → `completed`                                   |
-| PR closed unmerged                 | no change (surface a badge)                           |
-| issue closed upstream              | flag `upstream_gone_at` (today's behavior, unchanged) |
+Connection flow:
 
-**Pi Dash → GitHub** (extend the `github_signals.py` post-save hook; today it
-only fires the completion _comment_ on `group == completed`):
+1. Instance admin configures or creates the GitHub App.
+2. User starts an install session from Profile Settings -> Integrations (§6.5),
+   selects the target Pi Dash workspace, and installs the App on all or selected
+   GitHub repositories/accounts.
+3. Callback validates `state`, exchanges the OAuth `code`, confirms the GitHub
+   user can access the returned `installation_id`, fetches the installation
+   using the App JWT, creates/updates `GithubAppInstallation`, and marks the
+   install session complete.
+4. Pi Dash immediately runs a connection check:
+   - mint installation token;
+   - fetch the installation/account;
+   - list installation repositories or fetch the selected repository metadata;
+   - write `verified_at`, `last_checked_at`, `repository_count`, and
+     `last_check_error`.
+5. The settings UI shows one of: not configured, install started, connected,
+   connected but suspended, missing permissions, token-mint failed, or webhook
+   unreachable.
 
-| Pi Dash transition     | GitHub effect (opt-in)                                   |
-| ---------------------- | -------------------------------------------------------- |
-| issue → `completed`    | comment (today) **+ optionally** close linked PR / issue |
-| issue → `cancelled`    | optionally close the linked PR (the original example)    |
-| issue assigned to user | optionally assign the GitHub issue                       |
+UI placement:
 
-Reverse writes require the App installation to have been granted
-**Issues: write** and **Pull requests: write**; the handler no-ops with a
-surfaced warning if the grant is missing (mirrors today's
-`GithubPermissionError` handling).
+- The in-app GitHub App install entry point lives in **Profile Settings ->
+  Integrations** (`/settings/profile/integrations`). This profile tab does not
+  exist today; add it to the profile settings tab constants, route map, sidebar,
+  and content map.
+- The Profile Settings GitHub card owns "Install GitHub App", "Reconnect", and
+  "Refresh connection". It includes a required target-workspace selector before
+  starting a new install session, then displays the connected GitHub
+  account/installation, target Pi Dash workspace, selected-repository summary or
+  count, `verified_at`, `last_checked_at`, and the latest connection error.
+- **Workspace Settings -> Integrations** can retain the legacy PAT connection UI
+  and may show a read-only pointer to Profile Settings -> Integrations for the
+  App install flow, but it is not the primary App install surface.
+- Project-level GitHub settings remain consumers of the workspace connection.
+  They may show a read-only "GitHub App not connected" state with a link back to
+  Profile Settings -> Integrations, but this foundation must not add new
+  project-level App sync toggles or automatic issue/comment sync controls.
+- The existing PAT-backed project binding UI remains unchanged until a separate
+  sync design decides how App-backed repository binding should coexist with
+  `GithubRepositorySync`.
 
-**Loop prevention:** a write Pi Dash makes to GitHub comes back as a webhook.
-Tag Pi-Dash-originated changes (bot actor / a marker in `metadata`) and short-
-circuit in the handler when the incoming change matches one we just made — the
-same idempotency discipline as `completion_comment_id` today.
+The same connection check backs a manual "Refresh connection" action. It is a
+diagnostic and permission probe only; it does not create, update, close, or
+comment on Pi Dash issues or GitHub issues.
 
-## 10. Reconciliation — webhooks are not reliable
+## 10. Deferred sync design
 
-Webhooks get dropped, mis-delivered, or missed during downtime. The full-scan
-task (`sync_one_repo`) is **not deleted** — it is repurposed:
+Issue/comment/PR synchronization is intentionally out of scope and should get a
+new design before implementation. That future design must decide the conservative
+sync policy explicitly instead of inheriting "webhook event means mutate local
+state" by default.
 
-- Demote `github-issue-sync-every-4h` cadence (e.g. daily) and rename its intent
-  to "reconcile," not "sync."
-- It becomes the **drift-repair** pass: re-scan issues + PRs, compare to local
-  mirrors, fix anything webhooks missed.
-- Webhook handlers carry steady-state; the reconciler guarantees eventual
-  consistency. This is the standard belt-and-suspenders for webhook systems.
+Future design questions:
+
+- Which projects/repos opt into App-backed sync, and how does that coexist with
+  existing PAT-backed `GithubRepositorySync` rows?
+- What content is authoritative on each side: title/body/comments/state/labels/
+  assignees/milestones?
+- Are GitHub issue/comment webhooks used at all, or do we keep a polling-first
+  model with a manual "sync now" action and webhooks only as invalidation hints?
+- What is the backfill story for existing mirrored issues and comments?
+- How do we prevent duplicate mirrors when a workspace has both PAT and App
+  credentials?
+- If Pi Dash ever writes back, what is the transaction boundary, idempotency key,
+  and user/bot attribution model?
+
+Until that design exists, the current PAT sync stays exactly as it is:
+`sync_all_repos` runs every 4 hours, `sync_one_repo` imports open issues and
+comments, and `github_signals.py` only posts the existing one-shot completion
+comment.
 
 ## 11. Deployment modes — one design, two configs
 
@@ -360,10 +579,12 @@ task (`sync_one_repo`) is **not deleted** — it is repurposed:
 - **One** GitHub App, registered by Pi Dash, owned by the vendor org.
 - App id / private key / webhook secret live in the hosted instance's
   `InstanceConfiguration` (or env) — set once.
-- Each customer org **installs** the App; the `installation` webhook creates a
-  `WorkspaceIntegration` install record for their workspace.
+- Each customer org **installs** the App from a Pi-Dash-created install session
+  (§6.5). The verified installation callback creates/updates the workspace's
+  `GithubAppInstallation`; the raw `installation` webhook alone never creates the
+  binding.
 - One public webhook URL for all tenants; the handler routes by
-  `installation_id` → workspace.
+  verified `installation_id` → workspace mapping.
 
 ### Self-hosted single-org
 
@@ -371,105 +592,109 @@ task (`sync_one_repo`) is **not deleted** — it is repurposed:
   flow** — a one-click create that returns id + private key + webhook secret to a
   callback, far better self-host UX than manual field entry).
 - Those secrets are written to _that instance's_ `InstanceConfiguration`
-  (encrypted). Admin UI lives next to the existing GitHub OAuth config screen in
-  `apps/admin`.
+  (encrypted and write-only/redacted on read). Admin UI lives next to the
+  existing GitHub OAuth config screen in `apps/admin`.
 - Webhook URL is the instance's own public origin. Self-host docs must note the
   instance has to be reachable by GitHub (the one genuinely new operational
   requirement vs. PAT polling, which needed no inbound connectivity).
 
 The **only** differences are _who registers the App_ and _which origin receives
-webhooks_. Storage, token minting, handlers, and sync logic are identical —
-both read App secrets from `InstanceConfiguration` and installs from
-`WorkspaceIntegration`.
+webhooks_. Storage, token minting, verified install binding, lifecycle handlers,
+and connection checks are identical — both read App secrets from
+`InstanceConfiguration` and installs from `WorkspaceIntegration`.
 
-## 12. Layer 2 — runner / autonomous PRs (deferred, sketch only)
+## 12. Future runner / autonomous PRs (deferred)
 
-Not designed here; captured so Layer 1's data model doesn't paint us into a
-corner. The runner plane already has the needed seams:
+Not designed here. The only foundation this design intentionally provides for
+runner autonomy is durable GitHub App auth: the cloud can later mint an
+installation token for a verified workspace installation. Everything else needs
+the future sync/PR design first.
 
 - `AgentRun.run_config` already carries `repo_url`, `repo_ref`,
   `git_work_branch`; the `Assign` protocol message
   (`runner/src/cloud/protocol.rs`) already ships a branch to check out, and
   `runner/src/workspace/git.rs` already clones, branches, and manages worktrees.
 - The runner already pushes branches; it does **not** open PRs today.
-- **Future flow:** issue → `AgentRun` (existing dispatch via
-  `matcher.drain_pod`) → runner writes code + pushes branch → on
-  `RunCompleted`, the cloud (not the runner) opens a **draft PR** via the App
-  installation token and records a `GithubPullRequestSync` linked to the issue.
-  Because the PR is opened by the App, it is attributed to `pi-dash[bot]`, and
-  every Layer-1 mechanism (state mapping, checks, review surfacing) applies to it
-  automatically.
+- A future runner design may use the App installation token to open draft PRs,
+  but it must first define issue/PR linkage, state ownership, and write-back
+  idempotency in the separate sync/PR design.
 
-The point of doing Layer 1 on a GitHub App first is precisely that Layer 2 then
-needs _no new auth, no new client, no new linkage model_ — only a "create PR on
-run completion" step.
+Do not implement issue → runner → draft PR as part of this foundation.
 
-## 13. Phased roadmap
+## 13. Current and future roadmap
 
-| Phase                                     | Deliverable                                                                                                                                                                                                                                                                                                 | Gates unlocked                                               |
-| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| **0 — Foundation**                        | App registration (manifest flow for self-host; manual for hosted), secret storage in `InstanceConfiguration`, token-minting service (§6.2), `GithubClient.for_installation`, **inbound webhook receiver + verification + delivery persistence** (§7), `installation` event → `WorkspaceIntegration` record. | The App can be installed and we receive verified events.     |
-| **1 — Real-time issue sync**              | Webhook handlers for `issues` / `issue_comment` doing incremental upsert; reconciler demotion (§10). PAT path still works in parallel.                                                                                                                                                                      | Issues sync in real time instead of every 4h.                |
-| **2 — PR + checks + bidirectional state** | `GithubPullRequestSync` model + linkage discovery (§8); `pull_request` / `review` / `check_suite` handlers; PR/CI/review status surfaced on issues; opt-in reverse state mapping incl. close-PR-on-cancel (§9); new write methods on `GithubClient`.                                                        | The full Layer-1 vision: bidirectional, real-time, PR-aware. |
-| **3 — Runner autonomy**                   | (Separate design) issue → runner → draft PR via App token.                                                                                                                                                                                                                                                  | Layer 2 — the differentiator.                                |
+| Stage                                    | Deliverable                                                                                                                                                                                                                                                                                                       | Gates unlocked                                                             |
+| ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| **Current — App enablement**             | App registration (manifest flow for self-host; manual for hosted), write-only/redacted secret storage in `InstanceConfiguration`, token-minting service (§6.2), `GithubClient.for_installation`, verified install-session flow (§6.5), inbound lifecycle webhook receiver (§7), and connection verification (§9). | The App can be installed, safely bound to a workspace, and proven healthy. |
+| **Future design — conservative sync**    | Separate design for issue/comment sync policy: opt-in surface, authority rules, webhook-vs-polling posture, PAT/App coexistence, backfill, duplicate prevention, and failure handling (§10).                                                                                                                      | App-backed sync can be implemented without surprising users.               |
+| **Future design — PR/check/state layer** | Separate design for PR linkage, checks/reviews, bidirectional state writes, outbound operation idempotency, and attribution.                                                                                                                                                                                      | PR-aware workflows can be added safely.                                    |
+| **Future design — runner autonomy**      | Separate design for issue → runner → branch/PR workflows using the verified App installation.                                                                                                                                                                                                                     | Autonomous PR workflows.                                                   |
 
-Phases 0–2 deliver "catch up to Linear, in real time, both deployment modes."
-Phase 3 is the part competitors can't easily copy because Pi Dash owns the
-runner.
+Only the **Current — App enablement** stage is in scope for this document.
 
 ## 14. Security considerations
 
 - **Private key** is the crown jewel — encrypted at rest (Fernet), never logged,
-  never returned by any API (the config serializer must treat it like
-  `EMAIL_HOST_PASSWORD`).
+  and never returned by any API. The existing generic configuration serializer
+  decrypts encrypted values on read, so App secret keys must be excluded from
+  that serializer or represented only as redacted `set` / `unset` sentinels.
 - **Webhook signature** verified constant-time on the raw body before parsing;
   unsigned/mismatched → `401`, no side effects.
 - **Delivery idempotency** via `X-GitHub-Delivery` to survive GitHub's retries.
 - **Installation token scope** is the least-privilege boundary — request only the
-  permissions each phase needs (Phase 1: Issues read; Phase 2: + Pull requests
-  read/write, Checks read).
+  permissions this foundation needs. Current scope should not request Issues,
+  Pull requests, or Checks write permissions; future sync designs can justify
+  additional grants explicitly.
 - **Tenant isolation** (hosted): always resolve `installation_id` → workspace
-  from our own records; never trust a workspace id from the payload.
-- **Loop/echo prevention** (§9) so our own writes don't ping-pong.
+  from our own verified install-session records; never trust a workspace id from
+  the payload or a bare callback query parameter.
+- **No issue side effects from webhooks.** Non-lifecycle webhook events are
+  persisted/skipped only; they cannot mutate Pi Dash issues or comments.
 
-## 15. Open questions
+## 15. Implementation defaults
 
-1. **User attribution** — is bot-identity (`pi-dash[bot]`) acceptable for all
-   writes in Layer 1, or do some actions need user-to-server tokens (§6.1.3) for
-   correct authorship? (Affects whether we build the OAuth-on-App flow now.)
-2. **Reconciler cadence** — daily? hourly? Tunable per instance?
-3. **PAT deprecation timeline** — keep indefinitely as a fallback, or sunset
-   once App adoption crosses a threshold?
-4. **Multi-repo per project** — the current schema enforces one repo per project
-   (`github_repository_sync_unique_per_project_when_active`). Does deep
-   integration need many repos per project (monorepo vs polyrepo teams)?
-5. **Self-host reachability** — for instances not publicly reachable, do we offer
-   a polling-only degraded mode, or require a tunnel/relay?
+1. **Minimal permission set** — ship with the mandatory GitHub App metadata access
+   plus lifecycle webhooks only (`ping`, `installation`,
+   `installation_repositories`). Do not request Issues, Pull requests, Checks, or
+   Contents permissions in this foundation.
+2. **Install visibility** — Profile Settings shows GitHub account/login,
+   repository selection mode, repository count, verification timestamps, and
+   errors. Do not show the full selected-repository list until a later sync design
+   needs it.
+3. **PAT deprecation timeline** — keep PAT support indefinitely for now. Revisit
+   only after a separate App-backed sync design ships and has a migration plan.
+4. **Self-host reachability** — require a publicly reachable callback/webhook URL
+   or an operator-provided tunnel/relay for GitHub App setup. Do not add a
+   polling-only degraded mode in this foundation.
 
 ---
 
 ## Appendix A — File-level impact map
 
-| Area               | File(s)                                                                                             | Change                                                        |
-| ------------------ | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| App auth           | `apps/api/pi_dash/utils/github_app_auth.py` _(new)_                                                 | JWT + installation-token minting, Redis cache.                |
-| REST client        | `apps/api/pi_dash/utils/github_client.py`                                                           | `for_installation()` classmethod; new write methods.          |
-| Webhook receiver   | `apps/api/pi_dash/api/views/integration/github_webhook.py` _(new)_, `apps/api/pi_dash/api/urls/...` | Signed inbound endpoint + URL registration.                   |
-| Webhook processing | `apps/api/pi_dash/bgtasks/github_webhook_task.py` _(new)_                                           | Event router + handlers (incremental upsert).                 |
-| Models             | `apps/api/pi_dash/db/models/integration/github.py`                                                  | `GithubWebhookDelivery`, `GithubPullRequestSync` + migration. |
-| State hook         | `apps/api/pi_dash/bgtasks/github_signals.py`                                                        | Extend to reverse state mapping (opt-in).                     |
-| Reconciler         | `apps/api/pi_dash/bgtasks/github_sync_task.py`, `apps/api/pi_dash/celery.py`                        | Demote cadence; reframe as drift-repair.                      |
-| Instance config    | `apps/admin/...` GitHub config screens; `license/...` config keys                                   | App id/key/secret entry; manifest-flow callback (self-host).  |
-| Install state      | `apps/api/pi_dash/app/views/integration/github.py`                                                  | `installation` handling alongside existing PAT connect.       |
-| Types/UI           | `packages/types/src/integration.ts`, web settings components                                        | PR/check/review status surfaces; install vs PAT status.       |
+| Area               | File(s)                                                                                                                                                                                                                                                                                                                                                                                                                                          | Change                                                                                                                                                              |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| App auth           | `apps/api/pi_dash/utils/github_app_auth.py` _(new)_                                                                                                                                                                                                                                                                                                                                                                                              | JWT + installation-token minting, Redis cache.                                                                                                                      |
+| REST client        | `apps/api/pi_dash/utils/github_client.py`                                                                                                                                                                                                                                                                                                                                                                                                        | `for_installation()` classmethod; read-only connection-check methods.                                                                                               |
+| Webhook receiver   | `apps/api/pi_dash/app/views/integration/github.py`, `apps/api/pi_dash/app/urls/integration.py`                                                                                                                                                                                                                                                                                                                                                   | Signed inbound endpoint + URL registration; unauthenticated-by-session view method.                                                                                 |
+| Webhook processing | `apps/api/pi_dash/app/views/integration/github.py`                                                                                                                                                                                                                                                                                                                                                                                               | Bounded inline event router for `ping`, `installation`, `installation_repositories`; skip everything else.                                                          |
+| Models             | `apps/api/pi_dash/db/models/integration/github.py`                                                                                                                                                                                                                                                                                                                                                                                               | `GithubAppInstallation`, `GithubWebhookDelivery`, `GithubAppInstallSession` + migration, including install-session expiry indexes.                                  |
+| Lazy cleanup       | `apps/api/pi_dash/app/views/integration/github.py`                                                                                                                                                                                                                                                                                                                                                                                               | Best-effort request-triggered cleanup for stale/terminal `GithubAppInstallSession` rows; no Celery Beat fallback in the foundation.                                 |
+| Existing PAT sync  | `apps/api/pi_dash/bgtasks/github_sync_task.py`, `apps/api/pi_dash/celery.py`, `apps/api/pi_dash/bgtasks/github_signals.py`                                                                                                                                                                                                                                                                                                                       | No behavior change. Keep polling cadence and completion comment as-is.                                                                                              |
+| Instance config    | `apps/api/pi_dash/utils/instance_config_variables/core.py`, `apps/api/pi_dash/license/api/serializers/configuration.py`, future `apps/admin/...` GitHub config screen                                                                                                                                                                                                                                                                            | App id/key/secret config variables; redacted secret readback; manifest-flow callback/admin UI can follow.                                                           |
+| Install state      | `apps/api/pi_dash/app/views/integration/github.py`                                                                                                                                                                                                                                                                                                                                                                                               | Install-session start/callback, PAT/App coexistence, verified binding.                                                                                              |
+| Types/UI           | `packages/types/src/integration.ts`, `packages/types/src/settings.ts`, `packages/constants/src/settings/profile.ts`, `apps/web/core/components/settings/profile/content/pages/index.ts`, `apps/web/core/components/settings/profile/content/pages/integrations.tsx` _(new)_, optional legacy pointer in `apps/web/app/(all)/[workspaceSlug]/(settings)/settings/(workspace)/integrations/page.tsx`, project GitHub settings read-only link state | Add Profile Settings -> Integrations and put App install state, connection health, repository count, refresh/reconnect actions there; no new project sync controls. |
 
-## Appendix B — Why not just add write methods to the PAT client?
+## Appendix B — Why not sync issues/comments now?
 
-We could ship close-PR-on-cancel today purely on the PAT path (add
-`close_pull_request`, extend `github_signals.py`, bump the PAT scope). That is a
-legitimate **quick win** and nothing here blocks it. But every _other_ part of
-the vision (real-time, PR awareness, checks, durable identity, the runner loop)
-requires the App. Building the close-PR feature only on PAT means rebuilding it
-on the App later. The roadmap therefore treats the App as Phase 0 and folds
-close-PR into Phase 2, where it costs almost nothing on top of the PR model that
-already has to exist.
+Real-time webhook sync is powerful but easy to make surprising. If every GitHub
+issue/comment event immediately mutates Pi Dash, users inherit implicit field
+ownership, duplicate-prevention, backfill, delete/close semantics, and failure
+recovery rules before we have designed them. That is too aggressive for this
+step.
+
+The safer split is:
+
+1. First ship the GitHub App foundation and prove install/token/webhook health.
+2. Then design App-backed sync separately, with explicit opt-in and conservative
+   rules for what can change automatically.
+3. Only after that consider PR/check/state write-back and runner-created PRs.

--- a/.ai_design/github_deep_integration/design.md
+++ b/.ai_design/github_deep_integration/design.md
@@ -1,0 +1,446 @@
+# GitHub Deep Integration — Design
+
+**Status:** Draft (design only — no implementation in this PR)
+**Date:** 2026-06-16
+**Scope:** The foundation and Layer-1 plan for moving Pi Dash from a one-way,
+PAT-polled GitHub mirror to a real-time, bidirectional integration built on a
+**GitHub App**. Targets **both** hosted multi-tenant and self-hosted
+single-org deployments. The runner/autonomous-coding phase (Layer 2) is
+sketched at the end but deliberately deferred.
+
+---
+
+## 1. Problem
+
+Today Pi Dash connects to GitHub in three shallow ways:
+
+- **OAuth App** — login/SSO only; the user token is used to read identity, then
+  discarded. It is never reused for data access.
+- **Personal Access Token (PAT)** — the only credential used for data. Pasted
+  once per workspace, stored encrypted in `WorkspaceIntegration.config["token"]`
+  (`apps/api/pi_dash/app/views/integration/github.py`), and consumed by a single
+  REST client (`apps/api/pi_dash/utils/github_client.py`).
+- **A 4-hour polling sync** — `sync_all_repos` →​ `sync_one_repo`
+  (`apps/api/pi_dash/bgtasks/github_sync_task.py`) does a full scan per binding,
+  importing **open issues + comments** into Pi Dash. The only write-back is a
+  one-shot "completed in Pi Dash" comment
+  (`post_completion_comment`, triggered by `bgtasks/github_signals.py`).
+
+This is enough to mirror issues, but it cannot support the real goal:
+
+> Make Pi Dash a layer on top of GitHub that boosts software-development
+> efficiency — the developer's whole loop (plan → code → review → ship) lives in
+> Pi Dash while GitHub remains the execution substrate.
+
+The current model has four hard ceilings:
+
+1. **No real-time.** Polling every 4 hours means Pi Dash is always stale; there
+   is no way to react to a PR opening, a check failing, or a review landing.
+2. **No PR awareness.** The sync explicitly skips pull requests
+   (`if "pull_request" in gh_issue: continue`,
+   `github_sync_task.py:301`). There is no model linking a Pi Dash issue to a PR.
+3. **Identity is a person.** Every action is attributed to whoever pasted the
+   PAT; when they leave or rotate the token, sync silently breaks.
+4. **Read-mostly.** Content flows GitHub → Pi Dash; the only reverse signal is a
+   comment. State, PR actions, and checks do not flow at all.
+
+All four are properties of the **PAT auth model**, not of any one feature.
+Removing them requires a different foundation: a GitHub App.
+
+## 2. Goals
+
+- **Adopt a GitHub App as the data-plane credential.** Webhook-driven,
+  bot-identity, per-installation, granularly scoped. PAT becomes a legacy
+  fallback, not the primary path.
+- **Real-time, bidirectional Layer-1 sync.** Issues _and_ PRs, with state
+  mapping both ways, driven by webhooks with a polling reconciler as a safety net.
+- **Work in both deployment modes.** Hosted multi-tenant (one App, many
+  installations) and self-hosted single-org (each instance registers its own
+  App). Same code paths; configuration differs.
+- **Reuse existing infrastructure.** `WorkspaceIntegration` for per-tenant
+  install state, `InstanceConfiguration` for per-instance App secrets, the
+  `encrypt_data`/`decrypt_data` Fernet utilities, the Celery/Beat machinery, and
+  the `GithubClient` shape. No new secret store, no new queue.
+- **Clean migration from PAT.** Existing PAT bindings keep working until their
+  workspace adopts the App; no forced cutover, no data loss.
+- **Lay groundwork for Layer 2.** The data model (issue ↔ PR linkage, bot
+  identity, write scopes) must be the same one the runner will later use to open
+  PRs autonomously.
+
+## 3. Non-Goals (this design)
+
+- **No runner/autonomous-PR work.** Layer 2 is sketched (§12) but not designed
+  here. It is gated on Layer 1 shipping first.
+- **No GitHub Enterprise Server host support.** `github.com` (and GitHub-hosted
+  Enterprise Cloud) only, matching the current parser
+  (`parse_github_repo_url`). EGS on a custom host is a later, additive change.
+- **No removal of PAT.** PAT stays as a fallback and for the migration window.
+- **No GitLab/Bitbucket.** Provider abstraction is noted as a seam but not built.
+- **No frontend visual design.** UI surfaces are enumerated (what data appears
+  where) but pixel/interaction design is out of scope.
+- **No CI-check authoring.** We _read_ check/review status (Phase 2); Pi Dash
+  does not _publish_ its own commit statuses or checks in this design.
+
+## 4. Background — what we build on
+
+This design slots into existing systems rather than replacing them. The key
+anchors (verified in code):
+
+| System                        | Where                                                                                                                                         | What we reuse                                                                                             |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| Per-tenant integration row    | `WorkspaceIntegration` (`db/models/integration/base.py`) — `config`/`metadata` JSON, `unique_together = [workspace, integration]`             | Store the App **installation** state per workspace here, mirroring how PAT is stored today.               |
+| Per-instance config + secrets | `InstanceConfiguration` (`license/models/instance.py`), `get_configuration_value()` (`license/utils/instance_value.py`), admin PATCH endpoint | Store the App **id / private key / webhook secret** here (encrypted), exactly like `EMAIL_HOST_PASSWORD`. |
+| Encryption                    | `license/utils/encryption.py` — Fernet key derived from `SECRET_KEY` via PBKDF2                                                               | Encrypt the App private key and webhook secret at rest.                                                   |
+| REST client                   | `utils/github_client.py` — PAT-auth, paginated, typed errors                                                                                  | Generalize to accept _any_ bearer token (PAT **or** installation token).                                  |
+| Sync tasks + Beat             | `bgtasks/github_sync_task.py`, `celery.py` beat `github-issue-sync-every-4h`                                                                  | Keep the full-scan task as the **reconciler**; demote cadence; add webhook-driven incremental path.       |
+| State-transition hook         | `bgtasks/github_signals.py` (pre/post-save on `Issue`)                                                                                        | Extend the same hook pattern to push Pi Dash → GitHub state changes.                                      |
+| Outbound webhooks             | `db/models/webhook.py`, `bgtasks/webhook_task.py` — HMAC-SHA256 signing                                                                       | Reuse the **HMAC verification pattern** (inverted) for _inbound_ GitHub webhooks.                         |
+
+**Critical gap:** there is **no inbound webhook receiver anywhere** in the
+codebase today. The existing webhook system is outbound-only. Building a
+verified inbound receiver is the single biggest net-new piece of infrastructure
+in this design (§7).
+
+## 5. Why a GitHub App (vs PAT / OAuth)
+
+| Capability            | PAT (today)                | OAuth App        | **GitHub App (proposed)**                   |
+| --------------------- | -------------------------- | ---------------- | ------------------------------------------- |
+| Acts as               | a user                     | a user           | **its own bot identity** (`pi-dash[bot]`)   |
+| Webhooks              | none (manual per-repo)     | none             | **native, per-installation**                |
+| Permissions           | all-or-nothing user scopes | user scopes      | **granular, per-resource, admin-approved**  |
+| Rate limit            | 5k/hr/user, flat           | 5k/hr/user       | **scales with org size (15k+/hr)**          |
+| Token lifecycle       | manual paste + rotate      | refresh tokens   | **auto-minted, 1-hour installation tokens** |
+| Survives staff change | no                         | no               | **yes (org-owned install)**                 |
+| Install/uninstall UX  | paste a token              | per-user consent | **admin installs on selected repos**        |
+
+The decisive factor is **webhooks**: real-time and bidirectional sync are
+impossible on polling. Everything else (identity, scopes, rate limits) is why
+this is also the right home for the eventual runner phase.
+
+## 6. Auth architecture
+
+### 6.1 The three-token dance
+
+A GitHub App authenticates in three escalating forms; we need all three:
+
+1. **App JWT** — short-lived (≤10 min), signed with the App's **private key**
+   (RS256), `iss = App ID`. Identifies _the App itself_. Used only to call the
+   App-level endpoints below.
+2. **Installation token** — minted by `POST /app/installations/{id}/access_tokens`
+   using the App JWT. Scoped to one installation, expires in **1 hour**, carries
+   the granted permissions on the granted repos. **This is the token the data
+   plane uses** for all REST calls (issues, PRs, comments, checks).
+3. **User-to-server token** (optional) — OAuth-on-the-App, to act _as the
+   logged-in user_ for attribution-sensitive writes. Deferred; the bot identity
+   is sufficient for Layer 1.
+
+### 6.2 Token-minting service (new)
+
+A small service module — proposed `utils/github_app_auth.py` — owns:
+
+- `build_app_jwt()` — load the App private key (decrypted from config), sign an
+  RS256 JWT. Requires adding `PyJWT[crypto]` (or reusing `cryptography`, already
+  a dependency via Fernet) to the API.
+- `installation_token(installation_id)` — mint (or return cached) installation
+  token. **Cache** in Redis keyed by `installation_id` with TTL = expiry − 60s
+  (Valkey/Redis is already provisioned). One mint per installation per ~hour
+  keeps us far under rate limits.
+- `revoke_cache(installation_id)` — drop on uninstall / permission change.
+
+### 6.3 Generalizing `GithubClient`
+
+`GithubClient` currently takes a raw `token` and hard-codes
+`Authorization: Bearer {token}`. The change is minimal and backward-compatible:
+
+- Keep the `token=` constructor for PAT callers (the reconciler, legacy paths).
+- Add a classmethod `for_installation(installation_id)` that pulls a fresh
+  installation token from §6.2 and constructs the client. Internally identical
+  REST surface — the only difference is **where the bearer comes from**.
+- New write methods land here regardless of token source:
+  `close_pull_request`, `merge_pull_request`, `update_issue_state`,
+  `request_review`, `get_pull_request`, `list_check_runs`, etc.
+
+This keeps a single REST surface; PAT vs App is just credential provenance.
+
+### 6.4 Where credentials live (both deployment modes)
+
+```
+InstanceConfiguration (per deployment, encrypted via Fernet)
+  ├─ GITHUB_APP_ID            (plaintext)
+  ├─ GITHUB_APP_SLUG          (plaintext; for install URLs)
+  ├─ GITHUB_APP_PRIVATE_KEY   (is_encrypted=True)
+  ├─ GITHUB_APP_WEBHOOK_SECRET(is_encrypted=True)
+  └─ GITHUB_APP_CLIENT_ID/SECRET (is_encrypted; only if user-to-server used)
+
+WorkspaceIntegration.config (per workspace — the *installation*, not the App)
+  {
+    "auth_type": "github_app",
+    "installation_id": 12345678,
+    "account_login": "acme-corp",
+    "repository_selection": "selected" | "all",
+    "installed_at": "...",
+    "suspended_at": null
+  }
+```
+
+The App **secret** is always instance-level; the **installation** is always
+workspace-level. This split is what makes both deployment modes the same code.
+
+## 7. Inbound webhook receiver (new infrastructure)
+
+The largest net-new piece. Design mirrors the runner long-poll plane's
+discipline: verify at the edge, persist, ack fast, process async.
+
+### 7.1 Endpoint
+
+A single public endpoint on the **external API** surface
+(`pi_dash.api`, mounted `/api/v1/`), e.g.
+`POST /api/v1/integrations/github/webhook/`. It must be **unauthenticated by
+`X-Api-Key`** (GitHub won't send one) and instead authenticated by **signature**.
+
+### 7.2 Verification (reuse the HMAC pattern, inverted)
+
+GitHub signs each delivery with `X-Hub-Signature-256: sha256=<hmac>` over the
+raw body, keyed by the App's webhook secret. The outbound webhook code
+(`bgtasks/webhook_task.py:313`) already does the _forward_ of this exact
+construction; we invert it:
+
+```python
+expected = hmac.new(webhook_secret.encode(), raw_body, hashlib.sha256).hexdigest()
+hmac.compare_digest(expected, received_sig)   # constant-time
+```
+
+Reject on mismatch with `401` before any parsing. Resolve `webhook_secret` from
+`InstanceConfiguration` (self-hosted) or the single hosted App secret.
+
+### 7.3 Persist-then-process
+
+1. Verify signature on the **raw** body (must read body before DRF parses it).
+2. Persist a `GithubWebhookDelivery` row (dedupe on `X-GitHub-Delivery` UUID —
+   GitHub retries deliveries; we must be idempotent).
+3. Enqueue `process_github_webhook.delay(delivery_id)` and return `202`
+   immediately. GitHub enforces a ~10s delivery timeout; never process inline.
+4. The Celery task routes by `X-GitHub-Event` (`pull_request`, `issues`,
+   `issue_comment`, `check_suite`, `pull_request_review`,
+   `installation`, `installation_repositories`) to a handler.
+
+### 7.4 Handler routing
+
+| Event                                    | Action                                                                                 |
+| ---------------------------------------- | -------------------------------------------------------------------------------------- |
+| `installation` (created/deleted/suspend) | Create/disable the workspace `WorkspaceIntegration` install record; mint/evict tokens. |
+| `installation_repositories`              | Update which repos a binding may cover.                                                |
+| `issues`                                 | Upsert the issue mirror **incrementally** (replaces a full poll for that issue).       |
+| `issue_comment`                          | Upsert/delete the mirrored comment.                                                    |
+| `pull_request`                           | Upsert the PR mirror; map PR state → linked issue state (§9).                          |
+| `pull_request_review`                    | Update review status on the linked issue.                                              |
+| `check_suite` / `check_run`              | Update CI status on the linked PR/issue.                                               |
+
+Handlers are the **incremental** counterpart to today's full scan. The full scan
+survives as the reconciler (§10).
+
+## 8. Data model changes
+
+New rows; existing GitHub models (`GithubRepository`, `GithubRepositorySync`,
+`GithubIssueSync`, `GithubCommentSync`) are unchanged in shape, only joined to.
+
+```
+GithubWebhookDelivery (new)
+  delivery_id (UUID, unique)   # X-GitHub-Delivery — idempotency key
+  event        (str)           # X-GitHub-Event
+  action       (str)
+  installation_id (bigint, null)
+  payload      (JSON)
+  status       (received | processed | failed | skipped)
+  received_at, processed_at, error
+
+GithubPullRequestSync (new — the missing issue↔PR link)
+  repository_sync (FK GithubRepositorySync)
+  issue        (FK Issue, null)         # the linked Pi Dash issue, if any
+  repo_pr_number (int)
+  github_pr_id (bigint)
+  pr_url       (url)
+  head_ref, base_ref (str)
+  state        (open | draft | merged | closed)
+  review_state (str, null)              # approved / changes_requested / ...
+  check_state  (str, null)              # success / failure / pending
+  metadata     (JSON)                   # last_synced_sha, linkage_source, ...
+  unique_together = [repository_sync, repo_pr_number]
+```
+
+**Linkage discovery** (how an issue finds its PR), in priority order:
+
+1. PR body / title references (`closes #N`, `fixes #N`) → map `#N` to the
+   mirrored `GithubIssueSync.repo_issue_id`.
+2. Branch naming convention (e.g. `pi-dash/<issue-identifier>`), which is also
+   exactly what the runner will produce in Layer 2 (`Assign.git_work_branch`
+   already exists in the runner protocol).
+3. Manual link (paste a PR URL on the issue) — always-available fallback.
+
+## 9. Bidirectional state mapping (Layer 1)
+
+State sync is **policy**, and surprising automation is worse than none — so
+every reverse (Pi Dash → GitHub) mapping is **opt-in per project**.
+
+**GitHub → Pi Dash** (inbound webhook → issue state, via the existing
+`State.group` vocabulary `backlog/unstarted/started/review/completed/cancelled`):
+
+| GitHub event                       | Pi Dash effect (default)                              |
+| ---------------------------------- | ----------------------------------------------------- |
+| PR opened linked to issue          | issue → `started`                                     |
+| PR marked ready / review requested | issue → `review`                                      |
+| PR merged                          | issue → `completed`                                   |
+| PR closed unmerged                 | no change (surface a badge)                           |
+| issue closed upstream              | flag `upstream_gone_at` (today's behavior, unchanged) |
+
+**Pi Dash → GitHub** (extend the `github_signals.py` post-save hook; today it
+only fires the completion _comment_ on `group == completed`):
+
+| Pi Dash transition     | GitHub effect (opt-in)                                   |
+| ---------------------- | -------------------------------------------------------- |
+| issue → `completed`    | comment (today) **+ optionally** close linked PR / issue |
+| issue → `cancelled`    | optionally close the linked PR (the original example)    |
+| issue assigned to user | optionally assign the GitHub issue                       |
+
+Reverse writes require the App installation to have been granted
+**Issues: write** and **Pull requests: write**; the handler no-ops with a
+surfaced warning if the grant is missing (mirrors today's
+`GithubPermissionError` handling).
+
+**Loop prevention:** a write Pi Dash makes to GitHub comes back as a webhook.
+Tag Pi-Dash-originated changes (bot actor / a marker in `metadata`) and short-
+circuit in the handler when the incoming change matches one we just made — the
+same idempotency discipline as `completion_comment_id` today.
+
+## 10. Reconciliation — webhooks are not reliable
+
+Webhooks get dropped, mis-delivered, or missed during downtime. The full-scan
+task (`sync_one_repo`) is **not deleted** — it is repurposed:
+
+- Demote `github-issue-sync-every-4h` cadence (e.g. daily) and rename its intent
+  to "reconcile," not "sync."
+- It becomes the **drift-repair** pass: re-scan issues + PRs, compare to local
+  mirrors, fix anything webhooks missed.
+- Webhook handlers carry steady-state; the reconciler guarantees eventual
+  consistency. This is the standard belt-and-suspenders for webhook systems.
+
+## 11. Deployment modes — one design, two configs
+
+### Hosted multi-tenant
+
+- **One** GitHub App, registered by Pi Dash, owned by the vendor org.
+- App id / private key / webhook secret live in the hosted instance's
+  `InstanceConfiguration` (or env) — set once.
+- Each customer org **installs** the App; the `installation` webhook creates a
+  `WorkspaceIntegration` install record for their workspace.
+- One public webhook URL for all tenants; the handler routes by
+  `installation_id` → workspace.
+
+### Self-hosted single-org
+
+- Each instance **registers its own** GitHub App (via GitHub's **App manifest
+  flow** — a one-click create that returns id + private key + webhook secret to a
+  callback, far better self-host UX than manual field entry).
+- Those secrets are written to _that instance's_ `InstanceConfiguration`
+  (encrypted). Admin UI lives next to the existing GitHub OAuth config screen in
+  `apps/admin`.
+- Webhook URL is the instance's own public origin. Self-host docs must note the
+  instance has to be reachable by GitHub (the one genuinely new operational
+  requirement vs. PAT polling, which needed no inbound connectivity).
+
+The **only** differences are _who registers the App_ and _which origin receives
+webhooks_. Storage, token minting, handlers, and sync logic are identical —
+both read App secrets from `InstanceConfiguration` and installs from
+`WorkspaceIntegration`.
+
+## 12. Layer 2 — runner / autonomous PRs (deferred, sketch only)
+
+Not designed here; captured so Layer 1's data model doesn't paint us into a
+corner. The runner plane already has the needed seams:
+
+- `AgentRun.run_config` already carries `repo_url`, `repo_ref`,
+  `git_work_branch`; the `Assign` protocol message
+  (`runner/src/cloud/protocol.rs`) already ships a branch to check out, and
+  `runner/src/workspace/git.rs` already clones, branches, and manages worktrees.
+- The runner already pushes branches; it does **not** open PRs today.
+- **Future flow:** issue → `AgentRun` (existing dispatch via
+  `matcher.drain_pod`) → runner writes code + pushes branch → on
+  `RunCompleted`, the cloud (not the runner) opens a **draft PR** via the App
+  installation token and records a `GithubPullRequestSync` linked to the issue.
+  Because the PR is opened by the App, it is attributed to `pi-dash[bot]`, and
+  every Layer-1 mechanism (state mapping, checks, review surfacing) applies to it
+  automatically.
+
+The point of doing Layer 1 on a GitHub App first is precisely that Layer 2 then
+needs _no new auth, no new client, no new linkage model_ — only a "create PR on
+run completion" step.
+
+## 13. Phased roadmap
+
+| Phase                                     | Deliverable                                                                                                                                                                                                                                                                                                 | Gates unlocked                                               |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| **0 — Foundation**                        | App registration (manifest flow for self-host; manual for hosted), secret storage in `InstanceConfiguration`, token-minting service (§6.2), `GithubClient.for_installation`, **inbound webhook receiver + verification + delivery persistence** (§7), `installation` event → `WorkspaceIntegration` record. | The App can be installed and we receive verified events.     |
+| **1 — Real-time issue sync**              | Webhook handlers for `issues` / `issue_comment` doing incremental upsert; reconciler demotion (§10). PAT path still works in parallel.                                                                                                                                                                      | Issues sync in real time instead of every 4h.                |
+| **2 — PR + checks + bidirectional state** | `GithubPullRequestSync` model + linkage discovery (§8); `pull_request` / `review` / `check_suite` handlers; PR/CI/review status surfaced on issues; opt-in reverse state mapping incl. close-PR-on-cancel (§9); new write methods on `GithubClient`.                                                        | The full Layer-1 vision: bidirectional, real-time, PR-aware. |
+| **3 — Runner autonomy**                   | (Separate design) issue → runner → draft PR via App token.                                                                                                                                                                                                                                                  | Layer 2 — the differentiator.                                |
+
+Phases 0–2 deliver "catch up to Linear, in real time, both deployment modes."
+Phase 3 is the part competitors can't easily copy because Pi Dash owns the
+runner.
+
+## 14. Security considerations
+
+- **Private key** is the crown jewel — encrypted at rest (Fernet), never logged,
+  never returned by any API (the config serializer must treat it like
+  `EMAIL_HOST_PASSWORD`).
+- **Webhook signature** verified constant-time on the raw body before parsing;
+  unsigned/mismatched → `401`, no side effects.
+- **Delivery idempotency** via `X-GitHub-Delivery` to survive GitHub's retries.
+- **Installation token scope** is the least-privilege boundary — request only the
+  permissions each phase needs (Phase 1: Issues read; Phase 2: + Pull requests
+  read/write, Checks read).
+- **Tenant isolation** (hosted): always resolve `installation_id` → workspace
+  from our own records; never trust a workspace id from the payload.
+- **Loop/echo prevention** (§9) so our own writes don't ping-pong.
+
+## 15. Open questions
+
+1. **User attribution** — is bot-identity (`pi-dash[bot]`) acceptable for all
+   writes in Layer 1, or do some actions need user-to-server tokens (§6.1.3) for
+   correct authorship? (Affects whether we build the OAuth-on-App flow now.)
+2. **Reconciler cadence** — daily? hourly? Tunable per instance?
+3. **PAT deprecation timeline** — keep indefinitely as a fallback, or sunset
+   once App adoption crosses a threshold?
+4. **Multi-repo per project** — the current schema enforces one repo per project
+   (`github_repository_sync_unique_per_project_when_active`). Does deep
+   integration need many repos per project (monorepo vs polyrepo teams)?
+5. **Self-host reachability** — for instances not publicly reachable, do we offer
+   a polling-only degraded mode, or require a tunnel/relay?
+
+---
+
+## Appendix A — File-level impact map
+
+| Area               | File(s)                                                                                             | Change                                                        |
+| ------------------ | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| App auth           | `apps/api/pi_dash/utils/github_app_auth.py` _(new)_                                                 | JWT + installation-token minting, Redis cache.                |
+| REST client        | `apps/api/pi_dash/utils/github_client.py`                                                           | `for_installation()` classmethod; new write methods.          |
+| Webhook receiver   | `apps/api/pi_dash/api/views/integration/github_webhook.py` _(new)_, `apps/api/pi_dash/api/urls/...` | Signed inbound endpoint + URL registration.                   |
+| Webhook processing | `apps/api/pi_dash/bgtasks/github_webhook_task.py` _(new)_                                           | Event router + handlers (incremental upsert).                 |
+| Models             | `apps/api/pi_dash/db/models/integration/github.py`                                                  | `GithubWebhookDelivery`, `GithubPullRequestSync` + migration. |
+| State hook         | `apps/api/pi_dash/bgtasks/github_signals.py`                                                        | Extend to reverse state mapping (opt-in).                     |
+| Reconciler         | `apps/api/pi_dash/bgtasks/github_sync_task.py`, `apps/api/pi_dash/celery.py`                        | Demote cadence; reframe as drift-repair.                      |
+| Instance config    | `apps/admin/...` GitHub config screens; `license/...` config keys                                   | App id/key/secret entry; manifest-flow callback (self-host).  |
+| Install state      | `apps/api/pi_dash/app/views/integration/github.py`                                                  | `installation` handling alongside existing PAT connect.       |
+| Types/UI           | `packages/types/src/integration.ts`, web settings components                                        | PR/check/review status surfaces; install vs PAT status.       |
+
+## Appendix B — Why not just add write methods to the PAT client?
+
+We could ship close-PR-on-cancel today purely on the PAT path (add
+`close_pull_request`, extend `github_signals.py`, bump the PAT scope). That is a
+legitimate **quick win** and nothing here blocks it. But every _other_ part of
+the vision (real-time, PR awareness, checks, durable identity, the runner loop)
+requires the App. Building the close-PR feature only on PAT means rebuilding it
+on the App later. The roadmap therefore treats the App as Phase 0 and folds
+close-PR into Phase 2, where it costs almost nothing on top of the PR model that
+already has to exist.

--- a/apps/api/pi_dash/app/urls/integration.py
+++ b/apps/api/pi_dash/app/urls/integration.py
@@ -5,6 +5,11 @@
 from django.urls import path
 
 from pi_dash.app.views.integration.github import (
+    GithubAppCallbackEndpoint,
+    GithubAppInstallStartEndpoint,
+    GithubAppRefreshEndpoint,
+    GithubAppStatusEndpoint,
+    GithubAppWebhookEndpoint,
     GithubIntegrationConnectEndpoint,
     GithubIntegrationDisconnectEndpoint,
     GithubIntegrationReposEndpoint,
@@ -15,6 +20,32 @@ from pi_dash.app.views.integration.github import (
 
 
 urlpatterns = [
+    # Profile-level GitHub App install flow
+    path(
+        "users/me/integrations/github/app/",
+        GithubAppStatusEndpoint.as_view(),
+        name="github-app-status",
+    ),
+    path(
+        "users/me/integrations/github/app/install/",
+        GithubAppInstallStartEndpoint.as_view(),
+        name="github-app-install-start",
+    ),
+    path(
+        "users/me/integrations/github/app/refresh/",
+        GithubAppRefreshEndpoint.as_view(),
+        name="github-app-refresh",
+    ),
+    path(
+        "integrations/github/app/callback/",
+        GithubAppCallbackEndpoint.as_view(),
+        name="github-app-callback",
+    ),
+    path(
+        "integrations/github/app/webhook/",
+        GithubAppWebhookEndpoint.as_view(),
+        name="github-app-webhook",
+    ),
     # Workspace-level
     path(
         "workspaces/<str:slug>/integrations/github/",

--- a/apps/api/pi_dash/app/views/integration/github.py
+++ b/apps/api/pi_dash/app/views/integration/github.py
@@ -12,10 +12,19 @@ See .ai_design/github_sync/design.md §6.1 and §6.2.
 
 from __future__ import annotations
 
+import json
+import logging
+import secrets
+import uuid
+from datetime import timedelta
+from urllib.parse import urlencode
+
 from django.conf import settings
-from django.db import IntegrityError, transaction
+from django.db import transaction
+from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
+from rest_framework.permissions import AllowAny
 from rest_framework import status
 from rest_framework.response import Response
 
@@ -23,18 +32,34 @@ from pi_dash.app.permissions import ROLE, allow_permission
 from pi_dash.app.views.base import BaseAPIView
 from pi_dash.db.models import (
     APIToken,
+    GithubAppInstallation,
+    GithubAppInstallSession,
     GithubCommentSync,
     GithubIssueSync,
     GithubRepository,
     GithubRepositorySync,
+    GithubWebhookDelivery,
     Integration,
     Label,
     Project,
     Workspace,
+    WorkspaceMember,
     WorkspaceIntegration,
 )
 from pi_dash.license.utils.encryption import decrypt_data, encrypt_data
 from pi_dash.utils.exception_logger import log_exception
+from pi_dash.utils.github_app_auth import (
+    GithubAppAuthError,
+    GithubAppConfigError,
+    exchange_user_code,
+    get_github_app_config,
+    get_installation,
+    parse_github_datetime,
+    require_github_app_config,
+    revoke_installation_cache,
+    verify_user_can_access_installation,
+    verify_webhook_signature,
+)
 from pi_dash.utils.github_client import (
     GithubAuthError,
     GithubClient,
@@ -42,6 +67,8 @@ from pi_dash.utils.github_client import (
     GithubPermissionError,
     parse_github_repo_url,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def _feature_enabled() -> bool:
@@ -69,6 +96,146 @@ def _get_workspace_integration(workspace: Workspace) -> WorkspaceIntegration | N
     if integration is None:
         return None
     return WorkspaceIntegration.objects.filter(workspace=workspace, integration=integration).first()
+
+
+def _get_or_create_workspace_integration(workspace: Workspace, actor) -> WorkspaceIntegration:
+    integration = _get_or_create_github_integration()
+    wi = WorkspaceIntegration.objects.filter(workspace=workspace, integration=integration).first()
+    if wi is not None:
+        return wi
+    api_token = APIToken.objects.create(
+        user=actor,
+        workspace=workspace,
+        user_type=1,
+        is_active=False,
+        label=f"github-integration-{workspace.id}",
+        description="GitHub integration FK shim — not for auth",
+    )
+    return WorkspaceIntegration.objects.create(
+        workspace=workspace,
+        actor=actor,
+        integration=integration,
+        api_token=api_token,
+        config={},
+    )
+
+
+def _is_workspace_admin(user, workspace: Workspace) -> bool:
+    return WorkspaceMember.objects.filter(
+        member=user,
+        workspace=workspace,
+        role=ROLE.ADMIN.value,
+        is_active=True,
+    ).exists()
+
+
+def _redirect_to_profile_integrations(params: dict[str, str]) -> HttpResponseRedirect:
+    base = (getattr(settings, "WEB_URL", None) or getattr(settings, "APP_BASE_URL", None) or "").rstrip("/")
+    path = "/settings/profile/integrations/"
+    query = urlencode(params)
+    url = f"{base}{path}" if base else path
+    if query:
+        url = f"{url}?{query}"
+    return HttpResponseRedirect(url)
+
+
+def _serialize_app_installation(app_installation: GithubAppInstallation | None) -> dict:
+    if app_installation is None:
+        return {"connected": False}
+    return {
+        "connected": True,
+        "installation_id": app_installation.installation_id,
+        "account_login": app_installation.account_login,
+        "account_type": app_installation.account_type,
+        "repository_selection": app_installation.repository_selection,
+        "repository_count": app_installation.repository_count,
+        "permissions": app_installation.permissions,
+        "events": app_installation.events,
+        "installed_at": app_installation.installed_at.isoformat() if app_installation.installed_at else None,
+        "suspended_at": app_installation.suspended_at.isoformat() if app_installation.suspended_at else None,
+        "verified_at": app_installation.verified_at.isoformat() if app_installation.verified_at else None,
+        "last_checked_at": app_installation.last_checked_at.isoformat() if app_installation.last_checked_at else None,
+        "last_check_error": app_installation.last_check_error,
+    }
+
+
+def _lazy_cleanup_install_sessions() -> None:
+    now = timezone.now()
+    try:
+        expired_count = GithubAppInstallSession.objects.filter(
+            status=GithubAppInstallSession.Status.STARTED,
+            expires_at__lt=now,
+        ).update(status=GithubAppInstallSession.Status.EXPIRED, error="Install session expired")
+        deleted_count, _ = GithubAppInstallSession.objects.filter(
+            status__in=[
+                GithubAppInstallSession.Status.COMPLETED,
+                GithubAppInstallSession.Status.EXPIRED,
+                GithubAppInstallSession.Status.FAILED,
+            ],
+            updated_at__lt=now - timedelta(days=7),
+        ).delete(soft=False)
+        if expired_count or deleted_count:
+            logger.info("GitHub App install session cleanup: expired=%s, deleted=%s", expired_count, deleted_count)
+    except Exception as e:
+        log_exception(e)
+
+
+def _refresh_app_installation(app_installation: GithubAppInstallation) -> GithubAppInstallation:
+    now = timezone.now()
+    try:
+        _, _, repository_count = (
+            GithubClient.for_installation(app_installation.installation_id).list_installation_repositories()
+        )
+        app_installation.repository_count = repository_count
+        app_installation.verified_at = now
+        app_installation.last_checked_at = now
+        app_installation.last_check_error = ""
+    except Exception as e:
+        app_installation.last_checked_at = now
+        app_installation.last_check_error = str(e)[:2000]
+        log_exception(e)
+    app_installation.save(
+        update_fields=[
+            "repository_count",
+            "verified_at",
+            "last_checked_at",
+            "last_check_error",
+            "updated_at",
+        ]
+    )
+    return app_installation
+
+
+def _upsert_app_installation(workspace: Workspace, actor, installation: dict) -> GithubAppInstallation:
+    account = installation.get("account") or {}
+    installation_id = int(installation.get("id") or 0)
+    if not installation_id:
+        raise GithubAppAuthError("GitHub installation response did not include an id")
+    wi = _get_or_create_workspace_integration(workspace, actor)
+    existing = GithubAppInstallation.objects.filter(installation_id=installation_id).select_related(
+        "workspace_integration__workspace"
+    ).first()
+    if existing is not None and existing.workspace_integration_id != wi.id:
+        raise GithubAppAuthError(
+            f"GitHub installation is already connected to workspace {existing.workspace_integration.workspace.slug}"
+        )
+    defaults = {
+        "account_login": account.get("login") or "",
+        "account_type": account.get("type") or GithubAppInstallation.AccountType.UNKNOWN,
+        "repository_selection": installation.get("repository_selection")
+        or GithubAppInstallation.RepositorySelection.SELECTED,
+        "repository_count": int(installation.get("repository_count") or 0),
+        "permissions": installation.get("permissions") or {},
+        "events": installation.get("events") or [],
+        "installed_at": parse_github_datetime(installation.get("created_at")),
+        "suspended_at": parse_github_datetime(installation.get("suspended_at")),
+        "last_check_error": "",
+    }
+    app_installation, _ = GithubAppInstallation.objects.update_or_create(
+        workspace_integration=wi,
+        defaults={"installation_id": installation_id, **defaults},
+    )
+    return _refresh_app_installation(app_installation)
 
 
 def _serialize_repo(gh_repo: dict) -> dict:
@@ -250,6 +417,257 @@ class GithubIntegrationReposEndpoint(BaseAPIView):
             },
             status=status.HTTP_200_OK,
         )
+
+
+# --------------------------------------------------------------------- github app
+
+
+class GithubAppStatusEndpoint(BaseAPIView):
+    """GET /users/me/integrations/github/app/"""
+
+    def get(self, request):
+        if not _feature_enabled():
+            return _disabled_response()
+        _lazy_cleanup_install_sessions()
+
+        config = get_github_app_config()
+        configured = bool(
+            config.get("app_id")
+            and config.get("app_slug")
+            and config.get("private_key")
+            and config.get("webhook_secret")
+            and config.get("client_id")
+            and config.get("client_secret")
+        )
+        memberships = (
+            WorkspaceMember.objects.filter(member=request.user, role=ROLE.ADMIN.value, is_active=True)
+            .select_related("workspace")
+            .order_by("workspace__name")
+        )
+        workspace_payload = []
+        for membership in memberships:
+            wi = _get_workspace_integration(membership.workspace)
+            app_installation = None
+            if wi is not None:
+                app_installation = getattr(wi, "github_app_installation", None)
+            workspace_payload.append(
+                {
+                    "id": str(membership.workspace.id),
+                    "slug": membership.workspace.slug,
+                    "name": membership.workspace.name,
+                    "github_app": _serialize_app_installation(app_installation),
+                }
+            )
+
+        return Response(
+            {
+                "configured": configured,
+                "app_slug": config.get("app_slug") or "",
+                "workspaces": workspace_payload,
+            },
+            status=status.HTTP_200_OK,
+        )
+
+
+class GithubAppInstallStartEndpoint(BaseAPIView):
+    """POST /users/me/integrations/github/app/install/"""
+
+    def post(self, request):
+        if not _feature_enabled():
+            return _disabled_response()
+        _lazy_cleanup_install_sessions()
+        try:
+            config = require_github_app_config(oauth=True, webhook=True)
+        except GithubAppConfigError as e:
+            return Response({"error": str(e)}, status=status.HTTP_409_CONFLICT)
+
+        workspace_slug = (request.data.get("workspace_slug") or "").strip()
+        if not workspace_slug:
+            return Response({"error": "workspace_slug is required"}, status=status.HTTP_400_BAD_REQUEST)
+        workspace = get_object_or_404(Workspace, slug=workspace_slug)
+        if not _is_workspace_admin(request.user, workspace):
+            return Response({"error": "You must be a workspace admin to install the GitHub App"}, status=status.HTTP_403_FORBIDDEN)
+
+        state = secrets.token_urlsafe(32)
+        install_session = GithubAppInstallSession.objects.create(
+            state=state,
+            workspace=workspace,
+            actor=request.user,
+            expires_at=timezone.now() + timedelta(minutes=15),
+        )
+        install_url = f"https://github.com/apps/{config['app_slug']}/installations/new?{urlencode({'state': state})}"
+        return Response(
+            {
+                "state": install_session.state,
+                "expires_at": install_session.expires_at.isoformat(),
+                "install_url": install_url,
+            },
+            status=status.HTTP_201_CREATED,
+        )
+
+
+class GithubAppRefreshEndpoint(BaseAPIView):
+    """POST /users/me/integrations/github/app/refresh/"""
+
+    def post(self, request):
+        if not _feature_enabled():
+            return _disabled_response()
+        workspace_slug = (request.data.get("workspace_slug") or "").strip()
+        if not workspace_slug:
+            return Response({"error": "workspace_slug is required"}, status=status.HTTP_400_BAD_REQUEST)
+        workspace = get_object_or_404(Workspace, slug=workspace_slug)
+        if not _is_workspace_admin(request.user, workspace):
+            return Response({"error": "You must be a workspace admin to refresh this connection"}, status=status.HTTP_403_FORBIDDEN)
+        wi = _get_workspace_integration(workspace)
+        app_installation = getattr(wi, "github_app_installation", None) if wi else None
+        if app_installation is None:
+            return Response({"error": "GitHub App is not installed for this workspace"}, status=status.HTTP_404_NOT_FOUND)
+        return Response(_serialize_app_installation(_refresh_app_installation(app_installation)), status=status.HTTP_200_OK)
+
+
+class GithubAppCallbackEndpoint(BaseAPIView):
+    """GET /integrations/github/app/callback/"""
+
+    def get(self, request):
+        if not _feature_enabled():
+            return _redirect_to_profile_integrations({"github_app": "disabled"})
+        _lazy_cleanup_install_sessions()
+
+        state = request.GET.get("state") or ""
+        code = request.GET.get("code") or ""
+        installation_id_raw = request.GET.get("installation_id") or ""
+        if not state:
+            return _redirect_to_profile_integrations({"github_app": "error", "error": "missing_state"})
+
+        install_session = GithubAppInstallSession.objects.filter(state=state).select_related("workspace", "actor").first()
+        if install_session is None:
+            return _redirect_to_profile_integrations({"github_app": "error", "error": "unknown_state"})
+
+        def fail(error: str):
+            install_session.status = GithubAppInstallSession.Status.FAILED
+            install_session.error = error
+            install_session.save(update_fields=["status", "error", "updated_at"])
+            return _redirect_to_profile_integrations({"github_app": "error", "error": error})
+
+        if install_session.status != GithubAppInstallSession.Status.STARTED:
+            return _redirect_to_profile_integrations({"github_app": install_session.status})
+        if install_session.expires_at <= timezone.now():
+            install_session.status = GithubAppInstallSession.Status.EXPIRED
+            install_session.error = "Install session expired"
+            install_session.save(update_fields=["status", "error", "updated_at"])
+            return _redirect_to_profile_integrations({"github_app": "expired"})
+        if install_session.actor_id != request.user.id:
+            return fail("actor_mismatch")
+        if not _is_workspace_admin(request.user, install_session.workspace):
+            return fail("workspace_admin_required")
+        if not installation_id_raw.isdigit():
+            return fail("missing_installation_id")
+        if not code:
+            return fail("missing_oauth_code")
+
+        installation_id = int(installation_id_raw)
+        try:
+            user_token = exchange_user_code(code)
+            if verify_user_can_access_installation(user_token, installation_id) is None:
+                return fail("installation_not_visible_to_user")
+            installation = get_installation(installation_id)
+            app_installation = _upsert_app_installation(install_session.workspace, request.user, installation)
+        except Exception as e:
+            log_exception(e)
+            return fail("github_verification_failed")
+
+        install_session.installation_id = installation_id
+        install_session.account_login = app_installation.account_login
+        install_session.status = GithubAppInstallSession.Status.COMPLETED
+        install_session.completed_at = timezone.now()
+        install_session.error = ""
+        install_session.save(
+            update_fields=["installation_id", "account_login", "status", "completed_at", "error", "updated_at"]
+        )
+        return _redirect_to_profile_integrations(
+            {
+                "github_app": "connected",
+                "workspace_slug": install_session.workspace.slug,
+            }
+        )
+
+
+class GithubAppWebhookEndpoint(BaseAPIView):
+    """POST /integrations/github/app/webhook/"""
+
+    authentication_classes = []
+    permission_classes = [AllowAny]
+
+    def post(self, request):
+        if not _feature_enabled():
+            return _disabled_response()
+        try:
+            if not verify_webhook_signature(request.body, request.headers.get("X-Hub-Signature-256")):
+                return Response({"error": "Invalid signature"}, status=status.HTTP_401_UNAUTHORIZED)
+        except GithubAppConfigError as e:
+            return Response({"error": str(e)}, status=status.HTTP_409_CONFLICT)
+
+        delivery_id = request.headers.get("X-GitHub-Delivery")
+        event = request.headers.get("X-GitHub-Event") or ""
+        if not delivery_id:
+            return Response({"error": "Missing X-GitHub-Delivery"}, status=status.HTTP_400_BAD_REQUEST)
+        try:
+            delivery_uuid = uuid.UUID(delivery_id)
+        except ValueError:
+            return Response({"error": "Invalid X-GitHub-Delivery"}, status=status.HTTP_400_BAD_REQUEST)
+        try:
+            payload = json.loads(request.body.decode("utf-8") or "{}")
+        except json.JSONDecodeError:
+            return Response({"error": "Invalid JSON"}, status=status.HTTP_400_BAD_REQUEST)
+
+        installation = payload.get("installation") or {}
+        installation_id = installation.get("id")
+        action = payload.get("action") or ""
+        delivery, created = GithubWebhookDelivery.objects.get_or_create(
+            delivery_id=delivery_uuid,
+            defaults={
+                "event": event,
+                "action": action,
+                "installation_id": installation_id,
+                "payload": payload,
+                "status": GithubWebhookDelivery.Status.RECEIVED,
+            },
+        )
+        if not created:
+            return Response({"status": delivery.status}, status=status.HTTP_202_ACCEPTED)
+
+        try:
+            if event == "ping":
+                delivery.status = GithubWebhookDelivery.Status.PROCESSED
+            elif event in {"installation", "installation_repositories"}:
+                app_installation = None
+                if installation_id:
+                    app_installation = GithubAppInstallation.objects.filter(installation_id=installation_id).first()
+                if app_installation is None:
+                    delivery.status = GithubWebhookDelivery.Status.SKIPPED
+                else:
+                    if event == "installation" and action in {"deleted", "suspend"}:
+                        app_installation.suspended_at = timezone.now()
+                        app_installation.last_check_error = "GitHub App installation removed or suspended"
+                        app_installation.save(update_fields=["suspended_at", "last_check_error", "updated_at"])
+                        revoke_installation_cache(app_installation.installation_id)
+                    elif event == "installation" and action == "unsuspend":
+                        app_installation.suspended_at = None
+                        _refresh_app_installation(app_installation)
+                    elif event == "installation_repositories":
+                        _refresh_app_installation(app_installation)
+                    delivery.status = GithubWebhookDelivery.Status.PROCESSED
+            else:
+                delivery.status = GithubWebhookDelivery.Status.SKIPPED
+            delivery.processed_at = timezone.now()
+            delivery.save(update_fields=["status", "processed_at", "updated_at"])
+        except Exception as e:
+            log_exception(e)
+            delivery.status = GithubWebhookDelivery.Status.FAILED
+            delivery.error = str(e)[:2000]
+            delivery.processed_at = timezone.now()
+            delivery.save(update_fields=["status", "error", "processed_at", "updated_at"])
+        return Response({"status": delivery.status}, status=status.HTTP_202_ACCEPTED)
 
 
 # --------------------------------------------------------------------- project

--- a/apps/api/pi_dash/app/views/integration/github.py
+++ b/apps/api/pi_dash/app/views/integration/github.py
@@ -554,9 +554,16 @@ class GithubAppRefreshEndpoint(BaseAPIView):
 class GithubAppCallbackEndpoint(BaseAPIView):
     """GET /integrations/github/app/callback/"""
 
+    permission_classes = [AllowAny]
+
     def get(self, request):
         if not _feature_enabled():
             return _redirect_to_profile_integrations({"github_app": "disabled"})
+        # GitHub redirects the browser here; if the Pi Dash session isn't present
+        # (logged out / different browser), redirect with a friendly error instead
+        # of letting DRF return a bare 403. The actor check below is the real guard.
+        if not request.user.is_authenticated:
+            return _redirect_to_profile_integrations({"github_app": "error", "error": "login_required"})
         _lazy_cleanup_install_sessions()
 
         state = request.GET.get("state") or ""
@@ -628,6 +635,9 @@ class GithubAppWebhookEndpoint(BaseAPIView):
 
     authentication_classes = []
     permission_classes = [AllowAny]
+    # GitHub delivers from shared egress IPs; the default AnonRateThrottle
+    # (30/min) would 429 bursts of lifecycle deliveries. Signature is the auth.
+    throttle_classes = []
 
     def post(self, request):
         if not _feature_enabled():

--- a/apps/api/pi_dash/app/views/integration/github.py
+++ b/apps/api/pi_dash/app/views/integration/github.py
@@ -180,8 +180,23 @@ def _lazy_cleanup_install_sessions() -> None:
         log_exception(e)
 
 
-def _refresh_app_installation(app_installation: GithubAppInstallation) -> GithubAppInstallation:
+def _refresh_app_installation(
+    app_installation: GithubAppInstallation,
+    *,
+    raise_on_error: bool = False,
+    extra_update_fields: list[str] | None = None,
+) -> GithubAppInstallation:
     now = timezone.now()
+    update_fields = [
+        "repository_count",
+        "verified_at",
+        "last_checked_at",
+        "last_check_error",
+        "updated_at",
+    ]
+    if extra_update_fields:
+        update_fields.extend(field for field in extra_update_fields if field not in update_fields)
+
     try:
         _, _, repository_count = (
             GithubClient.for_installation(app_installation.installation_id).list_installation_repositories()
@@ -194,31 +209,26 @@ def _refresh_app_installation(app_installation: GithubAppInstallation) -> Github
         app_installation.last_checked_at = now
         app_installation.last_check_error = str(e)[:2000]
         log_exception(e)
-    app_installation.save(
-        update_fields=[
-            "repository_count",
-            "verified_at",
-            "last_checked_at",
-            "last_check_error",
-            "updated_at",
-        ]
-    )
+        app_installation.save(update_fields=update_fields)
+        if raise_on_error:
+            raise GithubAppAuthError("GitHub App connection check failed") from e
+        return app_installation
+
+    app_installation.save(update_fields=update_fields)
     return app_installation
 
 
-def _upsert_app_installation(workspace: Workspace, actor, installation: dict) -> GithubAppInstallation:
+def _upsert_app_installation(
+    workspace: Workspace,
+    actor,
+    installation: dict,
+    *,
+    require_verified: bool = False,
+) -> GithubAppInstallation:
     account = installation.get("account") or {}
     installation_id = int(installation.get("id") or 0)
     if not installation_id:
         raise GithubAppAuthError("GitHub installation response did not include an id")
-    wi = _get_or_create_workspace_integration(workspace, actor)
-    existing = GithubAppInstallation.objects.filter(installation_id=installation_id).select_related(
-        "workspace_integration__workspace"
-    ).first()
-    if existing is not None and existing.workspace_integration_id != wi.id:
-        raise GithubAppAuthError(
-            f"GitHub installation is already connected to workspace {existing.workspace_integration.workspace.slug}"
-        )
     defaults = {
         "account_login": account.get("login") or "",
         "account_type": account.get("type") or GithubAppInstallation.AccountType.UNKNOWN,
@@ -231,11 +241,20 @@ def _upsert_app_installation(workspace: Workspace, actor, installation: dict) ->
         "suspended_at": parse_github_datetime(installation.get("suspended_at")),
         "last_check_error": "",
     }
-    app_installation, _ = GithubAppInstallation.objects.update_or_create(
-        workspace_integration=wi,
-        defaults={"installation_id": installation_id, **defaults},
-    )
-    return _refresh_app_installation(app_installation)
+    with transaction.atomic():
+        wi = _get_or_create_workspace_integration(workspace, actor)
+        existing = GithubAppInstallation.objects.filter(installation_id=installation_id).select_related(
+            "workspace_integration__workspace"
+        ).first()
+        if existing is not None and existing.workspace_integration_id != wi.id:
+            raise GithubAppAuthError(
+                f"GitHub installation is already connected to workspace {existing.workspace_integration.workspace.slug}"
+            )
+        app_installation, _ = GithubAppInstallation.objects.update_or_create(
+            workspace_integration=wi,
+            defaults={"installation_id": installation_id, **defaults},
+        )
+        return _refresh_app_installation(app_installation, raise_on_error=require_verified)
 
 
 def _serialize_repo(gh_repo: dict) -> dict:
@@ -522,7 +541,14 @@ class GithubAppRefreshEndpoint(BaseAPIView):
         app_installation = getattr(wi, "github_app_installation", None) if wi else None
         if app_installation is None:
             return Response({"error": "GitHub App is not installed for this workspace"}, status=status.HTTP_404_NOT_FOUND)
-        return Response(_serialize_app_installation(_refresh_app_installation(app_installation)), status=status.HTTP_200_OK)
+        try:
+            app_installation = _refresh_app_installation(app_installation, raise_on_error=True)
+        except GithubAppAuthError:
+            return Response(
+                {"error": app_installation.last_check_error or "Failed to verify GitHub App installation"},
+                status=status.HTTP_502_BAD_GATEWAY,
+            )
+        return Response(_serialize_app_installation(app_installation), status=status.HTTP_200_OK)
 
 
 class GithubAppCallbackEndpoint(BaseAPIView):
@@ -571,7 +597,12 @@ class GithubAppCallbackEndpoint(BaseAPIView):
             if verify_user_can_access_installation(user_token, installation_id) is None:
                 return fail("installation_not_visible_to_user")
             installation = get_installation(installation_id)
-            app_installation = _upsert_app_installation(install_session.workspace, request.user, installation)
+            app_installation = _upsert_app_installation(
+                install_session.workspace,
+                request.user,
+                installation,
+                require_verified=True,
+            )
         except Exception as e:
             log_exception(e)
             return fail("github_verification_failed")
@@ -653,7 +684,7 @@ class GithubAppWebhookEndpoint(BaseAPIView):
                         revoke_installation_cache(app_installation.installation_id)
                     elif event == "installation" and action == "unsuspend":
                         app_installation.suspended_at = None
-                        _refresh_app_installation(app_installation)
+                        _refresh_app_installation(app_installation, extra_update_fields=["suspended_at"])
                     elif event == "installation_repositories":
                         _refresh_app_installation(app_installation)
                     delivery.status = GithubWebhookDelivery.Status.PROCESSED

--- a/apps/api/pi_dash/db/migrations/0150_github_app_foundation.py
+++ b/apps/api/pi_dash/db/migrations/0150_github_app_foundation.py
@@ -1,0 +1,242 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+import uuid
+
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("db", "0149_loop_mvp"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="GithubWebhookDelivery",
+            fields=[
+                ("created_at", models.DateTimeField(auto_now_add=True, verbose_name="Created At")),
+                ("updated_at", models.DateTimeField(auto_now=True, verbose_name="Last Modified At")),
+                ("deleted_at", models.DateTimeField(blank=True, null=True, verbose_name="Deleted At")),
+                (
+                    "id",
+                    models.UUIDField(
+                        db_index=True,
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                        unique=True,
+                    ),
+                ),
+                ("delivery_id", models.UUIDField(db_index=True, unique=True)),
+                ("event", models.CharField(max_length=100)),
+                ("action", models.CharField(blank=True, default="", max_length=100)),
+                ("installation_id", models.BigIntegerField(blank=True, db_index=True, null=True)),
+                ("payload", models.JSONField(default=dict)),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("received", "Received"),
+                            ("processed", "Processed"),
+                            ("failed", "Failed"),
+                            ("skipped", "Skipped"),
+                        ],
+                        default="received",
+                        max_length=16,
+                    ),
+                ),
+                ("received_at", models.DateTimeField(auto_now_add=True)),
+                ("processed_at", models.DateTimeField(blank=True, null=True)),
+                ("error", models.TextField(blank=True, default="")),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="%(class)s_created_by",
+                        to=settings.AUTH_USER_MODEL,
+                        verbose_name="Created By",
+                    ),
+                ),
+                (
+                    "updated_by",
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="%(class)s_updated_by",
+                        to=settings.AUTH_USER_MODEL,
+                        verbose_name="Last Modified By",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Github Webhook Delivery",
+                "verbose_name_plural": "Github Webhook Deliveries",
+                "db_table": "github_webhook_deliveries",
+                "ordering": ("-received_at",),
+            },
+        ),
+        migrations.CreateModel(
+            name="GithubAppInstallation",
+            fields=[
+                ("created_at", models.DateTimeField(auto_now_add=True, verbose_name="Created At")),
+                ("updated_at", models.DateTimeField(auto_now=True, verbose_name="Last Modified At")),
+                ("deleted_at", models.DateTimeField(blank=True, null=True, verbose_name="Deleted At")),
+                (
+                    "id",
+                    models.UUIDField(
+                        db_index=True,
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                        unique=True,
+                    ),
+                ),
+                ("installation_id", models.BigIntegerField(db_index=True, unique=True)),
+                ("account_login", models.CharField(blank=True, default="", max_length=255)),
+                (
+                    "account_type",
+                    models.CharField(
+                        choices=[("User", "User"), ("Organization", "Organization"), ("Unknown", "Unknown")],
+                        default="Unknown",
+                        max_length=32,
+                    ),
+                ),
+                (
+                    "repository_selection",
+                    models.CharField(choices=[("all", "All"), ("selected", "Selected")], default="selected", max_length=16),
+                ),
+                ("repository_count", models.PositiveIntegerField(default=0)),
+                ("permissions", models.JSONField(default=dict)),
+                ("events", models.JSONField(default=list)),
+                ("installed_at", models.DateTimeField(blank=True, null=True)),
+                ("suspended_at", models.DateTimeField(blank=True, null=True)),
+                ("verified_at", models.DateTimeField(blank=True, null=True)),
+                ("last_checked_at", models.DateTimeField(blank=True, null=True)),
+                ("last_check_error", models.TextField(blank=True, default="")),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="%(class)s_created_by",
+                        to=settings.AUTH_USER_MODEL,
+                        verbose_name="Created By",
+                    ),
+                ),
+                (
+                    "updated_by",
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="%(class)s_updated_by",
+                        to=settings.AUTH_USER_MODEL,
+                        verbose_name="Last Modified By",
+                    ),
+                ),
+                (
+                    "workspace_integration",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="github_app_installation",
+                        to="db.workspaceintegration",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Github App Installation",
+                "verbose_name_plural": "Github App Installations",
+                "db_table": "github_app_installations",
+                "ordering": ("-created_at",),
+            },
+        ),
+        migrations.CreateModel(
+            name="GithubAppInstallSession",
+            fields=[
+                ("created_at", models.DateTimeField(auto_now_add=True, verbose_name="Created At")),
+                ("updated_at", models.DateTimeField(auto_now=True, verbose_name="Last Modified At")),
+                ("deleted_at", models.DateTimeField(blank=True, null=True, verbose_name="Deleted At")),
+                (
+                    "id",
+                    models.UUIDField(
+                        db_index=True,
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                        unique=True,
+                    ),
+                ),
+                ("state", models.CharField(db_index=True, max_length=128, unique=True)),
+                ("installation_id", models.BigIntegerField(blank=True, null=True)),
+                ("account_login", models.CharField(blank=True, default="", max_length=255)),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("started", "Started"),
+                            ("completed", "Completed"),
+                            ("expired", "Expired"),
+                            ("failed", "Failed"),
+                        ],
+                        db_index=True,
+                        default="started",
+                        max_length=16,
+                    ),
+                ),
+                ("expires_at", models.DateTimeField(db_index=True)),
+                ("completed_at", models.DateTimeField(blank=True, null=True)),
+                ("error", models.TextField(blank=True, default="")),
+                (
+                    "actor",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="github_app_install_sessions",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="%(class)s_created_by",
+                        to=settings.AUTH_USER_MODEL,
+                        verbose_name="Created By",
+                    ),
+                ),
+                (
+                    "updated_by",
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="%(class)s_updated_by",
+                        to=settings.AUTH_USER_MODEL,
+                        verbose_name="Last Modified By",
+                    ),
+                ),
+                (
+                    "workspace",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="github_app_install_sessions",
+                        to="db.workspace",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Github App Install Session",
+                "verbose_name_plural": "Github App Install Sessions",
+                "db_table": "github_app_install_sessions",
+                "ordering": ("-created_at",),
+            },
+        ),
+    ]

--- a/apps/api/pi_dash/db/models/__init__.py
+++ b/apps/api/pi_dash/db/models/__init__.py
@@ -20,6 +20,9 @@ from .exporter import ExporterHistory
 from .importer import Importer
 from .intake import Intake, IntakeIssue
 from .integration import (
+    GithubAppInstallation,
+    GithubAppInstallSession,
+    GithubWebhookDelivery,
     GithubCommentSync,
     GithubIssueSync,
     GithubRepository,

--- a/apps/api/pi_dash/db/models/integration/__init__.py
+++ b/apps/api/pi_dash/db/models/integration/__init__.py
@@ -4,6 +4,9 @@
 
 from .base import Integration, WorkspaceIntegration
 from .github import (
+    GithubAppInstallation,
+    GithubAppInstallSession,
+    GithubWebhookDelivery,
     GithubRepository,
     GithubRepositorySync,
     GithubIssueSync,

--- a/apps/api/pi_dash/db/models/integration/github.py
+++ b/apps/api/pi_dash/db/models/integration/github.py
@@ -8,6 +8,7 @@
 from django.db import models
 
 # Module imports
+from pi_dash.db.models.base import BaseModel
 from pi_dash.db.models.project import ProjectBaseModel
 
 
@@ -114,4 +115,100 @@ class GithubCommentSync(ProjectBaseModel):
         verbose_name = "Github Comment Sync"
         verbose_name_plural = "Github Comment Syncs"
         db_table = "github_comment_syncs"
+        ordering = ("-created_at",)
+
+
+class GithubAppInstallation(BaseModel):
+    class AccountType(models.TextChoices):
+        USER = "User", "User"
+        ORGANIZATION = "Organization", "Organization"
+        UNKNOWN = "Unknown", "Unknown"
+
+    class RepositorySelection(models.TextChoices):
+        ALL = "all", "All"
+        SELECTED = "selected", "Selected"
+
+    workspace_integration = models.OneToOneField(
+        "db.WorkspaceIntegration",
+        related_name="github_app_installation",
+        on_delete=models.CASCADE,
+    )
+    installation_id = models.BigIntegerField(unique=True, db_index=True)
+    account_login = models.CharField(max_length=255, blank=True, default="")
+    account_type = models.CharField(max_length=32, choices=AccountType.choices, default=AccountType.UNKNOWN)
+    repository_selection = models.CharField(
+        max_length=16,
+        choices=RepositorySelection.choices,
+        default=RepositorySelection.SELECTED,
+    )
+    repository_count = models.PositiveIntegerField(default=0)
+    permissions = models.JSONField(default=dict)
+    events = models.JSONField(default=list)
+    installed_at = models.DateTimeField(null=True, blank=True)
+    suspended_at = models.DateTimeField(null=True, blank=True)
+    verified_at = models.DateTimeField(null=True, blank=True)
+    last_checked_at = models.DateTimeField(null=True, blank=True)
+    last_check_error = models.TextField(blank=True, default="")
+
+    def __str__(self):
+        return f"{self.account_login or self.installation_id} <{self.workspace_integration.workspace.name}>"
+
+    class Meta:
+        verbose_name = "Github App Installation"
+        verbose_name_plural = "Github App Installations"
+        db_table = "github_app_installations"
+        ordering = ("-created_at",)
+
+
+class GithubWebhookDelivery(BaseModel):
+    class Status(models.TextChoices):
+        RECEIVED = "received", "Received"
+        PROCESSED = "processed", "Processed"
+        FAILED = "failed", "Failed"
+        SKIPPED = "skipped", "Skipped"
+
+    delivery_id = models.UUIDField(unique=True, db_index=True)
+    event = models.CharField(max_length=100)
+    action = models.CharField(max_length=100, blank=True, default="")
+    installation_id = models.BigIntegerField(null=True, blank=True, db_index=True)
+    payload = models.JSONField(default=dict)
+    status = models.CharField(max_length=16, choices=Status.choices, default=Status.RECEIVED)
+    received_at = models.DateTimeField(auto_now_add=True)
+    processed_at = models.DateTimeField(null=True, blank=True)
+    error = models.TextField(blank=True, default="")
+
+    def __str__(self):
+        return f"{self.event}:{self.delivery_id}"
+
+    class Meta:
+        verbose_name = "Github Webhook Delivery"
+        verbose_name_plural = "Github Webhook Deliveries"
+        db_table = "github_webhook_deliveries"
+        ordering = ("-received_at",)
+
+
+class GithubAppInstallSession(BaseModel):
+    class Status(models.TextChoices):
+        STARTED = "started", "Started"
+        COMPLETED = "completed", "Completed"
+        EXPIRED = "expired", "Expired"
+        FAILED = "failed", "Failed"
+
+    state = models.CharField(max_length=128, unique=True, db_index=True)
+    workspace = models.ForeignKey("db.Workspace", related_name="github_app_install_sessions", on_delete=models.CASCADE)
+    actor = models.ForeignKey("db.User", related_name="github_app_install_sessions", on_delete=models.CASCADE)
+    installation_id = models.BigIntegerField(null=True, blank=True)
+    account_login = models.CharField(max_length=255, blank=True, default="")
+    status = models.CharField(max_length=16, choices=Status.choices, default=Status.STARTED, db_index=True)
+    expires_at = models.DateTimeField(db_index=True)
+    completed_at = models.DateTimeField(null=True, blank=True)
+    error = models.TextField(blank=True, default="")
+
+    def __str__(self):
+        return f"{self.workspace.slug}:{self.status}:{self.state}"
+
+    class Meta:
+        verbose_name = "Github App Install Session"
+        verbose_name_plural = "Github App Install Sessions"
+        db_table = "github_app_install_sessions"
         ordering = ("-created_at",)

--- a/apps/api/pi_dash/license/api/serializers/configuration.py
+++ b/apps/api/pi_dash/license/api/serializers/configuration.py
@@ -7,6 +7,13 @@ from pi_dash.license.models import InstanceConfiguration
 from pi_dash.license.utils.encryption import decrypt_data
 
 
+WRITE_ONLY_CONFIG_KEYS = {
+    "GITHUB_APP_PRIVATE_KEY",
+    "GITHUB_APP_WEBHOOK_SECRET",
+    "GITHUB_APP_CLIENT_SECRET",
+}
+
+
 class InstanceConfigurationSerializer(BaseSerializer):
     class Meta:
         model = InstanceConfiguration
@@ -14,6 +21,11 @@ class InstanceConfigurationSerializer(BaseSerializer):
 
     def to_representation(self, instance):
         data = super().to_representation(instance)
+        if instance.key in WRITE_ONLY_CONFIG_KEYS:
+            data["value"] = "set" if instance.value else ""
+            data["is_write_only"] = True
+            return data
+
         # Decrypt secrets value
         if instance.is_encrypted and instance.value is not None:
             data["value"] = decrypt_data(instance.value)

--- a/apps/api/pi_dash/license/api/views/configuration.py
+++ b/apps/api/pi_dash/license/api/views/configuration.py
@@ -24,6 +24,7 @@ from .base import BaseAPIView
 from pi_dash.license.api.permissions import InstanceAdminPermission
 from pi_dash.license.models import InstanceConfiguration
 from pi_dash.license.api.serializers import InstanceConfigurationSerializer
+from pi_dash.license.api.serializers.configuration import WRITE_ONLY_CONFIG_KEYS
 from pi_dash.license.utils.encryption import encrypt_data
 from pi_dash.utils.cache import cache_response, invalidate_cache
 from pi_dash.license.utils.instance_value import get_email_configuration
@@ -47,13 +48,16 @@ class InstanceConfigurationEndpoint(BaseAPIView):
         for configuration in configurations:
             raw_value = request.data.get(configuration.key, configuration.value)
             value = "" if raw_value is None else str(raw_value).strip()
+            if configuration.key in WRITE_ONLY_CONFIG_KEYS and value == "set":
+                continue
             if configuration.is_encrypted:
                 configuration.value = encrypt_data(value)
             else:
                 configuration.value = value
             bulk_configurations.append(configuration)
 
-        InstanceConfiguration.objects.bulk_update(bulk_configurations, ["value"], batch_size=100)
+        if bulk_configurations:
+            InstanceConfiguration.objects.bulk_update(bulk_configurations, ["value"], batch_size=100)
 
         serializer = InstanceConfigurationSerializer(configurations, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/apps/api/pi_dash/tests/contract/app/test_github_app_integration.py
+++ b/apps/api/pi_dash/tests/contract/app/test_github_app_integration.py
@@ -24,7 +24,7 @@ from pi_dash.db.models import (
 from pi_dash.license.models import Instance, InstanceAdmin, InstanceConfiguration
 from pi_dash.license.utils.encryption import decrypt_data, encrypt_data
 from pi_dash.tests.factories import UserFactory, WorkspaceFactory, WorkspaceMemberFactory
-from pi_dash.utils.github_app_auth import GithubAppAuthError
+from pi_dash.utils.github_app_auth import GithubAppAuthError, get_github_app_config
 
 
 pytestmark = [pytest.mark.contract, pytest.mark.django_db]
@@ -72,6 +72,47 @@ def _mark_refreshed(app_installation: GithubAppInstallation, **_kwargs) -> Githu
         update_fields=["verified_at", "last_checked_at", "repository_count", "last_check_error", "updated_at"]
     )
     return app_installation
+
+
+def test_github_app_config_prefers_env_values(settings, monkeypatch):
+    settings.SKIP_ENV_VAR = True
+    InstanceConfiguration.objects.create(key="GITHUB_APP_ID", value="db-app-id", category="GITHUB")
+    InstanceConfiguration.objects.create(key="GITHUB_APP_SLUG", value="db-app-slug", category="GITHUB")
+    InstanceConfiguration.objects.create(
+        key="GITHUB_APP_PRIVATE_KEY",
+        value=encrypt_data("db-private-key"),
+        category="GITHUB",
+        is_encrypted=True,
+    )
+    InstanceConfiguration.objects.create(
+        key="GITHUB_APP_WEBHOOK_SECRET",
+        value=encrypt_data("db-webhook-secret"),
+        category="GITHUB",
+        is_encrypted=True,
+    )
+    InstanceConfiguration.objects.create(key="GITHUB_APP_CLIENT_ID", value="db-client-id", category="GITHUB")
+    InstanceConfiguration.objects.create(
+        key="GITHUB_APP_CLIENT_SECRET",
+        value=encrypt_data("db-client-secret"),
+        category="GITHUB",
+        is_encrypted=True,
+    )
+
+    monkeypatch.setenv("GITHUB_APP_ID", "env-app-id")
+    monkeypatch.setenv("GITHUB_APP_SLUG", "env-app-slug")
+    monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY", "env-private-key")
+    monkeypatch.setenv("GITHUB_APP_WEBHOOK_SECRET", "env-webhook-secret")
+    monkeypatch.setenv("GITHUB_APP_CLIENT_ID", "env-client-id")
+    monkeypatch.setenv("GITHUB_APP_CLIENT_SECRET", "env-client-secret")
+
+    assert get_github_app_config() == {
+        "app_id": "env-app-id",
+        "app_slug": "env-app-slug",
+        "private_key": "env-private-key",
+        "webhook_secret": "env-webhook-secret",
+        "client_id": "env-client-id",
+        "client_secret": "env-client-secret",
+    }
 
 
 class _FakeInstallationClient:

--- a/apps/api/pi_dash/tests/contract/app/test_github_app_integration.py
+++ b/apps/api/pi_dash/tests/contract/app/test_github_app_integration.py
@@ -24,7 +24,7 @@ from pi_dash.db.models import (
 from pi_dash.license.models import Instance, InstanceAdmin, InstanceConfiguration
 from pi_dash.license.utils.encryption import decrypt_data, encrypt_data
 from pi_dash.tests.factories import UserFactory, WorkspaceFactory, WorkspaceMemberFactory
-from pi_dash.utils.github_app_auth import GithubAppAuthError, get_github_app_config
+from pi_dash.utils.github_app_auth import GithubAppAuthError
 
 
 pytestmark = [pytest.mark.contract, pytest.mark.django_db]
@@ -72,47 +72,6 @@ def _mark_refreshed(app_installation: GithubAppInstallation, **_kwargs) -> Githu
         update_fields=["verified_at", "last_checked_at", "repository_count", "last_check_error", "updated_at"]
     )
     return app_installation
-
-
-def test_github_app_config_prefers_env_values(settings, monkeypatch):
-    settings.SKIP_ENV_VAR = True
-    InstanceConfiguration.objects.create(key="GITHUB_APP_ID", value="db-app-id", category="GITHUB")
-    InstanceConfiguration.objects.create(key="GITHUB_APP_SLUG", value="db-app-slug", category="GITHUB")
-    InstanceConfiguration.objects.create(
-        key="GITHUB_APP_PRIVATE_KEY",
-        value=encrypt_data("db-private-key"),
-        category="GITHUB",
-        is_encrypted=True,
-    )
-    InstanceConfiguration.objects.create(
-        key="GITHUB_APP_WEBHOOK_SECRET",
-        value=encrypt_data("db-webhook-secret"),
-        category="GITHUB",
-        is_encrypted=True,
-    )
-    InstanceConfiguration.objects.create(key="GITHUB_APP_CLIENT_ID", value="db-client-id", category="GITHUB")
-    InstanceConfiguration.objects.create(
-        key="GITHUB_APP_CLIENT_SECRET",
-        value=encrypt_data("db-client-secret"),
-        category="GITHUB",
-        is_encrypted=True,
-    )
-
-    monkeypatch.setenv("GITHUB_APP_ID", "env-app-id")
-    monkeypatch.setenv("GITHUB_APP_SLUG", "env-app-slug")
-    monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY", "env-private-key")
-    monkeypatch.setenv("GITHUB_APP_WEBHOOK_SECRET", "env-webhook-secret")
-    monkeypatch.setenv("GITHUB_APP_CLIENT_ID", "env-client-id")
-    monkeypatch.setenv("GITHUB_APP_CLIENT_SECRET", "env-client-secret")
-
-    assert get_github_app_config() == {
-        "app_id": "env-app-id",
-        "app_slug": "env-app-slug",
-        "private_key": "env-private-key",
-        "webhook_secret": "env-webhook-secret",
-        "client_id": "env-client-id",
-        "client_secret": "env-client-secret",
-    }
 
 
 class _FakeInstallationClient:

--- a/apps/api/pi_dash/tests/contract/app/test_github_app_integration.py
+++ b/apps/api/pi_dash/tests/contract/app/test_github_app_integration.py
@@ -11,7 +11,9 @@ import pytest
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework import status
+from rest_framework.test import APIClient
 
+from pi_dash.app.views.integration.github import _get_or_create_workspace_integration
 from pi_dash.db.models import (
     GithubAppInstallation,
     GithubAppInstallSession,
@@ -19,7 +21,10 @@ from pi_dash.db.models import (
     WorkspaceIntegration,
     WorkspaceMember,
 )
+from pi_dash.license.models import Instance, InstanceAdmin, InstanceConfiguration
+from pi_dash.license.utils.encryption import decrypt_data, encrypt_data
 from pi_dash.tests.factories import UserFactory, WorkspaceFactory, WorkspaceMemberFactory
+from pi_dash.utils.github_app_auth import GithubAppAuthError
 
 
 pytestmark = [pytest.mark.contract, pytest.mark.django_db]
@@ -57,7 +62,7 @@ def _installation_payload(installation_id: int = 98765) -> dict:
     }
 
 
-def _mark_refreshed(app_installation: GithubAppInstallation) -> GithubAppInstallation:
+def _mark_refreshed(app_installation: GithubAppInstallation, **_kwargs) -> GithubAppInstallation:
     now = timezone.now()
     app_installation.verified_at = now
     app_installation.last_checked_at = now
@@ -67,6 +72,14 @@ def _mark_refreshed(app_installation: GithubAppInstallation) -> GithubAppInstall
         update_fields=["verified_at", "last_checked_at", "repository_count", "last_check_error", "updated_at"]
     )
     return app_installation
+
+
+class _FakeInstallationClient:
+    def __init__(self, repository_count: int = 3):
+        self.repository_count = repository_count
+
+    def list_installation_repositories(self):
+        return [], False, self.repository_count
 
 
 def test_github_app_status_lists_admin_workspaces(session_client, workspace):
@@ -185,6 +198,37 @@ def test_github_app_callback_verifies_and_binds_installation(session_client, wor
     assert app_installation.verified_at is not None
 
 
+def test_github_app_callback_fails_when_connection_check_fails(session_client, workspace, create_user):
+    install_session = GithubAppInstallSession.objects.create(
+        state="state-refresh-fails",
+        workspace=workspace,
+        actor=create_user,
+        expires_at=timezone.now() + timedelta(minutes=15),
+    )
+
+    with (
+        patch("pi_dash.app.views.integration.github.exchange_user_code", return_value="user-token"),
+        patch("pi_dash.app.views.integration.github.verify_user_can_access_installation", return_value={"id": 98765}),
+        patch("pi_dash.app.views.integration.github.get_installation", return_value=_installation_payload()),
+        patch(
+            "pi_dash.app.views.integration.github._refresh_app_installation",
+            side_effect=GithubAppAuthError("token rejected"),
+        ),
+    ):
+        response = session_client.get(
+            reverse("github-app-callback"),
+            {"state": install_session.state, "code": "oauth-code", "installation_id": "98765"},
+        )
+
+    assert response.status_code == status.HTTP_302_FOUND
+    assert "github_app=error" in response.headers["Location"]
+    assert "error=github_verification_failed" in response.headers["Location"]
+    install_session.refresh_from_db()
+    assert install_session.status == GithubAppInstallSession.Status.FAILED
+    assert GithubAppInstallation.objects.count() == 0
+    assert WorkspaceIntegration.objects.filter(workspace=workspace, integration__provider="github").count() == 0
+
+
 def test_github_app_callback_rejects_actor_mismatch(session_client, workspace):
     other_user = UserFactory(email="other@example.com", username="other-user")
     install_session = GithubAppInstallSession.objects.create(
@@ -205,6 +249,32 @@ def test_github_app_callback_rejects_actor_mismatch(session_client, workspace):
     install_session.refresh_from_db()
     assert install_session.status == GithubAppInstallSession.Status.FAILED
     assert GithubAppInstallation.objects.count() == 0
+
+
+def test_github_app_refresh_returns_error_when_connection_check_fails(session_client, workspace, create_user):
+    workspace_integration = _get_or_create_workspace_integration(workspace, create_user)
+    app_installation = GithubAppInstallation.objects.create(
+        workspace_integration=workspace_integration,
+        installation_id=98765,
+        account_login="acme-corp",
+        account_type=GithubAppInstallation.AccountType.ORGANIZATION,
+    )
+
+    with patch(
+        "pi_dash.app.views.integration.github.GithubClient.for_installation",
+        side_effect=RuntimeError("token rejected"),
+    ):
+        response = session_client.post(
+            reverse("github-app-refresh"),
+            {"workspace_slug": workspace.slug},
+            format="json",
+        )
+
+    assert response.status_code == status.HTTP_502_BAD_GATEWAY
+    assert response.data == {"error": "token rejected"}
+    app_installation.refresh_from_db()
+    assert app_installation.last_check_error == "token rejected"
+    assert app_installation.verified_at is None
 
 
 def test_github_app_webhook_rejects_invalid_signature(api_client):
@@ -242,3 +312,69 @@ def test_github_app_webhook_persists_ping_delivery(api_client):
     assert delivery.event == "ping"
     assert delivery.status == GithubWebhookDelivery.Status.PROCESSED
     assert delivery.processed_at is not None
+
+
+def test_github_app_webhook_unsuspend_persists_installation_state(api_client, workspace, create_user):
+    workspace_integration = _get_or_create_workspace_integration(workspace, create_user)
+    app_installation = GithubAppInstallation.objects.create(
+        workspace_integration=workspace_integration,
+        installation_id=98765,
+        account_login="acme-corp",
+        account_type=GithubAppInstallation.AccountType.ORGANIZATION,
+        suspended_at=timezone.now(),
+        last_check_error="GitHub App installation removed or suspended",
+    )
+    delivery_id = uuid4()
+
+    with (
+        patch("pi_dash.app.views.integration.github.verify_webhook_signature", return_value=True),
+        patch(
+            "pi_dash.app.views.integration.github.GithubClient.for_installation",
+            return_value=_FakeInstallationClient(repository_count=5),
+        ),
+    ):
+        response = api_client.post(
+            reverse("github-app-webhook"),
+            data=json.dumps({"action": "unsuspend", "installation": {"id": 98765}}),
+            content_type="application/json",
+            HTTP_X_GITHUB_DELIVERY=str(delivery_id),
+            HTTP_X_GITHUB_EVENT="installation",
+            HTTP_X_HUB_SIGNATURE_256="sha256=valid",
+        )
+
+    assert response.status_code == status.HTTP_202_ACCEPTED
+    assert response.data == {"status": GithubWebhookDelivery.Status.PROCESSED}
+    app_installation.refresh_from_db()
+    assert app_installation.suspended_at is None
+    assert app_installation.last_check_error == ""
+    assert app_installation.repository_count == 5
+
+
+def test_write_only_github_app_config_sentinel_does_not_overwrite_secret(create_user):
+    instance = Instance.objects.create(
+        instance_name="test",
+        instance_id=f"instance-{uuid4()}",
+        current_version="1.0.0",
+        last_checked_at=timezone.now(),
+    )
+    InstanceAdmin.objects.create(instance=instance, user=create_user, role=20, is_verified=True)
+    configuration = InstanceConfiguration.objects.create(
+        key="GITHUB_APP_PRIVATE_KEY",
+        value=encrypt_data("actual-private-key"),
+        category="GITHUB",
+        is_encrypted=True,
+    )
+    client = APIClient()
+    client.force_authenticate(user=create_user)
+
+    response = client.patch(
+        "/api/instances/configurations/",
+        {"GITHUB_APP_PRIVATE_KEY": "set"},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    configuration.refresh_from_db()
+    assert decrypt_data(configuration.value) == "actual-private-key"
+    assert response.data[0]["value"] == "set"
+    assert response.data[0]["is_write_only"] is True

--- a/apps/api/pi_dash/tests/contract/app/test_github_app_integration.py
+++ b/apps/api/pi_dash/tests/contract/app/test_github_app_integration.py
@@ -1,0 +1,244 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+import json
+from datetime import timedelta
+from uuid import uuid4
+from unittest.mock import patch
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+
+from pi_dash.db.models import (
+    GithubAppInstallation,
+    GithubAppInstallSession,
+    GithubWebhookDelivery,
+    WorkspaceIntegration,
+    WorkspaceMember,
+)
+from pi_dash.tests.factories import UserFactory, WorkspaceFactory, WorkspaceMemberFactory
+
+
+pytestmark = [pytest.mark.contract, pytest.mark.django_db]
+
+
+@pytest.fixture(autouse=True)
+def github_app_test_settings(settings):
+    settings.REST_FRAMEWORK = {
+        **settings.REST_FRAMEWORK,
+        "DEFAULT_THROTTLE_CLASSES": (),
+    }
+
+
+def _github_app_config() -> dict[str, str]:
+    return {
+        "app_id": "123",
+        "app_slug": "pi-dash-test",
+        "private_key": "private-key",
+        "webhook_secret": "webhook-secret",
+        "client_id": "client-id",
+        "client_secret": "client-secret",
+    }
+
+
+def _installation_payload(installation_id: int = 98765) -> dict:
+    return {
+        "id": installation_id,
+        "account": {"login": "acme-corp", "type": "Organization"},
+        "repository_selection": "selected",
+        "repository_count": 3,
+        "permissions": {"metadata": "read"},
+        "events": ["installation", "installation_repositories"],
+        "created_at": "2026-06-16T19:00:00Z",
+        "suspended_at": None,
+    }
+
+
+def _mark_refreshed(app_installation: GithubAppInstallation) -> GithubAppInstallation:
+    now = timezone.now()
+    app_installation.verified_at = now
+    app_installation.last_checked_at = now
+    app_installation.repository_count = 3
+    app_installation.last_check_error = ""
+    app_installation.save(
+        update_fields=["verified_at", "last_checked_at", "repository_count", "last_check_error", "updated_at"]
+    )
+    return app_installation
+
+
+def test_github_app_status_lists_admin_workspaces(session_client, workspace):
+    url = reverse("github-app-status")
+
+    with patch("pi_dash.app.views.integration.github.get_github_app_config", return_value=_github_app_config()):
+        response = session_client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["configured"] is True
+    assert response.data["app_slug"] == "pi-dash-test"
+    assert response.data["workspaces"] == [
+        {
+            "id": str(workspace.id),
+            "slug": workspace.slug,
+            "name": workspace.name,
+            "github_app": {"connected": False},
+        }
+    ]
+
+
+def test_github_app_status_requires_webhook_secret(session_client):
+    config = _github_app_config()
+    config["webhook_secret"] = ""
+
+    with patch("pi_dash.app.views.integration.github.get_github_app_config", return_value=config):
+        response = session_client.get(reverse("github-app-status"))
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["configured"] is False
+
+
+def test_github_app_status_excludes_non_admin_workspaces(session_client, create_user):
+    other_workspace = WorkspaceFactory(owner=create_user, slug="member-only-workspace")
+    WorkspaceMemberFactory(workspace=other_workspace, member=create_user, role=15)
+
+    with patch("pi_dash.app.views.integration.github.get_github_app_config", return_value=_github_app_config()):
+        response = session_client.get(reverse("github-app-status"))
+
+    assert response.status_code == status.HTTP_200_OK
+    assert all(item["slug"] != other_workspace.slug for item in response.data["workspaces"])
+
+
+def test_github_app_install_start_creates_session(session_client, workspace):
+    url = reverse("github-app-install-start")
+
+    with patch("pi_dash.app.views.integration.github.require_github_app_config", return_value=_github_app_config()) as require_config:
+        response = session_client.post(url, {"workspace_slug": workspace.slug}, format="json")
+
+    assert response.status_code == status.HTTP_201_CREATED
+    require_config.assert_called_once_with(oauth=True, webhook=True)
+    assert response.data["install_url"].startswith("https://github.com/apps/pi-dash-test/installations/new?")
+
+    install_session = GithubAppInstallSession.objects.get(state=response.data["state"])
+    assert install_session.workspace == workspace
+    assert install_session.actor.email == "test@example.com"
+    assert install_session.status == GithubAppInstallSession.Status.STARTED
+    assert install_session.expires_at > timezone.now()
+    assert f"state={install_session.state}" in response.data["install_url"]
+
+
+def test_github_app_install_start_requires_workspace_admin(session_client, workspace, create_user):
+    WorkspaceMember.objects.filter(workspace=workspace, member=create_user).update(role=15)
+
+    with patch("pi_dash.app.views.integration.github.require_github_app_config", return_value=_github_app_config()):
+        response = session_client.post(
+            reverse("github-app-install-start"),
+            {"workspace_slug": workspace.slug},
+            format="json",
+        )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert GithubAppInstallSession.objects.count() == 0
+
+
+def test_github_app_callback_verifies_and_binds_installation(session_client, workspace, create_user):
+    install_session = GithubAppInstallSession.objects.create(
+        state="state-123",
+        workspace=workspace,
+        actor=create_user,
+        expires_at=timezone.now() + timedelta(minutes=15),
+    )
+
+    with (
+        patch("pi_dash.app.views.integration.github.exchange_user_code", return_value="user-token") as exchange_code,
+        patch(
+            "pi_dash.app.views.integration.github.verify_user_can_access_installation",
+            return_value={"id": 98765},
+        ) as verify_user_install,
+        patch("pi_dash.app.views.integration.github.get_installation", return_value=_installation_payload()),
+        patch("pi_dash.app.views.integration.github._refresh_app_installation", side_effect=_mark_refreshed),
+    ):
+        response = session_client.get(
+            reverse("github-app-callback"),
+            {"state": install_session.state, "code": "oauth-code", "installation_id": "98765"},
+        )
+
+    assert response.status_code == status.HTTP_302_FOUND
+    assert response.headers["Location"].endswith(
+        f"/settings/profile/integrations/?github_app=connected&workspace_slug={workspace.slug}"
+    )
+    exchange_code.assert_called_once_with("oauth-code")
+    verify_user_install.assert_called_once_with("user-token", 98765)
+
+    install_session.refresh_from_db()
+    assert install_session.status == GithubAppInstallSession.Status.COMPLETED
+    assert install_session.installation_id == 98765
+    assert install_session.account_login == "acme-corp"
+
+    workspace_integration = WorkspaceIntegration.objects.get(workspace=workspace, integration__provider="github")
+    assert workspace_integration.config == {}
+    app_installation = GithubAppInstallation.objects.get(workspace_integration=workspace_integration)
+    assert app_installation.installation_id == 98765
+    assert app_installation.account_login == "acme-corp"
+    assert app_installation.repository_count == 3
+    assert app_installation.verified_at is not None
+
+
+def test_github_app_callback_rejects_actor_mismatch(session_client, workspace):
+    other_user = UserFactory(email="other@example.com", username="other-user")
+    install_session = GithubAppInstallSession.objects.create(
+        state="state-actor-mismatch",
+        workspace=workspace,
+        actor=other_user,
+        expires_at=timezone.now() + timedelta(minutes=15),
+    )
+
+    response = session_client.get(
+        reverse("github-app-callback"),
+        {"state": install_session.state, "code": "oauth-code", "installation_id": "98765"},
+    )
+
+    assert response.status_code == status.HTTP_302_FOUND
+    assert "github_app=error" in response.headers["Location"]
+    assert "error=actor_mismatch" in response.headers["Location"]
+    install_session.refresh_from_db()
+    assert install_session.status == GithubAppInstallSession.Status.FAILED
+    assert GithubAppInstallation.objects.count() == 0
+
+
+def test_github_app_webhook_rejects_invalid_signature(api_client):
+    with patch("pi_dash.app.views.integration.github.verify_webhook_signature", return_value=False):
+        response = api_client.post(
+            reverse("github-app-webhook"),
+            data=json.dumps({"zen": "hello"}),
+            content_type="application/json",
+            HTTP_X_GITHUB_DELIVERY=str(uuid4()),
+            HTTP_X_GITHUB_EVENT="ping",
+            HTTP_X_HUB_SIGNATURE_256="sha256=bad",
+        )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert GithubWebhookDelivery.objects.count() == 0
+
+
+def test_github_app_webhook_persists_ping_delivery(api_client):
+    delivery_id = uuid4()
+
+    with patch("pi_dash.app.views.integration.github.verify_webhook_signature", return_value=True):
+        response = api_client.post(
+            reverse("github-app-webhook"),
+            data=json.dumps({"zen": "hello"}),
+            content_type="application/json",
+            HTTP_X_GITHUB_DELIVERY=str(delivery_id),
+            HTTP_X_GITHUB_EVENT="ping",
+            HTTP_X_HUB_SIGNATURE_256="sha256=valid",
+        )
+
+    assert response.status_code == status.HTTP_202_ACCEPTED
+    assert response.data == {"status": GithubWebhookDelivery.Status.PROCESSED}
+
+    delivery = GithubWebhookDelivery.objects.get(delivery_id=delivery_id)
+    assert delivery.event == "ping"
+    assert delivery.status == GithubWebhookDelivery.Status.PROCESSED
+    assert delivery.processed_at is not None

--- a/apps/api/pi_dash/tests/contract/app/test_github_app_integration.py
+++ b/apps/api/pi_dash/tests/contract/app/test_github_app_integration.py
@@ -251,6 +251,27 @@ def test_github_app_callback_rejects_actor_mismatch(session_client, workspace):
     assert GithubAppInstallation.objects.count() == 0
 
 
+def test_github_app_callback_redirects_when_unauthenticated(api_client, workspace, create_user):
+    install_session = GithubAppInstallSession.objects.create(
+        state="state-logged-out",
+        workspace=workspace,
+        actor=create_user,
+        expires_at=timezone.now() + timedelta(minutes=15),
+    )
+
+    response = api_client.get(
+        reverse("github-app-callback"),
+        {"state": install_session.state, "code": "oauth-code", "installation_id": "98765"},
+    )
+
+    assert response.status_code == status.HTTP_302_FOUND
+    assert "github_app=error" in response.headers["Location"]
+    assert "error=login_required" in response.headers["Location"]
+    install_session.refresh_from_db()
+    assert install_session.status == GithubAppInstallSession.Status.STARTED
+    assert GithubAppInstallation.objects.count() == 0
+
+
 def test_github_app_refresh_returns_error_when_connection_check_fails(session_client, workspace, create_user):
     workspace_integration = _get_or_create_workspace_integration(workspace, create_user)
     app_installation = GithubAppInstallation.objects.create(

--- a/apps/api/pi_dash/utils/github_app_auth.py
+++ b/apps/api/pi_dash/utils/github_app_auth.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import hashlib
 import hmac
-import os
 import time
 from datetime import datetime, timezone as dt_timezone
 from typing import Any
@@ -21,14 +20,6 @@ GITHUB_API_BASE = "https://api.github.com"
 GITHUB_WEB_BASE = "https://github.com"
 DEFAULT_TIMEOUT_SECONDS = 30
 INSTALLATION_TOKEN_CACHE_PREFIX = "github_app_installation_token"
-GITHUB_APP_CONFIG_KEYS = {
-    "app_id": "GITHUB_APP_ID",
-    "app_slug": "GITHUB_APP_SLUG",
-    "private_key": "GITHUB_APP_PRIVATE_KEY",
-    "webhook_secret": "GITHUB_APP_WEBHOOK_SECRET",
-    "client_id": "GITHUB_APP_CLIENT_ID",
-    "client_secret": "GITHUB_APP_CLIENT_SECRET",
-}
 
 
 class GithubAppConfigError(Exception):
@@ -50,7 +41,7 @@ def get_github_app_config() -> dict[str, str]:
             {"key": "GITHUB_APP_CLIENT_SECRET", "default": None},
         ]
     )
-    config = {
+    return {
         "app_id": (app_id or "").strip(),
         "app_slug": (app_slug or "").strip(),
         "private_key": (private_key or "").strip(),
@@ -58,11 +49,6 @@ def get_github_app_config() -> dict[str, str]:
         "client_id": (client_id or "").strip(),
         "client_secret": (client_secret or "").strip(),
     }
-    for config_key, env_key in GITHUB_APP_CONFIG_KEYS.items():
-        env_value = os.environ.get(env_key)
-        if env_value:
-            config[config_key] = env_value.strip()
-    return config
 
 
 def require_github_app_config(*, oauth: bool = False, webhook: bool = False) -> dict[str, str]:

--- a/apps/api/pi_dash/utils/github_app_auth.py
+++ b/apps/api/pi_dash/utils/github_app_auth.py
@@ -1,0 +1,201 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import time
+from datetime import datetime, timezone as dt_timezone
+from typing import Any
+
+import jwt
+import requests
+from django.core.cache import cache
+
+from pi_dash.license.utils.instance_value import get_configuration_value
+
+GITHUB_API_BASE = "https://api.github.com"
+GITHUB_WEB_BASE = "https://github.com"
+DEFAULT_TIMEOUT_SECONDS = 30
+INSTALLATION_TOKEN_CACHE_PREFIX = "github_app_installation_token"
+
+
+class GithubAppConfigError(Exception):
+    """GitHub App is not configured for this Pi Dash instance."""
+
+
+class GithubAppAuthError(Exception):
+    """GitHub App authentication failed."""
+
+
+def get_github_app_config() -> dict[str, str]:
+    app_id, app_slug, private_key, webhook_secret, client_id, client_secret = get_configuration_value(
+        [
+            {"key": "GITHUB_APP_ID", "default": None},
+            {"key": "GITHUB_APP_SLUG", "default": None},
+            {"key": "GITHUB_APP_PRIVATE_KEY", "default": None},
+            {"key": "GITHUB_APP_WEBHOOK_SECRET", "default": None},
+            {"key": "GITHUB_APP_CLIENT_ID", "default": None},
+            {"key": "GITHUB_APP_CLIENT_SECRET", "default": None},
+        ]
+    )
+    return {
+        "app_id": (app_id or "").strip(),
+        "app_slug": (app_slug or "").strip(),
+        "private_key": (private_key or "").strip(),
+        "webhook_secret": (webhook_secret or "").strip(),
+        "client_id": (client_id or "").strip(),
+        "client_secret": (client_secret or "").strip(),
+    }
+
+
+def require_github_app_config(*, oauth: bool = False, webhook: bool = False) -> dict[str, str]:
+    config = get_github_app_config()
+    required = ["app_id", "app_slug", "private_key"]
+    if oauth:
+        required.extend(["client_id", "client_secret"])
+    if webhook:
+        required.append("webhook_secret")
+    missing = [key for key in required if not config.get(key)]
+    if missing:
+        raise GithubAppConfigError(f"GitHub App config missing: {', '.join(missing)}")
+    return config
+
+
+def build_app_jwt() -> str:
+    config = require_github_app_config()
+    now = int(time.time())
+    payload = {
+        # GitHub recommends issuing slightly in the past to avoid clock drift.
+        "iat": now - 60,
+        "exp": now + (9 * 60),
+        "iss": config["app_id"],
+    }
+    return jwt.encode(payload, config["private_key"], algorithm="RS256")
+
+
+def app_headers() -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {build_app_jwt()}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "pi-dash-github-app",
+    }
+
+
+def user_headers(token: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "pi-dash-github-app",
+    }
+
+
+def parse_github_datetime(value: str | None):
+    if not value:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def exchange_user_code(code: str) -> str:
+    config = require_github_app_config(oauth=True)
+    response = requests.post(
+        f"{GITHUB_WEB_BASE}/login/oauth/access_token",
+        headers={"Accept": "application/json"},
+        data={
+            "client_id": config["client_id"],
+            "client_secret": config["client_secret"],
+            "code": code,
+        },
+        timeout=DEFAULT_TIMEOUT_SECONDS,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    token = payload.get("access_token")
+    if not token:
+        raise GithubAppAuthError(
+            payload.get("error_description") or payload.get("error") or "GitHub did not return a user token"
+        )
+    return token
+
+
+def list_user_installations(user_token: str) -> list[dict[str, Any]]:
+    installations: list[dict[str, Any]] = []
+    url = f"{GITHUB_API_BASE}/user/installations?per_page=100"
+    while url:
+        response = requests.get(url, headers=user_headers(user_token), timeout=DEFAULT_TIMEOUT_SECONDS)
+        response.raise_for_status()
+        payload = response.json()
+        installations.extend(payload.get("installations") or [])
+        url = None
+        for link_part in (response.headers.get("Link") or "").split(","):
+            link_part = link_part.strip()
+            if 'rel="next"' in link_part and link_part.startswith("<"):
+                url = link_part.split(">", 1)[0][1:]
+                break
+    return installations
+
+
+def verify_user_can_access_installation(user_token: str, installation_id: int) -> dict[str, Any] | None:
+    for installation in list_user_installations(user_token):
+        if int(installation.get("id") or 0) == int(installation_id):
+            return installation
+    return None
+
+
+def get_installation(installation_id: int) -> dict[str, Any]:
+    response = requests.get(
+        f"{GITHUB_API_BASE}/app/installations/{installation_id}",
+        headers=app_headers(),
+        timeout=DEFAULT_TIMEOUT_SECONDS,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def mint_installation_token(installation_id: int) -> dict[str, Any]:
+    response = requests.post(
+        f"{GITHUB_API_BASE}/app/installations/{installation_id}/access_tokens",
+        headers=app_headers(),
+        timeout=DEFAULT_TIMEOUT_SECONDS,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def installation_token(installation_id: int) -> str:
+    cache_key = f"{INSTALLATION_TOKEN_CACHE_PREFIX}:{installation_id}"
+    cached = cache.get(cache_key)
+    if cached:
+        return cached
+
+    payload = mint_installation_token(installation_id)
+    token = payload.get("token")
+    if not token:
+        raise GithubAppAuthError("GitHub did not return an installation token")
+
+    expires_at = parse_github_datetime(payload.get("expires_at"))
+    ttl = 55 * 60
+    if expires_at:
+        ttl = max(60, int((expires_at - datetime.now(dt_timezone.utc)).total_seconds()) - 60)
+    cache.set(cache_key, token, ttl)
+    return token
+
+
+def revoke_installation_cache(installation_id: int) -> None:
+    cache.delete(f"{INSTALLATION_TOKEN_CACHE_PREFIX}:{installation_id}")
+
+
+def verify_webhook_signature(raw_body: bytes, signature: str | None) -> bool:
+    config = require_github_app_config(webhook=True)
+    if not signature or not signature.startswith("sha256="):
+        return False
+    expected = "sha256=" + hmac.new(
+        config["webhook_secret"].encode("utf-8"),
+        raw_body,
+        hashlib.sha256,
+    ).hexdigest()
+    return hmac.compare_digest(expected, signature)

--- a/apps/api/pi_dash/utils/github_app_auth.py
+++ b/apps/api/pi_dash/utils/github_app_auth.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import os
 import time
 from datetime import datetime, timezone as dt_timezone
 from typing import Any
@@ -20,6 +21,14 @@ GITHUB_API_BASE = "https://api.github.com"
 GITHUB_WEB_BASE = "https://github.com"
 DEFAULT_TIMEOUT_SECONDS = 30
 INSTALLATION_TOKEN_CACHE_PREFIX = "github_app_installation_token"
+GITHUB_APP_CONFIG_KEYS = {
+    "app_id": "GITHUB_APP_ID",
+    "app_slug": "GITHUB_APP_SLUG",
+    "private_key": "GITHUB_APP_PRIVATE_KEY",
+    "webhook_secret": "GITHUB_APP_WEBHOOK_SECRET",
+    "client_id": "GITHUB_APP_CLIENT_ID",
+    "client_secret": "GITHUB_APP_CLIENT_SECRET",
+}
 
 
 class GithubAppConfigError(Exception):
@@ -41,7 +50,7 @@ def get_github_app_config() -> dict[str, str]:
             {"key": "GITHUB_APP_CLIENT_SECRET", "default": None},
         ]
     )
-    return {
+    config = {
         "app_id": (app_id or "").strip(),
         "app_slug": (app_slug or "").strip(),
         "private_key": (private_key or "").strip(),
@@ -49,6 +58,11 @@ def get_github_app_config() -> dict[str, str]:
         "client_id": (client_id or "").strip(),
         "client_secret": (client_secret or "").strip(),
     }
+    for config_key, env_key in GITHUB_APP_CONFIG_KEYS.items():
+        env_value = os.environ.get(env_key)
+        if env_value:
+            config[config_key] = env_value.strip()
+    return config
 
 
 def require_github_app_config(*, oauth: bool = False, webhook: bool = False) -> dict[str, str]:

--- a/apps/api/pi_dash/utils/github_client.py
+++ b/apps/api/pi_dash/utils/github_client.py
@@ -34,11 +34,18 @@ class GithubNotFoundError(Exception):
 
 
 class GithubClient:
-    def __init__(self, token: str, *, timeout: int = DEFAULT_TIMEOUT_SECONDS):
+    def __init__(self, token: str, *, timeout: int = DEFAULT_TIMEOUT_SECONDS, api_base: str = GITHUB_API_BASE):
         if not token:
             raise GithubAuthError("empty token")
         self._token = token
         self._timeout = timeout
+        self._api_base = api_base.rstrip("/")
+
+    @classmethod
+    def for_installation(cls, installation_id: int, *, timeout: int = DEFAULT_TIMEOUT_SECONDS):
+        from pi_dash.utils.github_app_auth import installation_token
+
+        return cls(token=installation_token(installation_id), timeout=timeout)
 
     # ----- HTTP plumbing -----
 
@@ -75,7 +82,7 @@ class GithubClient:
         return None
 
     def _paginate(self, path: str, params: Optional[dict] = None) -> Iterator[dict]:
-        url = f"{GITHUB_API_BASE}{path}"
+        url = f"{self._api_base}{path}"
         if params:
             url = f"{url}?{urlencode(params)}"
         while url:
@@ -88,7 +95,7 @@ class GithubClient:
 
     def get_authenticated_user(self) -> dict:
         """GET /user — used to validate a PAT on connect."""
-        return self._request("GET", f"{GITHUB_API_BASE}/user").json()
+        return self._request("GET", f"{self._api_base}/user").json()
 
     def list_user_repos(self, *, page: int = 1, per_page: int = 100) -> tuple[list[dict], bool]:
         """One page of /user/repos with the affiliation filter required to
@@ -99,14 +106,26 @@ class GithubClient:
             "sort": "updated",
             "page": page,
         }
-        url = f"{GITHUB_API_BASE}/user/repos?{urlencode(params)}"
+        url = f"{self._api_base}/user/repos?{urlencode(params)}"
         response = self._request("GET", url)
         return response.json(), self._next_url(response) is not None
 
     def get_repo(self, owner: str, name: str) -> dict:
         """GET /repos/{owner}/{repo} — used to verify a bind request's
         (owner, name, repository_id) consistency."""
-        return self._request("GET", f"{GITHUB_API_BASE}/repos/{owner}/{name}").json()
+        return self._request("GET", f"{self._api_base}/repos/{owner}/{name}").json()
+
+    def list_installation_repositories(self, *, page: int = 1, per_page: int = 100) -> tuple[list[dict], bool, int]:
+        """One page of repos visible to the current installation token."""
+        params = {"per_page": per_page, "page": page}
+        url = f"{self._api_base}/installation/repositories?{urlencode(params)}"
+        response = self._request("GET", url)
+        payload = response.json()
+        return (
+            payload.get("repositories") or [],
+            self._next_url(response) is not None,
+            int(payload.get("total_count") or 0),
+        )
 
     def list_all_open_issues(self, owner: str, name: str) -> Iterable[dict]:
         """Paginated /issues with state=open. PRs are returned alongside
@@ -126,7 +145,7 @@ class GithubClient:
 
     def post_issue_comment(self, owner: str, name: str, issue_number: int, body: str) -> dict:
         """POST /repos/{owner}/{repo}/issues/{number}/comments."""
-        url = f"{GITHUB_API_BASE}/repos/{owner}/{name}/issues/{issue_number}/comments"
+        url = f"{self._api_base}/repos/{owner}/{name}/issues/{issue_number}/comments"
         response = self._request("POST", url, json={"body": body})
         return response.json()
 

--- a/apps/api/pi_dash/utils/instance_config_variables/core.py
+++ b/apps/api/pi_dash/utils/instance_config_variables/core.py
@@ -58,6 +58,42 @@ google_config_variables = [
 
 github_config_variables = [
     {
+        "key": "GITHUB_APP_ID",
+        "value": os.environ.get("GITHUB_APP_ID"),
+        "category": "GITHUB",
+        "is_encrypted": False,
+    },
+    {
+        "key": "GITHUB_APP_SLUG",
+        "value": os.environ.get("GITHUB_APP_SLUG"),
+        "category": "GITHUB",
+        "is_encrypted": False,
+    },
+    {
+        "key": "GITHUB_APP_PRIVATE_KEY",
+        "value": os.environ.get("GITHUB_APP_PRIVATE_KEY"),
+        "category": "GITHUB",
+        "is_encrypted": True,
+    },
+    {
+        "key": "GITHUB_APP_WEBHOOK_SECRET",
+        "value": os.environ.get("GITHUB_APP_WEBHOOK_SECRET"),
+        "category": "GITHUB",
+        "is_encrypted": True,
+    },
+    {
+        "key": "GITHUB_APP_CLIENT_ID",
+        "value": os.environ.get("GITHUB_APP_CLIENT_ID"),
+        "category": "GITHUB",
+        "is_encrypted": False,
+    },
+    {
+        "key": "GITHUB_APP_CLIENT_SECRET",
+        "value": os.environ.get("GITHUB_APP_CLIENT_SECRET"),
+        "category": "GITHUB",
+        "is_encrypted": True,
+    },
+    {
         "key": "GITHUB_CLIENT_ID",
         "value": os.environ.get("GITHUB_CLIENT_ID"),
         "category": "GITHUB",

--- a/apps/web/core/components/integration/github/github-pat-card.tsx
+++ b/apps/web/core/components/integration/github/github-pat-card.tsx
@@ -101,7 +101,7 @@ export function GithubPatCard({ integration }: Props) {
             {status?.connected && <CheckCircle className="h-3.5 w-3.5 fill-transparent text-success-primary" />}
           </h3>
           <p className="text-body-xs-regular text-secondary">
-            {status === undefined
+            {!status
               ? "Loading..."
               : status.connected
                 ? `Connected as ${status.github_user_login}. Bind a repository on a project's Settings → GitHub.`
@@ -118,7 +118,7 @@ export function GithubPatCard({ integration }: Props) {
         </div>
       </div>
 
-      {status === undefined ? (
+      {!status ? (
         <Loader>
           <Loader.Item height="32px" width="180px" />
         </Loader>

--- a/apps/web/core/components/project/settings/github-sync.tsx
+++ b/apps/web/core/components/project/settings/github-sync.tsx
@@ -80,7 +80,7 @@ export function ProjectGithubSyncSection() {
     }
   };
 
-  if (wsStatus !== undefined && !wsStatus.connected) {
+  if (wsStatus && !wsStatus.connected) {
     return (
       <div className="flex flex-col gap-2 rounded-md border border-subtle bg-surface-1 p-4">
         <h3 className="text-body-sm-medium">GitHub</h3>
@@ -92,7 +92,7 @@ export function ProjectGithubSyncSection() {
     );
   }
 
-  if (wsStatus === undefined || binding === undefined) {
+  if (!wsStatus || !binding) {
     return (
       <Loader className="flex flex-col gap-2 p-4">
         <Loader.Item height="20px" width="160px" />

--- a/apps/web/core/components/runners/runner-models.ts
+++ b/apps/web/core/components/runners/runner-models.ts
@@ -18,7 +18,7 @@
  */
 
 // Mirrors the runner CLI's ``--agent`` value-enum (kebab-case).
-export type TRunnerAgent = "claude-code" | "codex" | "cursor-agent";
+export type TRunnerAgent = "claude-code" | "codex" | "cursor-agent" | "open-claw";
 
 export interface IRunnerModelOption {
   /** Unique select value within an agent's list. */
@@ -100,6 +100,7 @@ export const RUNNER_MODEL_OPTIONS: Record<TRunnerAgent, IRunnerModelOption[]> = 
   "claude-code": [DEFAULT_OPTION, ...CLAUDE_OPTIONS],
   codex: [DEFAULT_OPTION, ...CODEX_OPTIONS],
   "cursor-agent": [DEFAULT_OPTION, ...CURSOR_OPTIONS],
+  "open-claw": [DEFAULT_OPTION],
 };
 
 /**
@@ -111,6 +112,7 @@ export const DEFAULT_MODEL_BY_AGENT: Record<TRunnerAgent, string> = {
   "claude-code": DEFAULT_MODEL_ID,
   codex: DEFAULT_MODEL_ID,
   "cursor-agent": DEFAULT_MODEL_ID,
+  "open-claw": DEFAULT_MODEL_ID,
 };
 
 /** Look up a selected option's label; falls back to the default label. */

--- a/apps/web/core/components/settings/profile/content/pages/index.ts
+++ b/apps/web/core/components/settings/profile/content/pages/index.ts
@@ -18,5 +18,6 @@ export const PROFILE_SETTINGS_PAGES_MAP: Record<TProfileSettingsTabs, React.Lazy
   notifications: lazy(() => import("./notifications").then((m) => ({ default: m.NotificationsProfileSettings }))),
   security: lazy(() => import("./security").then((m) => ({ default: m.SecurityProfileSettings }))),
   activity: lazy(() => import("./activity").then((m) => ({ default: m.ActivityProfileSettings }))),
+  integrations: lazy(() => import("./integrations").then((m) => ({ default: m.IntegrationsProfileSettings }))),
   "api-tokens": lazy(() => import("./api-tokens").then((m) => ({ default: m.APITokensProfileSettings }))),
 };

--- a/apps/web/core/components/settings/profile/content/pages/integrations.tsx
+++ b/apps/web/core/components/settings/profile/content/pages/integrations.tsx
@@ -1,0 +1,298 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { observer } from "mobx-react";
+import useSWR from "swr";
+import { CheckCircle, ExternalLink, RefreshCw } from "lucide-react";
+// pi dash imports
+import { Button } from "@pi-dash/propel/button";
+import { setToast, TOAST_TYPE } from "@pi-dash/propel/toast";
+import type { IGithubAppWorkspaceStatus } from "@pi-dash/types";
+import { Loader } from "@pi-dash/ui";
+// components
+import { ProfileSettingsHeading } from "@/components/settings/profile/heading";
+// constants
+import { GITHUB_APP_STATUS } from "@/constants/fetch-keys";
+// services
+import { GithubIntegrationService } from "@/services/integrations/github.service";
+
+const githubService = new GithubIntegrationService();
+
+const formatDateTime = (value?: string | null) => {
+  if (!value) return "Never";
+  return new Date(value).toLocaleString();
+};
+
+const installErrorMessage: Record<string, string> = {
+  actor_mismatch: "This install session was started by a different Pi Dash user.",
+  github_verification_failed: "Pi Dash could not verify the GitHub installation.",
+  installation_not_visible_to_user: "Your GitHub account cannot access that installation.",
+  missing_installation_id: "GitHub did not return an installation id.",
+  missing_oauth_code: "GitHub did not return a setup authorization code.",
+  workspace_admin_required: "You must be a workspace admin to connect GitHub.",
+};
+
+function InstallCallbackToast({ onWorkspaceSlug }: { onWorkspaceSlug: (workspaceSlug: string) => void }) {
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const result = params.get("github_app");
+    if (!result) return;
+
+    if (result === "connected") {
+      setToast({
+        type: TOAST_TYPE.SUCCESS,
+        title: "GitHub connected",
+        message: "The GitHub App installation was verified.",
+      });
+      const workspaceSlug = params.get("workspace_slug");
+      if (workspaceSlug) onWorkspaceSlug(workspaceSlug);
+    } else {
+      const error = params.get("error") || result;
+      setToast({
+        type: TOAST_TYPE.ERROR,
+        title: "GitHub connection failed",
+        message: installErrorMessage[error] || "The GitHub App installation could not be completed.",
+      });
+    }
+
+    params.delete("github_app");
+    params.delete("workspace_slug");
+    params.delete("error");
+    const nextQuery = params.toString();
+    const nextUrl = `${window.location.pathname}${nextQuery ? `?${nextQuery}` : ""}${window.location.hash}`;
+    window.history.replaceState(null, "", nextUrl);
+  }, [onWorkspaceSlug]);
+
+  return null;
+}
+
+function GithubAppWorkspacePanel({
+  configured,
+  selectedWorkspace,
+  onInstall,
+  onRefresh,
+  installing,
+  refreshing,
+}: {
+  configured: boolean;
+  selectedWorkspace: IGithubAppWorkspaceStatus;
+  onInstall: () => void;
+  onRefresh: () => void;
+  installing: boolean;
+  refreshing: boolean;
+}) {
+  const installation = selectedWorkspace.github_app;
+  const isConnected = installation.connected;
+  const isSuspended = !!installation.suspended_at;
+
+  return (
+    <div className="flex flex-col gap-4 rounded-md border border-subtle bg-surface-1 px-4 py-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <h3 className="truncate text-14 font-medium text-primary">GitHub App</h3>
+            {isConnected && !isSuspended ? (
+              <CheckCircle className="h-4 w-4 shrink-0 fill-transparent text-success-primary" />
+            ) : null}
+          </div>
+          <p className="mt-1 text-12 text-secondary">
+            {isConnected
+              ? `Installed for ${installation.account_login || "GitHub"} on ${selectedWorkspace.name}.`
+              : `Install the Pi Dash GitHub App for ${selectedWorkspace.name}.`}
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {isConnected ? (
+            <Button
+              variant="secondary"
+              size="sm"
+              prependIcon={<RefreshCw />}
+              loading={refreshing}
+              disabled={refreshing}
+              onClick={onRefresh}
+            >
+              Refresh
+            </Button>
+          ) : null}
+          <Button
+            variant="primary"
+            size="sm"
+            appendIcon={<ExternalLink />}
+            loading={installing}
+            disabled={!configured || installing}
+            onClick={onInstall}
+          >
+            {isConnected ? "Reconnect" : "Install"}
+          </Button>
+        </div>
+      </div>
+
+      {!configured ? (
+        <div className="rounded-md border border-warning-subtle bg-warning-subtle px-3 py-2 text-12 text-secondary">
+          GitHub App configuration is missing on this Pi Dash instance.
+        </div>
+      ) : null}
+
+      {isConnected ? (
+        <div className="grid gap-3 text-12 sm:grid-cols-2">
+          <StatusField label="Account" value={installation.account_login || "Unknown"} />
+          <StatusField label="Account type" value={installation.account_type || "Unknown"} />
+          <StatusField
+            label="Repository access"
+            value={installation.repository_selection === "all" ? "All repositories" : "Selected repositories"}
+          />
+          <StatusField label="Repositories visible" value={String(installation.repository_count ?? 0)} />
+          <StatusField label="Verified" value={formatDateTime(installation.verified_at)} />
+          <StatusField label="Last checked" value={formatDateTime(installation.last_checked_at)} />
+        </div>
+      ) : (
+        <p className="text-12 text-secondary">
+          No GitHub App installation is connected for this workspace yet. Pi Dash will verify installation access after
+          GitHub redirects you back.
+        </p>
+      )}
+
+      {isSuspended ? (
+        <div className="rounded-md border border-danger-subtle bg-danger-subtle px-3 py-2 text-12 text-danger-primary">
+          This GitHub App installation is suspended or removed in GitHub.
+        </div>
+      ) : null}
+
+      {installation.last_check_error ? (
+        <div className="rounded-md border border-danger-subtle bg-danger-subtle px-3 py-2 text-12 text-danger-primary">
+          Last check failed: {installation.last_check_error}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function StatusField({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-0 rounded-md bg-surface-2 px-3 py-2">
+      <div className="text-11 text-tertiary">{label}</div>
+      <div className="truncate text-12 font-medium text-primary">{value}</div>
+    </div>
+  );
+}
+
+export const IntegrationsProfileSettings = observer(function IntegrationsProfileSettings() {
+  const { data, mutate, isLoading } = useSWR(GITHUB_APP_STATUS, () => githubService.getAppStatus());
+  const [selectedWorkspaceSlug, setSelectedWorkspaceSlug] = useState("");
+  const [installing, setInstalling] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const selectedWorkspace = useMemo(
+    () => data?.workspaces.find((workspace) => workspace.slug === selectedWorkspaceSlug) ?? data?.workspaces[0],
+    [data?.workspaces, selectedWorkspaceSlug]
+  );
+
+  useEffect(() => {
+    if (!selectedWorkspaceSlug && data?.workspaces[0]) {
+      setSelectedWorkspaceSlug(data.workspaces[0].slug);
+    }
+  }, [data?.workspaces, selectedWorkspaceSlug]);
+
+  const startInstall = async () => {
+    if (!selectedWorkspace) return;
+    setInstalling(true);
+    try {
+      const response = await githubService.startAppInstall({ workspace_slug: selectedWorkspace.slug });
+      window.location.assign(response.install_url);
+    } catch (e: unknown) {
+      const error = e as { error?: string; detail?: string } | null;
+      setToast({
+        type: TOAST_TYPE.ERROR,
+        title: "Install failed",
+        message: error?.error || error?.detail || "Could not start the GitHub App install flow.",
+      });
+      setInstalling(false);
+    }
+  };
+
+  const refreshConnection = async () => {
+    if (!selectedWorkspace) return;
+    setRefreshing(true);
+    try {
+      await githubService.refreshAppConnection({ workspace_slug: selectedWorkspace.slug });
+      await mutate();
+      setToast({
+        type: TOAST_TYPE.SUCCESS,
+        title: "GitHub refreshed",
+        message: "The GitHub App installation was checked successfully.",
+      });
+    } catch (e: unknown) {
+      const error = e as { error?: string; detail?: string } | null;
+      setToast({
+        type: TOAST_TYPE.ERROR,
+        title: "Refresh failed",
+        message: error?.error || error?.detail || "Could not check the GitHub App installation.",
+      });
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  return (
+    <div className="size-full">
+      <InstallCallbackToast
+        onWorkspaceSlug={(workspaceSlug) => {
+          setSelectedWorkspaceSlug(workspaceSlug);
+          void mutate();
+        }}
+      />
+      <ProfileSettingsHeading
+        title="Integrations"
+        description="Connect external services to workspaces you administer."
+      />
+
+      <div className="mt-7 flex max-w-3xl flex-col gap-5">
+        {isLoading || !data ? (
+          <Loader className="flex flex-col gap-3">
+            <Loader.Item height="76px" width="100%" />
+            <Loader.Item height="180px" width="100%" />
+          </Loader>
+        ) : data.workspaces.length === 0 ? (
+          <div className="rounded-md border border-subtle bg-surface-1 px-4 py-5">
+            <h3 className="text-14 font-medium text-primary">No admin workspaces</h3>
+            <p className="mt-1 text-12 text-secondary">
+              You need workspace admin access before you can install GitHub for a Pi Dash workspace.
+            </p>
+          </div>
+        ) : (
+          <>
+            <label className="flex max-w-sm flex-col gap-1 text-13">
+              <span className="text-secondary">Workspace</span>
+              <select
+                value={selectedWorkspace?.slug ?? ""}
+                onChange={(event) => setSelectedWorkspaceSlug(event.target.value)}
+                className="rounded-md border border-subtle bg-surface-1 px-3 py-2 text-primary"
+              >
+                {data.workspaces.map((workspace) => (
+                  <option key={workspace.id} value={workspace.slug}>
+                    {workspace.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            {selectedWorkspace ? (
+              <GithubAppWorkspacePanel
+                configured={data.configured}
+                selectedWorkspace={selectedWorkspace}
+                onInstall={startInstall}
+                onRefresh={refreshConnection}
+                installing={installing}
+                refreshing={refreshing}
+              />
+            ) : null}
+          </>
+        )}
+      </div>
+    </div>
+  );
+});

--- a/apps/web/core/components/settings/profile/content/pages/integrations.tsx
+++ b/apps/web/core/components/settings/profile/content/pages/integrations.tsx
@@ -30,6 +30,7 @@ const formatDateTime = (value?: string | null) => {
 const installErrorMessage: Record<string, string> = {
   actor_mismatch: "This install session was started by a different Pi Dash user.",
   github_verification_failed: "Pi Dash could not verify the GitHub installation.",
+  login_required: "Sign in to Pi Dash and start the GitHub App install again.",
   installation_not_visible_to_user: "Your GitHub account cannot access that installation.",
   missing_installation_id: "GitHub did not return an installation id.",
   missing_oauth_code: "GitHub did not return a setup authorization code.",

--- a/apps/web/core/constants/fetch-keys.ts
+++ b/apps/web/core/constants/fetch-keys.ts
@@ -98,6 +98,7 @@ export const GITHUB_INTEGRATION_STATUS = (workspaceSlug: string) =>
 export const GITHUB_INTEGRATION_REPOS = (workspaceSlug: string, page: number) =>
   `GITHUB_INTEGRATION_REPOS_${workspaceSlug.toUpperCase()}_${page}`;
 export const GITHUB_PROJECT_BINDING = (projectId: string) => `GITHUB_PROJECT_BINDING_${projectId.toUpperCase()}`;
+export const GITHUB_APP_STATUS = "GITHUB_APP_STATUS";
 
 // cycles
 export const WORKSPACE_ACTIVE_CYCLES_LIST = (workspaceSlug: string, cursor: string, per_page: string) =>

--- a/apps/web/core/services/integrations/github.service.ts
+++ b/apps/web/core/services/integrations/github.service.ts
@@ -5,7 +5,16 @@
  */
 
 import { API_BASE_URL } from "@pi-dash/constants";
-import type { IGithubConnectionStatus, IGithubConnectRequest, IGithubReposPage } from "@pi-dash/types";
+import type {
+  IGithubAppInstallationStatus,
+  IGithubAppInstallStartRequest,
+  IGithubAppInstallStartResponse,
+  IGithubAppRefreshRequest,
+  IGithubAppStatus,
+  IGithubConnectionStatus,
+  IGithubConnectRequest,
+  IGithubReposPage,
+} from "@pi-dash/types";
 import { APIService } from "@/services/api.service";
 
 export class GithubIntegrationService extends APIService {
@@ -39,6 +48,30 @@ export class GithubIntegrationService extends APIService {
 
   async listRepos(workspaceSlug: string, page: number = 1): Promise<IGithubReposPage> {
     return this.get(`/api/workspaces/${workspaceSlug}/integrations/github/repos/`, { params: { page } })
+      .then((response) => response?.data)
+      .catch((error) => {
+        throw error?.response?.data;
+      });
+  }
+
+  async getAppStatus(): Promise<IGithubAppStatus> {
+    return this.get("/api/users/me/integrations/github/app/")
+      .then((response) => response?.data)
+      .catch((error) => {
+        throw error?.response?.data;
+      });
+  }
+
+  async startAppInstall(data: IGithubAppInstallStartRequest): Promise<IGithubAppInstallStartResponse> {
+    return this.post("/api/users/me/integrations/github/app/install/", data)
+      .then((response) => response?.data)
+      .catch((error) => {
+        throw error?.response?.data;
+      });
+  }
+
+  async refreshAppConnection(data: IGithubAppRefreshRequest): Promise<IGithubAppInstallationStatus> {
+    return this.post("/api/users/me/integrations/github/app/refresh/", data)
       .then((response) => response?.data)
       .catch((error) => {
         throw error?.response?.data;

--- a/apps/web/core/store/scheduler.store.ts
+++ b/apps/web/core/store/scheduler.store.ts
@@ -8,11 +8,7 @@ import { set, unset } from "lodash-es";
 import { action, makeObservable, observable, runInAction } from "mobx";
 import { computedFn } from "mobx-utils";
 // pi dash imports
-import type {
-  IScheduler,
-  ISchedulerCreatePayload,
-  ISchedulerUpdatePayload,
-} from "@pi-dash/services";
+import type { IScheduler, ISchedulerCreatePayload, ISchedulerUpdatePayload } from "@pi-dash/services";
 import { SchedulerService } from "@pi-dash/services";
 // store
 import type { CoreRootStore } from "./root.store";
@@ -71,7 +67,9 @@ export class SchedulerStore implements ISchedulerStore {
     const workspace = this.rootStore.workspaceRoot.getWorkspaceBySlug(workspaceSlug);
     if (!workspace) return [];
     const filtered = Object.values(this.schedulerMap).filter((s) => s.workspace === workspace.id);
-    return [...filtered].toSorted((a, b) => a.name.localeCompare(b.name));
+    // Use sort() because toSorted() isn't in this app's tsconfig lib (ES2022).
+    // eslint-disable-next-line unicorn/no-array-sort
+    return [...filtered].sort((a, b) => a.name.localeCompare(b.name));
   });
 
   getSchedulerById = computedFn((schedulerId: string): IScheduler | null => this.schedulerMap[schedulerId] ?? null);

--- a/packages/constants/src/settings/profile.ts
+++ b/packages/constants/src/settings/profile.ts
@@ -10,6 +10,7 @@ import {
   CircleUser,
   KeyRound,
   LockIcon,
+  Plug,
   type LucideIcon,
   RefreshCw,
   Settings2,
@@ -80,6 +81,11 @@ export const PROFILE_SETTINGS: Record<
     i18n_label: "Notifications",
     icon: Bell,
   },
+  integrations: {
+    key: "integrations",
+    i18n_label: "Integrations",
+    icon: Plug,
+  },
   "api-tokens": {
     key: "api-tokens",
     i18n_label: "Personal Access Tokens",
@@ -102,5 +108,5 @@ export const GROUPED_PROFILE_SETTINGS: Record<
     PROFILE_SETTINGS["security"],
     PROFILE_SETTINGS["activity"],
   ],
-  [PROFILE_SETTINGS_CATEGORY.DEVELOPER]: [PROFILE_SETTINGS["api-tokens"]],
+  [PROFILE_SETTINGS_CATEGORY.DEVELOPER]: [PROFILE_SETTINGS["integrations"], PROFILE_SETTINGS["api-tokens"]],
 };

--- a/packages/propel/src/icons/state/helper.tsx
+++ b/packages/propel/src/icons/state/helper.tsx
@@ -23,7 +23,7 @@ export interface IIntakeStateGroupIcon {
   percentage?: number;
 }
 
-export type TStateGroups = "backlog" | "unstarted" | "started" | "completed" | "cancelled";
+export type TStateGroups = "backlog" | "unstarted" | "started" | "review" | "completed" | "cancelled";
 
 export const STATE_GROUP_COLORS: {
   [key in TStateGroups]: string;
@@ -31,6 +31,7 @@ export const STATE_GROUP_COLORS: {
   backlog: "#60646C",
   unstarted: "#60646C",
   started: "#F59E0B",
+  review: "#3B82F6",
   completed: "#46A758",
   cancelled: "#9AA4BC",
 };

--- a/packages/propel/src/icons/state/state-group-icon.tsx
+++ b/packages/propel/src/icons/state/state-group-icon.tsx
@@ -19,6 +19,7 @@ const iconComponents = {
   backlog: BacklogGroupIcon,
   cancelled: CancelledGroupIcon,
   completed: CompletedGroupIcon,
+  review: StartedGroupIcon,
   started: StartedGroupIcon,
   unstarted: UnstartedGroupIcon,
 };

--- a/packages/types/src/integration.ts
+++ b/packages/types/src/integration.ts
@@ -82,7 +82,51 @@ export interface IGithubProjectBindingStatus {
   is_sync_enabled?: boolean;
   last_synced_at?: string | null;
   last_sync_error?: string;
+  repo_url?: string;
 }
+
+// GitHub App Enablement (.ai_design/github_deep_integration/design.md)
+
+export interface IGithubAppInstallationStatus {
+  connected: boolean;
+  installation_id?: number;
+  account_login?: string;
+  account_type?: "User" | "Organization" | "Unknown";
+  repository_selection?: "all" | "selected";
+  repository_count?: number;
+  permissions?: Record<string, string>;
+  events?: string[];
+  installed_at?: string | null;
+  suspended_at?: string | null;
+  verified_at?: string | null;
+  last_checked_at?: string | null;
+  last_check_error?: string;
+}
+
+export interface IGithubAppWorkspaceStatus {
+  id: string;
+  slug: string;
+  name: string;
+  github_app: IGithubAppInstallationStatus;
+}
+
+export interface IGithubAppStatus {
+  configured: boolean;
+  app_slug: string;
+  workspaces: IGithubAppWorkspaceStatus[];
+}
+
+export interface IGithubAppInstallStartRequest {
+  workspace_slug: string;
+}
+
+export interface IGithubAppInstallStartResponse {
+  state: string;
+  expires_at: string;
+  install_url: string;
+}
+
+export type IGithubAppRefreshRequest = IGithubAppInstallStartRequest;
 
 // slack integration
 export interface ISlackIntegration {

--- a/packages/types/src/settings.ts
+++ b/packages/types/src/settings.ts
@@ -16,6 +16,7 @@ export type TProfileSettingsTabs =
   | "activity"
   | "notifications"
   | "security"
+  | "integrations"
   | "api-tokens";
 
 export type TWorkspaceSettingsTabs =


### PR DESCRIPTION
## Summary

Implements the GitHub App foundation described in the design doc:

- Adds GitHub App install/session/webhook models and migration.
- Adds App JWT, OAuth callback verification, installation-token minting, and webhook signature verification helpers.
- Adds profile-level GitHub App status/install/refresh/callback/webhook API endpoints.
- Adds Profile Settings -> Integrations UI for workspace-admin App installation and connection refresh.
- Keeps existing PAT-backed issue/comment polling unchanged; no automatic GitHub issue/comment/PR sync is introduced.
- Adds focused contract coverage for status, install start, callback binding, actor mismatch, and webhook signature/ping behavior.
- Includes small web type fixes required for full app typecheck: review state icon typing, OpenClaw runner option typing, and ES2022-safe scheduler sorting.

This is intentionally stacked on the existing design PR branch (`design/github-deep-integration`) so the implementation PR does not duplicate the design-only commits from #260. After #260 merges, this PR can be retargeted to `main`.

## Validation

- `POSTGRES_DB=pi_dash POSTGRES_USER=pi_dash POSTGRES_PASSWORD=pi_dash POSTGRES_HOST=127.0.0.1 POSTGRES_PORT=5432 REDIS_URL=redis://127.0.0.1:6379/15 DJANGO_SETTINGS_MODULE=pi_dash.settings.test ./.venv/bin/python manage.py check`
- `POSTGRES_DB=pi_dash POSTGRES_USER=pi_dash POSTGRES_PASSWORD=pi_dash POSTGRES_HOST=127.0.0.1 POSTGRES_PORT=5432 REDIS_URL=redis://127.0.0.1:6379/15 DJANGO_SETTINGS_MODULE=pi_dash.settings.test ./.venv/bin/pytest pi_dash/tests/contract/app/test_github_app_integration.py`
- `pnpm --filter web check:types`
- `pnpm --filter @pi-dash/types check:types`
- `pnpm --filter @pi-dash/constants check:types`
- `pnpm --filter @pi-dash/propel check:types`
- `pnpm exec oxlint --deny-warnings ...` on touched frontend/type files
- `pnpm exec oxfmt --check ...` on touched frontend/type/design files
- `git diff --check`
- `./.venv/bin/python -m py_compile ...` on touched backend files

## Notes

`manage.py makemigrations --check --dry-run` still reports unrelated existing migration drift in `db` and `runner`; it no longer reports GitHub App migration changes.

Live GitHub installation was not exercised because this workspace does not have real GitHub App credentials configured; the Pi Dash callback and webhook paths are covered with mocked GitHub responses.
