### PR TITLE
Centralize config reads and remove SKIP_ENV_VAR

### DIFF
--- a/apps/api/pi_dash/config/__init__.py
+++ b/apps/api/pi_dash/config/__init__.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Centralized configuration access for the Pi Dash backend.
+
+Read every config value through this package instead of touching
+``os.environ`` or the ``InstanceConfiguration`` table directly::
+
+    from pi_dash import config
+
+    host = config.get_config("EMAIL_HOST")
+    signup_on = config.get_bool("ENABLE_SIGNUP")
+
+Where each key is read from (env vs. database) is declared once in
+``pi_dash.config.registry``.
+"""
+
+from .accessor import (
+    ConfigError,
+    get_bool,
+    get_config,
+    get_int,
+    get_many,
+)
+from .registry import CONFIG, all_keys, is_registered
+
+__all__ = [
+    "CONFIG",
+    "ConfigError",
+    "all_keys",
+    "get_bool",
+    "get_config",
+    "get_int",
+    "get_many",
+    "is_registered",
+]

--- a/apps/api/pi_dash/config/accessor.py
+++ b/apps/api/pi_dash/config/accessor.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""The single entry point for reading configuration values.
+
+All config reads should go through :func:`get_config` (or :func:`get_many`)
+rather than touching ``os.environ`` or the ``InstanceConfiguration`` table
+directly. The registry decides, per key, whether the value comes from the
+environment or the database.
+
+Two tiers, by necessity:
+
+* ``"env"`` keys resolve at any time, including Django settings import.
+* ``"db"`` keys require the app registry (ORM) to be ready, so they can only
+  be read at runtime. Reading one too early raises :class:`ConfigError` loudly
+  rather than failing in a confusing way — settings files must only read
+  ``"env"`` keys.
+
+This module must not import ``django.conf.settings`` or any model at import
+time: settings modules import *this*, so a top-level Django import would be
+circular. All Django access is lazy, inside the functions.
+"""
+
+import logging
+import os
+
+from .registry import CONFIG
+
+logger = logging.getLogger("pi_dash.config")
+
+# Sentinel so callers can pass ``default=None`` distinctly from "no override".
+_UNSET = object()
+
+
+class ConfigError(RuntimeError):
+    """Raised for unregistered keys (in strict mode) or misuse of the tiers."""
+
+
+def _strict() -> bool:
+    """Whether to raise (vs. warn) on an unregistered key.
+
+    Strict in tests and when DEBUG is on, so CI catches unregistered keys;
+    lenient in prod so a forgotten key degrades gracefully to an env read.
+    Reads the environment directly to avoid importing Django settings here.
+    """
+    if os.environ.get("DJANGO_SETTINGS_MODULE", "").endswith(".test"):
+        return True
+    return os.environ.get("DEBUG", "0") not in ("0", "", "false", "False")
+
+
+def _instance_configuration_model():
+    """Lazily import the model, mapping early access to a clear error."""
+    try:
+        from pi_dash.license.models import InstanceConfiguration
+    except Exception as exc:  # AppRegistryNotReady, ImportError, ...
+        raise ConfigError(
+            "a db-sourced config key was read before the app registry was "
+            "ready (e.g. during settings import). Settings modules must only "
+            "read 'env'-sourced keys."
+        ) from exc
+    return InstanceConfiguration
+
+
+def _decrypt(value):
+    if not value:
+        return value
+    from pi_dash.license.utils.encryption import decrypt_data
+
+    return decrypt_data(value)
+
+
+def _read_env(key, entry, default=_UNSET):
+    fallback = entry.get("default") if default is _UNSET else default
+    return os.environ.get(key, fallback)
+
+
+def _resolve_db_row(entry, row, default=_UNSET):
+    if row is None:
+        return entry.get("default") if default is _UNSET else default
+    value = row["value"]
+    if row["is_encrypted"]:
+        return _decrypt(value)
+    return value
+
+
+def _handle_unregistered(key, default=_UNSET):
+    msg = f"unregistered config key {key!r}"
+    if _strict():
+        raise ConfigError(f"{msg} — register it in pi_dash/config/registry.py")
+    logger.warning("%s; defaulting to env", msg)
+    return os.environ.get(key) if default is _UNSET else os.environ.get(key, default)
+
+
+def get_config(key: str, default=_UNSET):
+    """Return the configured value for ``key`` (a string, or its default).
+
+    ``default`` optionally overrides the registry default for this call — used
+    by settings modules that keep their inline fallbacks. It applies to both
+    env reads (when the var is unset) and db reads (when no row exists).
+    """
+    entry = CONFIG.get(key)
+    if entry is None:
+        return _handle_unregistered(key, default)
+    if entry["source"] == "env":
+        return _read_env(key, entry, default)
+    if entry["source"] == "db":
+        model = _instance_configuration_model()
+        row = model.objects.filter(key=key).values("value", "is_encrypted").first()
+        return _resolve_db_row(entry, row, default)
+    raise ConfigError(f"config key {key!r} has invalid source {entry['source']!r}")
+
+
+def get_many(keys) -> dict:
+    """Resolve several keys at once, batching the db reads into one query."""
+    result: dict = {}
+    db_entries: dict = {}
+    for key in keys:
+        entry = CONFIG.get(key)
+        if entry is None:
+            result[key] = _handle_unregistered(key)
+        elif entry["source"] == "env":
+            result[key] = _read_env(key, entry)
+        elif entry["source"] == "db":
+            db_entries[key] = entry
+        else:
+            raise ConfigError(f"config key {key!r} has invalid source {entry['source']!r}")
+
+    if db_entries:
+        model = _instance_configuration_model()
+        rows = {
+            r["key"]: r
+            for r in model.objects.filter(key__in=list(db_entries)).values("key", "value", "is_encrypted")
+        }
+        for key, entry in db_entries.items():
+            result[key] = _resolve_db_row(entry, rows.get(key))
+    return result
+
+
+def get_bool(key: str) -> bool:
+    """Truthy iff the value is the string ``"1"`` (the project's convention)."""
+    return get_config(key) == "1"
+
+
+def get_int(key: str, default: int | None = None) -> int | None:
+    value = get_config(key)
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default

--- a/apps/api/pi_dash/config/accessor.py
+++ b/apps/api/pi_dash/config/accessor.py
@@ -40,13 +40,12 @@ class ConfigError(RuntimeError):
 def _strict() -> bool:
     """Whether to raise (vs. warn) on an unregistered key.
 
-    Strict in tests and when DEBUG is on, so CI catches unregistered keys;
-    lenient in prod so a forgotten key degrades gracefully to an env read.
-    Reads the environment directly to avoid importing Django settings here.
+    Strict only under the test settings module, so CI catches unregistered
+    keys; lenient everywhere else (incl. prod, even with DEBUG on) so a
+    forgotten key degrades gracefully to an env read instead of crashing the
+    process. Reads the environment directly to avoid importing Django settings.
     """
-    if os.environ.get("DJANGO_SETTINGS_MODULE", "").endswith(".test"):
-        return True
-    return os.environ.get("DEBUG", "0") not in ("0", "", "false", "False")
+    return os.environ.get("DJANGO_SETTINGS_MODULE", "").endswith(".test")
 
 
 def _instance_configuration_model():
@@ -142,9 +141,12 @@ def get_bool(key: str) -> bool:
     return get_config(key) == "1"
 
 
-def get_int(key: str, default: int | None = None) -> int | None:
-    value = get_config(key)
+def get_int(key: str, default=_UNSET) -> int | None:
+    """Like get_config but coerced to int. When ``default`` is omitted the
+    registry default is used; when supplied it overrides for the lookup and is
+    also the fallback if the value can't be parsed as an int."""
+    value = get_config(key) if default is _UNSET else get_config(key, default)
     try:
         return int(value)
     except (TypeError, ValueError):
-        return default
+        return None if default is _UNSET else default

--- a/apps/api/pi_dash/config/registry.py
+++ b/apps/api/pi_dash/config/registry.py
@@ -1,0 +1,240 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Single source of truth for where each config value is read from.
+
+Every config key managed by ``pi_dash.config`` is declared here with a
+``source``:
+
+* ``"env"`` — read from the process environment (populated by a ``.env`` file
+  locally, or by SSM-injected env vars in the cloud). The code never
+  distinguishes ``.env`` from SSM; both just become ``os.environ``.
+* ``"db"`` — read from the ``InstanceConfiguration`` table, i.e. values an
+  instance admin can edit at runtime through the admin UI.
+
+A key belongs to exactly one source. The *system* is hybrid; no single key is.
+
+Entry fields:
+    source   : "env" | "db"          (required)
+    default  : value when unset/missing (optional, defaults to None)
+    secret   : True for values stored encrypted in the DB / sensitive in env
+
+Back-compat note (OSS): every key that the legacy ``get_configuration_value``
+resolver served from the DB under the default ``SKIP_ENV_VAR=1`` is classified
+``"db"`` here, so removing ``SKIP_ENV_VAR`` does not change self-hosted
+behavior. The cloud deployment reclassifies the secret/identity keys to
+``"env"`` via the ee-overlay (it overrides ``CONFIG_SOURCE_OVERRIDES`` below).
+"""
+
+import os
+
+# Keys the legacy resolver managed. Classified for back-compat: the values
+# that configure_instance seeds and serves from the DB stay "db"; analytics
+# keys that were never seeded (always fell through to env) are "env".
+_RESOLVER_CONFIG = {
+    # --- Authentication toggles (runtime, admin-editable) -----------------
+    "ENABLE_SIGNUP": {"source": "db", "default": "1"},
+    "ENABLE_EMAIL_PASSWORD": {"source": "db", "default": "1"},
+    "ENABLE_MAGIC_LINK_LOGIN": {"source": "db", "default": "0"},
+    "DISABLE_WORKSPACE_CREATION": {"source": "db", "default": "0"},
+    # --- Google OAuth -----------------------------------------------------
+    "GOOGLE_CLIENT_ID": {"source": "db", "default": None},
+    "GOOGLE_CLIENT_SECRET": {"source": "db", "default": None, "secret": True},
+    "ENABLE_GOOGLE_SYNC": {"source": "db", "default": "0"},
+    # --- GitHub OAuth -----------------------------------------------------
+    "GITHUB_CLIENT_ID": {"source": "db", "default": None},
+    "GITHUB_CLIENT_SECRET": {"source": "db", "default": None, "secret": True},
+    "GITHUB_ORGANIZATION_ID": {"source": "db", "default": None},
+    "ENABLE_GITHUB_SYNC": {"source": "db", "default": "0"},
+    # --- GitLab OAuth -----------------------------------------------------
+    "GITLAB_HOST": {"source": "db", "default": None},
+    "GITLAB_CLIENT_ID": {"source": "db", "default": None},
+    "GITLAB_CLIENT_SECRET": {"source": "db", "default": None, "secret": True},
+    "ENABLE_GITLAB_SYNC": {"source": "db", "default": "0"},
+    # --- Gitea OAuth ------------------------------------------------------
+    "IS_GITEA_ENABLED": {"source": "db", "default": "0"},
+    "GITEA_HOST": {"source": "db", "default": None},
+    "GITEA_CLIENT_ID": {"source": "db", "default": None},
+    "GITEA_CLIENT_SECRET": {"source": "db", "default": None, "secret": True},
+    "ENABLE_GITEA_SYNC": {"source": "db", "default": "0"},
+    # --- SMTP / email -----------------------------------------------------
+    "ENABLE_SMTP": {"source": "db", "default": "0"},
+    "EMAIL_HOST": {"source": "db", "default": ""},
+    "EMAIL_HOST_USER": {"source": "db", "default": ""},
+    "EMAIL_HOST_PASSWORD": {"source": "db", "default": "", "secret": True},
+    "EMAIL_PORT": {"source": "db", "default": "587"},
+    "EMAIL_FROM": {"source": "db", "default": ""},
+    "EMAIL_USE_TLS": {"source": "db", "default": "1"},
+    "EMAIL_USE_SSL": {"source": "db", "default": "0"},
+    # --- LLM --------------------------------------------------------------
+    "LLM_API_KEY": {"source": "db", "default": None, "secret": True},
+    "LLM_PROVIDER": {"source": "db", "default": "openai"},
+    "LLM_MODEL": {"source": "db", "default": "gpt-4o-mini"},
+    "GPT_ENGINE": {"source": "db", "default": "gpt-3.5-turbo"},  # deprecated, use LLM_MODEL
+    # --- Misc -------------------------------------------------------------
+    "UNSPLASH_ACCESS_KEY": {"source": "db", "default": "", "secret": True},
+    # --- Analytics (never seeded to DB; always env) -----------------------
+    "POSTHOG_API_KEY": {"source": "env", "default": None},
+    "POSTHOG_HOST": {"source": "env", "default": None},
+}
+
+# Infrastructure / framework config read at boot in the settings modules. These
+# are always "env" (they must exist before the DB is reachable — see the tier
+# note in accessor.py). Declared here so the registry is the single catalog of
+# every config key; settings modules still pass their own inline defaults to
+# get_config, so the values below are documentation of the effective default.
+_ENV_INFRA = {
+    # Core / security
+    "SECRET_KEY": None,
+    "DEBUG": "0",
+    "ALLOWED_HOSTS": "*",
+    "CORS_ALLOWED_ORIGINS": "",
+    # Database
+    "DATABASE_URL": None,
+    "POSTGRES_DB": None,
+    "POSTGRES_USER": None,
+    "POSTGRES_PASSWORD": None,
+    "POSTGRES_HOST": None,
+    "POSTGRES_PORT": "5432",
+    "ENABLE_READ_REPLICA": "0",
+    "DATABASE_READ_REPLICA_URL": None,
+    "POSTGRES_READ_REPLICA_DB": None,
+    "POSTGRES_READ_REPLICA_USER": None,
+    "POSTGRES_READ_REPLICA_PASSWORD": None,
+    "POSTGRES_READ_REPLICA_HOST": None,
+    "POSTGRES_READ_REPLICA_PORT": "5432",
+    # Redis
+    "REDIS_URL": None,
+    "REDIS_SOCKET_CONNECT_TIMEOUT": 2.0,
+    "REDIS_SOCKET_TIMEOUT": 5.0,
+    "REDIS_HEALTH_CHECK_INTERVAL": 30,
+    "REDIS_MAX_CONNECTIONS": None,
+    # AI assistant / KMS
+    "ASSISTANT_CRYPTO_BACKEND": "aws-kms",
+    "ASSISTANT_KMS_KEY_ID": "",
+    "ASSISTANT_KMS_ENDPOINT_URL": "",
+    "ASSISTANT_KEY_CACHE_TTL": 300,
+    "ASSISTANT_KEY_CACHE_MAXSIZE": 1000,
+    "ASSISTANT_BLOCK_PRIVATE_URLS": "false",
+    "ASSISTANT_TURN_SOFT_LIMIT": 300,
+    "ASSISTANT_TURN_HARD_LIMIT": 330,
+    "ASSISTANT_HISTORY_MAX_TURNS": 40,
+    "ASSISTANT_LOOP_HISTORY_MAX_TURNS": 5,
+    # Loop (auto project management)
+    "LOOP_ENABLED": "true",
+    "LOOP_STAGGER_WINDOW_MINUTES": 60,
+    "LOOP_MAX_DISPATCH_PER_TICK": 100,
+    "LOOP_RECONCILE_EVERY_MINUTES": 15,
+    "LOOP_ROTATION_HEADROOM": 30,
+    "LOOP_MAX_WRITES": 10,
+    "LOOP_PR_LOOKUPS_PER_RUN": 15,
+    # Storage / S3 / MinIO
+    "USE_MINIO": 0,
+    "AWS_ACCESS_KEY_ID": "access-key",
+    "AWS_SECRET_ACCESS_KEY": "secret-key",
+    "AWS_S3_BUCKET_NAME": "uploads",
+    "AWS_REGION": "",
+    "AWS_S3_ENDPOINT_URL": None,
+    "MINIO_ENDPOINT_URL": None,
+    "MINIO_ENDPOINT_SSL": None,
+    "SIGNED_URL_EXPIRATION": "3600",
+    "WEB_URL": None,
+    # RabbitMQ / Celery
+    "RABBITMQ_HOST": "localhost",
+    "RABBITMQ_PORT": "5672",
+    "RABBITMQ_USER": "guest",
+    "RABBITMQ_PASSWORD": "guest",
+    "RABBITMQ_VHOST": "/",
+    "AMQP_URL": None,
+    # Misc product config
+    "FILE_SIZE_LIMIT": 5242880,
+    "GITHUB_ACCESS_TOKEN": False,
+    "GITHUB_SYNC_ENABLED": "true",
+    "SCHEDULER_ENABLED": "true",
+    "ANALYTICS_SECRET_KEY": False,
+    "ANALYTICS_BASE_API": False,
+    # Runner transport / lifecycle tunables
+    "LONG_POLL_INTERVAL_SECS": 25,
+    "ACCESS_TOKEN_TTL_SECS": 3600,
+    "RUNNER_OFFLINE_THRESHOLD_SECS": 50,
+    "OFFLINE_STREAM_TTL_SECS": 86400,
+    "OFFLINE_STREAM_MAXLEN": 1000,
+    "RUNNER_STREAM_MIN_RETENTION_SECS": 3600,
+    "EVENT_BATCH_MAX_AGE_MS": 250,
+    "EVENT_BATCH_MAX_BYTES": 65536,
+    "RUN_MESSAGE_DEDUPE_TTL_SECS": 604800,
+    "LATEST_RUNNER_VERSION": None,
+    "MIN_RUNNER_VERSION": None,
+    "RUNNER_AGENT_STALL_THRESHOLD_SECS": 360,
+    "RUNNER_AGENT_OBSERVABILITY_STALE_SECS": 90,
+    # Sessions / cookies
+    "SESSION_COOKIE_AGE": 604800,
+    "SESSION_COOKIE_NAME": "session-id",
+    "COOKIE_DOMAIN": None,
+    "SESSION_SAVE_EVERY_REQUEST": "0",
+    "ADMIN_SESSION_COOKIE_AGE": 3600,
+    # Base URLs
+    "ADMIN_BASE_URL": None,
+    "ADMIN_BASE_PATH": "/god-mode/",
+    "SPACE_BASE_URL": None,
+    "SPACE_BASE_PATH": "/spaces/",
+    "APP_BASE_URL": None,
+    "APP_BASE_PATH": "/",
+    "LIVE_BASE_URL": None,
+    "LIVE_BASE_PATH": "/live/",
+    "HARD_DELETE_AFTER_DAYS": 60,
+    "INSTANCE_CHANGELOG_URL": "",
+    "ENABLE_DRF_SPECTACULAR": "0",
+    # Mongo (legacy / optional)
+    "MONGO_DB_URL": False,
+    "MONGO_DB_DATABASE": False,
+    # Production (Scout APM) + local
+    "SCOUT_MONITOR": False,
+    "SCOUT_KEY": "",
+    "EMAIL_BACKEND": "django.core.mail.backends.smtp.EmailBackend",
+}
+
+# Per-key source overrides applied on top of the base registry. Empty in OSS.
+# The cloud deployment flips secret/identity keys to "env" (so they are sourced
+# from SSM) via the ``PIDASH_CONFIG_ENV_KEYS`` environment variable — a
+# comma-separated list of keys to force to "env". This is the SSM-native seam:
+# the cloud already injects config through SSM → env, so the classification
+# travels the same path as the values it governs, with no file-overlay or
+# settings coupling. The in-module dict below is a secondary hook for tests.
+CONFIG_SOURCE_OVERRIDES: dict[str, str] = {}
+
+# Name of the env var that lists keys to force to "env" (see above).
+ENV_KEYS_OVERRIDE_VAR = "PIDASH_CONFIG_ENV_KEYS"
+
+
+def _load_env_overrides() -> dict[str, str]:
+    raw = os.environ.get(ENV_KEYS_OVERRIDE_VAR, "")
+    return {key.strip(): "env" for key in raw.split(",") if key.strip()}
+
+
+def _build_config() -> dict[str, dict]:
+    config = {key: dict(entry) for key, entry in _RESOLVER_CONFIG.items()}
+    # Infra keys are env-sourced; never override an already-declared resolver
+    # key (e.g. UNSPLASH_ACCESS_KEY stays db-managed for the admin UI).
+    for key, default in _ENV_INFRA.items():
+        config.setdefault(key, {"source": "env", "default": default})
+    overrides = {**_load_env_overrides(), **CONFIG_SOURCE_OVERRIDES}
+    for key, source in overrides.items():
+        if key in config:
+            config[key]["source"] = source
+        else:
+            config[key] = {"source": source, "default": None}
+    return config
+
+
+CONFIG = _build_config()
+
+
+def all_keys() -> frozenset[str]:
+    """Every registered config key (used by the registration guard)."""
+    return frozenset(CONFIG)
+
+
+def is_registered(key: str) -> bool:
+    return key in CONFIG

--- a/apps/api/pi_dash/config/registry.py
+++ b/apps/api/pi_dash/config/registry.py
@@ -24,7 +24,8 @@ Back-compat note (OSS): every key that the legacy ``get_configuration_value``
 resolver served from the DB under the default ``SKIP_ENV_VAR=1`` is classified
 ``"db"`` here, so removing ``SKIP_ENV_VAR`` does not change self-hosted
 behavior. The cloud deployment reclassifies the secret/identity keys to
-``"env"`` via the ee-overlay (it overrides ``CONFIG_SOURCE_OVERRIDES`` below).
+``"env"`` (so they are sourced from SSM) via the ``PIDASH_CONFIG_ENV_KEYS``
+environment variable — see ``_load_env_overrides`` below.
 """
 
 import os
@@ -42,16 +43,24 @@ _RESOLVER_CONFIG = {
     "GOOGLE_CLIENT_ID": {"source": "db", "default": None},
     "GOOGLE_CLIENT_SECRET": {"source": "db", "default": None, "secret": True},
     "ENABLE_GOOGLE_SYNC": {"source": "db", "default": "0"},
+    # IS_*_ENABLED flags are derived + seeded into the DB by configure_instance
+    # and read back by the instances endpoint, so they are db-sourced.
+    "IS_GOOGLE_ENABLED": {"source": "db", "default": "0"},
     # --- GitHub OAuth -----------------------------------------------------
     "GITHUB_CLIENT_ID": {"source": "db", "default": None},
     "GITHUB_CLIENT_SECRET": {"source": "db", "default": None, "secret": True},
     "GITHUB_ORGANIZATION_ID": {"source": "db", "default": None},
     "ENABLE_GITHUB_SYNC": {"source": "db", "default": "0"},
+    "IS_GITHUB_ENABLED": {"source": "db", "default": "0"},
+    # GITHUB_APP_NAME is read by the instances endpoint from the env only
+    # (never seeded into the DB), so it is env-sourced.
+    "GITHUB_APP_NAME": {"source": "env", "default": None},
     # --- GitLab OAuth -----------------------------------------------------
     "GITLAB_HOST": {"source": "db", "default": None},
     "GITLAB_CLIENT_ID": {"source": "db", "default": None},
     "GITLAB_CLIENT_SECRET": {"source": "db", "default": None, "secret": True},
     "ENABLE_GITLAB_SYNC": {"source": "db", "default": "0"},
+    "IS_GITLAB_ENABLED": {"source": "db", "default": "0"},
     # --- Gitea OAuth ------------------------------------------------------
     "IS_GITEA_ENABLED": {"source": "db", "default": "0"},
     "GITEA_HOST": {"source": "db", "default": None},
@@ -74,6 +83,8 @@ _RESOLVER_CONFIG = {
     "GPT_ENGINE": {"source": "db", "default": "gpt-3.5-turbo"},  # deprecated, use LLM_MODEL
     # --- Misc -------------------------------------------------------------
     "UNSPLASH_ACCESS_KEY": {"source": "db", "default": "", "secret": True},
+    # Read by the instances endpoint from the env only (never seeded to DB).
+    "SLACK_CLIENT_ID": {"source": "env", "default": None},
     # --- Analytics (never seeded to DB; always env) -----------------------
     "POSTHOG_API_KEY": {"source": "env", "default": None},
     "POSTHOG_HOST": {"source": "env", "default": None},

--- a/apps/api/pi_dash/license/api/serializers/configuration.py
+++ b/apps/api/pi_dash/license/api/serializers/configuration.py
@@ -3,6 +3,7 @@
 # See the LICENSE file for details.
 
 from .base import BaseSerializer
+from pi_dash.config.registry import CONFIG
 from pi_dash.license.models import InstanceConfiguration
 from pi_dash.license.utils.encryption import decrypt_data
 
@@ -17,5 +18,13 @@ class InstanceConfigurationSerializer(BaseSerializer):
         # Decrypt secrets value
         if instance.is_encrypted and instance.value is not None:
             data["value"] = decrypt_data(instance.value)
+
+        # Surface where this key is actually read from. When a key is sourced
+        # from the environment (e.g. SSM-managed in the cloud), the DB row is
+        # ignored at read time, so the admin UI should render it read-only.
+        entry = CONFIG.get(instance.key)
+        source = entry["source"] if entry else "db"
+        data["source"] = source
+        data["is_managed"] = source == "env"
 
         return data

--- a/apps/api/pi_dash/license/management/commands/configure_instance.py
+++ b/apps/api/pi_dash/license/management/commands/configure_instance.py
@@ -9,8 +9,18 @@ import os
 from django.core.management.base import BaseCommand, CommandError
 
 # Module imports
+from pi_dash.config.registry import CONFIG
 from pi_dash.license.models import InstanceConfiguration
 from pi_dash.utils.instance_config_variables import instance_config_variables
+
+
+def _is_db_sourced(key):
+    """Only db-sourced keys are seeded into InstanceConfiguration. env-sourced
+    keys (e.g. secrets routed to SSM in the cloud) are read from the
+    environment and must not get a DB row. Unregistered keys keep the legacy
+    behavior of being seeded."""
+    entry = CONFIG.get(key)
+    return entry is None or entry["source"] == "db"
 
 
 class Command(BaseCommand):
@@ -27,6 +37,8 @@ class Command(BaseCommand):
                 raise CommandError(f"{item} env variable is required.")
 
         for item in instance_config_variables:
+            if not _is_db_sourced(item.get("key")):
+                continue
             obj, created = InstanceConfiguration.objects.get_or_create(key=item.get("key"))
             if created:
                 obj.category = item.get("category")

--- a/apps/api/pi_dash/license/management/commands/configure_instance.py
+++ b/apps/api/pi_dash/license/management/commands/configure_instance.py
@@ -14,6 +14,12 @@ from pi_dash.license.models import InstanceConfiguration
 from pi_dash.utils.instance_config_variables import instance_config_variables
 
 
+# Derived auth flags computed and seeded as DB rows below (not part of
+# instance_config_variables). Exposed as a constant so the config registry can
+# assert every seeded key is registered as db-sourced.
+DERIVED_FLAG_KEYS = ["IS_GOOGLE_ENABLED", "IS_GITHUB_ENABLED", "IS_GITLAB_ENABLED", "IS_GITEA_ENABLED"]
+
+
 def _is_db_sourced(key):
     """Only db-sourced keys are seeded into InstanceConfiguration. env-sourced
     keys (e.g. secrets routed to SSM in the cloud) are read from the
@@ -52,7 +58,7 @@ class Command(BaseCommand):
             else:
                 self.stdout.write(self.style.WARNING(f"{obj.key} configuration already exists"))
 
-        keys = ["IS_GOOGLE_ENABLED", "IS_GITHUB_ENABLED", "IS_GITLAB_ENABLED", "IS_GITEA_ENABLED"]
+        keys = DERIVED_FLAG_KEYS
         if not InstanceConfiguration.objects.filter(key__in=keys).exists():
             for key in keys:
                 if key == "IS_GOOGLE_ENABLED":

--- a/apps/api/pi_dash/license/utils/instance_value.py
+++ b/apps/api/pi_dash/license/utils/instance_value.py
@@ -5,36 +5,51 @@
 # Python imports
 import os
 
-# Django imports
-from django.conf import settings
-
 # Module imports
+from pi_dash.config.registry import CONFIG
 from pi_dash.license.models import InstanceConfiguration
 from pi_dash.license.utils.encryption import decrypt_data
 
 
-# Helper function to return value from the passed key
+def _source(key):
+    """Where to read ``key`` from. Unregistered keys default to env, matching
+    the centralized accessor's policy (see pi_dash.config)."""
+    entry = CONFIG.get(key)
+    return entry["source"] if entry else "env"
+
+
+# Helper function to return value from the passed key.
+#
+# This is the legacy resolver, kept as a thin compatibility shim over the
+# per-key source registry. It honors the caller-supplied ``default`` exactly as
+# before; the only change from the old behavior is that the source (db vs env)
+# is now decided per key via the registry instead of by the global SKIP_ENV_VAR
+# flag. New code should prefer ``pi_dash.config.get_config`` directly.
 def get_configuration_value(keys):
+    db_keys = [key.get("key") for key in keys if _source(key.get("key")) == "db"]
+    rows = {}
+    if db_keys:
+        rows = {
+            row["key"]: row
+            for row in InstanceConfiguration.objects.filter(key__in=db_keys).values(
+                "key", "value", "is_encrypted"
+            )
+        }
+
     environment_list = []
-    if settings.SKIP_ENV_VAR:
-        # Get the configurations
-        instance_configuration = InstanceConfiguration.objects.values("key", "value", "is_encrypted")
-
-        for key in keys:
-            for item in instance_configuration:
-                if key.get("key") == item.get("key"):
-                    if item.get("is_encrypted", False):
-                        environment_list.append(decrypt_data(item.get("value")))
-                    else:
-                        environment_list.append(item.get("value"))
-
-                    break
+    for key in keys:
+        name = key.get("key")
+        default = key.get("default")
+        if _source(name) == "db":
+            row = rows.get(name)
+            if row is None:
+                environment_list.append(default)
+            elif row.get("is_encrypted", False):
+                environment_list.append(decrypt_data(row.get("value")))
             else:
-                environment_list.append(key.get("default"))
-    else:
-        # Get the configuration from os
-        for key in keys:
-            environment_list.append(os.environ.get(key.get("key"), key.get("default")))
+                environment_list.append(row.get("value"))
+        else:
+            environment_list.append(os.environ.get(name, default))
 
     return tuple(environment_list)
 

--- a/apps/api/pi_dash/settings/common.py
+++ b/apps/api/pi_dash/settings/common.py
@@ -25,7 +25,7 @@ from pi_dash.utils.url import is_valid_url
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # Secret Key
-SECRET_KEY = get_config("SECRET_KEY") or get_random_secret_key()
+SECRET_KEY = get_config("SECRET_KEY", get_random_secret_key())
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = int(get_config("DEBUG", "0"))

--- a/apps/api/pi_dash/settings/common.py
+++ b/apps/api/pi_dash/settings/common.py
@@ -18,22 +18,23 @@ from corsheaders.defaults import default_headers
 
 
 # Module imports
+from pi_dash.config import get_config
 from pi_dash.utils.url import is_valid_url
 
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # Secret Key
-SECRET_KEY = os.environ.get("SECRET_KEY", get_random_secret_key())
+SECRET_KEY = get_config("SECRET_KEY") or get_random_secret_key()
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = int(os.environ.get("DEBUG", "0"))
+DEBUG = int(get_config("DEBUG", "0"))
 
 # Self-hosted mode
 IS_SELF_MANAGED = True
 
 # Allowed Hosts
-ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS", "*").split(",")
+ALLOWED_HOSTS = get_config("ALLOWED_HOSTS", "*").split(",")
 
 # Application definition
 INSTALLED_APPS = [
@@ -132,7 +133,7 @@ TEMPLATES = [
 
 # CORS Settings
 CORS_ALLOW_CREDENTIALS = True
-cors_origins_raw = os.environ.get("CORS_ALLOWED_ORIGINS", "")
+cors_origins_raw = get_config("CORS_ALLOWED_ORIGINS", "")
 # filter out empty strings
 cors_allowed_origins = [origin.strip() for origin in cors_origins_raw.split(",") if origin.strip()]
 if cors_allowed_origins:
@@ -155,18 +156,18 @@ SITE_ID = 1
 AUTH_USER_MODEL = "db.User"
 
 # Database
-if bool(os.environ.get("DATABASE_URL")):
+if bool(get_config("DATABASE_URL")):
     # Parse database configuration from $DATABASE_URL
     DATABASES = {"default": dj_database_url.config()}
 else:
     DATABASES = {
         "default": {
             "ENGINE": "django.db.backends.postgresql",
-            "NAME": os.environ.get("POSTGRES_DB"),
-            "USER": os.environ.get("POSTGRES_USER"),
-            "PASSWORD": os.environ.get("POSTGRES_PASSWORD"),
-            "HOST": os.environ.get("POSTGRES_HOST"),
-            "PORT": os.environ.get("POSTGRES_PORT", "5432"),
+            "NAME": get_config("POSTGRES_DB"),
+            "USER": get_config("POSTGRES_USER"),
+            "PASSWORD": get_config("POSTGRES_PASSWORD"),
+            "HOST": get_config("POSTGRES_HOST"),
+            "PORT": get_config("POSTGRES_PORT", "5432"),
         }
     }
 
@@ -181,18 +182,18 @@ DATABASES["default"]["OPTIONS"]["options"] = (
 ).strip()
 
 
-if os.environ.get("ENABLE_READ_REPLICA", "0") == "1":
-    if bool(os.environ.get("DATABASE_READ_REPLICA_URL")):
+if get_config("ENABLE_READ_REPLICA", "0") == "1":
+    if bool(get_config("DATABASE_READ_REPLICA_URL")):
         # Parse database configuration from $DATABASE_URL
-        DATABASES["replica"] = dj_database_url.parse(os.environ.get("DATABASE_READ_REPLICA_URL"))
+        DATABASES["replica"] = dj_database_url.parse(get_config("DATABASE_READ_REPLICA_URL"))
     else:
         DATABASES["replica"] = {
             "ENGINE": "django.db.backends.postgresql",
-            "NAME": os.environ.get("POSTGRES_READ_REPLICA_DB"),
-            "USER": os.environ.get("POSTGRES_READ_REPLICA_USER"),
-            "PASSWORD": os.environ.get("POSTGRES_READ_REPLICA_PASSWORD"),
-            "HOST": os.environ.get("POSTGRES_READ_REPLICA_HOST"),
-            "PORT": os.environ.get("POSTGRES_READ_REPLICA_PORT", "5432"),
+            "NAME": get_config("POSTGRES_READ_REPLICA_DB"),
+            "USER": get_config("POSTGRES_READ_REPLICA_USER"),
+            "PASSWORD": get_config("POSTGRES_READ_REPLICA_PASSWORD"),
+            "HOST": get_config("POSTGRES_READ_REPLICA_HOST"),
+            "PORT": get_config("POSTGRES_READ_REPLICA_PORT", "5432"),
         }
 
     # Database Routers
@@ -202,12 +203,12 @@ if os.environ.get("ENABLE_READ_REPLICA", "0") == "1":
 
 
 # Redis Config
-REDIS_URL = os.environ.get("REDIS_URL")
+REDIS_URL = get_config("REDIS_URL")
 REDIS_SSL = REDIS_URL and "rediss" in REDIS_URL
-REDIS_SOCKET_CONNECT_TIMEOUT = os.environ.get("REDIS_SOCKET_CONNECT_TIMEOUT", 2.0)
-REDIS_SOCKET_TIMEOUT = os.environ.get("REDIS_SOCKET_TIMEOUT", 5.0)
-REDIS_HEALTH_CHECK_INTERVAL = os.environ.get("REDIS_HEALTH_CHECK_INTERVAL", 30)
-REDIS_MAX_CONNECTIONS = os.environ.get("REDIS_MAX_CONNECTIONS")
+REDIS_SOCKET_CONNECT_TIMEOUT = get_config("REDIS_SOCKET_CONNECT_TIMEOUT", 2.0)
+REDIS_SOCKET_TIMEOUT = get_config("REDIS_SOCKET_TIMEOUT", 5.0)
+REDIS_HEALTH_CHECK_INTERVAL = get_config("REDIS_HEALTH_CHECK_INTERVAL", 30)
+REDIS_MAX_CONNECTIONS = get_config("REDIS_MAX_CONNECTIONS")
 
 # AI Assistant — see .ai_design/integrate_ai_agent/
 # BYOK keys are encrypted at rest via AWS KMS (pi_dash.assistant.crypto).
@@ -219,53 +220,53 @@ REDIS_MAX_CONNECTIONS = os.environ.get("REDIS_MAX_CONNECTIONS")
 # Which crypto backend encrypts BYOK keys (pi_dash.assistant.crypto). Only
 # "aws-kms" ships today; the seam exists so other providers (GCP KMS, Azure
 # Key Vault, Vault Transit) can be added without touching call sites.
-ASSISTANT_CRYPTO_BACKEND = os.environ.get("ASSISTANT_CRYPTO_BACKEND", "aws-kms")
-ASSISTANT_KMS_KEY_ID = os.environ.get("ASSISTANT_KMS_KEY_ID", "")
-ASSISTANT_KMS_ENDPOINT_URL = os.environ.get("ASSISTANT_KMS_ENDPOINT_URL", "")
+ASSISTANT_CRYPTO_BACKEND = get_config("ASSISTANT_CRYPTO_BACKEND", "aws-kms")
+ASSISTANT_KMS_KEY_ID = get_config("ASSISTANT_KMS_KEY_ID", "")
+ASSISTANT_KMS_ENDPOINT_URL = get_config("ASSISTANT_KMS_ENDPOINT_URL", "")
 # Short-lived in-process cache of decrypted BYOK keys, so the assistant doesn't
 # call KMS Decrypt on every turn. In-memory per worker (plaintext never leaves
 # the process — unlike a shared store); keyed by a hash of the ciphertext so a
 # key change auto-invalidates. TTL also bounds how long a KMS-side revocation
 # lags. Set TTL=0 to disable. Eviction (TTL or LRU at MAXSIZE) is always safe —
 # a miss just costs one extra KMS Decrypt.
-ASSISTANT_KEY_CACHE_TTL = int(os.environ.get("ASSISTANT_KEY_CACHE_TTL", 300))
-ASSISTANT_KEY_CACHE_MAXSIZE = int(os.environ.get("ASSISTANT_KEY_CACHE_MAXSIZE", 1000))
+ASSISTANT_KEY_CACHE_TTL = int(get_config("ASSISTANT_KEY_CACHE_TTL", 300))
+ASSISTANT_KEY_CACHE_MAXSIZE = int(get_config("ASSISTANT_KEY_CACHE_MAXSIZE", 1000))
 # SSRF guard for BYOK base_url. Off in OSS (LAN vLLM/Ollama allowed); cloud sets True.
-ASSISTANT_BLOCK_PRIVATE_URLS = os.environ.get("ASSISTANT_BLOCK_PRIVATE_URLS", "false").lower() in (
+ASSISTANT_BLOCK_PRIVATE_URLS = get_config("ASSISTANT_BLOCK_PRIVATE_URLS", "false").lower() in (
     "1",
     "true",
     "yes",
 )
-ASSISTANT_TURN_SOFT_LIMIT = int(os.environ.get("ASSISTANT_TURN_SOFT_LIMIT", 300))
-ASSISTANT_TURN_HARD_LIMIT = int(os.environ.get("ASSISTANT_TURN_HARD_LIMIT", 330))
+ASSISTANT_TURN_SOFT_LIMIT = int(get_config("ASSISTANT_TURN_SOFT_LIMIT", 300))
+ASSISTANT_TURN_HARD_LIMIT = int(get_config("ASSISTANT_TURN_HARD_LIMIT", 330))
 # Max completed turns replayed to the model as history. Bounds per-turn token
 # cost (and context-window use) on long threads; the durable transcript shown
 # in the UI is unaffected — only what the model sees is truncated.
-ASSISTANT_HISTORY_MAX_TURNS = int(os.environ.get("ASSISTANT_HISTORY_MAX_TURNS", 40))
+ASSISTANT_HISTORY_MAX_TURNS = int(get_config("ASSISTANT_HISTORY_MAX_TURNS", 40))
 
 # Loop (Auto Project Management) — periodic assistant jobs.
 # See .ai_design/loop_project_management/design.md §11.
 # Instance kill switch: when false, the scanner and fire tasks short-circuit.
-LOOP_ENABLED = os.environ.get("LOOP_ENABLED", "true").lower() in ("1", "true", "yes")
+LOOP_ENABLED = get_config("LOOP_ENABLED", "true").lower() in ("1", "true", "yes")
 # Deterministic per-edge fire offset window (minutes) so a daily job doesn't
 # fire every membership edge in the same minute.
-LOOP_STAGGER_WINDOW_MINUTES = int(os.environ.get("LOOP_STAGGER_WINDOW_MINUTES", 60))
+LOOP_STAGGER_WINDOW_MINUTES = int(get_config("LOOP_STAGGER_WINDOW_MINUTES", 60))
 # Backpressure: at most this many targets dispatched per scanner tick; the rest
 # stay due and drain on later ticks.
-LOOP_MAX_DISPATCH_PER_TICK = int(os.environ.get("LOOP_MAX_DISPATCH_PER_TICK", 100))
+LOOP_MAX_DISPATCH_PER_TICK = int(get_config("LOOP_MAX_DISPATCH_PER_TICK", 100))
 # Reconcile (create missing targets for new membership edges) runs only when
 # minute % this == 0 — cheap throttle vs. the per-minute due scan.
-LOOP_RECONCILE_EVERY_MINUTES = int(os.environ.get("LOOP_RECONCILE_EVERY_MINUTES", 15))
+LOOP_RECONCILE_EVERY_MINUTES = int(get_config("LOOP_RECONCILE_EVERY_MINUTES", 15))
 # Rotate to a fresh hidden thread when within this many messages of the cap.
-LOOP_ROTATION_HEADROOM = int(os.environ.get("LOOP_ROTATION_HEADROOM", 30))
+LOOP_ROTATION_HEADROOM = int(get_config("LOOP_ROTATION_HEADROOM", 30))
 # Per-run blast-radius cap, enforced by instruction (hard backstop is the
 # assistant's tool_calls_limit).
-LOOP_MAX_WRITES = int(os.environ.get("LOOP_MAX_WRITES", 10))
+LOOP_MAX_WRITES = int(get_config("LOOP_MAX_WRITES", 10))
 # Per-run cap on get_pull_request_status calls (protects the unauthenticated
 # GitHub rate limit for the host IP).
-LOOP_PR_LOOKUPS_PER_RUN = int(os.environ.get("LOOP_PR_LOOKUPS_PER_RUN", 15))
+LOOP_PR_LOOKUPS_PER_RUN = int(get_config("LOOP_PR_LOOKUPS_PER_RUN", 15))
 # Completed loop turns replayed as history — tighter than chat (daily cost).
-ASSISTANT_LOOP_HISTORY_MAX_TURNS = int(os.environ.get("ASSISTANT_LOOP_HISTORY_MAX_TURNS", 5))
+ASSISTANT_LOOP_HISTORY_MAX_TURNS = int(get_config("ASSISTANT_LOOP_HISTORY_MAX_TURNS", 5))
 
 if REDIS_SSL:
     CACHES = {
@@ -339,30 +340,30 @@ EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 
 # Storage Settings
 # Use Minio settings
-USE_MINIO = int(os.environ.get("USE_MINIO", 0)) == 1
+USE_MINIO = int(get_config("USE_MINIO", 0)) == 1
 
 STORAGES = {"staticfiles": {"BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage"}}
 STORAGES["default"] = {"BACKEND": "pi_dash.settings.storage.S3Storage"}
-AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID", "access-key")
-AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY", "secret-key")
-AWS_STORAGE_BUCKET_NAME = os.environ.get("AWS_S3_BUCKET_NAME", "uploads")
-AWS_REGION = os.environ.get("AWS_REGION", "")
+AWS_ACCESS_KEY_ID = get_config("AWS_ACCESS_KEY_ID", "access-key")
+AWS_SECRET_ACCESS_KEY = get_config("AWS_SECRET_ACCESS_KEY", "secret-key")
+AWS_STORAGE_BUCKET_NAME = get_config("AWS_S3_BUCKET_NAME", "uploads")
+AWS_REGION = get_config("AWS_REGION", "")
 AWS_DEFAULT_ACL = "public-read"
 AWS_QUERYSTRING_AUTH = False
 AWS_S3_FILE_OVERWRITE = False
-AWS_S3_ENDPOINT_URL = os.environ.get("AWS_S3_ENDPOINT_URL", None) or os.environ.get("MINIO_ENDPOINT_URL", None)
+AWS_S3_ENDPOINT_URL = get_config("AWS_S3_ENDPOINT_URL", None) or get_config("MINIO_ENDPOINT_URL", None)
 if AWS_S3_ENDPOINT_URL and USE_MINIO:
-    parsed_url = urlparse(os.environ.get("WEB_URL", "http://localhost"))
+    parsed_url = urlparse(get_config("WEB_URL", "http://localhost"))
     AWS_S3_CUSTOM_DOMAIN = f"{parsed_url.netloc}/{AWS_STORAGE_BUCKET_NAME}"
     AWS_S3_URL_PROTOCOL = f"{parsed_url.scheme}:"
 
 # RabbitMQ connection settings
-RABBITMQ_HOST = os.environ.get("RABBITMQ_HOST", "localhost")
-RABBITMQ_PORT = os.environ.get("RABBITMQ_PORT", "5672")
-RABBITMQ_USER = os.environ.get("RABBITMQ_USER", "guest")
-RABBITMQ_PASSWORD = os.environ.get("RABBITMQ_PASSWORD", "guest")
-RABBITMQ_VHOST = os.environ.get("RABBITMQ_VHOST", "/")
-AMQP_URL = os.environ.get("AMQP_URL")
+RABBITMQ_HOST = get_config("RABBITMQ_HOST", "localhost")
+RABBITMQ_PORT = get_config("RABBITMQ_PORT", "5672")
+RABBITMQ_USER = get_config("RABBITMQ_USER", "guest")
+RABBITMQ_PASSWORD = get_config("RABBITMQ_PASSWORD", "guest")
+RABBITMQ_VHOST = get_config("RABBITMQ_VHOST", "/")
+AMQP_URL = get_config("AMQP_URL")
 
 # Celery Configuration
 if AMQP_URL:
@@ -393,30 +394,33 @@ CELERY_IMPORTS = (
     "pi_dash.runner.tasks",
 )
 
-FILE_SIZE_LIMIT = int(os.environ.get("FILE_SIZE_LIMIT", 5242880))
+FILE_SIZE_LIMIT = int(get_config("FILE_SIZE_LIMIT", 5242880))
 
-# Unsplash Access key
-UNSPLASH_ACCESS_KEY = os.environ.get("UNSPLASH_ACCESS_KEY")
+# Unsplash Access key. Intentionally read straight from the env here: the same
+# key is also admin-managed (db-sourced) via the InstanceConfiguration resolver
+# for the in-app Unsplash feature, so it cannot route through get_config (which
+# would resolve it from the DB at settings-import time).
+UNSPLASH_ACCESS_KEY = os.environ.get("UNSPLASH_ACCESS_KEY")  # noqa: config-env-read
 # Github Access Token
-GITHUB_ACCESS_TOKEN = os.environ.get("GITHUB_ACCESS_TOKEN", False)
+GITHUB_ACCESS_TOKEN = get_config("GITHUB_ACCESS_TOKEN", False)
 
 # GitHub Issue Sync feature gate. Default on; self-hosters who don't want
 # the integration set GITHUB_SYNC_ENABLED=false. See .ai_design/github_sync/
 # design.md §9 Rollout.
-GITHUB_SYNC_ENABLED = os.environ.get("GITHUB_SYNC_ENABLED", "true").lower() == "true"
+GITHUB_SYNC_ENABLED = get_config("GITHUB_SYNC_ENABLED", "true").lower() == "true"
 
 # Project Scheduler feature gate. Default on; self-hosters who don't want
 # periodic agent ticks against projects set SCHEDULER_ENABLED=false. See
 # .ai_design/project_scheduler/design.md §10 Rollout.
-SCHEDULER_ENABLED = os.environ.get("SCHEDULER_ENABLED", "true").lower() == "true"
+SCHEDULER_ENABLED = get_config("SCHEDULER_ENABLED", "true").lower() == "true"
 
 # Analytics
-ANALYTICS_SECRET_KEY = os.environ.get("ANALYTICS_SECRET_KEY", False)
-ANALYTICS_BASE_API = os.environ.get("ANALYTICS_BASE_API", False)
+ANALYTICS_SECRET_KEY = get_config("ANALYTICS_SECRET_KEY", False)
+ANALYTICS_BASE_API = get_config("ANALYTICS_BASE_API", False)
 
 # Posthog settings
-POSTHOG_API_KEY = os.environ.get("POSTHOG_API_KEY", False)
-POSTHOG_HOST = os.environ.get("POSTHOG_HOST", False)
+POSTHOG_API_KEY = get_config("POSTHOG_API_KEY", False)
+POSTHOG_HOST = get_config("POSTHOG_HOST", False)
 
 # Per-runner HTTPS transport tunables (see ``.ai_design/move_to_https/design.md`` §9).
 # Clamped to [1, 55] so the server-side block always finishes strictly
@@ -427,7 +431,7 @@ POSTHOG_HOST = os.environ.get("POSTHOG_HOST", False)
 # of silently getting a value they didn't ask for.
 _LONG_POLL_MIN_SECS = 1
 _LONG_POLL_MAX_SECS = 55
-_raw_long_poll_secs = int(os.environ.get("LONG_POLL_INTERVAL_SECS", 25))
+_raw_long_poll_secs = int(get_config("LONG_POLL_INTERVAL_SECS", 25))
 if _raw_long_poll_secs < _LONG_POLL_MIN_SECS or _raw_long_poll_secs > _LONG_POLL_MAX_SECS:
     import logging
 
@@ -444,16 +448,16 @@ if _raw_long_poll_secs < _LONG_POLL_MIN_SECS or _raw_long_poll_secs > _LONG_POLL
 LONG_POLL_INTERVAL_SECS = max(
     _LONG_POLL_MIN_SECS, min(_raw_long_poll_secs, _LONG_POLL_MAX_SECS)
 )
-ACCESS_TOKEN_TTL_SECS = int(os.environ.get("ACCESS_TOKEN_TTL_SECS", 3600))
-RUNNER_OFFLINE_THRESHOLD_SECS = int(os.environ.get("RUNNER_OFFLINE_THRESHOLD_SECS", 50))
-OFFLINE_STREAM_TTL_SECS = int(os.environ.get("OFFLINE_STREAM_TTL_SECS", 86400))
-OFFLINE_STREAM_MAXLEN = int(os.environ.get("OFFLINE_STREAM_MAXLEN", 1000))
+ACCESS_TOKEN_TTL_SECS = int(get_config("ACCESS_TOKEN_TTL_SECS", 3600))
+RUNNER_OFFLINE_THRESHOLD_SECS = int(get_config("RUNNER_OFFLINE_THRESHOLD_SECS", 50))
+OFFLINE_STREAM_TTL_SECS = int(get_config("OFFLINE_STREAM_TTL_SECS", 86400))
+OFFLINE_STREAM_MAXLEN = int(get_config("OFFLINE_STREAM_MAXLEN", 1000))
 RUNNER_STREAM_MIN_RETENTION_SECS = int(
-    os.environ.get("RUNNER_STREAM_MIN_RETENTION_SECS", 3600)
+    get_config("RUNNER_STREAM_MIN_RETENTION_SECS", 3600)
 )
-EVENT_BATCH_MAX_AGE_MS = int(os.environ.get("EVENT_BATCH_MAX_AGE_MS", 250))
-EVENT_BATCH_MAX_BYTES = int(os.environ.get("EVENT_BATCH_MAX_BYTES", 65536))
-RUN_MESSAGE_DEDUPE_TTL_SECS = int(os.environ.get("RUN_MESSAGE_DEDUPE_TTL_SECS", 604800))
+EVENT_BATCH_MAX_AGE_MS = int(get_config("EVENT_BATCH_MAX_AGE_MS", 250))
+EVENT_BATCH_MAX_BYTES = int(get_config("EVENT_BATCH_MAX_BYTES", 65536))
+RUN_MESSAGE_DEDUPE_TTL_SECS = int(get_config("RUN_MESSAGE_DEDUPE_TTL_SECS", 604800))
 RUNNER_PROTOCOL_VERSION = 4
 
 # Runner auto-update advisory. Cloud announces these in the welcome frame;
@@ -472,7 +476,7 @@ _RUNNER_VERSION_RE = _re_runner_version.compile(r"^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+
 
 
 def _validated_runner_version(name):
-    raw = os.environ.get(name, "") or None
+    raw = get_config(name, "") or None
     if raw is not None and not _RUNNER_VERSION_RE.match(raw):
         _logging_runner_version.getLogger(__name__).warning(
             "%s=%r does not match MAJOR.MINOR.PATCH[-pre]; "
@@ -491,14 +495,14 @@ MIN_RUNNER_VERSION = _validated_runner_version("MIN_RUNNER_VERSION")
 # 360s is slightly longer than the runner's own 5-minute internal stall
 # watchdog, so the cloud acts as a backstop rather than racing the runner.
 RUNNER_AGENT_STALL_THRESHOLD_SECS = int(
-    os.environ.get("RUNNER_AGENT_STALL_THRESHOLD_SECS", 360)
+    get_config("RUNNER_AGENT_STALL_THRESHOLD_SECS", 360)
 )
 # Snapshot-row freshness guard. The watchdog only acts on runners whose
 # poll-driven `RunnerLiveState.updated_at` is newer than this. Covers
 # roughly three missed 25s polls; stale rows from disabled / downgraded
 # runners age out instead of failing active runs.
 RUNNER_AGENT_OBSERVABILITY_STALE_SECS = int(
-    os.environ.get("RUNNER_AGENT_OBSERVABILITY_STALE_SECS", 90)
+    get_config("RUNNER_AGENT_OBSERVABILITY_STALE_SECS", 90)
 )
 # Access-token signing key ring. Each entry: {kid, secret, status} where
 # status ∈ {"active", "verify_only"}. Exactly one key is active.
@@ -506,66 +510,63 @@ RUNNER_AGENT_OBSERVABILITY_STALE_SECS = int(
 # dev/test setups Just Work; production should override via env / settings.
 RUNNER_ACCESS_TOKEN_KEYS = []
 
-# Skip environment variable configuration
-SKIP_ENV_VAR = os.environ.get("SKIP_ENV_VAR", "1") == "1"
-
-DATA_UPLOAD_MAX_MEMORY_SIZE = int(os.environ.get("FILE_SIZE_LIMIT", 5242880))
+DATA_UPLOAD_MAX_MEMORY_SIZE = int(get_config("FILE_SIZE_LIMIT", 5242880))
 
 # Cookie Settings
 SESSION_COOKIE_SECURE = secure_origins
 SESSION_COOKIE_HTTPONLY = True
 SESSION_ENGINE = "pi_dash.db.models.session"
-SESSION_COOKIE_AGE = int(os.environ.get("SESSION_COOKIE_AGE", 604800))
-SESSION_COOKIE_NAME = os.environ.get("SESSION_COOKIE_NAME", "session-id")
-SESSION_COOKIE_DOMAIN = os.environ.get("COOKIE_DOMAIN", None)
-SESSION_SAVE_EVERY_REQUEST = os.environ.get("SESSION_SAVE_EVERY_REQUEST", "0") == "1"
+SESSION_COOKIE_AGE = int(get_config("SESSION_COOKIE_AGE", 604800))
+SESSION_COOKIE_NAME = get_config("SESSION_COOKIE_NAME", "session-id")
+SESSION_COOKIE_DOMAIN = get_config("COOKIE_DOMAIN", None)
+SESSION_SAVE_EVERY_REQUEST = get_config("SESSION_SAVE_EVERY_REQUEST", "0") == "1"
 
 # Admin Cookie
 ADMIN_SESSION_COOKIE_NAME = "admin-session-id"
-ADMIN_SESSION_COOKIE_AGE = int(os.environ.get("ADMIN_SESSION_COOKIE_AGE", 3600))
+ADMIN_SESSION_COOKIE_AGE = int(get_config("ADMIN_SESSION_COOKIE_AGE", 3600))
 
 # CSRF cookies
 CSRF_COOKIE_SECURE = secure_origins
 CSRF_COOKIE_HTTPONLY = True
 CSRF_TRUSTED_ORIGINS = cors_allowed_origins
-CSRF_COOKIE_DOMAIN = os.environ.get("COOKIE_DOMAIN", None)
+CSRF_COOKIE_DOMAIN = get_config("COOKIE_DOMAIN", None)
 CSRF_FAILURE_VIEW = "pi_dash.authentication.views.common.csrf_failure"
 
 ######  Base URLs ######
 
 # Admin Base URL
-ADMIN_BASE_URL = os.environ.get("ADMIN_BASE_URL", None)
+ADMIN_BASE_URL = get_config("ADMIN_BASE_URL", None)
 if ADMIN_BASE_URL and not is_valid_url(ADMIN_BASE_URL):
     ADMIN_BASE_URL = None
-ADMIN_BASE_PATH = os.environ.get("ADMIN_BASE_PATH", "/god-mode/")
+ADMIN_BASE_PATH = get_config("ADMIN_BASE_PATH", "/god-mode/")
 
 # Space Base URL
-SPACE_BASE_URL = os.environ.get("SPACE_BASE_URL", None)
+SPACE_BASE_URL = get_config("SPACE_BASE_URL", None)
 if SPACE_BASE_URL and not is_valid_url(SPACE_BASE_URL):
     SPACE_BASE_URL = None
-SPACE_BASE_PATH = os.environ.get("SPACE_BASE_PATH", "/spaces/")
+SPACE_BASE_PATH = get_config("SPACE_BASE_PATH", "/spaces/")
 
 # App Base URL
-APP_BASE_URL = os.environ.get("APP_BASE_URL", None)
+APP_BASE_URL = get_config("APP_BASE_URL", None)
 if APP_BASE_URL and not is_valid_url(APP_BASE_URL):
     APP_BASE_URL = None
-APP_BASE_PATH = os.environ.get("APP_BASE_PATH", "/")
+APP_BASE_PATH = get_config("APP_BASE_PATH", "/")
 
 # Live Base URL
-LIVE_BASE_URL = os.environ.get("LIVE_BASE_URL", None)
+LIVE_BASE_URL = get_config("LIVE_BASE_URL", None)
 if LIVE_BASE_URL and not is_valid_url(LIVE_BASE_URL):
     LIVE_BASE_URL = None
-LIVE_BASE_PATH = os.environ.get("LIVE_BASE_PATH", "/live/")
+LIVE_BASE_PATH = get_config("LIVE_BASE_PATH", "/live/")
 
 LIVE_URL = urljoin(LIVE_BASE_URL, LIVE_BASE_PATH) if LIVE_BASE_URL else None
 
 # WEB URL
-WEB_URL = os.environ.get("WEB_URL")
+WEB_URL = get_config("WEB_URL")
 
-HARD_DELETE_AFTER_DAYS = int(os.environ.get("HARD_DELETE_AFTER_DAYS", 60))
+HARD_DELETE_AFTER_DAYS = int(get_config("HARD_DELETE_AFTER_DAYS", 60))
 
 # Instance Changelog URL
-INSTANCE_CHANGELOG_URL = os.environ.get("INSTANCE_CHANGELOG_URL", "")
+INSTANCE_CHANGELOG_URL = get_config("INSTANCE_CHANGELOG_URL", "")
 
 ATTACHMENT_MIME_TYPES = [
     # Images
@@ -660,7 +661,7 @@ ATTACHMENT_MIME_TYPES = [
 # Seed directory path
 SEED_DIR = os.path.join(BASE_DIR, "seeds")
 
-ENABLE_DRF_SPECTACULAR = os.environ.get("ENABLE_DRF_SPECTACULAR", "0") == "1"
+ENABLE_DRF_SPECTACULAR = get_config("ENABLE_DRF_SPECTACULAR", "0") == "1"
 
 if ENABLE_DRF_SPECTACULAR:
     REST_FRAMEWORK["DEFAULT_SCHEMA_CLASS"] = "drf_spectacular.openapi.AutoSchema"
@@ -668,5 +669,5 @@ if ENABLE_DRF_SPECTACULAR:
     from .openapi import SPECTACULAR_SETTINGS  # noqa: F401
 
 # MongoDB Settings
-MONGO_DB_URL = os.environ.get("MONGO_DB_URL", False)
-MONGO_DB_DATABASE = os.environ.get("MONGO_DB_DATABASE", False)
+MONGO_DB_URL = get_config("MONGO_DB_URL", False)
+MONGO_DB_DATABASE = get_config("MONGO_DB_DATABASE", False)

--- a/apps/api/pi_dash/settings/local.py
+++ b/apps/api/pi_dash/settings/local.py
@@ -7,6 +7,7 @@
 import os
 
 from .common import *  # noqa
+from pi_dash.config import get_config
 
 DEBUG = True
 
@@ -17,7 +18,7 @@ MIDDLEWARE += ("debug_toolbar.middleware.DebugToolbarMiddleware",)  # noqa
 DEBUG_TOOLBAR_PATCH_SETTINGS = False
 
 # Only show emails in console don't send it to smtp
-EMAIL_BACKEND = os.environ.get("EMAIL_BACKEND", "django.core.mail.backends.console.EmailBackend")
+EMAIL_BACKEND = get_config("EMAIL_BACKEND", "django.core.mail.backends.console.EmailBackend")
 
 CACHES = {
     "default": {

--- a/apps/api/pi_dash/settings/production.py
+++ b/apps/api/pi_dash/settings/production.py
@@ -7,9 +7,10 @@
 import os
 
 from .common import *  # noqa
+from pi_dash.config import get_config
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = int(os.environ.get("DEBUG", 0)) == 1
+DEBUG = int(get_config("DEBUG", 0)) == 1
 
 # Honor the 'X-Forwarded-Proto' header for request.is_secure()
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
@@ -18,8 +19,8 @@ INSTALLED_APPS += ("scout_apm.django",)  # noqa
 
 
 # Scout Settings
-SCOUT_MONITOR = os.environ.get("SCOUT_MONITOR", False)
-SCOUT_KEY = os.environ.get("SCOUT_KEY", "")
+SCOUT_MONITOR = get_config("SCOUT_MONITOR", False)
+SCOUT_KEY = get_config("SCOUT_KEY", "")
 SCOUT_NAME = "Pi Dash"
 
 LOG_DIR = os.path.join(BASE_DIR, "logs")  # noqa

--- a/apps/api/pi_dash/settings/storage.py
+++ b/apps/api/pi_dash/settings/storage.py
@@ -3,7 +3,6 @@
 # See the LICENSE file for details.
 
 # Python imports
-import os
 import uuid
 
 # Third party imports
@@ -12,6 +11,7 @@ from botocore.exceptions import ClientError
 from urllib.parse import quote
 
 # Module imports
+from pi_dash.config import get_config
 from pi_dash.utils.exception_logger import log_exception
 from storages.backends.s3boto3 import S3Boto3Storage
 
@@ -23,22 +23,22 @@ class S3Storage(S3Boto3Storage):
     """S3 storage class to generate presigned URLs for S3 objects"""
 
     def __init__(self, request=None):
-        # Get the AWS credentials and bucket name from the environment
-        self.aws_access_key_id = os.environ.get("AWS_ACCESS_KEY_ID")
+        # Get the AWS credentials and bucket name from config (env-sourced).
+        self.aws_access_key_id = get_config("AWS_ACCESS_KEY_ID", None)
         # Use the AWS_SECRET_ACCESS_KEY environment variable for the secret key
-        self.aws_secret_access_key = os.environ.get("AWS_SECRET_ACCESS_KEY")
+        self.aws_secret_access_key = get_config("AWS_SECRET_ACCESS_KEY", None)
         # Use the AWS_S3_BUCKET_NAME environment variable for the bucket name
-        self.aws_storage_bucket_name = os.environ.get("AWS_S3_BUCKET_NAME")
+        self.aws_storage_bucket_name = get_config("AWS_S3_BUCKET_NAME", None)
         # Use the AWS_REGION environment variable for the region
-        self.aws_region = os.environ.get("AWS_REGION")
+        self.aws_region = get_config("AWS_REGION", None)
         # Use the AWS_S3_ENDPOINT_URL environment variable for the endpoint URL
-        self.aws_s3_endpoint_url = os.environ.get("AWS_S3_ENDPOINT_URL") or os.environ.get("MINIO_ENDPOINT_URL")
+        self.aws_s3_endpoint_url = get_config("AWS_S3_ENDPOINT_URL", None) or get_config("MINIO_ENDPOINT_URL", None)
         # Use the SIGNED_URL_EXPIRATION environment variable for the expiration time (default: 3600 seconds)
-        self.signed_url_expiration = int(os.environ.get("SIGNED_URL_EXPIRATION", "3600"))
+        self.signed_url_expiration = int(get_config("SIGNED_URL_EXPIRATION", "3600"))
 
-        if os.environ.get("USE_MINIO") == "1":
+        if get_config("USE_MINIO", None) == "1":
             # Determine protocol based on environment variable
-            if os.environ.get("MINIO_ENDPOINT_SSL") == "1":
+            if get_config("MINIO_ENDPOINT_SSL", None) == "1":
                 endpoint_protocol = "https"
             else:
                 endpoint_protocol = request.scheme if request else "http"

--- a/apps/api/pi_dash/tests/unit/config/__init__.py
+++ b/apps/api/pi_dash/tests/unit/config/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.

--- a/apps/api/pi_dash/tests/unit/config/test_accessor.py
+++ b/apps/api/pi_dash/tests/unit/config/test_accessor.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+import pytest
+
+from pi_dash import config
+from pi_dash.config import accessor, registry
+from pi_dash.license.models import InstanceConfiguration
+from pi_dash.license.utils.encryption import encrypt_data
+
+
+# --------------------------------------------------------------------------- #
+# env-sourced keys
+# --------------------------------------------------------------------------- #
+@pytest.mark.unit
+def test_env_key_reads_from_environment(monkeypatch):
+    monkeypatch.setenv("POSTHOG_API_KEY", "ph_from_env")
+    assert config.get_config("POSTHOG_API_KEY") == "ph_from_env"
+
+
+@pytest.mark.unit
+def test_env_key_falls_back_to_registry_default(monkeypatch):
+    monkeypatch.delenv("POSTHOG_API_KEY", raising=False)
+    # POSTHOG_API_KEY default is None
+    assert config.get_config("POSTHOG_API_KEY") is None
+
+
+@pytest.mark.unit
+def test_env_key_resolves_without_database(monkeypatch):
+    """env-tier keys must work even if the ORM is untouched (settings import)."""
+    monkeypatch.setattr(registry, "CONFIG", {"FOO": {"source": "env", "default": "d"}})
+    monkeypatch.setattr(accessor, "CONFIG", registry.CONFIG)
+    monkeypatch.delenv("FOO", raising=False)
+    assert config.get_config("FOO") == "d"
+
+
+# --------------------------------------------------------------------------- #
+# db-sourced keys
+# --------------------------------------------------------------------------- #
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_db_key_reads_from_instance_configuration():
+    InstanceConfiguration.objects.create(key="EMAIL_HOST", value="smtp.test", category="SMTP")
+    assert config.get_config("EMAIL_HOST") == "smtp.test"
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_db_key_missing_row_returns_default():
+    # EMAIL_PORT default is "587"; no row created
+    assert config.get_config("EMAIL_PORT") == "587"
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_db_secret_key_is_decrypted():
+    InstanceConfiguration.objects.create(
+        key="EMAIL_HOST_PASSWORD",
+        value=encrypt_data("s3cret"),
+        category="SMTP",
+        is_encrypted=True,
+    )
+    assert config.get_config("EMAIL_HOST_PASSWORD") == "s3cret"
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_get_many_batches_db_and_env(monkeypatch):
+    monkeypatch.setenv("POSTHOG_HOST", "https://ph.test")
+    InstanceConfiguration.objects.create(key="EMAIL_HOST", value="smtp.test", category="SMTP")
+    result = config.get_many(["EMAIL_HOST", "EMAIL_PORT", "POSTHOG_HOST"])
+    assert result == {
+        "EMAIL_HOST": "smtp.test",
+        "EMAIL_PORT": "587",  # default, no row
+        "POSTHOG_HOST": "https://ph.test",
+    }
+
+
+# --------------------------------------------------------------------------- #
+# typed helpers
+# --------------------------------------------------------------------------- #
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_get_bool():
+    InstanceConfiguration.objects.create(key="ENABLE_SIGNUP", value="1", category="AUTHENTICATION")
+    InstanceConfiguration.objects.create(key="ENABLE_SMTP", value="0", category="SMTP")
+    assert config.get_bool("ENABLE_SIGNUP") is True
+    assert config.get_bool("ENABLE_SMTP") is False
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_get_int():
+    assert config.get_int("EMAIL_PORT") == 587  # default "587"
+
+
+@pytest.mark.unit
+def test_get_int_invalid_returns_fallback(monkeypatch):
+    monkeypatch.setenv("POSTHOG_HOST", "not-a-number")
+    assert config.get_int("POSTHOG_HOST", default=42) == 42
+
+
+# --------------------------------------------------------------------------- #
+# unregistered keys
+# --------------------------------------------------------------------------- #
+@pytest.mark.unit
+def test_unregistered_key_strict_raises(monkeypatch):
+    # the test settings module ends with ".test" -> strict mode
+    monkeypatch.setenv("WHATEVER_KEY", "x")
+    with pytest.raises(config.ConfigError):
+        config.get_config("WHATEVER_KEY")
+
+
+@pytest.mark.unit
+def test_unregistered_key_lenient_falls_back_to_env(monkeypatch):
+    monkeypatch.setattr(accessor, "_strict", lambda: False)
+    monkeypatch.setenv("WHATEVER_KEY", "from_env")
+    assert config.get_config("WHATEVER_KEY") == "from_env"
+
+
+# --------------------------------------------------------------------------- #
+# registry integrity
+# --------------------------------------------------------------------------- #
+@pytest.mark.unit
+def test_every_entry_has_valid_source():
+    for key, entry in registry.CONFIG.items():
+        assert entry["source"] in ("env", "db"), f"{key} has bad source {entry.get('source')!r}"
+
+
+@pytest.mark.unit
+def test_source_overrides_are_applied(monkeypatch):
+    monkeypatch.setattr(registry, "_RESOLVER_CONFIG", {"K": {"source": "db", "default": None}})
+    monkeypatch.setattr(registry, "CONFIG_SOURCE_OVERRIDES", {"K": "env"})
+    rebuilt = registry._build_config()
+    assert rebuilt["K"]["source"] == "env"
+
+
+@pytest.mark.unit
+def test_env_var_override_flips_keys_to_env(monkeypatch):
+    """The cloud's SSM-native seam: PIDASH_CONFIG_ENV_KEYS forces keys to env."""
+    monkeypatch.setenv(registry.ENV_KEYS_OVERRIDE_VAR, "EMAIL_HOST, GOOGLE_CLIENT_SECRET ,")
+    rebuilt = registry._build_config()
+    assert rebuilt["EMAIL_HOST"]["source"] == "env"
+    assert rebuilt["GOOGLE_CLIENT_SECRET"]["source"] == "env"
+    # untouched key stays db
+    assert rebuilt["ENABLE_SIGNUP"]["source"] == "db"

--- a/apps/api/pi_dash/tests/unit/config/test_legacy_resolver.py
+++ b/apps/api/pi_dash/tests/unit/config/test_legacy_resolver.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Regression tests for the legacy get_configuration_value resolver after the
+SKIP_ENV_VAR removal. Behavior must match the old resolver: db-sourced keys
+read the InstanceConfiguration row (decrypting secrets), env-sourced keys read
+the environment, and the caller-supplied ``default`` is the fallback in both
+cases when the value is absent."""
+
+import pytest
+
+from pi_dash.config import registry
+from pi_dash.license.models import InstanceConfiguration
+from pi_dash.license.utils.encryption import encrypt_data
+from pi_dash.license.utils.instance_value import get_configuration_value
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_db_key_reads_row():
+    InstanceConfiguration.objects.create(key="EMAIL_HOST", value="smtp.test", category="SMTP")
+    (value,) = get_configuration_value([{"key": "EMAIL_HOST", "default": "fallback"}])
+    assert value == "smtp.test"
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_db_key_missing_row_uses_caller_default():
+    (value,) = get_configuration_value([{"key": "EMAIL_HOST", "default": "fallback"}])
+    assert value == "fallback"
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_db_secret_is_decrypted():
+    InstanceConfiguration.objects.create(
+        key="GOOGLE_CLIENT_SECRET", value=encrypt_data("shh"), category="GOOGLE", is_encrypted=True
+    )
+    (value,) = get_configuration_value([{"key": "GOOGLE_CLIENT_SECRET", "default": None}])
+    assert value == "shh"
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_env_sourced_key_reads_environment(monkeypatch):
+    # POSTHOG_API_KEY is source="env" in the registry
+    monkeypatch.setenv("POSTHOG_API_KEY", "ph_env")
+    (value,) = get_configuration_value([{"key": "POSTHOG_API_KEY", "default": None}])
+    assert value == "ph_env"
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_env_sourced_key_uses_caller_default_when_unset(monkeypatch):
+    monkeypatch.delenv("POSTHOG_HOST", raising=False)
+    (value,) = get_configuration_value([{"key": "POSTHOG_HOST", "default": "https://default"}])
+    assert value == "https://default"
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_mixed_keys_single_call(monkeypatch):
+    monkeypatch.setenv("POSTHOG_API_KEY", "ph_env")
+    InstanceConfiguration.objects.create(key="EMAIL_HOST", value="smtp.test", category="SMTP")
+    result = get_configuration_value(
+        [
+            {"key": "EMAIL_HOST", "default": None},
+            {"key": "POSTHOG_API_KEY", "default": None},
+        ]
+    )
+    assert result == ("smtp.test", "ph_env")
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_cloud_style_override_routes_db_key_to_env(monkeypatch):
+    """Simulate the cloud overlay flipping a db key to env: the resolver must
+    then read it from the environment, not the DB row."""
+    patched = dict(registry.CONFIG)
+    patched["EMAIL_HOST"] = {"source": "env", "default": ""}
+    monkeypatch.setattr(registry, "CONFIG", patched)
+    monkeypatch.setattr("pi_dash.license.utils.instance_value.CONFIG", patched)
+    InstanceConfiguration.objects.create(key="EMAIL_HOST", value="db_value", category="SMTP")
+    monkeypatch.setenv("EMAIL_HOST", "env_value")
+    (value,) = get_configuration_value([{"key": "EMAIL_HOST", "default": ""}])
+    assert value == "env_value"

--- a/apps/api/pi_dash/tests/unit/config/test_serializer_source.py
+++ b/apps/api/pi_dash/tests/unit/config/test_serializer_source.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+import pytest
+
+from pi_dash.config import registry
+from pi_dash.license.api.serializers import InstanceConfigurationSerializer
+from pi_dash.license.models import InstanceConfiguration
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_serializer_exposes_source_and_is_managed(monkeypatch):
+    # Simulate the cloud flipping EMAIL_HOST to env-sourced.
+    patched = dict(registry.CONFIG)
+    patched["EMAIL_HOST"] = {"source": "env", "default": ""}
+    monkeypatch.setattr("pi_dash.license.api.serializers.configuration.CONFIG", patched)
+
+    InstanceConfiguration.objects.create(key="EMAIL_HOST", value="smtp.x", category="SMTP")
+    InstanceConfiguration.objects.create(key="ENABLE_SIGNUP", value="1", category="AUTHENTICATION")
+
+    rows = {
+        r["key"]: r
+        for r in InstanceConfigurationSerializer(InstanceConfiguration.objects.all(), many=True).data
+    }
+    assert rows["EMAIL_HOST"]["source"] == "env"
+    assert rows["EMAIL_HOST"]["is_managed"] is True
+    assert rows["ENABLE_SIGNUP"]["source"] == "db"
+    assert rows["ENABLE_SIGNUP"]["is_managed"] is False

--- a/apps/api/pi_dash/tests/unit/config/test_settings_centralization.py
+++ b/apps/api/pi_dash/tests/unit/config/test_settings_centralization.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Guard: configuration in the settings modules must be read through
+``pi_dash.config.get_config``, not ``os.environ`` directly. This keeps the
+registry the single catalog of every config key. Intentional exceptions carry
+a ``# noqa: config-env-read`` marker on the same line."""
+
+import pathlib
+
+import pytest
+
+import pi_dash.config as config_pkg
+import pi_dash.settings as settings_pkg
+
+ALLOW_MARKER = "noqa: config-env-read"
+
+
+def _settings_files():
+    root = pathlib.Path(settings_pkg.__path__[0])
+    # test.py legitimately seeds os.environ via setdefault for the test harness.
+    return [p for p in root.glob("*.py") if p.name not in {"__init__.py", "test.py"}]
+
+
+@pytest.mark.unit
+def test_settings_modules_do_not_read_os_environ_directly():
+    offenders = []
+    for path in _settings_files():
+        for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+            if "os.environ" in line and ALLOW_MARKER not in line:
+                offenders.append(f"{path.name}:{lineno}: {line.strip()}")
+    assert not offenders, (
+        "Settings modules must read config via pi_dash.config.get_config, not "
+        "os.environ. Offending lines:\n" + "\n".join(offenders)
+    )
+
+
+@pytest.mark.unit
+def test_registry_catalogs_every_key_settings_read():
+    """Every key passed to get_config(...) in the settings modules must be
+    registered, so the registry stays a complete catalog (and strict mode in
+    CI never trips at boot)."""
+    import re
+
+    call = re.compile(r"get_config\(\s*[\"']([A-Z0-9_]+)[\"']")
+    missing = set()
+    for path in _settings_files():
+        for key in call.findall(path.read_text()):
+            if not config_pkg.is_registered(key):
+                missing.add(f"{path.name}:{key}")
+    assert not missing, f"get_config called with unregistered keys: {sorted(missing)}"

--- a/apps/api/pi_dash/tests/unit/config/test_settings_centralization.py
+++ b/apps/api/pi_dash/tests/unit/config/test_settings_centralization.py
@@ -37,6 +37,20 @@ def test_settings_modules_do_not_read_os_environ_directly():
 
 
 @pytest.mark.unit
+def test_every_seeded_key_is_registered_as_db():
+    """Every key configure_instance seeds into InstanceConfiguration must be
+    registered as db-sourced in OSS. Otherwise the resolver routes it to env
+    and silently ignores the seeded DB row (the IS_*_ENABLED regression)."""
+    from pi_dash.config.registry import CONFIG
+    from pi_dash.license.management.commands.configure_instance import DERIVED_FLAG_KEYS
+    from pi_dash.utils.instance_config_variables import instance_config_variables
+
+    seeded = [item["key"] for item in instance_config_variables] + list(DERIVED_FLAG_KEYS)
+    bad = [key for key in seeded if CONFIG.get(key, {}).get("source") != "db"]
+    assert not bad, f"seeded keys not registered as db-sourced: {sorted(bad)}"
+
+
+@pytest.mark.unit
 def test_registry_catalogs_every_key_settings_read():
     """Every key passed to get_config(...) in the settings modules must be
     registered, so the registry stays a complete catalog (and strict mode in


### PR DESCRIPTION
## What & why

Config reads were split two confusing ways: a small set (email/OAuth/LLM) went through the `get_configuration_value` resolver gated by the global `SKIP_ENV_VAR` flag, while everything else read `os.environ` directly across the settings modules. `SKIP_ENV_VAR` caused more confusion than it helped.

This replaces the global flag with a **single registry + accessor** where each key declares its source (`env` vs `db`), and routes the settings modules through it.

## Changes

- **`pi_dash/config/`** — new package. `registry.py` is the single catalog of every config key; `accessor.py` exposes `get_config` / `get_many` / `get_bool` / `get_int`.
  - Unregistered keys: warn + fall back to env in prod, **raise in test/CI** (so misses are caught before shipping).
  - `db`-sourced keys read before the app registry is ready fail loudly (settings import must only touch `env` keys).
- **Removed `SKIP_ENV_VAR`.** `get_configuration_value` now decides source **per key** via the registry, preserving caller-supplied defaults exactly. `configure_instance` seeds DB rows only for `db`-sourced keys.
- **Settings modules** (`common`, `production`, `local`, `storage`) now read through `get_config`. A guard test bans direct `os.environ` in `settings/` and asserts every `get_config` key is registered.
- **Serializer** exposes `source` / `is_managed` on the instance-configuration API so the admin UI can render env-managed keys read-only.
- **Cloud seam:** `PIDASH_CONFIG_ENV_KEYS` (comma-separated) flips keys to `env` with no code change. OSS behavior is unchanged — every formerly-DB key stays `db`.

## Back-compat

Self-hosted behavior is identical: all keys the resolver served from the DB stay `db`-sourced; nothing is reclassified in OSS.

## Testing

25 config unit tests + the existing settings/bg_tasks suites pass, plus a verified production-settings import exercising the read-replica, MinIO, AMQP, runner-version, and CORS branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)