### PR TITLE
PIDASH-2 add "(github)" into the integrations item text

### DIFF
--- a/apps/web/core/components/settings/sidebar/item.tsx
+++ b/apps/web/core/components/settings/sidebar/item.tsx
@@ -13,7 +13,7 @@ import type { ISvgIcons } from "@pi-dash/propel/icons";
 
 type Props = {
   isActive: boolean;
-  label: string;
+  label: React.ReactNode;
 } & ({ as: "button"; onClick: () => void } | { as: "link"; href: string }) &
   (
     | {

--- a/apps/web/core/components/settings/workspace/sidebar/item-categories.tsx
+++ b/apps/web/core/components/settings/workspace/sidebar/item-categories.tsx
@@ -54,6 +54,15 @@ export const WorkspaceSettingsSidebarItemCategories = observer(function Workspac
                     ? pathname === `/${workspaceSlug}${item.href}/`
                     : new RegExp(`^/${workspaceSlug}${item.href}/`).test(pathname);
 
+                const label =
+                  item.key === "integrations" ? (
+                    <>
+                      {t(item.i18n_label)} <span className="text-caption-sm-medium text-tertiary">(github)</span>
+                    </>
+                  ) : (
+                    t(item.i18n_label)
+                  );
+
                 return (
                   <SettingsSidebarItem
                     key={item.key}
@@ -61,7 +70,7 @@ export const WorkspaceSettingsSidebarItemCategories = observer(function Workspac
                     href={joinUrlPath(workspaceSlug ?? "", item.href)}
                     isActive={isItemActive}
                     icon={WORKSPACE_SETTINGS_ICONS[item.key]}
-                    label={t(item.i18n_label)}
+                    label={label}
                   />
                 );
               })}


### PR DESCRIPTION
## What

Adds a smaller-font `(github)` suffix to the **Integrations** item in the workspace settings sidebar, so it reads **Integrations (github)**.

## Why

PIDASH-2 — small UI improvement to clarify that the Integrations tab is for installing the Pi Dash GitHub app.

## How

- `settings/sidebar/item.tsx`: widen the shared `SettingsSidebarItem` `label` prop from `string` to `React.ReactNode` (backward compatible — it was already rendered as a node) so a styled suffix can be passed.
- `settings/workspace/sidebar/item-categories.tsx`: for the `integrations` item, render the translated label followed by `(github)` in `text-caption-sm-medium text-tertiary` (smaller than the item's `text-body-sm-medium`).

## Validation

- `pnpm --filter=web check:types` — touched files clean (remaining repo-wide errors are pre-existing unbuilt-`@pi-dash/ui` module resolution, unrelated to this change).
- `oxlint` + `oxfmt --check` on touched files — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
