### PR TITLE
Link GitHub pull requests to work items

### DIFF
--- a/.ai_design/github_pr_issue_link/design.md
+++ b/.ai_design/github_pr_issue_link/design.md
@@ -1,0 +1,208 @@
+# GitHub PR ↔ Issue Linking — Design
+
+**Status:** Proposed — foundation slice (builds on the merged GitHub App foundation, PR #261)
+**Date:** 2026-06-17
+**Scope:** Let a Pi Dash issue carry an optional, possibly-empty set of links to GitHub
+**pull requests** (many PRs → one issue). A PR is attached explicitly — primarily by the
+coding agent running a new `pidash` CLI command after it opens a PR. The GitHub App keeps
+each linked PR's **own status** (open / merged / draft / closed) fresh so the issue can show
+an overview of its PRs.
+
+**Hard non-goals:** Attaching or refreshing a PR **never** changes the Pi Dash issue's
+workflow state or any other issue field. No write-back to GitHub. Updating *the PR's
+displayed status on the issue* is **not** the same as changing *the issue's* state — only
+the former is in scope.
+
+---
+
+## 1. Problem
+
+Pi Dash issues are a **superset** of GitHub issues — most have no GitHub issue at all, so
+the existing mirror path (`GithubIssueSync` → `GithubRepositorySync`) cannot represent
+"this issue is implemented by GitHub PR #42." Today, when an AI agent picks up an issue
+(e.g. *"change the home-page button to blue"*), opens a PR, and posts the PR URL as a
+free-text comment via `pidash comment add`, there is **no structured link**, **no overview
+of an issue's PRs**, and **no live status**. We want a first-class, optional **issue → PR**
+association that is cheap to create and whose PR status stays current — without inheriting
+any issue-state-mutation semantics.
+
+## 2. Goals
+
+1. **Link PRs to an issue.** A standalone model, independent of `GithubIssueSync`, so
+   superset issues (no GitHub issue) are supported. Cardinality: **one issue → many PRs;
+   one PR → one issue.**
+2. **Attach via the pidash CLI.** A new command the agent runs after opening a PR; the link
+   is created from authenticated, issue-scoped input — no GitHub-side marker, no parsing.
+3. **Keep each linked PR's status fresh.** The GitHub App `pull_request` webhook updates the
+   link's status snapshot when a link exists; if no link exists, it does nothing. This
+   powers a **PR overview** on the issue.
+
+## 3. Non-Goals
+
+- **No PR → issue state mapping.** Merging/closing a PR does not move the issue. (Updating
+  the PR's badge on the issue is display only.)
+- **No write-back to GitHub.** The agent continues to author its own PR; Pi Dash never
+  opens/edits/merges PRs.
+- **No runner protocol change.** Binding rides the existing authenticated CLI path, not a
+  new `AgentRunEvent` kind. (The coding agent can't speak the runner protocol; it can call
+  the CLI.)
+- **No GitHub-issue / PAT-sync changes.**
+- **No provider abstraction** (GitHub only; the CLI verb is named generically).
+- **No `agent_run` linkage.** Provenance is covered by `linked_by`/`linked_at`; a run FK
+  would only add a `db`→`runner` cross-app dependency for no real benefit.
+
+## 4. Background — what we build on (verified in code)
+
+| System | Where | Reuse |
+| --- | --- | --- |
+| Inbound webhook receiver | `GithubAppWebhookEndpoint` (`app/views/integration/github.py`, #261) | Add a `pull_request` branch (today it stores-and-skips it). |
+| Installation tokens (if needed) | `utils/github_app_auth.py`, `GithubClient.for_installation` (#261) | Optional best-effort snapshot at attach time when the App is connected. |
+| Issue conversation CLI | `pidash comment add <PROJECT-123> --agent-run-id "$PIDASH_AGENT_RUN_ID"` (`pi-dash-skill/shared/pidash-workflows.md`) | Add a sibling `pidash issue attach-pr` in the same style. |
+| External API surface | `pi_dash.api` (`/api/v1/`, `X-Api-Key`); `api/views/issue.py`, `api/urls/work_item.py` | New attach/detach/list endpoints. |
+| Issue identifier | `Issue.sequence_id` → `PROJECT-123` | Command accepts the human identifier. |
+| Soft-delete + partial unique pattern | `github_repository_sync_unique_per_project_when_active` (`db/models/integration/github.py`) | Same shape for detach/re-attach. |
+
+**Why not `GithubIssueSync`:** it requires a GitHub *issue* and a PAT-backed
+`GithubRepositorySync`; superset issues have neither. The PR link must be standalone.
+
+## 5. Data model
+
+```
+GithubPullRequestLink(BaseModel):
+  issue       FK(db.Issue, related_name="github_pull_requests")   # required
+  repo_owner  CharField
+  repo_name   CharField
+  pr_number   IntegerField
+  url         URLField
+  # PR status snapshot — display only; refreshed by the webhook (§7):
+  title       CharField(blank, default="")
+  state       CharField(choices=open|closed, default=open)
+  merged      BooleanField(default=False)
+  draft       BooleanField(default=False)
+  pr_updated_at DateTimeField(null=True)        # GitHub updated_at; out-of-order guard
+  linked_by   FK(User, null=True, on_delete=SET_NULL)   # CLI audit actor
+  # created_at / updated_at / deleted_at from BaseModel
+
+  constraints:
+    UniqueConstraint(fields=[repo_owner, repo_name, pr_number],
+                     condition=Q(deleted_at__isnull=True),
+                     name="github_pr_link_unique_per_pr_when_active")
+  indexes: (repo_owner, repo_name, pr_number), (issue)
+```
+
+- **Issue → many PRs:** `issue.github_pull_requests` (0..N); empty = zero rows.
+- **PR → one issue:** the partial-unique key. (Global across workspaces, matching the
+  stated "one PR → one issue" cardinality.)
+- **No `repo_id`/`installation_id`:** identity is `(owner, repo, number)`, parsed from the
+  URL and present in the webhook payload — so **attach needs no GitHub App / API call**, and
+  the webhook matches without a join. Repo renames are an accepted edge (see §9).
+- Normalize `repo_owner`/`repo_name` to lowercase on write (GitHub is case-insensitive) so
+  attach and webhook match consistently.
+
+## 6. Attach via the pidash CLI
+
+### 6.1 Command
+```bash
+pidash issue attach-pr <PROJECT-123> --url <pr-url>
+```
+The agent runs this after `gh pr create`. It supplies only the URL — the one datum it
+reliably has. The skill prompt (`pi-dash-skill/shared/pidash-workflows.md`) is updated to
+instruct the agent accordingly. A `detach`/`list` variant backs the UI.
+
+### 6.2 Endpoint (external API, `pi_dash.api`)
+`POST /api/v1/workspaces/.../issues/<id>/github/pull-requests/`:
+1. Resolve the issue from the identifier **within the API key's workspace**.
+2. **Authorize:** caller must have issue edit/comment permission (not just any workspace
+   key). Detach requires the same.
+3. Validate it is a GitHub PR URL; parse `owner / repo / number` (github.com only, matching
+   #261's host scope).
+4. Upsert the link on `(repo_owner, repo_name, pr_number)`:
+   - new → create, linked to the issue;
+   - same issue → no-op (idempotent re-report);
+   - **different issue → `409`** ("PR already linked to <ISSUE>").
+5. Record `linked_by`.
+6. **Optional best-effort snapshot:** if the issue's workspace has a connected App
+   installation covering the repo, fetch the PR once via `GithubClient.for_installation`
+   to pre-fill `title/state/merged/draft`. If not, leave them blank — they fill on the first
+   webhook (§7). Attach never *fails* for lack of an App.
+
+**Why CLI, not a PR-body marker or runner event:** GitHub has no per-PR metadata field, so a
+marker means embedding an id in the PR body/commit and parsing it back — editable
+(spoofable) and fragile. The authenticated, issue-scoped CLI call has no GitHub round-trip
+and no spoof surface. And the coding agent can't emit runner-protocol events — the CLI is
+its real capability.
+
+## 7. Keep PR status fresh — `pull_request` webhook
+
+Extend `GithubAppWebhookEndpoint` (#261), which currently persists `pull_request`
+deliveries and marks them `skipped`:
+
+- On a `pull_request` event, look up a link by `(owner, repo, number)` from
+  `payload.pull_request` / `payload.repository`.
+- **If a link exists:** copy `title`, `state`, `merged`, `draft`, `pr_updated_at` from the
+  payload onto the link. Skip if the payload `updated_at` is older than stored
+  `pr_updated_at` (out-of-order / replay; deliveries already dedupe on `X-GitHub-Delivery`).
+- **If no link exists:** do nothing (today's persist + `skipped`). We never auto-create
+  links from webhooks.
+- The handler touches **only the link row** — never the issue.
+
+GitHub App registration (one-time): add **Pull requests: Read** and subscribe to
+**`pull_request`**. This is the only part that needs the new scope; attach works without it.
+
+## 8. UI — PR overview on the issue
+
+On the Pi Dash issue detail, a **"Pull requests"** section lists
+`issue.github_pull_requests`: title, number, a status badge (open / draft / merged /
+closed), and an out-link to GitHub. Plus a manual **Attach PR** (paste a URL) and **Detach**
+action. Display only — no issue-state controls, no sync toggles.
+
+## 9. Security & edge cases
+
+- **Tenant scope:** attach resolves the issue within the caller's workspace; the unique key
+  is global so a PR can't be double-linked.
+- **No spoof surface:** the link comes from authenticated CLI input, nothing carried inside
+  the PR.
+- **Least privilege:** only Pull requests: Read added; no write scopes. Webhook stores only
+  public PR metadata the attacher already had access to.
+- **No issue side effects:** by construction, neither attach nor webhook mutates issue
+  fields.
+- **Repo rename:** keying on `(owner, repo, number)` means a rename orphans the snapshot
+  refresh until re-attached. Accepted for v1 (rare; webhook `repository.id` could be used to
+  self-heal later).
+- **Attach before App connected:** snapshot starts blank, fills on the first `pull_request`
+  event after the App is installed.
+
+## 10. Implementation slices
+
+1. **Slice A — link + attach + overview.** Model + migration, the `attach-pr`/`detach`/`list`
+   endpoints + CLI command + skill-prompt update, and the issue "Pull requests" section.
+   Snapshot is blank or best-effort at attach. No new GitHub scope.
+2. **Slice B — live status.** Add Pull requests: Read + `pull_request` subscription; extend
+   the webhook to refresh snapshots. Turns the overview's badges live.
+
+Slice A is independently useful; Slice B only makes the badges current.
+
+## 11. File-level impact map
+
+| Area | File(s) | Change |
+| --- | --- | --- |
+| Model + migration | `apps/api/pi_dash/db/models/integration/github.py`, `db/migrations/` | Add `GithubPullRequestLink` + migration. |
+| Attach/detach/list | `apps/api/pi_dash/api/views/issue.py` (or new `api/views/github_pr.py`), `api/urls/work_item.py` | Endpoints; parse + authorize + upsert. |
+| Installation client | `apps/api/pi_dash/utils/github_client.py` | `get_pull_request(owner, name, number)` (used by §6.2 optional snapshot + §7). |
+| Webhook refresh | `apps/api/pi_dash/app/views/integration/github.py` | `pull_request` branch: refresh link snapshot only (Slice B). |
+| GitHub App config | App registration | Pull requests: Read; subscribe `pull_request` (Slice B). |
+| CLI | pidash CLI (where `issue create` / `comment add` live; confirm `deployments/cli`) | New `issue attach-pr` / `detach` / `list-pr` commands. |
+| Skill prompt | `pi-dash-skill/shared/pidash-workflows.md` | Instruct the agent to run `attach-pr` after opening a PR. |
+| Types/UI | `packages/types/src/integration.ts`, issue-detail components | PR-link types + the "Pull requests" issue section. |
+
+## 12. To confirm at implementation (not re-design)
+
+1. **API surface/auth** the `pidash` CLI uses for `comment add`, so `attach-pr` matches it.
+2. **Permission level** for attach/detach — issue edit/comment.
+
+## 13. Deferred
+
+- PR → **issue** state automation (hard non-goal here; would be its own design).
+- Write-back / runner-authored PRs.
+- Provider abstraction (GitLab/Bitbucket) behind the generic `attach-pr` verb.
+- Repo-rename self-healing via `repository.id`.

--- a/apps/api/pi_dash/api/serializers/__init__.py
+++ b/apps/api/pi_dash/api/serializers/__init__.py
@@ -15,6 +15,7 @@ from .issue import (
     LabelCreateUpdateSerializer,
     LabelSerializer,
     IssueLinkSerializer,
+    GithubPullRequestLinkSerializer,
     IssueCommentSerializer,
     IssueAttachmentSerializer,
     IssueActivitySerializer,

--- a/apps/api/pi_dash/api/serializers/issue.py
+++ b/apps/api/pi_dash/api/serializers/issue.py
@@ -17,6 +17,7 @@ from pi_dash.db.models import (
     IssueActivity,
     IssueAssignee,
     FileAsset,
+    GithubPullRequestLink,
     IssueComment,
     IssueLabel,
     IssueLink,
@@ -496,6 +497,34 @@ class IssueLinkSerializer(BaseSerializer):
             "created_at",
             "updated_at",
         ]
+
+
+class GithubPullRequestLinkSerializer(BaseSerializer):
+    """Read serializer for a GitHub PR linked to a work item.
+
+    All PR-status fields are server-managed (set at attach time and refreshed by
+    the GitHub App webhook), so the client only ever supplies ``url`` on create.
+    """
+
+    class Meta:
+        model = GithubPullRequestLink
+        fields = [
+            "id",
+            "issue",
+            "repo_owner",
+            "repo_name",
+            "pr_number",
+            "url",
+            "title",
+            "state",
+            "merged",
+            "draft",
+            "pr_updated_at",
+            "created_at",
+            "updated_at",
+            "created_by",
+        ]
+        read_only_fields = fields
 
 
 class IssueRelationResponseSerializer(serializers.Serializer):

--- a/apps/api/pi_dash/api/urls/work_item.py
+++ b/apps/api/pi_dash/api/urls/work_item.py
@@ -5,6 +5,8 @@
 from django.urls import path
 
 from pi_dash.api.views import (
+    GithubPullRequestLinkListCreateAPIEndpoint,
+    GithubPullRequestLinkDetailAPIEndpoint,
     IssueListCreateAPIEndpoint,
     IssueDetailAPIEndpoint,
     IssueMoveAPIEndpoint,
@@ -168,6 +170,16 @@ new_url_patterns = [
         "workspaces/<str:slug>/projects/<str:project_id>/work-items/<uuid:issue_id>/workpad/",
         IssueWorkpadAPIEndpoint.as_view(http_method_names=["get", "patch"]),
         name="work-item-workpad",
+    ),
+    path(
+        "workspaces/<str:slug>/projects/<str:project_id>/work-items/<uuid:issue_id>/github/pull-requests/",
+        GithubPullRequestLinkListCreateAPIEndpoint.as_view(http_method_names=["get", "post"]),
+        name="work-item-github-pr-list",
+    ),
+    path(
+        "workspaces/<str:slug>/projects/<str:project_id>/work-items/<uuid:issue_id>/github/pull-requests/<uuid:pk>/",
+        GithubPullRequestLinkDetailAPIEndpoint.as_view(http_method_names=["delete"]),
+        name="work-item-github-pr-detail",
     ),
 ]
 

--- a/apps/api/pi_dash/api/views/__init__.py
+++ b/apps/api/pi_dash/api/views/__init__.py
@@ -35,6 +35,11 @@ from .issue import (
     IssueWorkpadAPIEndpoint,
 )
 
+from .github_pr import (
+    GithubPullRequestLinkListCreateAPIEndpoint,
+    GithubPullRequestLinkDetailAPIEndpoint,
+)
+
 from .cycle import (
     CycleListCreateAPIEndpoint,
     CycleDetailAPIEndpoint,

--- a/apps/api/pi_dash/api/views/github_pr.py
+++ b/apps/api/pi_dash/api/views/github_pr.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""External-API endpoints for linking a work item to GitHub pull requests.
+
+This is the server-side contract behind the ``pidash issue attach-pr`` CLI
+command. Attaching/detaching never mutates the issue's workflow state; the
+PR status snapshot is best-effort at attach time and refreshed by the GitHub
+App ``pull_request`` webhook (see ``app/views/integration/github.py``).
+"""
+
+from rest_framework import status
+from rest_framework.response import Response
+
+from pi_dash.api.serializers import GithubPullRequestLinkSerializer
+from pi_dash.api.views.base import BaseAPIView
+from pi_dash.app.permissions import ProjectEntityPermission
+from pi_dash.db.models import GithubPullRequestLink
+from pi_dash.utils.github_pr_links import (
+    InvalidPullRequestURL,
+    PullRequestAlreadyLinked,
+    attach_pull_request,
+)
+
+
+class GithubPullRequestLinkListCreateAPIEndpoint(BaseAPIView):
+    """List PRs linked to a work item, or attach a new one by URL."""
+
+    model = GithubPullRequestLink
+    serializer_class = GithubPullRequestLinkSerializer
+    permission_classes = [ProjectEntityPermission]
+    use_read_replica = True
+
+    def get_queryset(self):
+        return (
+            GithubPullRequestLink.objects.filter(workspace__slug=self.kwargs.get("slug"))
+            .filter(project_id=self.kwargs.get("project_id"))
+            .filter(issue_id=self.kwargs.get("issue_id"))
+            .filter(
+                project__project_projectmember__member=self.request.user,
+                project__project_projectmember__is_active=True,
+            )
+            .filter(project__archived_at__isnull=True)
+            .order_by(self.kwargs.get("order_by", "-created_at"))
+            .distinct()
+        )
+
+    def get(self, request, slug, project_id, issue_id):
+        return self.paginate(
+            request=request,
+            queryset=self.get_queryset(),
+            on_results=lambda links: GithubPullRequestLinkSerializer(links, many=True).data,
+        )
+
+    def post(self, request, slug, project_id, issue_id):
+        try:
+            link, created = attach_pull_request(
+                project_id=project_id, issue_id=issue_id, workspace_slug=slug, raw_url=request.data.get("url"),
+            )
+        except InvalidPullRequestURL:
+            return Response(
+                {"error": "A valid github.com pull request URL is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        except PullRequestAlreadyLinked as e:
+            return Response({"error": str(e)}, status=status.HTTP_409_CONFLICT)
+
+        return Response(
+            GithubPullRequestLinkSerializer(link).data,
+            status=status.HTTP_201_CREATED if created else status.HTTP_200_OK,
+        )
+
+
+class GithubPullRequestLinkDetailAPIEndpoint(BaseAPIView):
+    """Detach (soft-delete) a linked PR."""
+
+    model = GithubPullRequestLink
+    serializer_class = GithubPullRequestLinkSerializer
+    permission_classes = [ProjectEntityPermission]
+
+    def get_queryset(self):
+        return (
+            GithubPullRequestLink.objects.filter(workspace__slug=self.kwargs.get("slug"))
+            .filter(project_id=self.kwargs.get("project_id"))
+            .filter(issue_id=self.kwargs.get("issue_id"))
+            .filter(
+                project__project_projectmember__member=self.request.user,
+                project__project_projectmember__is_active=True,
+            )
+        )
+
+    def delete(self, request, slug, project_id, issue_id, pk):
+        link = self.get_queryset().get(pk=pk)
+        link.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/apps/api/pi_dash/api/views/github_pr.py
+++ b/apps/api/pi_dash/api/views/github_pr.py
@@ -19,6 +19,7 @@ from pi_dash.app.permissions import ProjectEntityPermission
 from pi_dash.db.models import GithubPullRequestLink
 from pi_dash.utils.github_pr_links import (
     InvalidPullRequestURL,
+    IssueNotFound,
     PullRequestAlreadyLinked,
     attach_pull_request,
 )
@@ -63,6 +64,8 @@ class GithubPullRequestLinkListCreateAPIEndpoint(BaseAPIView):
                 {"error": "A valid github.com pull request URL is required."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
+        except IssueNotFound:
+            return Response({"error": "Work item not found."}, status=status.HTTP_404_NOT_FOUND)
         except PullRequestAlreadyLinked as e:
             return Response({"error": str(e)}, status=status.HTTP_409_CONFLICT)
 

--- a/apps/api/pi_dash/app/serializers/__init__.py
+++ b/apps/api/pi_dash/app/serializers/__init__.py
@@ -63,6 +63,7 @@ from .issue import (
     IssueFlatSerializer,
     IssueStateSerializer,
     IssueLinkSerializer,
+    GithubPullRequestLinkSerializer,
     IssueIntakeSerializer,
     IssueLiteSerializer,
     IssueAttachmentSerializer,

--- a/apps/api/pi_dash/app/serializers/issue.py
+++ b/apps/api/pi_dash/app/serializers/issue.py
@@ -32,6 +32,7 @@ from pi_dash.db.models import (
     Module,
     ModuleIssue,
     IssueLink,
+    GithubPullRequestLink,
     FileAsset,
     IssueReaction,
     CommentReaction,
@@ -649,6 +650,37 @@ class IssueModuleDetailSerializer(BaseSerializer):
             "created_at",
             "updated_at",
         ]
+
+
+class GithubPullRequestLinkSerializer(BaseSerializer):
+    """Read serializer for a GitHub PR linked to a work item (web overview).
+
+    All PR-status fields are server-managed (set at attach time and refreshed by
+    the GitHub App webhook), so the client only ever supplies ``url`` on create.
+    """
+
+    created_by_detail = UserLiteSerializer(read_only=True, source="created_by")
+
+    class Meta:
+        model = GithubPullRequestLink
+        fields = [
+            "id",
+            "issue",
+            "repo_owner",
+            "repo_name",
+            "pr_number",
+            "url",
+            "title",
+            "state",
+            "merged",
+            "draft",
+            "pr_updated_at",
+            "created_at",
+            "updated_at",
+            "created_by",
+            "created_by_detail",
+        ]
+        read_only_fields = fields
 
 
 class IssueLinkSerializer(BaseSerializer):

--- a/apps/api/pi_dash/app/urls/issue.py
+++ b/apps/api/pi_dash/app/urls/issue.py
@@ -9,6 +9,7 @@ from pi_dash.app.views import (
     BulkDeleteIssuesEndpoint,
     SubIssuesEndpoint,
     IssueLinkViewSet,
+    GithubPullRequestLinkViewSet,
     IssueAttachmentEndpoint,
     CommentReactionViewSet,
     IssueActivityEndpoint,
@@ -122,6 +123,16 @@ urlpatterns = [
             }
         ),
         name="project-issue-links",
+    ),
+    path(
+        "workspaces/<str:slug>/projects/<str:project_id>/issues/<uuid:issue_id>/github-pull-requests/",
+        GithubPullRequestLinkViewSet.as_view({"get": "list", "post": "create"}),
+        name="project-issue-github-pull-requests",
+    ),
+    path(
+        "workspaces/<str:slug>/projects/<str:project_id>/issues/<uuid:issue_id>/github-pull-requests/<uuid:pk>/",
+        GithubPullRequestLinkViewSet.as_view({"delete": "destroy"}),
+        name="project-issue-github-pull-requests",
     ),
     path(
         "workspaces/<str:slug>/projects/<str:project_id>/issues/<uuid:issue_id>/issue-attachments/",

--- a/apps/api/pi_dash/app/views/__init__.py
+++ b/apps/api/pi_dash/app/views/__init__.py
@@ -144,6 +144,8 @@ from .issue.label import LabelViewSet, BulkCreateIssueLabelsEndpoint
 
 from .issue.link import IssueLinkViewSet
 
+from .issue.github_pr import GithubPullRequestLinkViewSet
+
 from .issue.relation import IssueRelationViewSet
 
 from .issue.reaction import IssueReactionViewSet

--- a/apps/api/pi_dash/app/views/integration/github.py
+++ b/apps/api/pi_dash/app/views/integration/github.py
@@ -636,8 +636,10 @@ def _refresh_pr_links(payload: dict) -> int:
     """Refresh the display snapshot of any `GithubPullRequestLink` matching the
     PR in a `pull_request` webhook. Touches only the link row — never the issue.
 
-    Returns the number of links updated (0 when no link is attached, which the
-    caller maps to a `skipped` delivery). Out-of-order/replayed deliveries are
+    Returns the number of links the PR *matched* (0 when no link is attached,
+    which the caller maps to a `skipped` delivery). A matched-but-stale delivery
+    still counts as matched — it is a real, processed delivery, just not applied —
+    so it is not mislabelled `skipped`. Out-of-order/replayed deliveries are
     ignored via the PR's `updated_at`.
     """
     pull_request = payload.get("pull_request") or {}
@@ -651,15 +653,15 @@ def _refresh_pr_links(payload: dict) -> int:
     snapshot = pr_snapshot_from_payload(pull_request)
     incoming = snapshot.get("pr_updated_at")
 
-    updated = 0
+    matched = 0
     for link in GithubPullRequestLink.objects.filter(repo_owner=owner, repo_name=name, pr_number=number):
+        matched += 1
         if incoming and link.pr_updated_at and incoming < link.pr_updated_at:
-            continue  # stale / out-of-order delivery
+            continue  # stale / out-of-order delivery — matched but not applied
         for field, value in snapshot.items():
             setattr(link, field, value)
         link.save(update_fields=["title", "state", "merged", "draft", "pr_updated_at", "updated_at"])
-        updated += 1
-    return updated
+    return matched
 
 
 class GithubAppWebhookEndpoint(BaseAPIView):

--- a/apps/api/pi_dash/app/views/integration/github.py
+++ b/apps/api/pi_dash/app/views/integration/github.py
@@ -36,6 +36,7 @@ from pi_dash.db.models import (
     GithubAppInstallSession,
     GithubCommentSync,
     GithubIssueSync,
+    GithubPullRequestLink,
     GithubRepository,
     GithubRepositorySync,
     GithubWebhookDelivery,
@@ -66,6 +67,7 @@ from pi_dash.utils.github_client import (
     GithubNotFoundError,
     GithubPermissionError,
     parse_github_repo_url,
+    pr_snapshot_from_payload,
 )
 
 logger = logging.getLogger(__name__)
@@ -630,6 +632,36 @@ class GithubAppCallbackEndpoint(BaseAPIView):
         )
 
 
+def _refresh_pr_links(payload: dict) -> int:
+    """Refresh the display snapshot of any `GithubPullRequestLink` matching the
+    PR in a `pull_request` webhook. Touches only the link row — never the issue.
+
+    Returns the number of links updated (0 when no link is attached, which the
+    caller maps to a `skipped` delivery). Out-of-order/replayed deliveries are
+    ignored via the PR's `updated_at`.
+    """
+    pull_request = payload.get("pull_request") or {}
+    repository = payload.get("repository") or {}
+    number = pull_request.get("number")
+    owner = ((repository.get("owner") or {}).get("login") or "").lower()
+    name = (repository.get("name") or "").lower()
+    if not (owner and name and number):
+        return 0
+
+    snapshot = pr_snapshot_from_payload(pull_request)
+    incoming = snapshot.get("pr_updated_at")
+
+    updated = 0
+    for link in GithubPullRequestLink.objects.filter(repo_owner=owner, repo_name=name, pr_number=number):
+        if incoming and link.pr_updated_at and incoming < link.pr_updated_at:
+            continue  # stale / out-of-order delivery
+        for field, value in snapshot.items():
+            setattr(link, field, value)
+        link.save(update_fields=["title", "state", "merged", "draft", "pr_updated_at", "updated_at"])
+        updated += 1
+    return updated
+
+
 class GithubAppWebhookEndpoint(BaseAPIView):
     """POST /integrations/github/app/webhook/"""
 
@@ -680,6 +712,11 @@ class GithubAppWebhookEndpoint(BaseAPIView):
         try:
             if event == "ping":
                 delivery.status = GithubWebhookDelivery.Status.PROCESSED
+            elif event == "pull_request":
+                updated = _refresh_pr_links(payload)
+                delivery.status = (
+                    GithubWebhookDelivery.Status.PROCESSED if updated else GithubWebhookDelivery.Status.SKIPPED
+                )
             elif event in {"installation", "installation_repositories"}:
                 app_installation = None
                 if installation_id:

--- a/apps/api/pi_dash/app/views/issue/github_pr.py
+++ b/apps/api/pi_dash/app/views/issue/github_pr.py
@@ -18,6 +18,7 @@ from pi_dash.app.serializers import GithubPullRequestLinkSerializer
 from pi_dash.db.models import GithubPullRequestLink
 from pi_dash.utils.github_pr_links import (
     InvalidPullRequestURL,
+    IssueNotFound,
     PullRequestAlreadyLinked,
     attach_pull_request,
 )
@@ -55,6 +56,8 @@ class GithubPullRequestLinkViewSet(BaseViewSet):
                 {"error": "A valid github.com pull request URL is required."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
+        except IssueNotFound:
+            return Response({"error": "Work item not found."}, status=status.HTTP_404_NOT_FOUND)
         except PullRequestAlreadyLinked as e:
             return Response({"error": str(e)}, status=status.HTTP_409_CONFLICT)
 

--- a/apps/api/pi_dash/app/views/issue/github_pr.py
+++ b/apps/api/pi_dash/app/views/issue/github_pr.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Session app-API endpoints for the issue-detail "Pull requests" overview.
+
+Mirrors the external-API ``pidash issue attach-pr`` contract (which the coding
+agent uses) but with session auth for the web UI. Both surfaces share
+``utils.github_pr_links`` so attach behaviour is identical.
+"""
+
+from rest_framework import status
+from rest_framework.response import Response
+
+from .. import BaseViewSet
+from pi_dash.app.permissions import ProjectEntityPermission
+from pi_dash.app.serializers import GithubPullRequestLinkSerializer
+from pi_dash.db.models import GithubPullRequestLink
+from pi_dash.utils.github_pr_links import (
+    InvalidPullRequestURL,
+    PullRequestAlreadyLinked,
+    attach_pull_request,
+)
+
+
+class GithubPullRequestLinkViewSet(BaseViewSet):
+    permission_classes = [ProjectEntityPermission]
+
+    model = GithubPullRequestLink
+    serializer_class = GithubPullRequestLinkSerializer
+
+    def get_queryset(self):
+        return (
+            super()
+            .get_queryset()
+            .filter(workspace__slug=self.kwargs.get("slug"))
+            .filter(project_id=self.kwargs.get("project_id"))
+            .filter(issue_id=self.kwargs.get("issue_id"))
+            .filter(
+                project__project_projectmember__member=self.request.user,
+                project__project_projectmember__is_active=True,
+                project__archived_at__isnull=True,
+            )
+            .order_by("-created_at")
+            .distinct()
+        )
+
+    def create(self, request, slug, project_id, issue_id):
+        try:
+            link, created = attach_pull_request(
+                project_id=project_id, issue_id=issue_id, workspace_slug=slug, raw_url=request.data.get("url"),
+            )
+        except InvalidPullRequestURL:
+            return Response(
+                {"error": "A valid github.com pull request URL is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        except PullRequestAlreadyLinked as e:
+            return Response({"error": str(e)}, status=status.HTTP_409_CONFLICT)
+
+        return Response(
+            GithubPullRequestLinkSerializer(link).data,
+            status=status.HTTP_201_CREATED if created else status.HTTP_200_OK,
+        )
+
+    def destroy(self, request, slug, project_id, issue_id, pk):
+        link = self.get_queryset().get(pk=pk)
+        link.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/apps/api/pi_dash/db/migrations/0151_github_pr_issue_link.py
+++ b/apps/api/pi_dash/db/migrations/0151_github_pr_issue_link.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+import uuid
+
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("db", "0150_github_app_foundation"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="GithubPullRequestLink",
+            fields=[
+                ("created_at", models.DateTimeField(auto_now_add=True, verbose_name="Created At")),
+                ("updated_at", models.DateTimeField(auto_now=True, verbose_name="Last Modified At")),
+                ("deleted_at", models.DateTimeField(blank=True, null=True, verbose_name="Deleted At")),
+                (
+                    "id",
+                    models.UUIDField(
+                        db_index=True,
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                        unique=True,
+                    ),
+                ),
+                ("repo_owner", models.CharField(max_length=255)),
+                ("repo_name", models.CharField(max_length=255)),
+                ("pr_number", models.PositiveIntegerField()),
+                ("url", models.URLField(max_length=500)),
+                ("title", models.CharField(blank=True, default="", max_length=500)),
+                (
+                    "state",
+                    models.CharField(
+                        choices=[("open", "Open"), ("closed", "Closed")],
+                        default="open",
+                        max_length=12,
+                    ),
+                ),
+                ("merged", models.BooleanField(default=False)),
+                ("draft", models.BooleanField(default=False)),
+                ("pr_updated_at", models.DateTimeField(blank=True, null=True)),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="%(class)s_created_by",
+                        to=settings.AUTH_USER_MODEL,
+                        verbose_name="Created By",
+                    ),
+                ),
+                (
+                    "issue",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="github_pull_requests",
+                        to="db.issue",
+                    ),
+                ),
+                (
+                    "project",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="project_%(class)s",
+                        to="db.project",
+                    ),
+                ),
+                (
+                    "updated_by",
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="%(class)s_updated_by",
+                        to=settings.AUTH_USER_MODEL,
+                        verbose_name="Last Modified By",
+                    ),
+                ),
+                (
+                    "workspace",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="workspace_%(class)s",
+                        to="db.workspace",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Github Pull Request Link",
+                "verbose_name_plural": "Github Pull Request Links",
+                "db_table": "github_pull_request_links",
+                "ordering": ("-created_at",),
+            },
+        ),
+        migrations.AddIndex(
+            model_name="githubpullrequestlink",
+            index=models.Index(
+                fields=["repo_owner", "repo_name", "pr_number"],
+                name="github_pr_l_repo_ow_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="githubpullrequestlink",
+            index=models.Index(fields=["issue"], name="github_pr_l_issue_idx"),
+        ),
+        migrations.AddConstraint(
+            model_name="githubpullrequestlink",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(("deleted_at__isnull", True)),
+                fields=("repo_owner", "repo_name", "pr_number"),
+                name="github_pr_link_unique_per_pr_when_active",
+            ),
+        ),
+    ]

--- a/apps/api/pi_dash/db/models/__init__.py
+++ b/apps/api/pi_dash/db/models/__init__.py
@@ -22,6 +22,7 @@ from .intake import Intake, IntakeIssue
 from .integration import (
     GithubAppInstallation,
     GithubAppInstallSession,
+    GithubPullRequestLink,
     GithubWebhookDelivery,
     GithubCommentSync,
     GithubIssueSync,

--- a/apps/api/pi_dash/db/models/integration/__init__.py
+++ b/apps/api/pi_dash/db/models/integration/__init__.py
@@ -6,6 +6,7 @@ from .base import Integration, WorkspaceIntegration
 from .github import (
     GithubAppInstallation,
     GithubAppInstallSession,
+    GithubPullRequestLink,
     GithubWebhookDelivery,
     GithubRepository,
     GithubRepositorySync,

--- a/apps/api/pi_dash/db/models/integration/github.py
+++ b/apps/api/pi_dash/db/models/integration/github.py
@@ -212,3 +212,51 @@ class GithubAppInstallSession(BaseModel):
         verbose_name_plural = "Github App Install Sessions"
         db_table = "github_app_install_sessions"
         ordering = ("-created_at",)
+
+
+class GithubPullRequestLink(ProjectBaseModel):
+    """Optional link from a Pi Dash issue to a GitHub pull request.
+
+    Standalone (not tied to ``GithubIssueSync``/``GithubRepository``) so that
+    Pi Dash issues with no mirrored GitHub issue can still reference PRs. One
+    issue may link many PRs; a PR links to exactly one issue (the partial-unique
+    constraint below). The ``title``/``state``/``merged``/``draft`` snapshot is
+    display-only and refreshed by the GitHub App ``pull_request`` webhook; it
+    never drives the linked issue's workflow state.
+    """
+
+    class State(models.TextChoices):
+        OPEN = "open", "Open"
+        CLOSED = "closed", "Closed"
+
+    issue = models.ForeignKey("db.Issue", on_delete=models.CASCADE, related_name="github_pull_requests")
+    repo_owner = models.CharField(max_length=255)
+    repo_name = models.CharField(max_length=255)
+    pr_number = models.PositiveIntegerField()
+    url = models.URLField(max_length=500)
+    # Display snapshot — refreshed by the pull_request webhook; never mutates the issue.
+    title = models.CharField(max_length=500, blank=True, default="")
+    state = models.CharField(max_length=12, choices=State.choices, default=State.OPEN)
+    merged = models.BooleanField(default=False)
+    draft = models.BooleanField(default=False)
+    pr_updated_at = models.DateTimeField(null=True, blank=True)
+
+    def __str__(self):
+        return f"{self.repo_owner}/{self.repo_name}#{self.pr_number} <{self.issue_id}>"
+
+    class Meta:
+        verbose_name = "Github Pull Request Link"
+        verbose_name_plural = "Github Pull Request Links"
+        db_table = "github_pull_request_links"
+        ordering = ("-created_at",)
+        constraints = [
+            models.UniqueConstraint(
+                fields=["repo_owner", "repo_name", "pr_number"],
+                condition=models.Q(deleted_at__isnull=True),
+                name="github_pr_link_unique_per_pr_when_active",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["repo_owner", "repo_name", "pr_number"], name="github_pr_l_repo_ow_idx"),
+            models.Index(fields=["issue"], name="github_pr_l_issue_idx"),
+        ]

--- a/apps/api/pi_dash/tests/contract/api/test_github_pr_link.py
+++ b/apps/api/pi_dash/tests/contract/api/test_github_pr_link.py
@@ -1,0 +1,246 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Contract tests for the GitHub PR ↔ work-item link endpoints.
+
+Covers ``pidash issue attach-pr``'s server contract: attach by URL, idempotent
+re-attach, one-PR-one-issue conflict, URL validation, list, detach, and the
+best-effort snapshot at attach time. See
+``.ai_design/github_pr_issue_link/design.md``.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from rest_framework import status as http_status
+
+from pi_dash.db.models import (
+    GithubPullRequestLink,
+    Issue,
+    Project,
+    ProjectMember,
+)
+
+
+pytestmark = [pytest.mark.contract, pytest.mark.django_db]
+
+
+@pytest.fixture(autouse=True)
+def _no_throttle(settings):
+    settings.REST_FRAMEWORK = {**settings.REST_FRAMEWORK, "DEFAULT_THROTTLE_CLASSES": ()}
+
+
+@pytest.fixture
+def pr_project(db, workspace, create_user):
+    project = Project.objects.create(
+        name="PR Link Project",
+        identifier="PRL",
+        workspace=workspace,
+        created_by=create_user,
+    )
+    ProjectMember.objects.create(project=project, member=create_user, role=20, is_active=True)
+    return project
+
+
+@pytest.fixture
+def issue(pr_project, create_user):
+    return Issue.objects.create(
+        name="change the home page button to blue",
+        project=pr_project,
+        workspace=pr_project.workspace,
+        created_by=create_user,
+    )
+
+
+def _list_url(slug, project_id, issue_id):
+    return f"/api/v1/workspaces/{slug}/projects/{project_id}/work-items/{issue_id}/github/pull-requests/"
+
+
+def _detail_url(slug, project_id, issue_id, pk):
+    return f"/api/v1/workspaces/{slug}/projects/{project_id}/work-items/{issue_id}/github/pull-requests/{pk}/"
+
+
+def test_attach_creates_link(api_key_client, workspace, pr_project, issue):
+    url = _list_url(workspace.slug, pr_project.id, issue.id)
+
+    response = api_key_client.post(
+        url, {"url": "https://github.com/Acme-Corp/Web/pull/42"}, format="json"
+    )
+
+    assert response.status_code == http_status.HTTP_201_CREATED
+    assert response.data["pr_number"] == 42
+    # owner/repo normalized to lowercase so the webhook can match.
+    assert response.data["repo_owner"] == "acme-corp"
+    assert response.data["repo_name"] == "web"
+    assert response.data["url"] == "https://github.com/acme-corp/web/pull/42"
+
+    link = GithubPullRequestLink.objects.get(pk=response.data["id"])
+    assert link.issue_id == issue.id
+    assert link.state == "open"
+    assert link.merged is False
+
+
+def test_attach_is_idempotent_for_same_issue(api_key_client, workspace, pr_project, issue):
+    url = _list_url(workspace.slug, pr_project.id, issue.id)
+    body = {"url": "https://github.com/acme/web/pull/7"}
+
+    first = api_key_client.post(url, body, format="json")
+    second = api_key_client.post(url, body, format="json")
+
+    assert first.status_code == http_status.HTTP_201_CREATED
+    assert second.status_code == http_status.HTTP_200_OK
+    assert second.data["id"] == first.data["id"]
+    assert GithubPullRequestLink.objects.filter(repo_owner="acme", repo_name="web", pr_number=7).count() == 1
+
+
+def test_attach_conflict_when_pr_linked_to_other_issue(api_key_client, workspace, pr_project, issue, create_user):
+    other_issue = Issue.objects.create(
+        name="another issue",
+        project=pr_project,
+        workspace=pr_project.workspace,
+        created_by=create_user,
+    )
+    GithubPullRequestLink.objects.create(
+        project=pr_project, issue=other_issue, repo_owner="acme", repo_name="web", pr_number=9,
+        url="https://github.com/acme/web/pull/9",
+    )
+
+    response = api_key_client.post(
+        _list_url(workspace.slug, pr_project.id, issue.id),
+        {"url": "https://github.com/acme/web/pull/9"},
+        format="json",
+    )
+
+    assert response.status_code == http_status.HTTP_409_CONFLICT
+    assert GithubPullRequestLink.objects.filter(repo_owner="acme", repo_name="web", pr_number=9).count() == 1
+
+
+@pytest.mark.parametrize(
+    "bad_url",
+    [
+        "",
+        "not-a-url",
+        "https://github.com/acme/web",  # repo, not a PR
+        "https://github.com/acme/web/issues/42",  # issue, not a PR
+        "https://gitlab.com/acme/web/pull/42",  # non-github host
+    ],
+)
+def test_attach_rejects_invalid_url(api_key_client, workspace, pr_project, issue, bad_url):
+    response = api_key_client.post(
+        _list_url(workspace.slug, pr_project.id, issue.id), {"url": bad_url}, format="json"
+    )
+    assert response.status_code == http_status.HTTP_400_BAD_REQUEST
+    assert GithubPullRequestLink.objects.count() == 0
+
+
+def _install_app(workspace, actor, account_login="acme"):
+    """Create a real WorkspaceIntegration + GithubAppInstallation so the
+    best-effort snapshot path resolves an installation for ``account_login``."""
+    from pi_dash.app.views.integration.github import _get_or_create_workspace_integration
+    from pi_dash.db.models import GithubAppInstallation
+
+    wi = _get_or_create_workspace_integration(workspace, actor)
+    return GithubAppInstallation.objects.create(
+        workspace_integration=wi, installation_id=4242, account_login=account_login
+    )
+
+
+class _FakePRClient:
+    def __init__(self, pr):
+        self._pr = pr
+
+    def get_pull_request(self, owner, name, number):
+        return self._pr
+
+
+def test_attach_fills_snapshot_when_app_installed(api_key_client, workspace, pr_project, issue, create_user):
+    """When the workspace has an App installation covering the account, attach
+    best-effort fetches the PR to pre-fill the display snapshot."""
+    _install_app(workspace, create_user, account_login="acme")
+    fake_pr = {"title": "Make the button blue", "state": "open", "draft": True, "merged": False, "updated_at": "2026-06-17T09:00:00Z"}
+
+    with patch(
+        "pi_dash.utils.github_pr_links.GithubClient.for_installation",
+        return_value=_FakePRClient(fake_pr),
+    ):
+        response = api_key_client.post(
+            _list_url(workspace.slug, pr_project.id, issue.id),
+            {"url": "https://github.com/Acme/Web/pull/55"},
+            format="json",
+        )
+
+    assert response.status_code == http_status.HTTP_201_CREATED
+    assert response.data["title"] == "Make the button blue"
+    assert response.data["draft"] is True
+    assert response.data["pr_updated_at"] is not None
+
+
+def test_attach_survives_snapshot_failure(api_key_client, workspace, pr_project, issue, create_user):
+    """A failing best-effort snapshot must not fail the attach (link still created, blank snapshot)."""
+    _install_app(workspace, create_user, account_login="acme")
+
+    with patch(
+        "pi_dash.utils.github_pr_links.GithubClient.for_installation",
+        side_effect=RuntimeError("boom"),
+    ):
+        response = api_key_client.post(
+            _list_url(workspace.slug, pr_project.id, issue.id),
+            {"url": "https://github.com/acme/web/pull/56"},
+            format="json",
+        )
+
+    assert response.status_code == http_status.HTTP_201_CREATED
+    assert response.data["title"] == ""
+
+
+def test_list_returns_attached_prs(api_key_client, workspace, pr_project, issue):
+    for n in (1, 2):
+        GithubPullRequestLink.objects.create(
+            project=pr_project, issue=issue, repo_owner="acme", repo_name="web", pr_number=n,
+            url=f"https://github.com/acme/web/pull/{n}",
+        )
+
+    response = api_key_client.get(_list_url(workspace.slug, pr_project.id, issue.id))
+
+    assert response.status_code == http_status.HTTP_200_OK
+    numbers = {row["pr_number"] for row in response.data["results"]}
+    assert numbers == {1, 2}
+
+
+@patch("pi_dash.db.mixins.soft_delete_related_objects.delay")
+def test_detach_soft_deletes_link(_delay, api_key_client, workspace, pr_project, issue):
+    link = GithubPullRequestLink.objects.create(
+        project=pr_project, issue=issue, repo_owner="acme", repo_name="web", pr_number=3,
+        url="https://github.com/acme/web/pull/3",
+    )
+
+    response = api_key_client.delete(_detail_url(workspace.slug, pr_project.id, issue.id, link.id))
+
+    assert response.status_code == http_status.HTTP_204_NO_CONTENT
+    assert GithubPullRequestLink.objects.filter(pk=link.id).count() == 0  # soft-deleted (default manager hides it)
+    # the same PR can be re-attached after detach (partial-unique on deleted_at)
+    reattach = api_key_client.post(
+        _list_url(workspace.slug, pr_project.id, issue.id),
+        {"url": "https://github.com/acme/web/pull/3"},
+        format="json",
+    )
+    assert reattach.status_code == http_status.HTTP_201_CREATED
+
+
+def test_attach_requires_project_membership(api_client, workspace, pr_project, issue, create_user):
+    """A valid API key whose user is not a member of the project is rejected."""
+    from pi_dash.db.models.api import APIToken
+
+    outsider = type(create_user).objects.create(email="outsider@example.com", username="outsider")
+    token = APIToken.objects.create(user=outsider, label="outsider", token="outsider-token")
+    api_client.credentials(HTTP_X_API_KEY=token.token)
+
+    response = api_client.post(
+        _list_url(workspace.slug, pr_project.id, issue.id),
+        {"url": "https://github.com/acme/web/pull/11"},
+        format="json",
+    )
+
+    assert response.status_code in (http_status.HTTP_403_FORBIDDEN, http_status.HTTP_404_NOT_FOUND)
+    assert GithubPullRequestLink.objects.count() == 0

--- a/apps/api/pi_dash/tests/contract/api/test_github_pr_link.py
+++ b/apps/api/pi_dash/tests/contract/api/test_github_pr_link.py
@@ -228,6 +228,26 @@ def test_detach_soft_deletes_link(_delay, api_key_client, workspace, pr_project,
     assert reattach.status_code == http_status.HTTP_201_CREATED
 
 
+def test_attach_rejects_issue_not_in_project(api_key_client, workspace, pr_project, create_user):
+    """A member of the named project cannot attach a PR to an arbitrary issue id
+    that lives in a different project."""
+    other_project = Project.objects.create(
+        name="Other", identifier="OTH", workspace=workspace, created_by=create_user
+    )
+    foreign_issue = Issue.objects.create(
+        name="foreign", project=other_project, workspace=workspace, created_by=create_user
+    )
+
+    response = api_key_client.post(
+        _list_url(workspace.slug, pr_project.id, foreign_issue.id),
+        {"url": "https://github.com/acme/web/pull/77"},
+        format="json",
+    )
+
+    assert response.status_code == http_status.HTTP_404_NOT_FOUND
+    assert GithubPullRequestLink.objects.count() == 0
+
+
 def test_attach_requires_project_membership(api_client, workspace, pr_project, issue, create_user):
     """A valid API key whose user is not a member of the project is rejected."""
     from pi_dash.db.models.api import APIToken

--- a/apps/api/pi_dash/tests/contract/app/test_github_pr_link_app.py
+++ b/apps/api/pi_dash/tests/contract/app/test_github_pr_link_app.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Contract tests for the session app-API PR-link ViewSet (web overview).
+
+The attach/dedupe logic is shared with — and exhaustively covered by — the
+external-API tests; here we verify the session surface, routing, and that the
+web overview can list and detach.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from django.urls import reverse
+
+from rest_framework import status
+
+from pi_dash.db.models import GithubPullRequestLink, Issue, Project, ProjectMember
+
+
+pytestmark = [pytest.mark.contract, pytest.mark.django_db]
+
+
+@pytest.fixture(autouse=True)
+def _no_throttle(settings):
+    settings.REST_FRAMEWORK = {**settings.REST_FRAMEWORK, "DEFAULT_THROTTLE_CLASSES": ()}
+
+
+@pytest.fixture
+def setup(workspace, create_user):
+    project = Project.objects.create(name="Web P", identifier="WBP", workspace=workspace, created_by=create_user)
+    ProjectMember.objects.create(project=project, member=create_user, role=20, is_active=True)
+    issue = Issue.objects.create(name="i", project=project, workspace=workspace, created_by=create_user)
+    return workspace, project, issue
+
+
+def _list_url(workspace, project, issue):
+    return reverse(
+        "project-issue-github-pull-requests",
+        kwargs={"slug": workspace.slug, "project_id": project.id, "issue_id": issue.id},
+    )
+
+
+def test_attach_and_list_via_session(session_client, setup):
+    workspace, project, issue = setup
+    url = _list_url(workspace, project, issue)
+
+    created = session_client.post(url, {"url": "https://github.com/acme/web/pull/12"}, format="json")
+    assert created.status_code == status.HTTP_201_CREATED
+
+    listed = session_client.get(url)
+    assert listed.status_code == status.HTTP_200_OK
+    assert any(row["pr_number"] == 12 for row in listed.data)
+
+
+def test_attach_invalid_url_via_session(session_client, setup):
+    workspace, project, issue = setup
+    response = session_client.post(_list_url(workspace, project, issue), {"url": "nope"}, format="json")
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@patch("pi_dash.db.mixins.soft_delete_related_objects.delay")
+def test_detach_via_session(_delay, session_client, setup):
+    workspace, project, issue = setup
+    link = GithubPullRequestLink.objects.create(
+        project=project, issue=issue, repo_owner="acme", repo_name="web", pr_number=13,
+        url="https://github.com/acme/web/pull/13",
+    )
+    detail = reverse(
+        "project-issue-github-pull-requests",
+        kwargs={"slug": workspace.slug, "project_id": project.id, "issue_id": issue.id, "pk": link.id},
+    )
+    response = session_client.delete(detail)
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    assert GithubPullRequestLink.objects.filter(pk=link.id).count() == 0

--- a/apps/api/pi_dash/tests/contract/app/test_github_pr_webhook.py
+++ b/apps/api/pi_dash/tests/contract/app/test_github_pr_webhook.py
@@ -100,6 +100,8 @@ def test_pull_request_ignores_out_of_order_delivery(api_client, link):
     response = _post(api_client, _pr_payload(state="closed", merged=True, updated_at="2020-01-01T00:00:00Z"))
 
     assert response.status_code == status.HTTP_202_ACCEPTED
+    # It matched a real link (so it's processed, not skipped) but was not applied.
+    assert response.data == {"status": GithubWebhookDelivery.Status.PROCESSED}
     link.refresh_from_db()
     assert link.state == "open"  # stale delivery ignored
 

--- a/apps/api/pi_dash/tests/contract/app/test_github_pr_webhook.py
+++ b/apps/api/pi_dash/tests/contract/app/test_github_pr_webhook.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Contract tests for the ``pull_request`` branch of the GitHub App webhook.
+
+The webhook refreshes the *display snapshot* of an attached
+``GithubPullRequestLink`` — and only that. It never reads or writes the linked
+issue's state. If no link matches the PR, the delivery is ``skipped``.
+"""
+
+import json
+from uuid import uuid4
+from unittest.mock import patch
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+
+from pi_dash.db.models import GithubPullRequestLink, GithubWebhookDelivery, Issue, Project, ProjectMember
+
+
+pytestmark = [pytest.mark.contract, pytest.mark.django_db]
+
+
+@pytest.fixture(autouse=True)
+def _no_throttle(settings):
+    settings.REST_FRAMEWORK = {**settings.REST_FRAMEWORK, "DEFAULT_THROTTLE_CLASSES": ()}
+
+
+@pytest.fixture
+def link(workspace, create_user):
+    project = Project.objects.create(name="Hook P", identifier="HKP", workspace=workspace, created_by=create_user)
+    ProjectMember.objects.create(project=project, member=create_user, role=20, is_active=True)
+    issue = Issue.objects.create(name="i", project=project, workspace=workspace, created_by=create_user)
+    return GithubPullRequestLink.objects.create(
+        project=project, issue=issue, repo_owner="acme", repo_name="web", pr_number=42,
+        url="https://github.com/acme/web/pull/42", state="open",
+    )
+
+
+def _pr_payload(*, action="closed", state="closed", merged=True, updated_at="2026-06-17T12:00:00Z",
+                owner="Acme", name="Web", number=42, title="Make button blue", draft=False):
+    return {
+        "action": action,
+        "pull_request": {
+            "number": number, "title": title, "state": state, "draft": draft,
+            "merged": merged, "merged_at": updated_at if merged else None, "updated_at": updated_at,
+        },
+        "repository": {"name": name, "owner": {"login": owner}},
+    }
+
+
+def _post(api_client, payload, event="pull_request"):
+    with patch("pi_dash.app.views.integration.github.verify_webhook_signature", return_value=True):
+        return api_client.post(
+            reverse("github-app-webhook"),
+            data=json.dumps(payload),
+            content_type="application/json",
+            HTTP_X_GITHUB_DELIVERY=str(uuid4()),
+            HTTP_X_GITHUB_EVENT=event,
+            HTTP_X_HUB_SIGNATURE_256="sha256=valid",
+        )
+
+
+def test_pull_request_refreshes_snapshot(api_client, link):
+    issue_state_before = link.issue.state_id
+
+    response = _post(api_client, _pr_payload())
+
+    assert response.status_code == status.HTTP_202_ACCEPTED
+    assert response.data == {"status": GithubWebhookDelivery.Status.PROCESSED}
+    link.refresh_from_db()
+    # case-insensitive repo match worked (payload owner "Acme" vs stored "acme")
+    assert link.state == "closed"
+    assert link.merged is True
+    assert link.title == "Make button blue"
+    assert link.pr_updated_at is not None
+    # the issue's own state is never touched
+    link.issue.refresh_from_db()
+    assert link.issue.state_id == issue_state_before
+
+
+def test_pull_request_with_no_link_is_skipped(api_client, link):
+    response = _post(api_client, _pr_payload(number=999))
+
+    assert response.status_code == status.HTTP_202_ACCEPTED
+    assert response.data == {"status": GithubWebhookDelivery.Status.SKIPPED}
+    link.refresh_from_db()
+    assert link.state == "open"  # untouched
+
+
+def test_pull_request_ignores_out_of_order_delivery(api_client, link):
+    link.pr_updated_at = timezone.now()
+    link.state = "open"
+    link.save(update_fields=["pr_updated_at", "state"])
+
+    # An older delivery must not regress the snapshot.
+    response = _post(api_client, _pr_payload(state="closed", merged=True, updated_at="2020-01-01T00:00:00Z"))
+
+    assert response.status_code == status.HTTP_202_ACCEPTED
+    link.refresh_from_db()
+    assert link.state == "open"  # stale delivery ignored
+
+
+def test_pull_request_draft_reflected(api_client, link):
+    response = _post(api_client, _pr_payload(action="opened", state="open", merged=False, draft=True))
+
+    assert response.data == {"status": GithubWebhookDelivery.Status.PROCESSED}
+    link.refresh_from_db()
+    assert link.draft is True
+    assert link.merged is False
+    assert link.state == "open"

--- a/apps/api/pi_dash/tests/unit/utils/test_github_client.py
+++ b/apps/api/pi_dash/tests/unit/utils/test_github_client.py
@@ -18,8 +18,71 @@ from pi_dash.utils.github_client import (
     GithubClient,
     GithubNotFoundError,
     GithubPermissionError,
+    parse_github_pull_request_url,
     parse_issue_number_from_url,
+    pr_snapshot_from_payload,
 )
+
+
+@pytest.mark.unit
+class TestParsePullRequestUrl:
+    @pytest.mark.parametrize(
+        "url,expected",
+        [
+            ("https://github.com/acme/web/pull/42", ("acme", "web", 42)),
+            ("http://github.com/acme/web/pull/7", ("acme", "web", 7)),
+            ("https://github.com/acme/web/pull/42/files", ("acme", "web", 42)),
+            ("https://github.com/Org-Name/Repo.name/pull/1", ("Org-Name", "Repo.name", 1)),
+        ],
+    )
+    def test_valid(self, url, expected):
+        assert parse_github_pull_request_url(url) == expected
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "",
+            None,
+            "not-a-url",
+            "https://github.com/acme/web",  # repo, no PR
+            "https://github.com/acme/web/issues/42",  # issue, not PR
+            "https://gitlab.com/acme/web/pull/42",  # wrong host
+            "https://github.com/acme/web/pull/abc",  # non-numeric
+        ],
+    )
+    def test_invalid(self, url):
+        assert parse_github_pull_request_url(url) is None
+
+
+@pytest.mark.unit
+class TestPrSnapshotFromPayload:
+    def test_open_draft(self):
+        snap = pr_snapshot_from_payload(
+            {"title": "T", "state": "open", "draft": True, "merged": False, "updated_at": "2026-06-17T09:00:00Z"}
+        )
+        assert snap["state"] == "open"
+        assert snap["draft"] is True
+        assert snap["merged"] is False
+        assert snap["pr_updated_at"] is not None
+
+    def test_merged_via_merged_at(self):
+        # Webhook payloads report merged_at rather than a boolean.
+        snap = pr_snapshot_from_payload(
+            {"state": "closed", "merged_at": "2026-06-17T10:00:00Z", "updated_at": "2026-06-17T10:00:00Z"}
+        )
+        assert snap["state"] == "closed"
+        assert snap["merged"] is True
+
+    def test_closed_not_merged(self):
+        snap = pr_snapshot_from_payload({"state": "closed", "merged": False, "merged_at": None})
+        assert snap["state"] == "closed"
+        assert snap["merged"] is False
+
+    def test_title_truncated_and_missing_fields_safe(self):
+        snap = pr_snapshot_from_payload({"title": "x" * 600})
+        assert len(snap["title"]) == 500
+        assert snap["state"] == "open"
+        assert snap["pr_updated_at"] is None
 
 
 @pytest.mark.unit

--- a/apps/api/pi_dash/utils/github_client.py
+++ b/apps/api/pi_dash/utils/github_client.py
@@ -12,6 +12,7 @@ needs, paginated iteration via the Link header. See
 from __future__ import annotations
 
 import re
+from datetime import datetime
 from typing import Iterable, Iterator, Optional
 from urllib.parse import urlencode
 
@@ -149,6 +150,11 @@ class GithubClient:
         response = self._request("POST", url, json={"body": body})
         return response.json()
 
+    def get_pull_request(self, owner: str, name: str, number: int) -> dict:
+        """GET /repos/{owner}/{repo}/pulls/{number} — used to snapshot a PR's
+        title/state/draft/merged when an issue link is attached."""
+        return self._request("GET", f"{self._api_base}/repos/{owner}/{name}/pulls/{number}").json()
+
 
 _ISSUE_URL_RE = re.compile(r"/repos/[^/]+/[^/]+/issues/(\d+)$")
 
@@ -185,3 +191,51 @@ def parse_github_repo_url(url: str) -> Optional[tuple[str, str]]:
         if match:
             return match.group("owner"), match.group("name")
     return None
+
+
+# github.com PR URL, e.g. https://github.com/<owner>/<repo>/pull/<number>.
+# github.com only, matching parse_github_repo_url's host scope.
+_HTTPS_PR_RE = re.compile(
+    r"^https?://github\.com/(?P<owner>[^/\s]+)/(?P<name>[^/\s]+?)/pull/(?P<number>\d+)(?:/[^\s]*)?$"
+)
+
+
+def parse_github_pull_request_url(url: str) -> Optional[tuple[str, str, int]]:
+    """Parse a github.com PR URL into ``(owner, name, number)``.
+
+    Returns ``None`` if the URL is empty, malformed, points at a non-github
+    host, or is not a ``/pull/<n>`` URL (e.g. an ``/issues/<n>`` URL).
+    """
+    if not url:
+        return None
+    match = _HTTPS_PR_RE.match(url.strip())
+    if not match:
+        return None
+    return match.group("owner"), match.group("name"), int(match.group("number"))
+
+
+def _parse_iso8601(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def pr_snapshot_from_payload(pull_request: dict) -> dict:
+    """Map a GitHub pull-request object (REST API or webhook payload) onto the
+    display-only snapshot fields stored on ``GithubPullRequestLink``.
+
+    GitHub reports ``merged_at`` rather than a boolean on the webhook payload,
+    so derive ``merged`` from either ``merged`` or ``merged_at``. ``pr_updated_at``
+    is returned as a parsed (tz-aware) ``datetime`` for direct model assignment.
+    """
+    merged = bool(pull_request.get("merged") or pull_request.get("merged_at"))
+    return {
+        "title": (pull_request.get("title") or "")[:500],
+        "state": "closed" if (pull_request.get("state") == "closed") else "open",
+        "merged": merged,
+        "draft": bool(pull_request.get("draft")),
+        "pr_updated_at": _parse_iso8601(pull_request.get("updated_at")),
+    }

--- a/apps/api/pi_dash/utils/github_pr_links.py
+++ b/apps/api/pi_dash/utils/github_pr_links.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Shared service for attaching GitHub pull requests to work items.
+
+Used by both API surfaces — the external API (``pidash issue attach-pr``) and
+the session app API (the web overview) — so the parse / dedupe / best-effort
+snapshot logic lives in exactly one place.
+"""
+
+import logging
+
+from pi_dash.db.models import GithubAppInstallation, GithubPullRequestLink
+from pi_dash.utils.exception_logger import log_exception
+from pi_dash.utils.github_client import (
+    GithubClient,
+    parse_github_pull_request_url,
+    pr_snapshot_from_payload,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class InvalidPullRequestURL(ValueError):
+    """The supplied string is not a valid github.com pull request URL."""
+
+
+class PullRequestAlreadyLinked(Exception):
+    """The PR is already linked to a different work item (one PR → one issue)."""
+
+    def __init__(self, issue_id):
+        self.issue_id = issue_id
+        super().__init__(f"This pull request is already linked to issue {issue_id}.")
+
+
+def best_effort_snapshot(workspace_slug: str, owner: str, name: str, number: int) -> dict:
+    """Fetch the PR via the workspace's GitHub App installation, if one covers
+    this account. Returns the display snapshot, or ``{}`` on any failure — the
+    webhook keeps the link fresh regardless, so attach must never fail here."""
+    installation = GithubAppInstallation.objects.filter(
+        workspace_integration__workspace__slug=workspace_slug,
+        account_login__iexact=owner,
+    ).first()
+    if installation is None:
+        return {}
+    try:
+        pull_request = GithubClient.for_installation(installation.installation_id).get_pull_request(owner, name, number)
+        return pr_snapshot_from_payload(pull_request)
+    except Exception as e:  # network / token / 404 — non-fatal
+        log_exception(e)
+        return {}
+
+
+def attach_pull_request(*, project_id, issue_id, workspace_slug: str, raw_url: str):
+    """Attach (or idempotently re-attach) a PR to a work item.
+
+    Returns ``(link, created)``. Raises :class:`InvalidPullRequestURL` for a bad
+    URL and :class:`PullRequestAlreadyLinked` when the PR already belongs to a
+    different issue.
+    """
+    parsed = parse_github_pull_request_url((raw_url or "").strip())
+    if parsed is None:
+        raise InvalidPullRequestURL()
+    owner, name, number = parsed
+    # GitHub owners/repos are case-insensitive; normalize so attach and the
+    # webhook lookup agree.
+    owner, name = owner.lower(), name.lower()
+
+    existing = GithubPullRequestLink.objects.filter(repo_owner=owner, repo_name=name, pr_number=number).first()
+    if existing is not None:
+        if str(existing.issue_id) != str(issue_id):
+            raise PullRequestAlreadyLinked(existing.issue_id)
+        return existing, False
+
+    snapshot = best_effort_snapshot(workspace_slug, owner, name, number)
+    link = GithubPullRequestLink.objects.create(
+        project_id=project_id,
+        issue_id=issue_id,
+        repo_owner=owner,
+        repo_name=name,
+        pr_number=number,
+        url=f"https://github.com/{owner}/{name}/pull/{number}",
+        **snapshot,
+    )
+    return link, True

--- a/apps/api/pi_dash/utils/github_pr_links.py
+++ b/apps/api/pi_dash/utils/github_pr_links.py
@@ -11,7 +11,9 @@ snapshot logic lives in exactly one place.
 
 import logging
 
-from pi_dash.db.models import GithubAppInstallation, GithubPullRequestLink
+from django.db import IntegrityError
+
+from pi_dash.db.models import GithubAppInstallation, GithubPullRequestLink, Issue
 from pi_dash.utils.exception_logger import log_exception
 from pi_dash.utils.github_client import (
     GithubClient,
@@ -24,6 +26,10 @@ logger = logging.getLogger(__name__)
 
 class InvalidPullRequestURL(ValueError):
     """The supplied string is not a valid github.com pull request URL."""
+
+
+class IssueNotFound(Exception):
+    """The work item does not exist in the given project/workspace."""
 
 
 class PullRequestAlreadyLinked(Exception):
@@ -56,8 +62,9 @@ def attach_pull_request(*, project_id, issue_id, workspace_slug: str, raw_url: s
     """Attach (or idempotently re-attach) a PR to a work item.
 
     Returns ``(link, created)``. Raises :class:`InvalidPullRequestURL` for a bad
-    URL and :class:`PullRequestAlreadyLinked` when the PR already belongs to a
-    different issue.
+    URL, :class:`IssueNotFound` when the work item is not in the given
+    project/workspace, and :class:`PullRequestAlreadyLinked` when the PR already
+    belongs to a different issue.
     """
     parsed = parse_github_pull_request_url((raw_url or "").strip())
     if parsed is None:
@@ -67,6 +74,12 @@ def attach_pull_request(*, project_id, issue_id, workspace_slug: str, raw_url: s
     # webhook lookup agree.
     owner, name = owner.lower(), name.lower()
 
+    # The permission class only proves project membership; confirm the work item
+    # actually belongs to this project/workspace so a member can't attach a PR
+    # to an arbitrary issue id.
+    if not Issue.objects.filter(id=issue_id, project_id=project_id, workspace__slug=workspace_slug).exists():
+        raise IssueNotFound()
+
     existing = GithubPullRequestLink.objects.filter(repo_owner=owner, repo_name=name, pr_number=number).first()
     if existing is not None:
         if str(existing.issue_id) != str(issue_id):
@@ -74,13 +87,23 @@ def attach_pull_request(*, project_id, issue_id, workspace_slug: str, raw_url: s
         return existing, False
 
     snapshot = best_effort_snapshot(workspace_slug, owner, name, number)
-    link = GithubPullRequestLink.objects.create(
-        project_id=project_id,
-        issue_id=issue_id,
-        repo_owner=owner,
-        repo_name=name,
-        pr_number=number,
-        url=f"https://github.com/{owner}/{name}/pull/{number}",
-        **snapshot,
-    )
-    return link, True
+    try:
+        link = GithubPullRequestLink.objects.create(
+            project_id=project_id,
+            issue_id=issue_id,
+            repo_owner=owner,
+            repo_name=name,
+            pr_number=number,
+            url=f"https://github.com/{owner}/{name}/pull/{number}",
+            **snapshot,
+        )
+        return link, True
+    except IntegrityError:
+        # A concurrent attach won the partial-unique race; resolve to the row
+        # that now exists instead of surfacing a 500.
+        existing = GithubPullRequestLink.objects.filter(repo_owner=owner, repo_name=name, pr_number=number).first()
+        if existing is None:
+            raise
+        if str(existing.issue_id) != str(issue_id):
+            raise PullRequestAlreadyLinked(existing.issue_id)
+        return existing, False

--- a/apps/web/core/components/issues/issue-detail-widgets/issue-detail-widget-collapsibles.tsx
+++ b/apps/web/core/components/issues/issue-detail-widgets/issue-detail-widget-collapsibles.tsx
@@ -13,6 +13,8 @@ import { useIssueDetail } from "@/hooks/store/use-issue-detail";
 // Pi Dash-web
 import { WorkItemAdditionalWidgetCollapsibles } from "@/pi-dash-web/components/issues/issue-detail-widgets/collapsibles";
 import { useTimeLineRelationOptions } from "@/pi-dash-web/components/relations";
+// components
+import { IssueGithubPullRequestsRoot } from "@/components/issues/issue-detail/github-pull-requests";
 // local imports
 import { AttachmentsCollapsible } from "./attachments";
 import { LinksCollapsible } from "./links";
@@ -80,6 +82,12 @@ export const IssueDetailWidgetCollapsibles = observer(function IssueDetailWidget
           issueServiceType={issueServiceType}
         />
       )}
+      <IssueGithubPullRequestsRoot
+        workspaceSlug={workspaceSlug}
+        projectId={projectId}
+        issueId={issueId}
+        disabled={disabled}
+      />
       {shouldRenderAttachments && (
         <AttachmentsCollapsible
           workspaceSlug={workspaceSlug}

--- a/apps/web/core/components/issues/issue-detail/github-pull-requests/index.ts
+++ b/apps/web/core/components/issues/issue-detail/github-pull-requests/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+export * from "./root";

--- a/apps/web/core/components/issues/issue-detail/github-pull-requests/root.tsx
+++ b/apps/web/core/components/issues/issue-detail/github-pull-requests/root.tsx
@@ -16,7 +16,7 @@ import { Input } from "@pi-dash/propel/input";
 import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
 import { Tooltip } from "@pi-dash/propel/tooltip";
 import type { IGithubPullRequestLink } from "@pi-dash/types";
-import { Loader } from "@pi-dash/ui";
+import { Collapsible } from "@pi-dash/ui";
 // constants
 import { GITHUB_ISSUE_PULL_REQUESTS } from "@/constants/fetch-keys";
 // services
@@ -44,21 +44,22 @@ const getPullRequestBadge = (link: IGithubPullRequestLink): TBadge => {
   return { label: "Closed", variant: "danger", icon: GitPullRequest };
 };
 
+const toErrorMessage = (error: unknown, fallback: string): string => {
+  const data = error as { error?: string; detail?: string } | null;
+  return data?.error ?? data?.detail ?? fallback;
+};
+
 export const IssueGithubPullRequestsRoot = observer(function IssueGithubPullRequestsRoot(props: Props) {
   const { workspaceSlug, projectId, issueId, disabled = false } = props;
   // state
+  const [isOpen, setIsOpen] = useState(true);
   const [url, setUrl] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   // fetching
-  const {
-    data: pullRequests,
-    isLoading,
-    mutate: mutatePullRequests,
-  } = useSWR(
-    workspaceSlug && projectId && issueId ? GITHUB_ISSUE_PULL_REQUESTS(issueId) : null,
-    workspaceSlug && projectId && issueId
-      ? () => githubService.listIssuePullRequests(workspaceSlug, projectId, issueId)
-      : null
+  const shouldFetch = Boolean(workspaceSlug && projectId && issueId);
+  const { data: pullRequests, mutate: mutatePullRequests } = useSWR(
+    shouldFetch ? GITHUB_ISSUE_PULL_REQUESTS(issueId) : null,
+    shouldFetch ? () => githubService.listIssuePullRequests(workspaceSlug, projectId, issueId) : null
   );
 
   const handleAttach = async () => {
@@ -69,11 +70,11 @@ export const IssueGithubPullRequestsRoot = observer(function IssueGithubPullRequ
       await githubService.attachIssuePullRequest(workspaceSlug, projectId, issueId, { url: trimmedUrl });
       setUrl("");
       await mutatePullRequests();
-    } catch (error: any) {
+    } catch (error: unknown) {
       setToast({
         type: TOAST_TYPE.ERROR,
         title: "Pull request not attached",
-        message: error?.error ?? "The pull request could not be attached.",
+        message: toErrorMessage(error, "The pull request could not be attached."),
       });
     } finally {
       setIsSubmitting(false);
@@ -84,67 +85,69 @@ export const IssueGithubPullRequestsRoot = observer(function IssueGithubPullRequ
     try {
       await githubService.detachIssuePullRequest(workspaceSlug, projectId, issueId, linkId);
       await mutatePullRequests();
-    } catch (error: any) {
+    } catch (error: unknown) {
       setToast({
         type: TOAST_TYPE.ERROR,
         title: "Pull request not detached",
-        message: error?.error ?? "The pull request could not be detached.",
+        message: toErrorMessage(error, "The pull request could not be detached."),
       });
     }
   };
 
-  return (
-    <div className="py-1 text-11">
-      <div className="flex items-center justify-between gap-2">
-        <h4>Pull requests</h4>
-      </div>
+  // Gate: keep issue detail uncluttered — only surface the section once at least
+  // one PR is linked (the coding agent attaches the first one via the CLI). The
+  // attach/detach controls then live alongside the existing links.
+  if (!pullRequests || pullRequests.length === 0) return null;
 
+  return (
+    <Collapsible
+      isOpen={isOpen}
+      onToggle={() => setIsOpen((prev) => !prev)}
+      buttonClassName="w-full"
+      title={
+        <div className="flex items-center gap-1 py-1 text-13 font-medium text-primary">
+          <span>Pull requests</span>
+          <span className="text-tertiary">{pullRequests.length}</span>
+        </div>
+      }
+    >
       <div className="mt-1 flex flex-col gap-1">
-        {isLoading && !pullRequests ? (
-          <Loader className="space-y-2">
-            <Loader.Item height="28px" />
-            <Loader.Item height="28px" />
-          </Loader>
-        ) : pullRequests && pullRequests.length > 0 ? (
-          pullRequests.map((link) => {
-            const badge = getPullRequestBadge(link);
-            const BadgeIcon = badge.icon;
-            return (
-              <div
-                key={link.id}
-                className="group flex items-center gap-2 rounded-md px-2 py-1.5 duration-300 hover:bg-surface-2"
+        {pullRequests.map((link) => {
+          const badge = getPullRequestBadge(link);
+          const BadgeIcon = badge.icon;
+          return (
+            <div
+              key={link.id}
+              className="group flex items-center gap-2 rounded-md px-2 py-1.5 duration-300 hover:bg-surface-2"
+            >
+              <Badge variant={badge.variant} size="sm" prependIcon={<BadgeIcon />}>
+                {badge.label}
+              </Badge>
+              <a
+                href={link.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex min-w-0 flex-1 items-center gap-1 truncate text-secondary hover:text-primary"
               >
-                <Badge variant={badge.variant} size="sm" prependIcon={<BadgeIcon />}>
-                  {badge.label}
-                </Badge>
-                <a
-                  href={link.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex min-w-0 flex-1 items-center gap-1 truncate text-secondary hover:text-primary"
-                >
-                  <span className="truncate">
-                    {link.title || `${link.repo_owner}/${link.repo_name} #${link.pr_number}`}
-                  </span>
-                  <ExternalLink className="h-3 w-3 shrink-0" />
-                </a>
-                {!disabled && (
-                  <Tooltip tooltipContent="Detach pull request">
-                    <button
-                      type="button"
-                      className="hover:bg-surface-3 grid h-6 w-6 shrink-0 place-items-center rounded-sm text-tertiary opacity-0 duration-300 outline-none group-hover:opacity-100 hover:text-danger-primary"
-                      onClick={() => handleDetach(link.id)}
-                    >
-                      <TrashIcon className="h-3.5 w-3.5" />
-                    </button>
-                  </Tooltip>
-                )}
-              </div>
-            );
-          })
-        ) : (
-          <p className="px-2 py-1 text-tertiary">No pull requests linked</p>
-        )}
+                <span className="truncate">
+                  {link.title || `${link.repo_owner}/${link.repo_name} #${link.pr_number}`}
+                </span>
+                <ExternalLink className="h-3 w-3 shrink-0" />
+              </a>
+              {!disabled && (
+                <Tooltip tooltipContent="Detach pull request">
+                  <button
+                    type="button"
+                    className="hover:bg-surface-3 grid h-6 w-6 shrink-0 place-items-center rounded-sm text-tertiary opacity-0 duration-300 outline-none group-hover:opacity-100 hover:text-danger-primary"
+                    onClick={() => handleDetach(link.id)}
+                  >
+                    <TrashIcon className="h-3.5 w-3.5" />
+                  </button>
+                </Tooltip>
+              )}
+            </div>
+          );
+        })}
 
         {!disabled && (
           <form
@@ -173,6 +176,6 @@ export const IssueGithubPullRequestsRoot = observer(function IssueGithubPullRequ
           </form>
         )}
       </div>
-    </div>
+    </Collapsible>
   );
 });

--- a/apps/web/core/components/issues/issue-detail/github-pull-requests/root.tsx
+++ b/apps/web/core/components/issues/issue-detail/github-pull-requests/root.tsx
@@ -1,0 +1,178 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useState } from "react";
+import { observer } from "mobx-react";
+import { ExternalLink, GitMerge, GitPullRequest, GitPullRequestDraft } from "lucide-react";
+import useSWR from "swr";
+// pi dash imports
+import { Badge } from "@pi-dash/propel/badge";
+import type { TBadgeVariant } from "@pi-dash/propel/badge";
+import { TrashIcon } from "@pi-dash/propel/icons";
+import { Input } from "@pi-dash/propel/input";
+import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
+import { Tooltip } from "@pi-dash/propel/tooltip";
+import type { IGithubPullRequestLink } from "@pi-dash/types";
+import { Loader } from "@pi-dash/ui";
+// constants
+import { GITHUB_ISSUE_PULL_REQUESTS } from "@/constants/fetch-keys";
+// services
+import { GithubIntegrationService } from "@/services/integrations/github.service";
+
+const githubService = new GithubIntegrationService();
+
+type Props = {
+  workspaceSlug: string;
+  projectId: string;
+  issueId: string;
+  disabled?: boolean;
+};
+
+type TBadge = {
+  label: string;
+  variant: TBadgeVariant;
+  icon: typeof GitPullRequest;
+};
+
+const getPullRequestBadge = (link: IGithubPullRequestLink): TBadge => {
+  if (link.merged) return { label: "Merged", variant: "brand", icon: GitMerge };
+  if (link.draft) return { label: "Draft", variant: "neutral", icon: GitPullRequestDraft };
+  if (link.state === "open") return { label: "Open", variant: "success", icon: GitPullRequest };
+  return { label: "Closed", variant: "danger", icon: GitPullRequest };
+};
+
+export const IssueGithubPullRequestsRoot = observer(function IssueGithubPullRequestsRoot(props: Props) {
+  const { workspaceSlug, projectId, issueId, disabled = false } = props;
+  // state
+  const [url, setUrl] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  // fetching
+  const {
+    data: pullRequests,
+    isLoading,
+    mutate: mutatePullRequests,
+  } = useSWR(
+    workspaceSlug && projectId && issueId ? GITHUB_ISSUE_PULL_REQUESTS(issueId) : null,
+    workspaceSlug && projectId && issueId
+      ? () => githubService.listIssuePullRequests(workspaceSlug, projectId, issueId)
+      : null
+  );
+
+  const handleAttach = async () => {
+    const trimmedUrl = url.trim();
+    if (!trimmedUrl || isSubmitting) return;
+    setIsSubmitting(true);
+    try {
+      await githubService.attachIssuePullRequest(workspaceSlug, projectId, issueId, { url: trimmedUrl });
+      setUrl("");
+      await mutatePullRequests();
+    } catch (error: any) {
+      setToast({
+        type: TOAST_TYPE.ERROR,
+        title: "Pull request not attached",
+        message: error?.error ?? "The pull request could not be attached.",
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleDetach = async (linkId: string) => {
+    try {
+      await githubService.detachIssuePullRequest(workspaceSlug, projectId, issueId, linkId);
+      await mutatePullRequests();
+    } catch (error: any) {
+      setToast({
+        type: TOAST_TYPE.ERROR,
+        title: "Pull request not detached",
+        message: error?.error ?? "The pull request could not be detached.",
+      });
+    }
+  };
+
+  return (
+    <div className="py-1 text-11">
+      <div className="flex items-center justify-between gap-2">
+        <h4>Pull requests</h4>
+      </div>
+
+      <div className="mt-1 flex flex-col gap-1">
+        {isLoading && !pullRequests ? (
+          <Loader className="space-y-2">
+            <Loader.Item height="28px" />
+            <Loader.Item height="28px" />
+          </Loader>
+        ) : pullRequests && pullRequests.length > 0 ? (
+          pullRequests.map((link) => {
+            const badge = getPullRequestBadge(link);
+            const BadgeIcon = badge.icon;
+            return (
+              <div
+                key={link.id}
+                className="group flex items-center gap-2 rounded-md px-2 py-1.5 duration-300 hover:bg-surface-2"
+              >
+                <Badge variant={badge.variant} size="sm" prependIcon={<BadgeIcon />}>
+                  {badge.label}
+                </Badge>
+                <a
+                  href={link.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex min-w-0 flex-1 items-center gap-1 truncate text-secondary hover:text-primary"
+                >
+                  <span className="truncate">
+                    {link.title || `${link.repo_owner}/${link.repo_name} #${link.pr_number}`}
+                  </span>
+                  <ExternalLink className="h-3 w-3 shrink-0" />
+                </a>
+                {!disabled && (
+                  <Tooltip tooltipContent="Detach pull request">
+                    <button
+                      type="button"
+                      className="hover:bg-surface-3 grid h-6 w-6 shrink-0 place-items-center rounded-sm text-tertiary opacity-0 duration-300 outline-none group-hover:opacity-100 hover:text-danger-primary"
+                      onClick={() => handleDetach(link.id)}
+                    >
+                      <TrashIcon className="h-3.5 w-3.5" />
+                    </button>
+                  </Tooltip>
+                )}
+              </div>
+            );
+          })
+        ) : (
+          <p className="px-2 py-1 text-tertiary">No pull requests linked</p>
+        )}
+
+        {!disabled && (
+          <form
+            className="mt-1 flex items-center gap-2"
+            onSubmit={(e) => {
+              e.preventDefault();
+              void handleAttach();
+            }}
+          >
+            <Input
+              type="url"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              placeholder="Paste a GitHub pull request URL"
+              className="w-full text-11"
+              inputSize="xs"
+              disabled={isSubmitting}
+            />
+            <button
+              type="submit"
+              className="text-on-accent shrink-0 rounded-md bg-accent-primary px-2.5 py-1 font-medium duration-300 outline-none hover:bg-accent-primary-hover disabled:cursor-not-allowed disabled:opacity-60"
+              disabled={isSubmitting || !url.trim()}
+            >
+              Attach PR
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+});

--- a/apps/web/core/constants/fetch-keys.ts
+++ b/apps/web/core/constants/fetch-keys.ts
@@ -99,6 +99,7 @@ export const GITHUB_INTEGRATION_REPOS = (workspaceSlug: string, page: number) =>
   `GITHUB_INTEGRATION_REPOS_${workspaceSlug.toUpperCase()}_${page}`;
 export const GITHUB_PROJECT_BINDING = (projectId: string) => `GITHUB_PROJECT_BINDING_${projectId.toUpperCase()}`;
 export const GITHUB_APP_STATUS = "GITHUB_APP_STATUS";
+export const GITHUB_ISSUE_PULL_REQUESTS = (issueId: string) => `GITHUB_ISSUE_PULL_REQUESTS_${issueId.toUpperCase()}`;
 
 // cycles
 export const WORKSPACE_ACTIVE_CYCLES_LIST = (workspaceSlug: string, cursor: string, per_page: string) =>

--- a/apps/web/core/services/integrations/github.service.ts
+++ b/apps/web/core/services/integrations/github.service.ts
@@ -13,6 +13,8 @@ import type {
   IGithubAppStatus,
   IGithubConnectionStatus,
   IGithubConnectRequest,
+  IGithubPullRequestLink,
+  IGithubPullRequestLinkCreateRequest,
   IGithubReposPage,
 } from "@pi-dash/types";
 import { APIService } from "@/services/api.service";
@@ -72,6 +74,49 @@ export class GithubIntegrationService extends APIService {
 
   async refreshAppConnection(data: IGithubAppRefreshRequest): Promise<IGithubAppInstallationStatus> {
     return this.post("/api/users/me/integrations/github/app/refresh/", data)
+      .then((response) => response?.data)
+      .catch((error) => {
+        throw error?.response?.data;
+      });
+  }
+
+  async listIssuePullRequests(
+    workspaceSlug: string,
+    projectId: string,
+    issueId: string
+  ): Promise<IGithubPullRequestLink[]> {
+    return this.get(`/api/workspaces/${workspaceSlug}/projects/${projectId}/issues/${issueId}/github-pull-requests/`)
+      .then((response) => response?.data)
+      .catch((error) => {
+        throw error?.response?.data;
+      });
+  }
+
+  async attachIssuePullRequest(
+    workspaceSlug: string,
+    projectId: string,
+    issueId: string,
+    data: IGithubPullRequestLinkCreateRequest
+  ): Promise<IGithubPullRequestLink> {
+    return this.post(
+      `/api/workspaces/${workspaceSlug}/projects/${projectId}/issues/${issueId}/github-pull-requests/`,
+      data
+    )
+      .then((response) => response?.data)
+      .catch((error) => {
+        throw error?.response?.data;
+      });
+  }
+
+  async detachIssuePullRequest(
+    workspaceSlug: string,
+    projectId: string,
+    issueId: string,
+    linkId: string
+  ): Promise<void> {
+    return this.delete(
+      `/api/workspaces/${workspaceSlug}/projects/${projectId}/issues/${issueId}/github-pull-requests/${linkId}/`
+    )
       .then((response) => response?.data)
       .catch((error) => {
         throw error?.response?.data;

--- a/packages/types/src/integration.ts
+++ b/packages/types/src/integration.ts
@@ -4,6 +4,8 @@
  * See the LICENSE file for details.
  */
 
+import type { IUserLite } from "./users";
+
 // All the app integrations that are available
 export interface IAppIntegration {
   author: string;
@@ -127,6 +129,32 @@ export interface IGithubAppInstallStartResponse {
 }
 
 export type IGithubAppRefreshRequest = IGithubAppInstallStartRequest;
+
+// GitHub Pull Request links (.ai_design/github_pr_issue_link/design.md)
+
+export type TGithubPullRequestState = "open" | "closed";
+
+export interface IGithubPullRequestLink {
+  id: string;
+  issue: string;
+  repo_owner: string;
+  repo_name: string;
+  pr_number: number;
+  url: string;
+  title: string;
+  state: TGithubPullRequestState;
+  merged: boolean;
+  draft: boolean;
+  pr_updated_at: string | null;
+  created_at: string;
+  updated_at: string;
+  created_by: string | null;
+  created_by_detail?: IUserLite | null;
+}
+
+export interface IGithubPullRequestLinkCreateRequest {
+  url: string;
+}
 
 // slack integration
 export interface ISlackIntegration {


### PR DESCRIPTION
## Summary

Implements the first GitHub-App use case from `.ai_design/github_pr_issue_link/design.md`: an **optional, standalone link from a Pi Dash issue to GitHub pull requests**.

- **One issue → many PRs; one PR → one issue.**
- A PR is attached explicitly (the server contract behind a future `pidash issue attach-pr` CLI command), and the GitHub App `pull_request` webhook keeps each linked PR's **display status** fresh.
- **Hard boundary:** attaching or refreshing a PR **never** changes the issue's workflow state. Updating *the PR's badge on the issue* is not the same as changing *the issue's* state — only the former is in scope. No write-back to GitHub.

## What's included

**Backend**
- `GithubPullRequestLink` model + migration `0151` (partial-unique `(repo_owner, repo_name, pr_number)` on active rows → one PR per issue, re-attachable after detach).
- `utils/github_pr_links.py` — shared attach service (parse → dedupe → best-effort snapshot), used by both API surfaces so behaviour is identical.
- **External API** `…/work-items/<id>/github/pull-requests/` — the CLI contract (`X-Api-Key`).
- **Session app API** `…/issues/<id>/github-pull-requests/` — what the web overview uses.
- Both gated by `ProjectEntityPermission` (issue edit/comment level).
- `pull_request` webhook branch: refreshes `title/state/merged/draft` **only when a link exists** (no link → `skipped`), out-of-order-safe via `updated_at`. Identity is `(owner, repo, number)` from the payload, so attach needs no App/API call and the webhook matches without a join.

**Frontend**
- `IGithubPullRequestLink` types, `GithubIntegrationService` methods, and a **"Pull requests"** section in the issue-detail widgets: status badges (Merged/Draft/Open/Closed), attach-by-URL, per-row detach.

**Tests** (61 passing locally, incl. 14 #261 regression)
- External + app contract (attach, idempotent, one-PR-one-issue conflict, URL validation, best-effort snapshot + failure, list, detach, membership gate), webhook contract (refresh, no-link skip, out-of-order, draft), and URL-parse / snapshot unit tests.

## Validation

- `pytest` feature suites + adjacent regression: **61 passed**, `manage.py check` clean, migration validated via `sqlmigrate`.
- `oxfmt --check` and `oxlint` clean on all touched frontend files.
- Frontend typecheck was **not** run (the isolated worktree has no `node_modules`); propel/types APIs used were verified against the package source. Please run `pnpm --filter web check:types` in CI/locally.

## Follow-ups (separate repos — not in this PR)

1. The `pidash` CLI `attach-pr` subcommand — its source isn't in this repo.
2. The `pi-dash-skill` prompt update — deliberately deferred until the CLI command ships (so agents aren't told to run a command that doesn't exist yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)