### PR TITLE
Register GitHub App config keys (secret → env, non-secret → db)

### DIFF
--- a/apps/api/pi_dash/config/registry.py
+++ b/apps/api/pi_dash/config/registry.py
@@ -55,6 +55,16 @@ _RESOLVER_CONFIG = {
     # GITHUB_APP_NAME is read by the instances endpoint from the env only
     # (never seeded into the DB), so it is env-sourced.
     "GITHUB_APP_NAME": {"source": "env", "default": None},
+    # --- GitHub App -------------------------------------------------------
+    # Non-secret identity is db-sourced (admin-editable in god-mode, seeded
+    # from env by configure_instance); the secrets are env-sourced (SSM in
+    # cloud, env locally) and never touch the DB.
+    "GITHUB_APP_ID": {"source": "db", "default": None},
+    "GITHUB_APP_SLUG": {"source": "db", "default": None},
+    "GITHUB_APP_CLIENT_ID": {"source": "db", "default": None},
+    "GITHUB_APP_PRIVATE_KEY": {"source": "env", "default": None, "secret": True},
+    "GITHUB_APP_WEBHOOK_SECRET": {"source": "env", "default": None, "secret": True},
+    "GITHUB_APP_CLIENT_SECRET": {"source": "env", "default": None, "secret": True},
     # --- GitLab OAuth -----------------------------------------------------
     "GITLAB_HOST": {"source": "db", "default": None},
     "GITLAB_CLIENT_ID": {"source": "db", "default": None},

--- a/apps/api/pi_dash/license/api/serializers/configuration.py
+++ b/apps/api/pi_dash/license/api/serializers/configuration.py
@@ -8,13 +8,6 @@ from pi_dash.license.models import InstanceConfiguration
 from pi_dash.license.utils.encryption import decrypt_data
 
 
-WRITE_ONLY_CONFIG_KEYS = {
-    "GITHUB_APP_PRIVATE_KEY",
-    "GITHUB_APP_WEBHOOK_SECRET",
-    "GITHUB_APP_CLIENT_SECRET",
-}
-
-
 class InstanceConfigurationSerializer(BaseSerializer):
     class Meta:
         model = InstanceConfiguration
@@ -22,11 +15,6 @@ class InstanceConfigurationSerializer(BaseSerializer):
 
     def to_representation(self, instance):
         data = super().to_representation(instance)
-        if instance.key in WRITE_ONLY_CONFIG_KEYS:
-            data["value"] = "set" if instance.value else ""
-            data["is_write_only"] = True
-            return data
-
         # Decrypt secrets value
         if instance.is_encrypted and instance.value is not None:
             data["value"] = decrypt_data(instance.value)

--- a/apps/api/pi_dash/license/api/views/configuration.py
+++ b/apps/api/pi_dash/license/api/views/configuration.py
@@ -24,7 +24,6 @@ from .base import BaseAPIView
 from pi_dash.license.api.permissions import InstanceAdminPermission
 from pi_dash.license.models import InstanceConfiguration
 from pi_dash.license.api.serializers import InstanceConfigurationSerializer
-from pi_dash.license.api.serializers.configuration import WRITE_ONLY_CONFIG_KEYS
 from pi_dash.license.utils.encryption import encrypt_data
 from pi_dash.utils.cache import cache_response, invalidate_cache
 from pi_dash.license.utils.instance_value import get_email_configuration
@@ -48,8 +47,6 @@ class InstanceConfigurationEndpoint(BaseAPIView):
         for configuration in configurations:
             raw_value = request.data.get(configuration.key, configuration.value)
             value = "" if raw_value is None else str(raw_value).strip()
-            if configuration.key in WRITE_ONLY_CONFIG_KEYS and value == "set":
-                continue
             if configuration.is_encrypted:
                 configuration.value = encrypt_data(value)
             else:

--- a/apps/api/pi_dash/tests/contract/app/test_github_app_integration.py
+++ b/apps/api/pi_dash/tests/contract/app/test_github_app_integration.py
@@ -11,7 +11,6 @@ import pytest
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework import status
-from rest_framework.test import APIClient
 
 from pi_dash.app.views.integration.github import _get_or_create_workspace_integration
 from pi_dash.db.models import (
@@ -21,8 +20,6 @@ from pi_dash.db.models import (
     WorkspaceIntegration,
     WorkspaceMember,
 )
-from pi_dash.license.models import Instance, InstanceAdmin, InstanceConfiguration
-from pi_dash.license.utils.encryption import decrypt_data, encrypt_data
 from pi_dash.tests.factories import UserFactory, WorkspaceFactory, WorkspaceMemberFactory
 from pi_dash.utils.github_app_auth import GithubAppAuthError
 
@@ -369,33 +366,3 @@ def test_github_app_webhook_unsuspend_persists_installation_state(api_client, wo
     assert app_installation.suspended_at is None
     assert app_installation.last_check_error == ""
     assert app_installation.repository_count == 5
-
-
-def test_write_only_github_app_config_sentinel_does_not_overwrite_secret(create_user):
-    instance = Instance.objects.create(
-        instance_name="test",
-        instance_id=f"instance-{uuid4()}",
-        current_version="1.0.0",
-        last_checked_at=timezone.now(),
-    )
-    InstanceAdmin.objects.create(instance=instance, user=create_user, role=20, is_verified=True)
-    configuration = InstanceConfiguration.objects.create(
-        key="GITHUB_APP_PRIVATE_KEY",
-        value=encrypt_data("actual-private-key"),
-        category="GITHUB",
-        is_encrypted=True,
-    )
-    client = APIClient()
-    client.force_authenticate(user=create_user)
-
-    response = client.patch(
-        "/api/instances/configurations/",
-        {"GITHUB_APP_PRIVATE_KEY": "set"},
-        format="json",
-    )
-
-    assert response.status_code == status.HTTP_200_OK
-    configuration.refresh_from_db()
-    assert decrypt_data(configuration.value) == "actual-private-key"
-    assert response.data[0]["value"] == "set"
-    assert response.data[0]["is_write_only"] is True

--- a/apps/api/pi_dash/tests/unit/config/test_accessor.py
+++ b/apps/api/pi_dash/tests/unit/config/test_accessor.py
@@ -129,6 +129,17 @@ def test_every_entry_has_valid_source():
 
 
 @pytest.mark.unit
+def test_github_app_keys_classified_by_secret():
+    """GitHub App identity is db-sourced (god-mode editable); the secrets are
+    env-sourced (SSM in cloud, env locally) and flagged secret."""
+    for key in ("GITHUB_APP_ID", "GITHUB_APP_SLUG", "GITHUB_APP_CLIENT_ID"):
+        assert registry.CONFIG[key]["source"] == "db", key
+    for key in ("GITHUB_APP_PRIVATE_KEY", "GITHUB_APP_WEBHOOK_SECRET", "GITHUB_APP_CLIENT_SECRET"):
+        assert registry.CONFIG[key]["source"] == "env", key
+        assert registry.CONFIG[key].get("secret") is True, key
+
+
+@pytest.mark.unit
 def test_source_overrides_are_applied(monkeypatch):
     monkeypatch.setattr(registry, "_RESOLVER_CONFIG", {"K": {"source": "db", "default": None}})
     monkeypatch.setattr(registry, "CONFIG_SOURCE_OVERRIDES", {"K": "env"})

--- a/apps/api/pi_dash/utils/instance_config_variables/core.py
+++ b/apps/api/pi_dash/utils/instance_config_variables/core.py
@@ -70,28 +70,10 @@ github_config_variables = [
         "is_encrypted": False,
     },
     {
-        "key": "GITHUB_APP_PRIVATE_KEY",
-        "value": os.environ.get("GITHUB_APP_PRIVATE_KEY"),
-        "category": "GITHUB",
-        "is_encrypted": True,
-    },
-    {
-        "key": "GITHUB_APP_WEBHOOK_SECRET",
-        "value": os.environ.get("GITHUB_APP_WEBHOOK_SECRET"),
-        "category": "GITHUB",
-        "is_encrypted": True,
-    },
-    {
         "key": "GITHUB_APP_CLIENT_ID",
         "value": os.environ.get("GITHUB_APP_CLIENT_ID"),
         "category": "GITHUB",
         "is_encrypted": False,
-    },
-    {
-        "key": "GITHUB_APP_CLIENT_SECRET",
-        "value": os.environ.get("GITHUB_APP_CLIENT_SECRET"),
-        "category": "GITHUB",
-        "is_encrypted": True,
     },
     {
         "key": "GITHUB_CLIENT_ID",


### PR DESCRIPTION
## Summary

The `GITHUB_APP_*` config keys (added in #261) were never registered in the #262 config registry, so they silently fell through the *"unregistered → env"* default — and the DB-config code #261 shipped (`WRITE_ONLY_CONFIG_KEYS` redaction, `core.py` seeding) was dead/misleading (it implied a god-mode path that never actually worked, since the read goes to env).

Classify them explicitly, following the **secret → env, non-secret → db** model:

| Key | Source |
|---|---|
| `GITHUB_APP_ID`, `GITHUB_APP_SLUG`, `GITHUB_APP_CLIENT_ID` | **db** (admin-editable in god-mode; seeded from env by `configure_instance`) |
| `GITHUB_APP_PRIVATE_KEY`, `GITHUB_APP_WEBHOOK_SECRET`, `GITHUB_APP_CLIENT_SECRET` | **env** (`secret: True`) — SSM in cloud, env locally; never in the DB |

## Changes
- `config/registry.py`: register the 6 keys (3 db / 3 env-secret).
- `serializers/configuration.py`: remove `WRITE_ONLY_CONFIG_KEYS` + its `to_representation` branch. The secrets are env-sourced so they never reach the DB config API; env keys are already surfaced read-only via the existing `is_managed`/`source` path.
- `views/configuration.py`: drop the obsolete `WRITE_ONLY` import + the `"set"`-sentinel skip in `patch()`.
- `core.py`: keep the 3 non-secret seed entries; drop the 3 secret ones (secrets aren't DB-seeded).
- Remove the now-obsolete `test_write_only_github_app_config_sentinel_does_not_overwrite_secret` + its orphaned imports.

## Why this is more secure
Secrets never touch the DB → closes the decrypt-on-read exposure the #261 design doc flagged (the `EMAIL_HOST_PASSWORD`-style leak via the config API).

## Validation
- `manage.py check` clean; **53 tests pass** (`tests/unit/config`, the GitHub App contract suite, PR-link contract).
- No remaining references to `WRITE_ONLY_CONFIG_KEYS` / `is_write_only` anywhere (backend or admin frontend).

## Required companion (separate repo)
**private-pi-dash:** add `GITHUB_APP_PRIVATE_KEY,GITHUB_APP_WEBHOOK_SECRET,GITHUB_APP_CLIENT_SECRET` to `PIDASH_CONFIG_ENV_KEYS` and provision the matching SSM parameters, so cloud sources them from SSM. Until then, cloud falls back to reading them from env.

## Scope
GitHub App only. Migrating the *other* existing secrets (`GOOGLE_CLIENT_SECRET`, `GITHUB_CLIENT_SECRET`, GitLab/Gitea, `EMAIL_HOST_PASSWORD`, `LLM_API_KEY`) from db→env is a larger, separate sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)