### PR TITLE
feat(peek): show AI agent run status panel above Properties

### DIFF
--- a/apps/web/core/components/issues/peek-overview/view.tsx
+++ b/apps/web/core/components/issues/peek-overview/view.tsx
@@ -18,6 +18,7 @@ import useKeypress from "@/hooks/use-keypress";
 import usePeekOverviewOutsideClickDetector from "@/hooks/use-peek-overview-outside-click";
 // local imports
 import type { TIssueOperations } from "../issue-detail";
+import { IssueAgentStatusPanel } from "../issue-detail/agent-status";
 import { IssueActivity } from "../issue-detail/issue-activity";
 import { IssueDetailWidgets } from "../issue-detail-widgets";
 import { IssuePeekOverviewError } from "./error";
@@ -197,6 +198,14 @@ export const IssueView = observer(function IssueView(props: IIssueView) {
                       />
                     </div>
 
+                    <IssueAgentStatusPanel
+                      workspaceSlug={workspaceSlug}
+                      projectId={projectId}
+                      issueId={issueId}
+                      issue={issue}
+                      issueOperations={issueOperations}
+                    />
+
                     <PeekOverviewProperties
                       workspaceSlug={workspaceSlug}
                       projectId={projectId}
@@ -251,6 +260,14 @@ export const IssueView = observer(function IssueView(props: IIssueView) {
                         is_archived ? "pointer-events-none" : ""
                       }`}
                     >
+                      <IssueAgentStatusPanel
+                        workspaceSlug={workspaceSlug}
+                        projectId={projectId}
+                        issueId={issueId}
+                        issue={issue}
+                        issueOperations={issueOperations}
+                      />
+
                       <PeekOverviewProperties
                         workspaceSlug={workspaceSlug}
                         projectId={projectId}


### PR DESCRIPTION
## What

Render the **AI agent run status panel** (`IssueAgentStatusPanel`) in **peek issue mode**, above the Properties section.

## Why

The panel was only wired into the full issue-detail view (desktop sidebar + mobile main content). The peek overview is a separate, parallel component tree that never got the panel, so peek mode never displayed the agent run status card — even when an agent run or ticker was active.

## Changes

In `apps/web/core/components/issues/peek-overview/view.tsx`, render `IssueAgentStatusPanel` directly above `PeekOverviewProperties` in both peek layouts:

- **side-peek / modal** — inline, above Properties
- **full-screen** — in the right-hand sidebar, above Properties

The panel is self-gating (`if (!view) return null` — returns null when there's no active/latest run and no ticker), so it only appears when there's something to show, matching its behavior in the full issue view. No new prop plumbing was needed; `issue` and the other props were already in scope.

## Testing

- `pnpm turbo run check:types --filter=web` — no new errors in the touched file (pre-existing unrelated errors remain elsewhere).
- Pre-commit hooks (oxfmt + oxlint) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)