### PR TITLE
GitHub PR-link follow-ups: env-key PEM fix + move section above Activity

### DIFF
--- a/apps/api/pi_dash/tests/unit/utils/test_github_app_auth.py
+++ b/apps/api/pi_dash/tests/unit/utils/test_github_app_auth.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Unit tests for github_app_auth helpers."""
+
+import pytest
+
+from pi_dash.utils.github_app_auth import _normalize_private_key
+
+PEM = "-----BEGIN RSA PRIVATE KEY-----\nMIIabc\nDEF==\n-----END RSA PRIVATE KEY-----\n"
+
+
+@pytest.mark.unit
+class TestNormalizePrivateKey:
+    def test_escaped_newlines_become_real(self):
+        # As stored single-line in an env/SSM var: literal backslash-n.
+        escaped = PEM.replace("\n", "\\n")
+        assert "\\n" in escaped  # precondition: the stored form is escaped
+        result = _normalize_private_key(escaped)
+        assert result == PEM.strip()
+        assert "\\n" not in result and "\n" in result
+
+    def test_escaped_crlf_becomes_real(self):
+        escaped = PEM.replace("\n", "\\r\\n")
+        result = _normalize_private_key(escaped)
+        assert result == PEM.strip()
+        assert "\\r" not in result and "\\n" not in result
+
+    def test_real_newline_key_unchanged(self):
+        assert _normalize_private_key(PEM) == PEM.strip()
+
+    @pytest.mark.parametrize("value", ["", None, "   "])
+    def test_empty_or_none(self, value):
+        assert _normalize_private_key(value) == ""

--- a/apps/api/pi_dash/utils/github_app_auth.py
+++ b/apps/api/pi_dash/utils/github_app_auth.py
@@ -44,13 +44,20 @@ def get_github_app_config() -> dict[str, str]:
     return {
         "app_id": (app_id or "").strip(),
         "app_slug": (app_slug or "").strip(),
-        # A PEM stored in env/SSM commonly arrives with escaped newlines
-        # (single-line ``\n``); normalize so cryptography can parse it.
-        "private_key": (private_key or "").strip().replace("\\n", "\n"),
+        "private_key": _normalize_private_key(private_key),
         "webhook_secret": (webhook_secret or "").strip(),
         "client_id": (client_id or "").strip(),
         "client_secret": (client_secret or "").strip(),
     }
+
+
+def _normalize_private_key(value: str | None) -> str:
+    """A PEM stored in env/SSM commonly arrives single-line with escaped
+    newlines (``\\n`` or ``\\r\\n``); turn those into real newlines so
+    cryptography/PyJWT can parse the key. A PEM that already has real
+    newlines passes through unchanged. Unescape before stripping so the
+    escaped and real-newline forms normalize identically."""
+    return (value or "").replace("\\r\\n", "\n").replace("\\n", "\n").strip()
 
 
 def require_github_app_config(*, oauth: bool = False, webhook: bool = False) -> dict[str, str]:

--- a/apps/api/pi_dash/utils/github_app_auth.py
+++ b/apps/api/pi_dash/utils/github_app_auth.py
@@ -44,7 +44,9 @@ def get_github_app_config() -> dict[str, str]:
     return {
         "app_id": (app_id or "").strip(),
         "app_slug": (app_slug or "").strip(),
-        "private_key": (private_key or "").strip(),
+        # A PEM stored in env/SSM commonly arrives with escaped newlines
+        # (single-line ``\n``); normalize so cryptography can parse it.
+        "private_key": (private_key or "").strip().replace("\\n", "\n"),
         "webhook_secret": (webhook_secret or "").strip(),
         "client_id": (client_id or "").strip(),
         "client_secret": (client_secret or "").strip(),

--- a/apps/web/core/components/issues/issue-detail-widgets/issue-detail-widget-collapsibles.tsx
+++ b/apps/web/core/components/issues/issue-detail-widgets/issue-detail-widget-collapsibles.tsx
@@ -13,8 +13,6 @@ import { useIssueDetail } from "@/hooks/store/use-issue-detail";
 // Pi Dash-web
 import { WorkItemAdditionalWidgetCollapsibles } from "@/pi-dash-web/components/issues/issue-detail-widgets/collapsibles";
 import { useTimeLineRelationOptions } from "@/pi-dash-web/components/relations";
-// components
-import { IssueGithubPullRequestsRoot } from "@/components/issues/issue-detail/github-pull-requests";
 // local imports
 import { AttachmentsCollapsible } from "./attachments";
 import { LinksCollapsible } from "./links";
@@ -82,12 +80,6 @@ export const IssueDetailWidgetCollapsibles = observer(function IssueDetailWidget
           issueServiceType={issueServiceType}
         />
       )}
-      <IssueGithubPullRequestsRoot
-        workspaceSlug={workspaceSlug}
-        projectId={projectId}
-        issueId={issueId}
-        disabled={disabled}
-      />
       {shouldRenderAttachments && (
         <AttachmentsCollapsible
           workspaceSlug={workspaceSlug}

--- a/apps/web/core/components/issues/issue-detail/main-content.tsx
+++ b/apps/web/core/components/issues/issue-detail/main-content.tsx
@@ -33,9 +33,8 @@ import { NameDescriptionUpdateStatus } from "../issue-update-status";
 import { PeekOverviewProperties } from "../peek-overview/properties";
 import { IssueTitleInput } from "../title-input";
 import { IssueAgentStatusPanel } from "./agent-status";
-import { IssueGithubPullRequestsRoot } from "./github-pull-requests";
-import { IssueActivity } from "./issue-activity";
 import { IssueParentDetail } from "./parent";
+import { IssuePullRequestsAndActivity } from "./pull-requests-and-activity";
 import { IssueReaction } from "./reactions";
 import type { TIssueOperations } from "./root";
 // services init
@@ -235,14 +234,13 @@ export const IssueMainContent = observer(function IssueMainContent(props: Props)
         </div>
       )}
 
-      <IssueGithubPullRequestsRoot
+      <IssuePullRequestsAndActivity
         workspaceSlug={workspaceSlug}
         projectId={projectId}
         issueId={issueId}
         disabled={!isEditable || isArchived || isMetadataHydrating}
+        activityDisabled={isArchived}
       />
-
-      <IssueActivity workspaceSlug={workspaceSlug} projectId={projectId} issueId={issueId} disabled={isArchived} />
     </>
   );
 });

--- a/apps/web/core/components/issues/issue-detail/main-content.tsx
+++ b/apps/web/core/components/issues/issue-detail/main-content.tsx
@@ -33,6 +33,7 @@ import { NameDescriptionUpdateStatus } from "../issue-update-status";
 import { PeekOverviewProperties } from "../peek-overview/properties";
 import { IssueTitleInput } from "../title-input";
 import { IssueAgentStatusPanel } from "./agent-status";
+import { IssueGithubPullRequestsRoot } from "./github-pull-requests";
 import { IssueActivity } from "./issue-activity";
 import { IssueParentDetail } from "./parent";
 import { IssueReaction } from "./reactions";
@@ -233,6 +234,13 @@ export const IssueMainContent = observer(function IssueMainContent(props: Props)
           />
         </div>
       )}
+
+      <IssueGithubPullRequestsRoot
+        workspaceSlug={workspaceSlug}
+        projectId={projectId}
+        issueId={issueId}
+        disabled={!isEditable || isArchived || isMetadataHydrating}
+      />
 
       <IssueActivity workspaceSlug={workspaceSlug} projectId={projectId} issueId={issueId} disabled={isArchived} />
     </>

--- a/apps/web/core/components/issues/issue-detail/pull-requests-and-activity.tsx
+++ b/apps/web/core/components/issues/issue-detail/pull-requests-and-activity.tsx
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { observer } from "mobx-react";
+// local imports
+import { IssueGithubPullRequestsRoot } from "./github-pull-requests";
+import { IssueActivity } from "./issue-activity";
+
+type Props = {
+  workspaceSlug: string;
+  projectId: string;
+  issueId: string;
+  /** Disables the PR attach/detach controls (broader rule: non-editable / hydrating). */
+  disabled?: boolean;
+  /** Disables the activity/comment input (typically just archived). */
+  activityDisabled?: boolean;
+};
+
+/**
+ * Renders the "Pull requests" section directly above the Activity section.
+ * They are composed here so every issue layout (full detail + peek variants)
+ * stays in sync — render this once instead of two separate components.
+ */
+export const IssuePullRequestsAndActivity = observer(function IssuePullRequestsAndActivity(props: Props) {
+  const { workspaceSlug, projectId, issueId, disabled = false, activityDisabled = false } = props;
+  return (
+    <>
+      <IssueGithubPullRequestsRoot
+        workspaceSlug={workspaceSlug}
+        projectId={projectId}
+        issueId={issueId}
+        disabled={disabled}
+      />
+      <IssueActivity
+        workspaceSlug={workspaceSlug}
+        projectId={projectId}
+        issueId={issueId}
+        disabled={activityDisabled}
+      />
+    </>
+  );
+});

--- a/apps/web/core/components/issues/peek-overview/view.tsx
+++ b/apps/web/core/components/issues/peek-overview/view.tsx
@@ -18,9 +18,8 @@ import useKeypress from "@/hooks/use-keypress";
 import usePeekOverviewOutsideClickDetector from "@/hooks/use-peek-overview-outside-click";
 // local imports
 import type { TIssueOperations } from "../issue-detail";
-import { IssueActivity } from "../issue-detail/issue-activity";
-import { IssueGithubPullRequestsRoot } from "../issue-detail/github-pull-requests";
 import { IssueDetailWidgets } from "../issue-detail-widgets";
+import { IssuePullRequestsAndActivity } from "../issue-detail/pull-requests-and-activity";
 import { IssuePeekOverviewError } from "./error";
 import type { TPeekModes } from "./header";
 import { IssuePeekOverviewHeader } from "./header";
@@ -206,18 +205,12 @@ export const IssueView = observer(function IssueView(props: IIssueView) {
                       disabled={disabled || is_archived}
                     />
 
-                    <IssueGithubPullRequestsRoot
+                    <IssuePullRequestsAndActivity
                       workspaceSlug={workspaceSlug}
                       projectId={projectId}
                       issueId={issueId}
                       disabled={disabled || is_archived}
-                    />
-
-                    <IssueActivity
-                      workspaceSlug={workspaceSlug}
-                      projectId={projectId}
-                      issueId={issueId}
-                      disabled={is_archived}
+                      activityDisabled={is_archived}
                     />
                   </div>
                 ) : (
@@ -246,18 +239,12 @@ export const IssueView = observer(function IssueView(props: IIssueView) {
                           />
                         </div>
 
-                        <IssueGithubPullRequestsRoot
+                        <IssuePullRequestsAndActivity
                           workspaceSlug={workspaceSlug}
                           projectId={projectId}
                           issueId={issueId}
                           disabled={disabled || is_archived}
-                        />
-
-                        <IssueActivity
-                          workspaceSlug={workspaceSlug}
-                          projectId={projectId}
-                          issueId={issueId}
-                          disabled={is_archived}
+                          activityDisabled={is_archived}
                         />
                       </div>
                     </div>

--- a/apps/web/core/components/issues/peek-overview/view.tsx
+++ b/apps/web/core/components/issues/peek-overview/view.tsx
@@ -19,6 +19,7 @@ import usePeekOverviewOutsideClickDetector from "@/hooks/use-peek-overview-outsi
 // local imports
 import type { TIssueOperations } from "../issue-detail";
 import { IssueActivity } from "../issue-detail/issue-activity";
+import { IssueGithubPullRequestsRoot } from "../issue-detail/github-pull-requests";
 import { IssueDetailWidgets } from "../issue-detail-widgets";
 import { IssuePeekOverviewError } from "./error";
 import type { TPeekModes } from "./header";
@@ -205,6 +206,13 @@ export const IssueView = observer(function IssueView(props: IIssueView) {
                       disabled={disabled || is_archived}
                     />
 
+                    <IssueGithubPullRequestsRoot
+                      workspaceSlug={workspaceSlug}
+                      projectId={projectId}
+                      issueId={issueId}
+                      disabled={disabled || is_archived}
+                    />
+
                     <IssueActivity
                       workspaceSlug={workspaceSlug}
                       projectId={projectId}
@@ -237,6 +245,13 @@ export const IssueView = observer(function IssueView(props: IIssueView) {
                             issueServiceType={EIssueServiceType.ISSUES}
                           />
                         </div>
+
+                        <IssueGithubPullRequestsRoot
+                          workspaceSlug={workspaceSlug}
+                          projectId={projectId}
+                          issueId={issueId}
+                          disabled={disabled || is_archived}
+                        />
 
                         <IssueActivity
                           workspaceSlug={workspaceSlug}


### PR DESCRIPTION
Two follow-ups to the GitHub PR ↔ issue link feature (#263), verified in a local deployment.

## 1. Env/SSM private-key parsing (`github_app_auth.py`)
`get_github_app_config()` now normalizes escaped newlines (`\n`) in `GITHUB_APP_PRIVATE_KEY`. A PEM stored in **env/SSM** — the intended source for this secret per the config split (#262) — arrives single-line with `\n`, which `cryptography`/PyJWT can't parse as-is. Without this, the App can't sign its JWT when the key comes from env/SSM. Verified locally: `build_app_jwt()` succeeds with an env-provided key.

## 2. Move the "Pull requests" section above Activity
The section previously lived inside the shared `IssueDetailWidgets` group. Moved it to render **directly above the Activity section** in **all three** render sites so it can't fall out of sync:
- full-page detail (`main-content.tsx`)
- peek-overview **bottom/full** layout
- peek-overview **side-panel** layout

## Validation
- Local end-to-end: App configured (`configured: true`), `pidash issue attach-pr` creates the link, the PR shows on the issue (full page + peek). 
- `oxfmt` + `oxlint` clean on touched files; husky lint-staged passed.
- Frontend `tsc` not run in this loop — please run `pnpm --filter web check:types` in CI.

## Still pending (separate follow-ups, not in this PR)
- **#262 config compliance:** register the 6 `GITHUB_APP_*` keys in `config/registry.py` as `{"source": "env"}` and remove the now-dead `WRITE_ONLY_CONFIG_KEYS` + `core.py` DB-seed entries.
- DRY the PR section's three mount points so it can't drift.
- Live PR-status webhook — to be verified in the test deployment (needs a public tunnel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)