### PR TITLE
PIDASH-2 remove "preferences" in user center

### DIFF
--- a/apps/web/core/components/workspace/sidebar/user-menu-root.tsx
+++ b/apps/web/core/components/workspace/sidebar/user-menu-root.tsx
@@ -7,7 +7,7 @@
 import { useState, useEffect } from "react";
 import { observer } from "mobx-react";
 import { useRouter } from "next/navigation";
-import { ChevronsUpDown, Globe, LogOut, Settings, Settings2 } from "lucide-react";
+import { ChevronsUpDown, Globe, LogOut, Settings } from "lucide-react";
 // pi dash imports
 import { GOD_MODE_URL } from "@pi-dash/constants";
 import { useTranslation } from "@pi-dash/i18n";
@@ -169,18 +169,6 @@ export const UserMenuRoot = observer(function UserMenuRoot({ variant = "compact"
           >
             <Settings className="size-3.5 shrink-0" />
             {t("Settings")}
-          </CustomMenu.MenuItem>
-          <CustomMenu.MenuItem
-            onClick={() =>
-              toggleProfileSettingsModal({
-                activeTab: "preferences",
-                isOpen: true,
-              })
-            }
-            className="flex items-center gap-2"
-          >
-            <Settings2 className="size-3.5 shrink-0" />
-            {t("Preferences")}
           </CustomMenu.MenuItem>
         </div>
         <CustomMenu.MenuItem onClick={() => setIsCommunityModalOpen(true)} className="flex items-center gap-2">


### PR DESCRIPTION
## Summary

- Remove the duplicate Preferences entry from the sidebar user-center menu.
- Keep the Settings entry intact so users can still open profile settings from the same menu.

## Validation

- `rg -n "t\\(\"Settings\"\\)|t\\(\"Preferences\"\\)|activeTab: \"preferences\"|activeTab: \"general\"|Settings2" apps/web/core/components/workspace/sidebar/user-menu-root.tsx`
- `pnpm turbo run check:lint --filter=web`
- `pnpm turbo run check:types --filter=web`
