### PR TITLE
feat(runner): preempt issue runs when no eligible runner is registered

### DIFF
--- a/.ai_design/issue_runner/design.md
+++ b/.ai_design/issue_runner/design.md
@@ -35,13 +35,74 @@
 >   and issue creation both default to the workspace pod when unspecified.
 >   Soft-delete now guards against removing the last pod of a workspace.
 
+## 0. Model correction — runners are private (2026-06)
+
+> **Sections affected:** §1 Goal (bullet 1 and 5), §2 Conceptual Model
+> (the Runner row and the "Key conceptual shift" paragraph), decision #5
+> framing, §4.2 ("`owner` stays — it no longer gates usage"). Treat the
+> text below as authoritative when it conflicts with those sections.
+
+The cooperative-pod story sketched in §1–§2 ("any workspace member can
+delegate work to any runner in the workspace") was **not** what shipped.
+Commit `1b590146` ("Add private dev machine visibility model", PR #196,
+2026-05-29) introduced `Visibility.PRIVATE` as the only runner-visibility
+value and added `filter_runs_usable_by_runner` to the matcher. From that
+point on, **owner remains the dispatch gate**, not just the billing /
+revoke anchor. Every Pod's queue is *physically* shared but *logically*
+partitioned by runner owner.
+
+**Why the original cooperative model can't work as documented.** The
+runner daemon authenticates against the cloud with a `MachineToken`
+bound to its owner (`runner/authentication.py:120-162`). DRF's
+`request.user` for every runner-originated API call is therefore the
+runner's owner — a real human. Every write the runner makes (issue
+comments via `IssueComment.actor`, state transitions, activity log
+`actor_id`, approvals) is stamped with that human's identity. Letting
+B's runner serve A's issue would put B's name on every audit row of
+A's ticket. There is no per-run dynamic-identity mechanism today (no
+short-lived `created_by`-scoped token, no all-bot writes with a
+side-channel responsibility tag). Until one of those lands, dispatching
+across owners is *inherently mis-attributing*, so the matcher gates on
+owner.
+
+**The actual dispatch rule** (live in
+`runner/services/permissions.py::filter_runs_usable_by_runner`):
+a PRIVATE runner may only consume an `AgentRun` when at least one of
+the following holds —
+
+1. `run.created_by_id == runner.owner_id` (the run's triggering user
+   owns this runner), or
+2. `run.owner_id == runner.owner_id` (legacy billed-to match), or
+3. The run's issue has `created_by == runner.owner_id` **or** lists
+   `runner.owner` as an `assignee`, or
+4. The run's `scheduler_binding.actor_id == runner.owner_id`.
+
+**Where the original design still holds**: Pod data model, soft-delete,
+project-pod relationship, `AgentRun.created_by` vs `owner` split, all
+permission-endpoint refactors (list / detail / cancel / approval move
+to `created_by`). Only the *cooperative-dispatch* narrative is wrong.
+
+**Open follow-up**: if we ever want true workspace-shared runners, the
+auth-attribution layer must be redesigned in lockstep — either per-run
+credentials (the cloud mints a short-lived token scoped to
+`AgentRun.id` whose `request.user = AgentRun.created_by`) or all writes
+go through `agent_system_user` with a `responsible_user_id` side-channel
+on every row. Either approach is a separate design.
+
+See §6.6 below for the eligibility-preflight behavior introduced
+alongside this correction.
+
 ## 1. Goal
 
-- Reframe runners as cooperative AI-agent instances available to a workspace, not personal machines owned by an individual.
-- Introduce `Pod` — a workspace-scoped group of runners that shares a work queue.
+> ⚠ Bullets 1 and 5 below describe the original cooperative-pod
+> aspiration. The shipped behavior is owner-gated dispatch — see §0
+> "Model correction" for the authoritative model.
+
+- ~~Reframe runners as cooperative AI-agent instances available to a workspace, not personal machines owned by an individual.~~ **Corrected:** runners remain private to their owner; they represent that human inside the workspace. Pods are still the queue boundary, but each runner only consumes work where its owner is the run's principal (creator / billed party / issue creator / assignee / scheduler actor).
+- Introduce `Pod` — a project-scoped group of runners that shares a work queue. (Workspace-scoped in the original draft; superseded by `.ai_design/n_runners_in_same_machine/new_pod_project_relationship/` which pinned pods to projects.)
 - Let issues pre-assign to a **pod** (stable, doesn't go offline) instead of a runner (which does).
-- Fix the stranded-QUEUED bug: when a runner finishes a job, its pod's queue drains automatically.
-- Preserve individual accountability: a runner still has an `owner` for management and billing, but not for access gating.
+- Fix the stranded-QUEUED bug: when a runner finishes a job, its pod's queue drains automatically. (A *new* class of stranded-QUEUED bug emerges when a pod has no runner whose owner matches the run's principal; see §6.6 "Eligibility preflight + bounce to Backlog" for the resolution.)
+- ~~Preserve individual accountability: a runner still has an `owner` for management and billing, but not for access gating.~~ **Corrected:** `owner` *is* the access gate for dispatch, in addition to its management/billing role. The intended decoupling was reverted by `1b590146` because the auth transport stamps `request.user = runner.owner` on every write the runner makes.
 
 ## 2. Conceptual Model
 
@@ -50,11 +111,11 @@
 | **Account** (User)    | A human                                                                      | —                                | themselves                      |
 | **Workspace**         | The cooperation boundary — a team                                            | any member                       | workspace admin                 |
 | **Pod**               | A logical group of AI agents (runners)                                       | any workspace member             | pod creator or workspace admin  |
-| **Runner**            | An AI agent instance (a running daemon on some host)                         | any workspace member (via a pod) | runner owner or workspace admin |
-| **Owner** (of runner) | The human who registered the runner and is responsible for its host / budget | —                                | —                               |
+| **Runner**            | An AI agent instance (a running daemon on some host)                         | **its owner**, plus runs whose issue lists the owner as creator or assignee (and runs the owner billed / scheduled) | runner owner or workspace admin |
+| **Owner** (of runner) | The human the runner represents in this workspace. Identifies the runner on every write it makes (via `MachineToken` → `request.user`), pays for its compute, can revoke it | — | — |
 | **Issue**             | Work item                                                                    | its workspace members            | per existing issue permissions  |
 
-**Key conceptual shift**: runner ownership is an _administrative bond_ (who pays for its uptime, who can revoke it), **not** an access gate. Any workspace member can delegate work to any runner in the workspace — mediated through pods.
+**Key conceptual shift (corrected, see §0)**: runner ownership is **both** an administrative bond *and* the access gate for dispatch. A runner only consumes work the matcher's `filter_runs_usable_by_runner` allows for its owner. A user can "borrow" someone else's runner only by being added to the issue (creator or assignee) so the four-predicate filter matches that runner's owner. The original draft of this section claimed any workspace member could dispatch to any runner; that did not ship — see §0.
 
 ## 3. Decisions Locked In
 
@@ -158,7 +219,7 @@ pod = models.ForeignKey(
 
 - `on_delete=PROTECT`: deleting (soft-deleting) a pod with runners is blocked; admin must move or revoke them first.
 - `null=False` from the start — there's no legacy data to backfill. Registration flow resolves a pod before insert (defaulting to `workspace.default_pod` when none is explicitly requested).
-- **`owner` stays** — it continues to mean "responsible human for this specific runner instance" (billing, revoke). It no longer gates usage.
+- **`owner` stays** — it continues to mean "responsible human for this specific runner instance" (billing, revoke). ~~It no longer gates usage.~~ **Corrected (§0):** `owner` also gates dispatch via `Visibility.PRIVATE` + `filter_runs_usable_by_runner`. A runner only takes work where its owner is one of: run creator, run billed-party, issue creator, issue assignee, scheduler binding actor.
 - Name uniqueness changes from `(workspace, name)` to `(pod, name)` — so two pods in the same workspace can each have a runner named "mac-mini". Tradeoff: human-friendly addressing via `(workspace, name)` is less direct, but pod scope is the natural namespace.
 
 Keep `MAX_PER_USER = 5` as a per-operator cap on how many agents one human can onboard. Pod membership is orthogonal.
@@ -390,6 +451,100 @@ Mandatory pre-create validation, in order:
 The orchestration path (`service._create_and_dispatch_run`) bypasses the HTTP layer but still enforces 2–4 before writing the `AgentRun` row. The `actor` parameter is the authoritative `created_by`; if `actor is None`, fall back to `_resolve_fallback_creator(issue)` (renamed from the legacy `_resolve_owner`, see §12) for back-compat only, and log a warning. **Implementation TODO**: grep for all callers of `handle_issue_state_transition` during implementation and ensure each passes an explicit `actor`; a follow-up change should promote `actor=None` from "warn" to "reject" once call sites are audited.
 
 A shared helper `validate_run_creation(user, workspace_id, work_item_id, pod_id)` is factored out and called by both paths.
+
+### 6.6 Eligibility preflight + bounce to Backlog (2026-06)
+
+Companion to §0. Closes the silent-jam case the original design didn't
+anticipate: a pod resolves cleanly, but no runner inside it has an
+owner the matcher would accept for this run. Without a preflight the
+`AgentRun` is created in `QUEUED`, `drain_pod` finishes with zero
+assignments, and the issue gets stuck forever — the ticker's
+`_active_run_for(issue)` short-circuits on the orphaned QUEUED row.
+
+**Eligibility set**: the set of `User.id`s whose runner *could* legally
+serve a hypothetical run on this issue with this creator —
+
+```
+eligible_owner_ids =
+    {run_creator_id, issue.created_by_id}
+    ∪ {assignee.id for assignee in issue.assignees}
+```
+
+`scheduler_binding.actor_id` is added when the run path is the project
+scheduler. The `run_creator_id` is the resolved actor for the current
+trigger (the clicker for `RUN_AI` / `COMMENT_AND_RUN`, the issue
+creator for `STATE_TRANSITION`, the `agent_system_user` bot for `TICK`).
+
+**Eligibility predicate**:
+
+```python
+Runner.objects.filter(
+    pod=resolved_pod,
+    owner_id__in=eligible_owner_ids,
+).exists()
+```
+
+**Liveness scope**: the predicate **ignores `Runner.status`** —
+`OFFLINE`, `BUSY`, and even `REVOKED` runners count as "registered". A
+runner the owner just turned off shouldn't bounce the issue back to
+Backlog (the owner can flip it on); the bounce is reserved for the
+truly-no-chance case where nobody's runner is set up for it. Transient
+unavailability is handled by `drain_pod` re-firing on heartbeat or
+re-enrollment.
+
+**Where the gate runs**: all four issue-run-creation paths preempt
+*before* inserting the `AgentRun` row —
+
+| Path                                                            | Entry                                                       | Trigger              |
+|-----------------------------------------------------------------|-------------------------------------------------------------|----------------------|
+| State transition into a ticking state (e.g. Todo → In Progress) | `orchestration.service._create_and_dispatch_run`            | `STATE_TRANSITION`   |
+| Auto ticker                                                     | `orchestration.scheduling.dispatch_continuation_run`        | `TICK`               |
+| "Run AI" button                                                 | `orchestration.scheduling.dispatch_run_ai_run`              | `RUN_AI`             |
+| "Comment & Run" button                                          | `orchestration.scheduling.dispatch_continuation_run`        | `COMMENT_AND_RUN`    |
+
+The direct `POST /api/v1/runner/runs/` endpoint with an explicit prompt
+(no `work_item`) is **not** gated — direct prompts have no issue to
+move and no audience to comment to; that path returns the existing
+"could not dispatch" error if no runner is online.
+
+**Bounce action** (atomic with the dispatch decision):
+
+1. **Resolve Backlog state**: pick the issue's project's `State` with
+   `group == StateGroup.BACKLOG` ordered by `(-default, sequence)`.
+   Fall back to project's `default_state` if no backlog state exists
+   (defensive — `DEFAULT_STATES` seeds one for every project).
+2. **Move the issue** (skip if already in `BACKLOG` group):
+   `issue.state = backlog_state; issue.save()`. The save fires
+   `fire_state_transition`, which calls
+   `handle_issue_state_transition`. Because Backlog isn't a delegation
+   trigger, the handler's path is: disarm ticker (we're leaving a
+   ticking state) → `not-a-trigger-state` early return. The recursive
+   re-entry terminates immediately.
+3. **Post a system comment** via `IssueComment.objects.create`
+   with `actor=get_agent_system_user()` and
+   `speaker_type=SpeakerType.AGENT`. Canonical body:
+   > *Agent run skipped — no eligible runner.*
+   >
+   > No runner is registered in this pod that can serve this issue.
+   > Add a runner under your account, or assign this issue to a
+   > workspace member whose runner is registered here.
+4. **No `AgentRun` row is created.** Caller returns
+   `TransitionOutcome(reason="no-eligible-runner")` (orchestration
+   path) or `409 Conflict` with `{"code": "no_eligible_runner"}` (HTTP
+   path).
+
+**Why preempt rather than create-then-cancel.** Avoids leaving an
+orphan QUEUED row in the audit trail every time the user lacks a
+runner; avoids the per-tick re-fire problem (a tombstoned FAILED row
+doesn't satisfy `_active_run_for`, so the next tick would re-create
+and re-fail in a loop until manual intervention).
+
+**Idempotence on the ticker**: after the bounce, the issue is in
+Backlog, which is not a ticking state, so the ticker is disarmed by
+step 2. Subsequent ticks do nothing — the issue stays calm until a
+human re-arms it by moving it back into a ticking state, at which
+point the eligibility check fires again with whatever runner
+registration / assignee changes have happened in the meantime.
 
 ## 7. Lifecycle
 

--- a/.ai_design/issue_runner/design.md
+++ b/.ai_design/issue_runner/design.md
@@ -48,7 +48,7 @@ Commit `1b590146` ("Add private dev machine visibility model", PR #196,
 2026-05-29) introduced `Visibility.PRIVATE` as the only runner-visibility
 value and added `filter_runs_usable_by_runner` to the matcher. From that
 point on, **owner remains the dispatch gate**, not just the billing /
-revoke anchor. Every Pod's queue is *physically* shared but *logically*
+revoke anchor. Every Pod's queue is _physically_ shared but _logically_
 partitioned by runner owner.
 
 **Why the original cooperative model can't work as documented.** The
@@ -62,7 +62,7 @@ B's runner serve A's issue would put B's name on every audit row of
 A's ticket. There is no per-run dynamic-identity mechanism today (no
 short-lived `created_by`-scoped token, no all-bot writes with a
 side-channel responsibility tag). Until one of those lands, dispatching
-across owners is *inherently mis-attributing*, so the matcher gates on
+across owners is _inherently mis-attributing_, so the matcher gates on
 owner.
 
 **The actual dispatch rule** (live in
@@ -80,7 +80,7 @@ the following holds —
 **Where the original design still holds**: Pod data model, soft-delete,
 project-pod relationship, `AgentRun.created_by` vs `owner` split, all
 permission-endpoint refactors (list / detail / cancel / approval move
-to `created_by`). Only the *cooperative-dispatch* narrative is wrong.
+to `created_by`). Only the _cooperative-dispatch_ narrative is wrong.
 
 **Open follow-up**: if we ever want true workspace-shared runners, the
 auth-attribution layer must be redesigned in lockstep — either per-run
@@ -101,21 +101,21 @@ alongside this correction.
 - ~~Reframe runners as cooperative AI-agent instances available to a workspace, not personal machines owned by an individual.~~ **Corrected:** runners remain private to their owner; they represent that human inside the workspace. Pods are still the queue boundary, but each runner only consumes work where its owner is the run's principal (creator / billed party / issue creator / assignee / scheduler actor).
 - Introduce `Pod` — a project-scoped group of runners that shares a work queue. (Workspace-scoped in the original draft; superseded by `.ai_design/n_runners_in_same_machine/new_pod_project_relationship/` which pinned pods to projects.)
 - Let issues pre-assign to a **pod** (stable, doesn't go offline) instead of a runner (which does).
-- Fix the stranded-QUEUED bug: when a runner finishes a job, its pod's queue drains automatically. (A *new* class of stranded-QUEUED bug emerges when a pod has no runner whose owner matches the run's principal; see §6.6 "Eligibility preflight + bounce to Backlog" for the resolution.)
-- ~~Preserve individual accountability: a runner still has an `owner` for management and billing, but not for access gating.~~ **Corrected:** `owner` *is* the access gate for dispatch, in addition to its management/billing role. The intended decoupling was reverted by `1b590146` because the auth transport stamps `request.user = runner.owner` on every write the runner makes.
+- Fix the stranded-QUEUED bug: when a runner finishes a job, its pod's queue drains automatically. (A _new_ class of stranded-QUEUED bug emerges when a pod has no runner whose owner matches the run's principal; see §6.6 "Eligibility preflight + bounce to Backlog" for the resolution.)
+- ~~Preserve individual accountability: a runner still has an `owner` for management and billing, but not for access gating.~~ **Corrected:** `owner` _is_ the access gate for dispatch, in addition to its management/billing role. The intended decoupling was reverted by `1b590146` because the auth transport stamps `request.user = runner.owner` on every write the runner makes.
 
 ## 2. Conceptual Model
 
-| Concept               | What it is                                                                   | Who can use it                   | Who can manage it               |
-| --------------------- | ---------------------------------------------------------------------------- | -------------------------------- | ------------------------------- |
-| **Account** (User)    | A human                                                                      | —                                | themselves                      |
-| **Workspace**         | The cooperation boundary — a team                                            | any member                       | workspace admin                 |
-| **Pod**               | A logical group of AI agents (runners)                                       | any workspace member             | pod creator or workspace admin  |
-| **Runner**            | An AI agent instance (a running daemon on some host)                         | **its owner**, plus runs whose issue lists the owner as creator or assignee (and runs the owner billed / scheduled) | runner owner or workspace admin |
-| **Owner** (of runner) | The human the runner represents in this workspace. Identifies the runner on every write it makes (via `MachineToken` → `request.user`), pays for its compute, can revoke it | — | — |
-| **Issue**             | Work item                                                                    | its workspace members            | per existing issue permissions  |
+| Concept               | What it is                                                                                                                                                                  | Who can use it                                                                                                      | Who can manage it               |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| **Account** (User)    | A human                                                                                                                                                                     | —                                                                                                                   | themselves                      |
+| **Workspace**         | The cooperation boundary — a team                                                                                                                                           | any member                                                                                                          | workspace admin                 |
+| **Pod**               | A logical group of AI agents (runners)                                                                                                                                      | any workspace member                                                                                                | pod creator or workspace admin  |
+| **Runner**            | An AI agent instance (a running daemon on some host)                                                                                                                        | **its owner**, plus runs whose issue lists the owner as creator or assignee (and runs the owner billed / scheduled) | runner owner or workspace admin |
+| **Owner** (of runner) | The human the runner represents in this workspace. Identifies the runner on every write it makes (via `MachineToken` → `request.user`), pays for its compute, can revoke it | —                                                                                                                   | —                               |
+| **Issue**             | Work item                                                                                                                                                                   | its workspace members                                                                                               | per existing issue permissions  |
 
-**Key conceptual shift (corrected, see §0)**: runner ownership is **both** an administrative bond *and* the access gate for dispatch. A runner only consumes work the matcher's `filter_runs_usable_by_runner` allows for its owner. A user can "borrow" someone else's runner only by being added to the issue (creator or assignee) so the four-predicate filter matches that runner's owner. The original draft of this section claimed any workspace member could dispatch to any runner; that did not ship — see §0.
+**Key conceptual shift (corrected, see §0)**: runner ownership is **both** an administrative bond _and_ the access gate for dispatch. A runner only consumes work the matcher's `filter_runs_usable_by_runner` allows for its owner. A user can "borrow" someone else's runner only by being added to the issue (creator or assignee) so the four-predicate filter matches that runner's owner. The original draft of this section claimed any workspace member could dispatch to any runner; that did not ship — see §0.
 
 ## 3. Decisions Locked In
 
@@ -461,7 +461,7 @@ owner the matcher would accept for this run. Without a preflight the
 assignments, and the issue gets stuck forever — the ticker's
 `_active_run_for(issue)` short-circuits on the orphaned QUEUED row.
 
-**Eligibility set**: the set of `User.id`s whose runner *could* legally
+**Eligibility set**: the set of `User.id`s whose runner _could_ legally
 serve a hypothetical run on this issue with this creator —
 
 ```
@@ -484,23 +484,28 @@ Runner.objects.filter(
 ).exists()
 ```
 
-**Liveness scope**: the predicate **ignores `Runner.status`** —
-`OFFLINE`, `BUSY`, and even `REVOKED` runners count as "registered". A
-runner the owner just turned off shouldn't bounce the issue back to
-Backlog (the owner can flip it on); the bounce is reserved for the
-truly-no-chance case where nobody's runner is set up for it. Transient
-unavailability is handled by `drain_pod` re-firing on heartbeat or
-re-enrollment.
+**Liveness scope**: the predicate ignores **transient** status —
+`OFFLINE` and `BUSY` runners count as "registered". A runner the owner
+just turned off shouldn't bounce the issue back to Backlog (the owner can
+flip it on); transient unavailability is handled by `drain_pod` re-firing
+on heartbeat or re-enrollment. `REVOKED` runners, however, are **excluded**:
+revocation is permanent (a revoked runner can never be un-revoked) and
+`drain_pod` only ever assigns `ONLINE` runners, so counting a REVOKED-only
+match would let the run be created and then jam in `QUEUED` forever — the
+exact silent-jam this preflight exists to close. Excluding REVOKED is
+consistent with `count_active` / `can_register_another`, which already
+`.exclude(status=REVOKED)`. The bounce is reserved for the truly-no-chance
+case where nobody's _live-or-revivable_ runner is set up for it.
 
 **Where the gate runs**: all four issue-run-creation paths preempt
-*before* inserting the `AgentRun` row —
+_before_ inserting the `AgentRun` row —
 
-| Path                                                            | Entry                                                       | Trigger              |
-|-----------------------------------------------------------------|-------------------------------------------------------------|----------------------|
-| State transition into a ticking state (e.g. Todo → In Progress) | `orchestration.service._create_and_dispatch_run`            | `STATE_TRANSITION`   |
-| Auto ticker                                                     | `orchestration.scheduling.dispatch_continuation_run`        | `TICK`               |
-| "Run AI" button                                                 | `orchestration.scheduling.dispatch_run_ai_run`              | `RUN_AI`             |
-| "Comment & Run" button                                          | `orchestration.scheduling.dispatch_continuation_run`        | `COMMENT_AND_RUN`    |
+| Path                                                            | Entry                                                | Trigger            |
+| --------------------------------------------------------------- | ---------------------------------------------------- | ------------------ |
+| State transition into a ticking state (e.g. Todo → In Progress) | `orchestration.service._create_and_dispatch_run`     | `STATE_TRANSITION` |
+| Auto ticker                                                     | `orchestration.scheduling.dispatch_continuation_run` | `TICK`             |
+| "Run AI" button                                                 | `orchestration.scheduling.dispatch_run_ai_run`       | `RUN_AI`           |
+| "Comment & Run" button                                          | `orchestration.scheduling.dispatch_continuation_run` | `COMMENT_AND_RUN`  |
 
 The direct `POST /api/v1/runner/runs/` endpoint with an explicit prompt
 (no `work_item`) is **not** gated — direct prompts have no issue to
@@ -512,18 +517,23 @@ move and no audience to comment to; that path returns the existing
 1. **Resolve Backlog state**: pick the issue's project's `State` with
    `group == StateGroup.BACKLOG` ordered by `(-default, sequence)`.
    Fall back to project's `default_state` if no backlog state exists
-   (defensive — `DEFAULT_STATES` seeds one for every project).
+   (defensive — `DEFAULT_STATES` seeds one for every project) — **but
+   only when that fallback is not itself a ticking state**, since moving
+   _into_ a ticking state re-fires dispatch and would re-bounce in a loop.
 2. **Move the issue** (skip if already in `BACKLOG` group):
    `issue.state = backlog_state; issue.save()`. The save fires
    `fire_state_transition`, which calls
    `handle_issue_state_transition`. Because Backlog isn't a delegation
    trigger, the handler's path is: disarm ticker (we're leaving a
    ticking state) → `not-a-trigger-state` early return. The recursive
-   re-entry terminates immediately.
+   re-entry terminates immediately. If no safe non-ticking target exists
+   (no backlog state and no non-ticking `default_state`), the issue is
+   left in place and the ticker is **disarmed explicitly** so a
+   subsequent tick can't re-enter the bounce and spam a comment per tick.
 3. **Post a system comment** via `IssueComment.objects.create`
    with `actor=get_agent_system_user()` and
    `speaker_type=SpeakerType.AGENT`. Canonical body:
-   > *Agent run skipped — no eligible runner.*
+   > _Agent run skipped — no eligible runner._
    >
    > No runner is registered in this pod that can serve this issue.
    > Add a runner under your account, or assign this issue to a

--- a/apps/api/pi_dash/orchestration/scheduling.py
+++ b/apps/api/pi_dash/orchestration/scheduling.py
@@ -427,6 +427,15 @@ def _bounce_issue_no_eligible_runner(issue: Issue, *, triggered_by: str) -> None
     issue is already in the BACKLOG state group — the comment still posts
     so the user sees *why* a click / tick produced no run.
 
+    Target resolution (design §6.6 step 1): prefer the project's Backlog
+    state (``default`` first, then ``sequence``); if the project has no
+    Backlog state at all, fall back to ``project.default_state`` **only
+    when it is not itself a ticking state** — moving into a ticking state
+    would re-fire dispatch and bounce again in a loop. When neither a
+    Backlog nor a safe fallback exists, the issue is left in place and the
+    ticker is disarmed explicitly (below) so the next tick can't re-enter
+    this bounce forever.
+
     The state move + comment post are wrapped in a single atomic block
     so a partial bounce (state changed, no comment) can't survive a
     crash mid-write — the user would otherwise be staring at an issue
@@ -463,15 +472,32 @@ def _bounce_issue_no_eligible_runner(issue: Issue, *, triggered_by: str) -> None
                 .first()
             )
             if target_state is None:
-                logger.warning(
-                    "agent_dispatch: no backlog state for project=%s; "
-                    "issue=%s stays in current state",
-                    issue.project_id,
-                    issue.pk,
-                )
-            else:
+                # Defensive: DEFAULT_STATES seeds a Backlog state for every
+                # project, but if one is missing fall back to the project's
+                # default_state — only when it isn't itself a ticking state,
+                # since moving into a ticking state re-fires dispatch and
+                # re-bounces (design §6.6 step 1).
+                fallback = issue.project.default_state
+                if fallback is not None and not is_ticking_state(fallback):
+                    target_state = fallback
+                else:
+                    logger.warning(
+                        "agent_dispatch: no safe backlog target for "
+                        "project=%s; issue=%s stays in current state, "
+                        "ticker disarmed",
+                        issue.project_id,
+                        issue.pk,
+                    )
+            if target_state is not None and target_state.pk != issue.state_id:
                 issue.state = target_state
                 issue.save(update_fields=["state", "updated_at"])
+
+        # If the issue couldn't be moved out of a ticking state, the
+        # state-move signal never disarmed the ticker — do it explicitly so
+        # a subsequent tick doesn't re-enter this bounce endlessly, spamming
+        # a comment each time.
+        if is_ticking_state(issue.state if issue.state_id else None):
+            disarm_ticker(issue)
 
         IssueComment.objects.create(
             issue=issue,

--- a/apps/api/pi_dash/orchestration/scheduling.py
+++ b/apps/api/pi_dash/orchestration/scheduling.py
@@ -394,6 +394,88 @@ def _resolve_creator_for_trigger(issue: Issue, *, triggered_by: str, actor=None)
     return project.project_lead or project.default_assignee
 
 
+def preflight_eligibility_or_bounce(
+    issue: Issue, *, run_creator, pod, triggered_by: str
+) -> bool:
+    """Return True if dispatch can proceed; False if the issue was bounced.
+
+    Companion preflight to the four issue-run dispatch paths. When no
+    runner registered in ``pod`` has an owner the matcher's
+    ``filter_runs_usable_by_runner`` would accept for a run on ``issue``
+    created by ``run_creator``, this moves the issue back to its
+    project's Backlog state and posts a system comment explaining why.
+    The caller must NOT create the ``AgentRun`` when this returns False.
+
+    See ``.ai_design/issue_runner/design.md`` §6.6.
+    """
+    from pi_dash.runner.services.matcher import (
+        pod_has_runner_for_issue_principal,
+    )
+
+    creator_id = getattr(run_creator, "id", None) if run_creator is not None else None
+    if pod_has_runner_for_issue_principal(pod, issue, creator_id):
+        return True
+    _bounce_issue_no_eligible_runner(issue, triggered_by=triggered_by)
+    return False
+
+
+def _bounce_issue_no_eligible_runner(issue: Issue, *, triggered_by: str) -> None:
+    """Move ``issue`` back to Backlog and post the no-eligible-runner notice.
+
+    State move fires ``fire_state_transition`` which disarms the ticker as
+    a side-effect (Backlog isn't a delegation trigger). Skipped when the
+    issue is already in the BACKLOG state group — the comment still posts
+    so the user sees *why* a click / tick produced no run.
+    """
+    from django.utils.html import format_html
+
+    from pi_dash.db.models.issue import IssueComment
+    from pi_dash.db.models.state import State, StateGroup
+    from pi_dash.orchestration.workpad import get_agent_system_user
+
+    logger.info(
+        "agent_dispatch: bounce issue=%s reason=no-eligible-runner triggered_by=%s",
+        issue.pk,
+        triggered_by,
+    )
+
+    current_state_group = issue.state.group if issue.state_id else None
+    if current_state_group != StateGroup.BACKLOG.value:
+        target_state = (
+            State.objects.filter(
+                project_id=issue.project_id,
+                group=StateGroup.BACKLOG.value,
+            )
+            .order_by("-default", "sequence")
+            .first()
+        )
+        if target_state is None:
+            logger.warning(
+                "agent_dispatch: no backlog state for project=%s; "
+                "issue=%s stays in current state",
+                issue.project_id,
+                issue.pk,
+            )
+        else:
+            issue.state = target_state
+            issue.save(update_fields=["state", "updated_at"])
+
+    body = format_html(
+        "<p><strong>Agent run skipped — no eligible runner.</strong></p>"
+        "<p>No runner is registered in this pod that can serve this issue. "
+        "Add a runner under your account, or assign this issue to a "
+        "workspace member whose runner is registered here.</p>"
+    )
+    IssueComment.objects.create(
+        issue=issue,
+        project_id=issue.project_id,
+        workspace_id=issue.workspace_id,
+        actor=get_agent_system_user(),
+        comment_html=body,
+        speaker_type=IssueComment.SpeakerType.AGENT,
+    )
+
+
 def dispatch_continuation_run(
     issue: Issue,
     *,
@@ -406,7 +488,8 @@ def dispatch_continuation_run(
     explicit ``actor`` for Comment & Run), pod, then delegates to
     :func:`pi_dash.orchestration.service._create_continuation_run`.
     Returns the created run, or ``None`` when the single-active-run
-    guardrail blocks creation or no pod is available.
+    guardrail blocks creation, no pod is available, or the eligibility
+    preflight bounced the issue (§6.6).
     """
     from pi_dash.orchestration import service as orchestration_service
 
@@ -445,6 +528,11 @@ def dispatch_continuation_run(
             issue.pk,
             triggered_by,
         )
+        return None
+
+    if not preflight_eligibility_or_bounce(
+        issue, run_creator=creator, pod=pod, triggered_by=triggered_by
+    ):
         return None
 
     outcome = orchestration_service._create_continuation_run(
@@ -505,6 +593,11 @@ def dispatch_run_ai_run(issue: Issue, *, actor) -> Optional[AgentRun]:
             issue.pk,
             TRIGGER_RUN_AI,
         )
+        return None
+
+    if not preflight_eligibility_or_bounce(
+        issue, run_creator=creator, pod=pod, triggered_by=TRIGGER_RUN_AI
+    ):
         return None
 
     parent = orchestration_service._latest_prior_run(issue)

--- a/apps/api/pi_dash/orchestration/scheduling.py
+++ b/apps/api/pi_dash/orchestration/scheduling.py
@@ -412,7 +412,7 @@ def preflight_eligibility_or_bounce(
         pod_has_runner_for_issue_principal,
     )
 
-    creator_id = getattr(run_creator, "id", None) if run_creator is not None else None
+    creator_id = getattr(run_creator, "id", None)
     if pod_has_runner_for_issue_principal(pod, issue, creator_id):
         return True
     _bounce_issue_no_eligible_runner(issue, triggered_by=triggered_by)
@@ -426,6 +426,11 @@ def _bounce_issue_no_eligible_runner(issue: Issue, *, triggered_by: str) -> None
     a side-effect (Backlog isn't a delegation trigger). Skipped when the
     issue is already in the BACKLOG state group — the comment still posts
     so the user sees *why* a click / tick produced no run.
+
+    The state move + comment post are wrapped in a single atomic block
+    so a partial bounce (state changed, no comment) can't survive a
+    crash mid-write — the user would otherwise be staring at an issue
+    that silently jumped back to Backlog with no explanation.
     """
     from django.utils.html import format_html
 
@@ -439,41 +444,43 @@ def _bounce_issue_no_eligible_runner(issue: Issue, *, triggered_by: str) -> None
         triggered_by,
     )
 
-    current_state_group = issue.state.group if issue.state_id else None
-    if current_state_group != StateGroup.BACKLOG.value:
-        target_state = (
-            State.objects.filter(
-                project_id=issue.project_id,
-                group=StateGroup.BACKLOG.value,
-            )
-            .order_by("-default", "sequence")
-            .first()
-        )
-        if target_state is None:
-            logger.warning(
-                "agent_dispatch: no backlog state for project=%s; "
-                "issue=%s stays in current state",
-                issue.project_id,
-                issue.pk,
-            )
-        else:
-            issue.state = target_state
-            issue.save(update_fields=["state", "updated_at"])
-
     body = format_html(
         "<p><strong>Agent run skipped — no eligible runner.</strong></p>"
         "<p>No runner is registered in this pod that can serve this issue. "
         "Add a runner under your account, or assign this issue to a "
         "workspace member whose runner is registered here.</p>"
     )
-    IssueComment.objects.create(
-        issue=issue,
-        project_id=issue.project_id,
-        workspace_id=issue.workspace_id,
-        actor=get_agent_system_user(),
-        comment_html=body,
-        speaker_type=IssueComment.SpeakerType.AGENT,
-    )
+
+    with transaction.atomic():
+        current_state_group = issue.state.group if issue.state_id else None
+        if current_state_group != StateGroup.BACKLOG.value:
+            target_state = (
+                State.objects.filter(
+                    project_id=issue.project_id,
+                    group=StateGroup.BACKLOG.value,
+                )
+                .order_by("-default", "sequence")
+                .first()
+            )
+            if target_state is None:
+                logger.warning(
+                    "agent_dispatch: no backlog state for project=%s; "
+                    "issue=%s stays in current state",
+                    issue.project_id,
+                    issue.pk,
+                )
+            else:
+                issue.state = target_state
+                issue.save(update_fields=["state", "updated_at"])
+
+        IssueComment.objects.create(
+            issue=issue,
+            project=issue.project,
+            workspace=issue.workspace,
+            actor=get_agent_system_user(),
+            comment_html=body,
+            speaker_type=IssueComment.SpeakerType.AGENT,
+        )
 
 
 def dispatch_continuation_run(

--- a/apps/api/pi_dash/orchestration/service.py
+++ b/apps/api/pi_dash/orchestration/service.py
@@ -244,6 +244,14 @@ def handle_issue_state_transition(
         )
         return TransitionOutcome(reason="no-pod-available")
 
+    if not scheduling.preflight_eligibility_or_bounce(
+        issue,
+        run_creator=creator,
+        pod=pod,
+        triggered_by=AgentRunTrigger.STATE_TRANSITION.value,
+    ):
+        return TransitionOutcome(reason="no-eligible-runner")
+
     return _create_and_dispatch_run(
         issue=issue,
         parent=parent,

--- a/apps/api/pi_dash/runner/services/matcher.py
+++ b/apps/api/pi_dash/runner/services/matcher.py
@@ -374,6 +374,10 @@ def pod_has_runner_for_issue_principal(pod, issue, run_creator_id) -> bool:
     - ``issue.created_by_id`` (the issue creator),
     - any current ``issue.assignees``.
 
+    ``issue.assignees`` is the M2M live manager; the existing matcher
+    (``filter_runs_usable_by_runner``) traverses it the same way, so
+    the preflight stays consistent with the dispatch gate it shadows.
+
     Status is **deliberately ignored** — OFFLINE / BUSY / REVOKED runners
     all count as "registered". The intent is to detect the structural
     "nobody on this pod could ever serve this" case, not transient

--- a/apps/api/pi_dash/runner/services/matcher.py
+++ b/apps/api/pi_dash/runner/services/matcher.py
@@ -378,10 +378,16 @@ def pod_has_runner_for_issue_principal(pod, issue, run_creator_id) -> bool:
     (``filter_runs_usable_by_runner``) traverses it the same way, so
     the preflight stays consistent with the dispatch gate it shadows.
 
-    Status is **deliberately ignored** — OFFLINE / BUSY / REVOKED runners
-    all count as "registered". The intent is to detect the structural
-    "nobody on this pod could ever serve this" case, not transient
-    unavailability (``drain_pod`` re-fires on heartbeat). See
+    Transient status is **deliberately ignored** — OFFLINE / BUSY runners
+    still count as "registered" because the owner can flip them back on and
+    ``drain_pod`` re-fires on heartbeat. REVOKED runners, however, are
+    **permanent** — a revoked runner can never be un-revoked and
+    ``drain_pod`` only ever assigns ONLINE runners, so a REVOKED-only match
+    would let the run be created and then jam in QUEUED forever (the exact
+    silent-jam this preflight exists to prevent). They are therefore
+    excluded, consistent with ``count_active`` / ``can_register_another``.
+    The intent is to detect the structural "nobody on this pod could ever
+    serve this" case, not transient unavailability. See
     ``.ai_design/issue_runner/design.md`` §6.6.
     """
     eligible_owner_ids: set = set()
@@ -395,10 +401,14 @@ def pod_has_runner_for_issue_principal(pod, issue, run_creator_id) -> bool:
     eligible_owner_ids.discard(None)
     if not eligible_owner_ids:
         return False
-    return Runner.objects.filter(
-        pod=pod,
-        owner_id__in=eligible_owner_ids,
-    ).exists()
+    return (
+        Runner.objects.filter(
+            pod=pod,
+            owner_id__in=eligible_owner_ids,
+        )
+        .exclude(status=RunnerStatus.REVOKED)
+        .exists()
+    )
 
 
 def count_active(user_id, workspace_id) -> int:

--- a/apps/api/pi_dash/runner/services/matcher.py
+++ b/apps/api/pi_dash/runner/services/matcher.py
@@ -361,6 +361,42 @@ def can_register_another(user_id, workspace_id) -> bool:
     return active.count() < Runner.MAX_PER_USER
 
 
+def pod_has_runner_for_issue_principal(pod, issue, run_creator_id) -> bool:
+    """Does ``pod`` contain any registered runner whose owner could serve a
+    run on ``issue`` triggered by ``run_creator_id``?
+
+    Mirrors the eligibility set used by
+    :func:`pi_dash.runner.services.permissions.filter_runs_usable_by_runner`
+    for ``Visibility.PRIVATE`` runners — the only visibility today. A
+    runner is "potentially serviceable" if its owner is one of:
+
+    - ``run_creator_id`` (the user the dispatch is being attributed to),
+    - ``issue.created_by_id`` (the issue creator),
+    - any current ``issue.assignees``.
+
+    Status is **deliberately ignored** — OFFLINE / BUSY / REVOKED runners
+    all count as "registered". The intent is to detect the structural
+    "nobody on this pod could ever serve this" case, not transient
+    unavailability (``drain_pod`` re-fires on heartbeat). See
+    ``.ai_design/issue_runner/design.md`` §6.6.
+    """
+    eligible_owner_ids: set = set()
+    if run_creator_id is not None:
+        eligible_owner_ids.add(run_creator_id)
+    if issue.created_by_id is not None:
+        eligible_owner_ids.add(issue.created_by_id)
+    eligible_owner_ids.update(
+        issue.assignees.values_list("id", flat=True)
+    )
+    eligible_owner_ids.discard(None)
+    if not eligible_owner_ids:
+        return False
+    return Runner.objects.filter(
+        pod=pod,
+        owner_id__in=eligible_owner_ids,
+    ).exists()
+
+
 def count_active(user_id, workspace_id) -> int:
     return (
         Runner.objects.filter(owner_id=user_id, workspace_id=workspace_id).exclude(status=RunnerStatus.REVOKED).count()

--- a/apps/api/pi_dash/tests/unit/orchestration/test_eligibility_preflight.py
+++ b/apps/api/pi_dash/tests/unit/orchestration/test_eligibility_preflight.py
@@ -206,16 +206,51 @@ def test_pod_has_runner_no_eligible_owner(db, pod, issue, user_a, user_b):
 
 
 @pytest.mark.unit
-def test_pod_has_runner_revoked_runner_still_counts(db, pod, issue, user_a):
-    """Per design §6.6: status-agnostic. Even REVOKED counts as registered."""
+def test_pod_has_runner_revoked_runner_does_not_count(db, pod, issue, user_a):
+    """REVOKED is permanent — a revoked runner can never pick the run up
+    (``drain_pod`` assigns ONLINE only), so counting it would let the run be
+    created and jam in QUEUED forever. It must NOT satisfy the predicate
+    (consistent with ``count_active`` / ``can_register_another``)."""
     _make_runner(user_a, issue.workspace, pod, status=RunnerStatus.REVOKED)
-    assert matcher.pod_has_runner_for_issue_principal(pod, issue, user_a.id) is True
+    assert matcher.pod_has_runner_for_issue_principal(pod, issue, user_a.id) is False
 
 
 @pytest.mark.unit
 def test_pod_has_runner_offline_runner_still_counts(db, pod, issue, user_a):
     _make_runner(user_a, issue.workspace, pod, status=RunnerStatus.OFFLINE)
     assert matcher.pod_has_runner_for_issue_principal(pod, issue, user_a.id) is True
+
+
+@pytest.mark.unit
+def test_pod_has_runner_revoked_ignored_but_live_owner_still_counts(
+    db, pod, issue, user_a
+):
+    """A REVOKED runner doesn't count, but a second ONLINE runner under the
+    same eligible owner still makes the pod eligible."""
+    _make_runner(user_a, issue.workspace, pod, name="dead", status=RunnerStatus.REVOKED)
+    _make_runner(user_a, issue.workspace, pod, name="live", status=RunnerStatus.ONLINE)
+    assert matcher.pod_has_runner_for_issue_principal(pod, issue, user_a.id) is True
+
+
+@pytest.mark.unit
+def test_dispatch_run_ai_run_bounces_when_only_runner_revoked(
+    db, issue, pod, user_a, states
+):
+    """Regression for the silent-QUEUED jam: the eligible owner's *only*
+    runner is REVOKED (permanent — ``drain_pod`` assigns ONLINE only). The
+    preflight must bounce rather than create an AgentRun that would jam in
+    QUEUED forever."""
+    Issue.all_objects.filter(pk=issue.pk).update(state=states["in_progress"])
+    issue.refresh_from_db()
+    _make_runner(user_a, issue.workspace, pod, status=RunnerStatus.REVOKED)
+
+    run = scheduling.dispatch_run_ai_run(issue, actor=user_a)
+
+    assert run is None
+    assert AgentRun.objects.filter(work_item=issue).count() == 0
+    issue.refresh_from_db()
+    assert issue.state.group == "backlog"
+    assert IssueComment.objects.filter(issue=issue).count() == 1
 
 
 @pytest.mark.unit
@@ -343,8 +378,10 @@ def test_bounce_skips_state_move_when_already_in_backlog(
 def test_bounce_falls_back_gracefully_when_no_backlog_state(
     db, workspace, create_user, user_a, user_b
 ):
-    """Defensive: project has no Backlog state at all. Bounce should not
-    crash; it skips the state move but still posts the comment."""
+    """Defensive: project has no Backlog state and no non-ticking fallback.
+    The bounce must not crash, must still post the comment, and must
+    **disarm the ticker** — otherwise the issue stays in a ticking state and
+    the next tick re-enters the bounce, spamming a comment each time."""
     with impersonate(create_user):
         bare_project = Project.objects.create(
             name="Bare",
@@ -353,6 +390,12 @@ def test_bounce_falls_back_gracefully_when_no_backlog_state(
             created_by=create_user,
         )
     pod = Pod.default_for_project(bare_project)
+    # Neutral (non-ticking) state to create the issue in, so issue creation
+    # doesn't itself fire the state-transition dispatch. There is
+    # deliberately no Backlog state and no default_state fallback.
+    unstarted = State.objects.create(
+        name="Todo", project=bare_project, group="unstarted"
+    )
     started = State.objects.create(
         name="In Progress", project=bare_project, group="started"
     )
@@ -361,9 +404,14 @@ def test_bounce_falls_back_gracefully_when_no_backlog_state(
             name="No-backlog",
             workspace=workspace,
             project=bare_project,
-            state=started,
+            state=unstarted,
             created_by=user_a,
         )
+    # Move into the ticking state without firing the signal, and arm the
+    # ticker as if the issue were actively running.
+    Issue.all_objects.filter(pk=bare_issue.pk).update(state=started)
+    bare_issue.refresh_from_db()
+    IssueAgentTicker.objects.create(issue=bare_issue, enabled=True, tick_count=1)
 
     _make_runner(user_b, workspace, pod)
 
@@ -378,6 +426,8 @@ def test_bounce_falls_back_gracefully_when_no_backlog_state(
     bare_issue.refresh_from_db()
     assert bare_issue.state_id == started.id  # unchanged — no backlog target
     assert IssueComment.objects.filter(issue=bare_issue).count() == 1
+    # The loop-breaker: ticker disarmed even though the issue couldn't move.
+    assert IssueAgentTicker.objects.get(issue=bare_issue).enabled is False
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/pi_dash/tests/unit/orchestration/test_eligibility_preflight.py
+++ b/apps/api/pi_dash/tests/unit/orchestration/test_eligibility_preflight.py
@@ -1,0 +1,508 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Tests for the runner-eligibility preflight + bounce-to-Backlog behavior.
+
+See ``.ai_design/issue_runner/design.md`` §6.6.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+from uuid import uuid4
+
+import pytest
+from crum import impersonate
+from django.utils import timezone
+
+from pi_dash.db.models import Issue, Project, State
+from pi_dash.db.models.issue import IssueAssignee, IssueComment
+from pi_dash.db.models.issue_agent_ticker import IssueAgentTicker
+from pi_dash.db.models.user import User
+from pi_dash.db.models.workspace import WorkspaceMember
+from pi_dash.orchestration import scheduling, service as orchestration_service
+from pi_dash.orchestration.workpad import get_agent_system_user
+from pi_dash.runner.models import (
+    AgentRun,
+    AgentRunTrigger,
+    Pod,
+    Runner,
+    RunnerStatus,
+)
+from pi_dash.runner.services import matcher
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def project(db, workspace, create_user):
+    with impersonate(create_user):
+        return Project.objects.create(
+            name="Web",
+            identifier="WEB",
+            workspace=workspace,
+            created_by=create_user,
+        )
+
+
+@pytest.fixture
+def pod(project):
+    return Pod.default_for_project(project)
+
+
+@pytest.fixture
+def states(project, create_user):
+    """Project states. Two Backlog states so the 'prefers default' rule
+    can be checked. Includes In Progress so we can transition issues into
+    a ticking state for the integration tests."""
+    with impersonate(create_user):
+        return {
+            "backlog_default": State.objects.create(
+                name="Backlog",
+                project=project,
+                group="backlog",
+                default=True,
+                sequence=100,
+            ),
+            "backlog_other": State.objects.create(
+                name="Icebox",
+                project=project,
+                group="backlog",
+                default=False,
+                sequence=200,
+            ),
+            "todo": State.objects.create(
+                name="Todo", project=project, group="unstarted"
+            ),
+            "in_progress": State.objects.create(
+                name="In Progress", project=project, group="started"
+            ),
+        }
+
+
+def _make_user(email_suffix: str) -> User:
+    user = User.objects.create(
+        email=f"{email_suffix}@example.com",
+        username=f"user_{email_suffix}_{uuid4().hex[:6]}",
+        first_name=email_suffix.capitalize(),
+        last_name="Tester",
+    )
+    user.set_password("pw")
+    user.save()
+    return user
+
+
+@pytest.fixture
+def user_a(create_user):
+    """The default user from the conftest workspace fixture; the workspace
+    admin / issue creator in most scenarios."""
+    return create_user
+
+
+@pytest.fixture
+def user_b(db, workspace):
+    u = _make_user("b")
+    WorkspaceMember.objects.create(workspace=workspace, member=u, role=15)
+    return u
+
+
+@pytest.fixture
+def user_c(db, workspace):
+    u = _make_user("c")
+    WorkspaceMember.objects.create(workspace=workspace, member=u, role=15)
+    return u
+
+
+def _make_runner(owner, workspace, pod, name="rnr", status=RunnerStatus.ONLINE):
+    return Runner.objects.create(
+        owner=owner,
+        workspace=workspace,
+        pod=pod,
+        name=name,
+        status=status,
+        last_heartbeat_at=(
+            timezone.now() if status == RunnerStatus.ONLINE else None
+        ),
+    )
+
+
+@pytest.fixture
+def issue(workspace, project, states, user_a):
+    """Issue created in Backlog by user_a so the state-transition signal
+    does not auto-fire on creation."""
+    with impersonate(user_a):
+        return Issue.objects.create(
+            name="Task",
+            workspace=workspace,
+            project=project,
+            state=states["backlog_default"],
+            created_by=user_a,
+        )
+
+
+@pytest.fixture(autouse=True)
+def _on_commit_immediate(monkeypatch):
+    """Pytest-django wraps each test in a rolled-back transaction so
+    on_commit callbacks never fire. Run them inline so dispatch
+    side-effects (drain, ticker arming) are observable."""
+    monkeypatch.setattr(
+        "django.db.transaction.on_commit", lambda fn, **kw: fn()
+    )
+
+
+@pytest.fixture(autouse=True)
+def _stub_drain(monkeypatch):
+    """The matcher's drain isn't under test here; suppress it so dispatch
+    paths don't try to dispatch over a (mocked) WebSocket."""
+    monkeypatch.setattr(
+        matcher, "drain_pod_by_id", mock.Mock()
+    )
+    monkeypatch.setattr(
+        matcher, "drain_pod", mock.Mock()
+    )
+
+
+# ---------------------------------------------------------------------------
+# matcher.pod_has_runner_for_issue_principal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_pod_has_runner_matches_run_creator(db, pod, issue, user_a):
+    _make_runner(user_a, issue.workspace, pod)
+    assert matcher.pod_has_runner_for_issue_principal(pod, issue, user_a.id) is True
+
+
+@pytest.mark.unit
+def test_pod_has_runner_matches_issue_creator(db, pod, issue, user_a, user_b):
+    # Run is created by user_b (e.g., via Comment & Run), but issue.created_by
+    # is user_a. user_a's runner should make the pod eligible.
+    _make_runner(user_a, issue.workspace, pod)
+    assert matcher.pod_has_runner_for_issue_principal(pod, issue, user_b.id) is True
+
+
+@pytest.mark.unit
+def test_pod_has_runner_matches_assignee(db, pod, issue, user_a, user_b, user_c):
+    # Only user_c has a runner. user_c is assigned. Run creator is user_a,
+    # issue creator is user_a — neither has a runner. The assignee path
+    # should still pass.
+    _make_runner(user_c, issue.workspace, pod)
+    IssueAssignee.objects.create(
+        issue=issue, assignee=user_c, project=issue.project
+    )
+    assert matcher.pod_has_runner_for_issue_principal(pod, issue, user_a.id) is True
+
+
+@pytest.mark.unit
+def test_pod_has_runner_no_eligible_owner(db, pod, issue, user_a, user_b):
+    # Only user_b has a runner; user_b is NOT the creator, issue.created_by,
+    # or an assignee.
+    _make_runner(user_b, issue.workspace, pod)
+    assert matcher.pod_has_runner_for_issue_principal(pod, issue, user_a.id) is False
+
+
+@pytest.mark.unit
+def test_pod_has_runner_revoked_runner_still_counts(db, pod, issue, user_a):
+    """Per design §6.6: status-agnostic. Even REVOKED counts as registered."""
+    _make_runner(user_a, issue.workspace, pod, status=RunnerStatus.REVOKED)
+    assert matcher.pod_has_runner_for_issue_principal(pod, issue, user_a.id) is True
+
+
+@pytest.mark.unit
+def test_pod_has_runner_offline_runner_still_counts(db, pod, issue, user_a):
+    _make_runner(user_a, issue.workspace, pod, status=RunnerStatus.OFFLINE)
+    assert matcher.pod_has_runner_for_issue_principal(pod, issue, user_a.id) is True
+
+
+@pytest.mark.unit
+def test_pod_has_runner_empty_pod(db, pod, issue, user_a):
+    assert matcher.pod_has_runner_for_issue_principal(pod, issue, user_a.id) is False
+
+
+@pytest.mark.unit
+def test_pod_has_runner_other_pod_does_not_count(
+    db, project, pod, issue, user_a, create_user
+):
+    # A runner owned by user_a exists, but in a different pod (different
+    # project) — must not satisfy the predicate.
+    other_project = Project.objects.create(
+        name="Other",
+        identifier="OTH",
+        workspace=issue.workspace,
+        created_by=create_user,
+    )
+    other_pod = Pod.default_for_project(other_project)
+    _make_runner(user_a, issue.workspace, other_pod, name="elsewhere")
+    assert matcher.pod_has_runner_for_issue_principal(pod, issue, user_a.id) is False
+
+
+# ---------------------------------------------------------------------------
+# scheduling.preflight_eligibility_or_bounce — happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_preflight_returns_true_when_eligible(db, issue, pod, user_a):
+    _make_runner(user_a, issue.workspace, pod)
+    assert (
+        scheduling.preflight_eligibility_or_bounce(
+            issue,
+            run_creator=user_a,
+            pod=pod,
+            triggered_by=AgentRunTrigger.STATE_TRANSITION.value,
+        )
+        is True
+    )
+    # No bounce side-effects.
+    assert IssueComment.objects.filter(issue=issue).count() == 0
+    issue.refresh_from_db()
+    assert issue.state.group == "backlog"  # unchanged (already in backlog)
+
+
+# ---------------------------------------------------------------------------
+# scheduling.preflight_eligibility_or_bounce — bounce path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_preflight_bounces_when_no_eligible_runner(
+    db, issue, pod, user_a, user_b, states
+):
+    """B's runner exists, but A creates run on A's issue — bounce."""
+    # Put the issue in In Progress so we can verify the state move back.
+    Issue.all_objects.filter(pk=issue.pk).update(state=states["in_progress"])
+    issue.refresh_from_db()
+
+    _make_runner(user_b, issue.workspace, pod)
+    result = scheduling.preflight_eligibility_or_bounce(
+        issue,
+        run_creator=user_a,
+        pod=pod,
+        triggered_by=AgentRunTrigger.STATE_TRANSITION.value,
+    )
+    assert result is False
+
+    issue.refresh_from_db()
+    assert issue.state.group == "backlog"
+    assert issue.state.name == "Backlog"  # default backlog state, not "Icebox"
+
+    comment = IssueComment.objects.get(issue=issue)
+    assert comment.actor == get_agent_system_user()
+    assert comment.speaker_type == IssueComment.SpeakerType.AGENT
+    assert "no eligible runner" in comment.comment_html.lower()
+
+
+@pytest.mark.unit
+def test_bounce_prefers_default_backlog_state(
+    db, issue, pod, user_a, user_b, states, project
+):
+    """When project has two Backlog states, the one with default=True wins."""
+    Issue.all_objects.filter(pk=issue.pk).update(state=states["in_progress"])
+    issue.refresh_from_db()
+
+    _make_runner(user_b, issue.workspace, pod)
+    scheduling.preflight_eligibility_or_bounce(
+        issue,
+        run_creator=user_a,
+        pod=pod,
+        triggered_by=AgentRunTrigger.RUN_AI.value,
+    )
+
+    issue.refresh_from_db()
+    assert issue.state == states["backlog_default"]
+    assert issue.state != states["backlog_other"]
+
+
+@pytest.mark.unit
+def test_bounce_skips_state_move_when_already_in_backlog(
+    db, issue, pod, user_a, user_b
+):
+    """Issue is already Backlog. State must not change, but the comment
+    explaining why dispatch was skipped still posts."""
+    original_state_id = issue.state_id
+    _make_runner(user_b, issue.workspace, pod)
+
+    result = scheduling.preflight_eligibility_or_bounce(
+        issue,
+        run_creator=user_a,
+        pod=pod,
+        triggered_by=AgentRunTrigger.RUN_AI.value,
+    )
+    assert result is False
+
+    issue.refresh_from_db()
+    assert issue.state_id == original_state_id
+    assert IssueComment.objects.filter(issue=issue).count() == 1
+
+
+@pytest.mark.unit
+def test_bounce_falls_back_gracefully_when_no_backlog_state(
+    db, workspace, create_user, user_a, user_b
+):
+    """Defensive: project has no Backlog state at all. Bounce should not
+    crash; it skips the state move but still posts the comment."""
+    with impersonate(create_user):
+        bare_project = Project.objects.create(
+            name="Bare",
+            identifier="BARE",
+            workspace=workspace,
+            created_by=create_user,
+        )
+    pod = Pod.default_for_project(bare_project)
+    started = State.objects.create(
+        name="In Progress", project=bare_project, group="started"
+    )
+    with impersonate(user_a):
+        bare_issue = Issue.objects.create(
+            name="No-backlog",
+            workspace=workspace,
+            project=bare_project,
+            state=started,
+            created_by=user_a,
+        )
+
+    _make_runner(user_b, workspace, pod)
+
+    result = scheduling.preflight_eligibility_or_bounce(
+        bare_issue,
+        run_creator=user_a,
+        pod=pod,
+        triggered_by=AgentRunTrigger.TICK.value,
+    )
+    assert result is False
+
+    bare_issue.refresh_from_db()
+    assert bare_issue.state_id == started.id  # unchanged — no backlog target
+    assert IssueComment.objects.filter(issue=bare_issue).count() == 1
+
+
+# ---------------------------------------------------------------------------
+# Integration: dispatch entry points are gated
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_dispatch_run_ai_run_bounces_when_no_runner(
+    db, issue, pod, user_a, user_b, states
+):
+    Issue.all_objects.filter(pk=issue.pk).update(state=states["in_progress"])
+    issue.refresh_from_db()
+    _make_runner(user_b, issue.workspace, pod)  # not eligible for user_a's issue
+
+    run = scheduling.dispatch_run_ai_run(issue, actor=user_a)
+
+    assert run is None
+    assert AgentRun.objects.filter(work_item=issue).count() == 0
+    issue.refresh_from_db()
+    assert issue.state.group == "backlog"
+    assert IssueComment.objects.filter(issue=issue).count() == 1
+
+
+@pytest.mark.unit
+def test_dispatch_run_ai_run_proceeds_when_eligible(
+    db, issue, pod, user_a, states, project
+):
+    """Sanity: with an eligible runner present, no bounce; a run is
+    created. We don't assert on the run's status because drain is stubbed
+    out — the run stays QUEUED, which is fine for this preflight test."""
+    from pi_dash.prompting.seed import seed_default_template
+
+    seed_default_template()
+    Issue.all_objects.filter(pk=issue.pk).update(state=states["in_progress"])
+    issue.refresh_from_db()
+    _make_runner(user_a, issue.workspace, pod)
+
+    run = scheduling.dispatch_run_ai_run(issue, actor=user_a)
+    assert run is not None
+    assert AgentRun.objects.filter(work_item=issue).count() == 1
+    issue.refresh_from_db()
+    assert issue.state.group == "started"  # NOT bounced
+    assert IssueComment.objects.filter(issue=issue).count() == 0
+
+
+@pytest.mark.unit
+def test_dispatch_continuation_run_tick_bounces_when_no_runner(
+    db, issue, pod, user_a, user_b, states
+):
+    """Tick path: created_by = agent_system_user (the bot, no runner of
+    its own), so eligibility falls to issue.created_by + assignees.
+    Neither matches B's runner — bounce."""
+    Issue.all_objects.filter(pk=issue.pk).update(state=states["in_progress"])
+    issue.refresh_from_db()
+    _make_runner(user_b, issue.workspace, pod)
+
+    # Continuation needs a prior run to derive the parent.
+    parent = AgentRun.objects.create(
+        workspace=issue.workspace,
+        created_by=user_a,
+        pod=pod,
+        work_item=issue,
+        status="completed",
+        prompt="prior",
+    )
+    assert parent is not None
+
+    run = scheduling.dispatch_continuation_run(
+        issue, triggered_by=scheduling.TRIGGER_TICK
+    )
+    assert run is None
+    # The parent still exists; only the new continuation was skipped.
+    assert AgentRun.objects.filter(work_item=issue, status="queued").count() == 0
+    issue.refresh_from_db()
+    assert issue.state.group == "backlog"
+
+
+@pytest.mark.unit
+def test_state_transition_to_in_progress_bounces_when_no_runner(
+    db, issue, pod, user_a, user_b, states
+):
+    """Full integration through ``handle_issue_state_transition``: A moves
+    issue Todo → In Progress, only B has a runner → end state is Backlog
+    with the comment posted, no AgentRun created."""
+    Issue.all_objects.filter(pk=issue.pk).update(state=states["todo"])
+    issue.refresh_from_db()
+    _make_runner(user_b, issue.workspace, pod)
+
+    outcome = orchestration_service.handle_issue_state_transition(
+        issue=issue,
+        from_state=states["todo"],
+        to_state=states["in_progress"],
+        actor=user_a,
+    )
+    assert outcome.created_run is None
+    assert outcome.reason == "no-eligible-runner"
+    assert AgentRun.objects.filter(work_item=issue).count() == 0
+
+    issue.refresh_from_db()
+    assert issue.state.group == "backlog"
+    assert IssueComment.objects.filter(issue=issue).count() == 1
+
+
+@pytest.mark.unit
+def test_bounce_disarms_ticker(db, issue, pod, user_a, user_b, states):
+    """The recursive issue.save() inside the bounce fires the state
+    transition signal, which disarms the ticker as a side-effect.
+
+    Test sequence: arm the ticker manually (simulating an already-running
+    issue), then run the preflight bounce, then check the ticker row has
+    enabled=False."""
+    Issue.all_objects.filter(pk=issue.pk).update(state=states["in_progress"])
+    issue.refresh_from_db()
+    IssueAgentTicker.objects.create(
+        issue=issue, enabled=True, tick_count=3
+    )
+    _make_runner(user_b, issue.workspace, pod)
+
+    scheduling.preflight_eligibility_or_bounce(
+        issue,
+        run_creator=user_a,
+        pod=pod,
+        triggered_by=AgentRunTrigger.TICK.value,
+    )
+
+    ticker = IssueAgentTicker.objects.get(issue=issue)
+    assert ticker.enabled is False

--- a/apps/api/pi_dash/tests/unit/orchestration/test_eligibility_preflight.py
+++ b/apps/api/pi_dash/tests/unit/orchestration/test_eligibility_preflight.py
@@ -404,14 +404,18 @@ def test_dispatch_run_ai_run_bounces_when_no_runner(
 
 @pytest.mark.unit
 def test_dispatch_run_ai_run_proceeds_when_eligible(
-    db, issue, pod, user_a, states, project
+    db, issue, pod, user_a, states, monkeypatch
 ):
-    """Sanity: with an eligible runner present, no bounce; a run is
-    created. We don't assert on the run's status because drain is stubbed
-    out — the run stays QUEUED, which is fine for this preflight test."""
-    from pi_dash.prompting.seed import seed_default_template
+    """With an eligible runner present, no bounce; the dispatch proceeds.
 
-    seed_default_template()
+    We stub ``build_first_turn`` so the test stays focused on the
+    preflight wiring (otherwise this would silently couple to the
+    prompting / templating subsystem).
+    """
+    monkeypatch.setattr(
+        "pi_dash.orchestration.service.build_first_turn",
+        lambda issue, run: "stub-prompt",
+    )
     Issue.all_objects.filter(pk=issue.pk).update(state=states["in_progress"])
     issue.refresh_from_db()
     _make_runner(user_a, issue.workspace, pod)
@@ -422,6 +426,44 @@ def test_dispatch_run_ai_run_proceeds_when_eligible(
     issue.refresh_from_db()
     assert issue.state.group == "started"  # NOT bounced
     assert IssueComment.objects.filter(issue=issue).count() == 0
+
+
+@pytest.mark.unit
+def test_dispatch_continuation_run_comment_and_run_bounces(
+    db, issue, pod, user_a, user_b, states
+):
+    """Comment & Run uses an explicit user actor (the commenter), not
+    the agent bot. The preflight still bounces when neither the actor,
+    the issue creator, nor any assignee owns a runner in the pod."""
+    Issue.all_objects.filter(pk=issue.pk).update(state=states["in_progress"])
+    issue.refresh_from_db()
+    _make_runner(user_b, issue.workspace, pod)  # B has a runner, A doesn't
+
+    # Prior run so dispatch_continuation_run finds a parent.
+    AgentRun.objects.create(
+        workspace=issue.workspace,
+        created_by=user_a,
+        pod=pod,
+        work_item=issue,
+        status="completed",
+        prompt="prior",
+    )
+
+    # user_a (issue creator) clicks Comment & Run — actor is a real user
+    # here, distinguishing this from the tick path. Eligibility set is
+    # {user_a.id} (creator + issue.created_by) — user_b's runner doesn't
+    # match.
+    run = scheduling.dispatch_continuation_run(
+        issue,
+        triggered_by=scheduling.TRIGGER_COMMENT_AND_RUN,
+        actor=user_a,
+    )
+    assert run is None
+    issue.refresh_from_db()
+    assert issue.state.group == "backlog"
+    # Both the bounce comment AND the issue creator's prior comment
+    # context aren't here — only the bounce comment.
+    assert IssueComment.objects.filter(issue=issue).count() == 1
 
 
 @pytest.mark.unit

--- a/apps/api/pi_dash/tests/unit/orchestration/test_service.py
+++ b/apps/api/pi_dash/tests/unit/orchestration/test_service.py
@@ -86,7 +86,9 @@ def no_runner_dispatch(monkeypatch):
 
 
 @pytest.mark.unit
-def test_todo_to_in_progress_creates_run(seeded, issue, states):
+def test_todo_to_in_progress_creates_run(
+    seeded, issue, states, runner_for_workspace
+):
     outcome = service.handle_issue_state_transition(
         issue=issue,
         from_state=states["todo"],
@@ -141,7 +143,7 @@ def test_no_op_when_waiting_for_worktree_run_exists(
 
 @pytest.mark.unit
 def test_follow_up_run_links_parent(
-    seeded, issue, states, workspace, create_user
+    seeded, issue, states, workspace, create_user, runner_for_workspace
 ):
     prior = AgentRun.objects.create(
         owner=create_user,
@@ -172,7 +174,7 @@ def test_non_trigger_state_does_nothing(seeded, issue, states):
 
 @pytest.mark.unit
 def test_run_config_carries_git_fields_from_issue_and_project(
-    seeded, project, issue, states
+    seeded, project, issue, states, runner_for_workspace
 ):
     project.repo_url = "git@github.com:acme/web.git"
     project.base_branch = "develop"
@@ -199,7 +201,9 @@ def test_run_config_carries_git_fields_from_issue_and_project(
 
 
 @pytest.mark.unit
-def test_run_config_empty_git_fields_surface_as_none(seeded, issue, states):
+def test_run_config_empty_git_fields_surface_as_none(
+    seeded, issue, states, runner_for_workspace
+):
     # Project defaults to blank repo_url; issue defaults to blank work branch.
     # Both must land as ``None`` so the runner / prompt fallbacks kick in
     # rather than comparing against empty strings.

--- a/apps/api/pi_dash/tests/unit/runner/test_runs_views.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_runs_views.py
@@ -219,6 +219,24 @@ def _make_issue(workspace, *, created_by, assignees=()):
     return issue
 
 
+def _add_online_runner(workspace, project, *, owner=None, name="rnr"):
+    """Register an ONLINE runner owned by ``owner`` (default: workspace
+    owner) in ``project``'s default pod, so the eligibility preflight lets
+    a run on that owner's issue dispatch instead of bouncing to Backlog."""
+    from django.utils import timezone
+
+    from pi_dash.runner.models import Runner, RunnerStatus
+
+    return Runner.objects.create(
+        owner=owner or workspace.owner,
+        workspace=workspace,
+        pod=Pod.default_for_project(project),
+        name=name,
+        status=RunnerStatus.ONLINE,
+        last_heartbeat_at=timezone.now(),
+    )
+
+
 @pytest.mark.unit
 def test_get_runs_includes_tick_runs_on_issue_user_created(db, session_client, workspace, project):
     """An issue I created has a tick-driven run authored by the bot.
@@ -427,16 +445,6 @@ def _make_in_progress_issue_with_paused_run(workspace):
     from pi_dash.db.models import Issue, Project, State
     from pi_dash.runner.models import Runner, RunnerStatus
 
-    project = Project.objects.filter(workspace=workspace).first()
-    pod = Pod.default_for_project(project)
-    runner = Runner.objects.create(
-        owner=workspace.owner,
-        workspace=workspace,
-        pod=pod,
-        name="carun",
-        status=RunnerStatus.ONLINE,
-        last_heartbeat_at=timezone.now(),
-    )
     with impersonate(workspace.owner):
         project = Project.objects.create(
             name="CARun",
@@ -455,6 +463,18 @@ def _make_in_progress_issue_with_paused_run(workspace):
             state=in_progress,
             created_by=workspace.owner,
         )
+    # Runner must live in the *issue's* pod (the CARun project's default pod)
+    # so the eligibility preflight sees a runner whose owner is the issue
+    # creator — otherwise dispatch bounces the issue to Backlog.
+    pod = Pod.default_for_project(project)
+    runner = Runner.objects.create(
+        owner=workspace.owner,
+        workspace=workspace,
+        pod=pod,
+        name="carun",
+        status=RunnerStatus.ONLINE,
+        last_heartbeat_at=timezone.now(),
+    )
     # The state-transition signal auto-creates an immediate-dispatch run
     # (and the matcher may have flipped it to ASSIGNED). Delete it so the
     # test's PAUSED parent is the only prior run, with no active-run noise.
@@ -694,6 +714,7 @@ def test_run_ai_succeeds_when_no_prior_run(db, session_client, workspace):
             name="Fresh task", workspace=workspace, project=fresh_project,
             state=in_progress, created_by=workspace.owner,
         )
+    _add_online_runner(workspace, fresh_project)
     # Discard the run the state-transition signal auto-created so the
     # endpoint genuinely sees no prior.
     AgentRun.objects.filter(work_item=issue).delete()
@@ -850,6 +871,7 @@ def test_skip_immediate_dispatch_header_suppresses_run_creation_on_state_change(
             name="Task", workspace=workspace, project=project,
             state=todo, created_by=workspace.owner,
         )
+    _add_online_runner(workspace, project)
 
     # PATCH state=In Progress with the skip header — signal must not
     # create an AgentRun, but must still arm the schedule.
@@ -892,6 +914,7 @@ def test_no_skip_header_creates_run_on_state_change(db, session_client, workspac
             name="Task", workspace=workspace, project=project,
             state=todo, created_by=workspace.owner,
         )
+    _add_online_runner(workspace, project)
 
     resp = session_client.patch(
         f"/api/workspaces/{workspace.slug}/projects/{project.id}/issues/{issue.id}/",


### PR DESCRIPTION
## Summary

- Closes the silent-jam case where an issue's pod has no runner whose owner satisfies the matcher's private-runner eligibility gate. Today the run sits in `QUEUED` forever and the per-issue ticker locks on the orphan.
- Adds a preflight at the four issue-dispatch entry points (state transition into a ticking state, auto ticker, Run AI button, Comment & Run button). On miss the issue is moved back to Backlog and a comment from the agent system user explains why nothing ran. **No `AgentRun` row is created.**
- Corrects `.ai_design/issue_runner/design.md`. The original doc still described the cooperative-pod model that commit `1b590146` reverted via `Visibility.PRIVATE`. New §0 records the actual model and the `MachineToken` auth-attribution invariant (`request.user = runner.owner` on every runner-originated write) that makes cross-owner dispatch unsafe. New §6.6 specs the preflight + bounce behavior.

## Eligibility set

A pod is eligible for a run on `issue` triggered by `run_creator` when at least one registered runner in the pod has an `owner_id` in:

```
{run_creator.id, issue.created_by_id} ∪ {a.id for a in issue.assignees}
```

`Runner.status` is **deliberately ignored** — `OFFLINE` / `BUSY` / `REVOKED` runners all count as "registered". The bounce is reserved for the structural "nobody on this pod could ever serve this" case; transient liveness is handled by the existing `drain_pod` re-fire on heartbeat.

## Bounce action

1. Resolve the issue's project Backlog state (prefers `default=True`, then `sequence`). Skipped when the issue is already in the `BACKLOG` group.
2. `issue.state = backlog; issue.save()` — `fire_state_transition` disarms the ticker as a side effect because Backlog isn't a delegation trigger.
3. Post an `IssueComment` from `get_agent_system_user()` with `speaker_type=AGENT` explaining the user's options: add a runner under their account, or assign the issue to a workspace member who has a runner in this pod.

## Files

- `apps/api/pi_dash/runner/services/matcher.py` — new `pod_has_runner_for_issue_principal(pod, issue, run_creator_id)` helper.
- `apps/api/pi_dash/orchestration/scheduling.py` — new `preflight_eligibility_or_bounce(...)` chokepoint and private `_bounce_issue_no_eligible_runner(...)`. Wired into `dispatch_continuation_run` (tick + Comment & Run) and `dispatch_run_ai_run`.
- `apps/api/pi_dash/orchestration/service.py` — wired into `handle_issue_state_transition` before `_create_and_dispatch_run`. New `TransitionOutcome(reason="no-eligible-runner")`.
- `.ai_design/issue_runner/design.md` — §0 model correction, inline patches in §1 / §2 / §4.2, new §6.6 spec.
- `apps/api/pi_dash/tests/unit/orchestration/test_eligibility_preflight.py` — new unit-test module.

## Out of scope

- The direct `POST /api/v1/runs/` path with an explicit prompt (no button trigger) is not gated. Direct prompt callers are programmatic; surfacing "no runner" through the existing 409 is fine.
- No frontend change. The bounce flows through the existing WS issue / comment update streams; the user sees the state revert and the new comment appear.
- No per-run dynamic-identity (the proper fix for true cooperative dispatch). Captured as a follow-up note in design doc §0.

## Test plan

- [ ] `pytest apps/api/pi_dash/tests/unit/orchestration/test_eligibility_preflight.py -v` passes (CI).
- [ ] Manual: workspace where A is admin, B/C members; B/C each register a runner; A creates an issue and clicks "Run AI" → issue moves to Backlog, comment appears.
- [ ] Manual: A assigns B to the issue and clicks "Run AI" → no bounce, runner takes the work.
- [ ] Manual: A registers her own runner, takes it offline (status `OFFLINE`), clicks "Run AI" → **no bounce** (status-agnostic per design).
- [ ] Manual: state transition Todo → In Progress with no eligible runner → ticker disarmed, no orphan QUEUED row, issue back in Backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)