### PR TITLE
feat(cli): pidash issue attach-pr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1382,7 +1382,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pidash"
-version = "0.1.15"
+version = "0.1.16-rc.1"
 dependencies = [
  "anyhow",
  "axoupdater",

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pidash"
-version = "0.1.15"
+version = "0.1.16-rc.1"
 edition = "2024"
 rust-version = "1.93"
 description = "Pi Dash local runner: connects a dev machine to the Pi Dash cloud and drives Codex for assigned tasks."

--- a/runner/src/cli/issue.rs
+++ b/runner/src/cli/issue.rs
@@ -46,6 +46,10 @@ pub enum IssueCommand {
     /// and a relevance rank. Use it to recover historical context before
     /// starting similar work.
     Search(SearchArgs),
+    /// Attach a GitHub pull request to a work item so Pi Dash links it and
+    /// tracks its status. Idempotent (re-attaching the same PR is a no-op);
+    /// one issue may have many PRs, but a PR attaches to exactly one issue.
+    AttachPr(AttachPrArgs),
 }
 
 #[derive(Debug, Args)]
@@ -123,6 +127,16 @@ pub struct MoveArgs {
 }
 
 #[derive(Debug, Args)]
+pub struct AttachPrArgs {
+    /// Project-scoped identifier, e.g. `ENG-42`.
+    pub identifier: String,
+
+    /// GitHub pull request URL, e.g. `https://github.com/owner/repo/pull/42`.
+    #[arg(long)]
+    pub url: String,
+}
+
+#[derive(Debug, Args)]
 pub struct SearchArgs {
     /// Search pattern. Supports websearch syntax: quoted phrases, `OR`,
     /// `-exclude`. Stem-aware (e.g. `color` finds `colors`, `colored`).
@@ -171,6 +185,7 @@ pub async fn run(args: IssueArgs, paths: &crate::util::paths::Paths) -> i32 {
         IssueCommand::Patch(p) => cmd_patch(&client, p).await,
         IssueCommand::Move(m) => cmd_move(&client, m).await,
         IssueCommand::Search(s) => cmd_search(&client, s).await,
+        IssueCommand::AttachPr(a) => cmd_attach_pr(&client, a).await,
     };
     match result {
         Ok(()) => 0,
@@ -354,6 +369,30 @@ async fn cmd_patch(client: &ApiClient, args: PatchArgs) -> Result<(), CliError> 
         client.env.workspace_slug, issue.project_id, issue.id
     );
     let resp = client.patch(&path, &Value::Object(body)).await?;
+    println!(
+        "{}",
+        serde_json::to_string(&resp).expect("serialize JSON value")
+    );
+    Ok(())
+}
+
+async fn cmd_attach_pr(client: &ApiClient, args: AttachPrArgs) -> Result<(), CliError> {
+    let url = args.url.trim();
+    if url.is_empty() {
+        return Err(CliError::new(EXIT_INVALID, "--url must not be empty"));
+    }
+
+    // Resolve issue first — we need project_id for the work-item-scoped URL.
+    let issue = resolve_issue(client, &args.identifier).await?;
+
+    let mut body: Map<String, Value> = Map::new();
+    body.insert("url".into(), Value::String(url.to_string()));
+
+    let path = format!(
+        "workspaces/{}/projects/{}/work-items/{}/github/pull-requests/",
+        client.env.workspace_slug, issue.project_id, issue.id
+    );
+    let resp = client.post(&path, &Value::Object(body)).await?;
     println!(
         "{}",
         serde_json::to_string(&resp).expect("serialize JSON value")


### PR DESCRIPTION
## Summary

Adds the `pidash issue attach-pr` subcommand — the CLI half of the GitHub PR ↔ issue link feature. This is the command the run prompt (#264) and the skill (pi-dash-skill #8) already instruct agents to run after opening a PR; it was missing from #263.

```
pidash issue attach-pr <IDENTIFIER> --url <github-pr-url>
```

- Resolves the `PROJ-123` identifier (via the existing `resolve_issue`), then `POST {url}` to the work-item endpoint added in #263:
  `/api/v1/workspaces/<slug>/projects/<project_id>/work-items/<issue_id>/github/pull-requests/`.
- Mirrors the existing `issue create/patch/move/search` pattern (same `ApiClient`, error/exit-code handling, JSON output).
- Idempotent server-side; one issue → many PRs, one PR → one issue (409 on conflict), 404 if the work item isn't in the project.

Bumps `pidash` **0.1.15 → 0.1.16-rc.1** for a pre-release.

## Validation
- `cargo check`, `cargo clippy -- -D warnings` — clean.
- `cargo test --lib cli::` — 60 passed.
- `pidash issue attach-pr --help` confirms usage matches the agent prompts.

## Note
This is the piece #263 should have shipped — I'd mistakenly concluded the CLI lived in a separate repo. It's the `runner/` crate here. With this merged + released, the PR-link flow (#261/#262/#263/#264 + skill #8) is end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)