### PR TITLE
fix(runner): surface agent failures and pin TUI runner selection

### DIFF
--- a/apps/api/pi_dash/app/serializers/issue.py
+++ b/apps/api/pi_dash/app/serializers/issue.py
@@ -46,6 +46,7 @@ from pi_dash.db.models import (
     EstimatePoint,
 )
 from pi_dash.runner.models import Pod
+from pi_dash.runner.diagnostics import classify_run_error
 from pi_dash.utils.content_validator import (
     validate_html_content,
     validate_binary_data,
@@ -1228,6 +1229,7 @@ class IssueDetailSerializer(IssueSerializer):
             "ended_at": self._serialize_datetime(run.ended_at),
             "done_payload": run.done_payload,
             "error": run.error,
+            "error_diagnostic": classify_run_error(run.error),
             "llm_model": run.llm_model,
             "input_tokens": run.input_tokens,
             "output_tokens": run.output_tokens,

--- a/apps/api/pi_dash/runner/diagnostics.py
+++ b/apps/api/pi_dash/runner/diagnostics.py
@@ -1,0 +1,204 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Human-facing diagnostics for terminal agent runs.
+
+These helpers intentionally derive from the persisted ``AgentRun.error`` text
+instead of adding new columns. That lets old failed runs become more legible as
+soon as the API ships.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+_ENRICHED_RAW_ERROR_MARKER = "Raw agent error:"
+_AGENT_AUTH_HEADER = "401 authentication_failed"
+
+
+def _first_non_empty_line(value: str) -> str:
+    for line in value.splitlines():
+        line = line.strip()
+        if line:
+            return line
+    return ""
+
+
+def _iter_text_values(value: Any):
+    if isinstance(value, str):
+        yield value
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            yield from _iter_text_values(key)
+            yield from _iter_text_values(item)
+        return
+    if isinstance(value, (list, tuple, set)):
+        for item in value:
+            yield from _iter_text_values(item)
+
+
+def _match_agent_label(value: str) -> str:
+    lowered = value.lower()
+    if "claude_code" in lowered or "claude-code" in lowered or "claude code" in lowered or "claude" in lowered:
+        return "Claude Code"
+    if "codex" in lowered:
+        return "Codex"
+    if "cursor_agent" in lowered or "cursor-agent" in lowered or "cursor" in lowered:
+        return "Cursor"
+    if "openclaw" in lowered or "open-claw" in lowered or "acpx" in lowered:
+        return "OpenClaw"
+    return ""
+
+
+def _agent_label_from_enriched_error(detail: str) -> str:
+    for line in detail.splitlines():
+        line = line.strip()
+        if not line.lower().startswith("ai agent:"):
+            continue
+        body = line.split(":", 1)[1].strip()
+        marker = " auth "
+        idx = body.lower().find(marker)
+        if idx > 0:
+            return body[:idx].strip()
+    return ""
+
+
+def infer_agent_label(*, runner: Any = None, error: str = "", model: Any = None) -> str:
+    """Best-effort display name for the local agent behind a run."""
+
+    for value in [model, error]:
+        label = _match_agent_label(str(value or ""))
+        if label:
+            return label
+
+    capabilities = getattr(runner, "capabilities", None)
+    for value in _iter_text_values(capabilities):
+        label = _match_agent_label(value)
+        if label:
+            return label
+
+    for attr in ("name", "host_label"):
+        label = _match_agent_label(str(getattr(runner, attr, "") or ""))
+        if label:
+            return label
+
+    return ""
+
+
+def _runner_location(runner: Any = None) -> str:
+    runner_name = str(getattr(runner, "name", "") or "").strip()
+    dev_machine = getattr(runner, "dev_machine", None)
+    machine_label = ""
+    if dev_machine is not None:
+        machine_label = str(getattr(dev_machine, "label", "") or getattr(dev_machine, "host_label", "") or "").strip()
+    if not machine_label:
+        machine_label = str(getattr(runner, "host_label", "") or "").strip()
+
+    if machine_label and runner_name:
+        return f'dev machine "{machine_label}" for runner "{runner_name}"'
+    if runner_name:
+        return f'dev machine for runner "{runner_name}"'
+    if machine_label:
+        return f'dev machine "{machine_label}"'
+    return "dev machine"
+
+
+def enrich_run_error(error: str, *, runner: Any = None, model: Any = None) -> str:
+    """Add operator guidance before persisting known agent failures."""
+
+    detail = (error or "").strip()
+    if not detail or _ENRICHED_RAW_ERROR_MARKER in detail:
+        return detail
+
+    diagnostic = classify_run_error(detail)
+    if diagnostic is None or diagnostic["kind"] != "agent_authentication":
+        return detail
+
+    agent_label = infer_agent_label(runner=runner, error=detail, model=model)
+    auth_subject = f"{agent_label} auth" if agent_label else "AI agent auth"
+    agent_command = agent_label or "the AI agent"
+    return (
+        f"{_AGENT_AUTH_HEADER}\n"
+        f"AI agent: {auth_subject} appears expired or invalid. "
+        f"Go to the {_runner_location(runner)} and re-authenticate {agent_command}, "
+        "then restart the Pi Dash runner.\n\n"
+        f"{_ENRICHED_RAW_ERROR_MARKER}\n"
+        f"{detail}"
+    )
+
+
+def classify_run_error(error: str) -> dict[str, Any] | None:
+    """Return a compact diagnostic for a stored run error.
+
+    ``source`` answers the operator question "did Pi Dash fail, or did the
+    spawned agent fail?" while ``kind`` is a stable-ish category the UI can
+    render without brittle text matching.
+    """
+
+    detail = (error or "").strip()
+    if not detail:
+        return None
+
+    lowered = detail.lower()
+    summary = _first_non_empty_line(detail)
+    agent_label = _agent_label_from_enriched_error(detail)
+
+    if (
+        "invalid authentication credentials" in lowered
+        or "authentication_failed" in lowered
+        or "failed to authenticate" in lowered
+    ):
+        action_agent = agent_label or "the agent CLI"
+        return {
+            "source": "agent",
+            "source_label": agent_label or "Agent CLI",
+            "kind": "agent_authentication",
+            "summary": summary,
+            "action": f"Re-authenticate {action_agent} on the runner machine, then restart the Pi Dash runner.",
+        }
+
+    if "selected model" in lowered and ("may not exist" in lowered or "may not have access" in lowered):
+        return {
+            "source": "agent",
+            "source_label": "Agent CLI",
+            "kind": "agent_model_access",
+            "summary": summary,
+            "action": "Choose a model the agent account can access, then retry the run.",
+        }
+
+    if "runner_not_found" in lowered or "run_not_owned_by_runner" in lowered:
+        return {
+            "source": "pidash_cloud",
+            "source_label": "Pi Dash cloud",
+            "kind": "runner_registration",
+            "summary": summary,
+            "action": "Remove or re-add the stale local runner registration.",
+        }
+
+    if "daemon shutdown requested" in lowered or "runner revoked" in lowered or "session_evicted" in lowered:
+        return {
+            "source": "pidash_runner",
+            "source_label": "Pi Dash runner",
+            "kind": "runner_lifecycle",
+            "summary": summary,
+            "action": "Check runner service status and restart the runner if it should still accept work.",
+        }
+
+    if "agent stalled" in lowered or "without new agent events" in lowered:
+        return {
+            "source": "agent",
+            "source_label": "Agent CLI",
+            "kind": "agent_stalled",
+            "summary": summary,
+            "action": "Inspect the runner machine for a stuck agent process or long-running tool call.",
+        }
+
+    return {
+        "source": "unknown",
+        "source_label": "Unknown",
+        "kind": "unknown",
+        "summary": summary,
+        "action": "",
+    }

--- a/apps/api/pi_dash/runner/diagnostics.py
+++ b/apps/api/pi_dash/runner/diagnostics.py
@@ -11,10 +11,26 @@ soon as the API ships.
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 _ENRICHED_RAW_ERROR_MARKER = "Raw agent error:"
-_AGENT_AUTH_HEADER = "401 authentication_failed"
+_AUTH_HEADER_SUFFIX = "authentication_failed"
+_AUTH_STATUS_RE = re.compile(r"\b(401|403)\b")
+
+
+def _auth_header(detail: str) -> str:
+    """Synthetic header line for an enriched auth failure.
+
+    Derives the HTTP status from the raw error when present instead of
+    assuming ``401`` — a ``403`` or a code-less token-refresh failure also
+    classifies as an auth error and must not be mislabeled as a 401.
+    """
+
+    match = _AUTH_STATUS_RE.search(detail)
+    if match:
+        return f"{match.group(1)} {_AUTH_HEADER_SUFFIX}"
+    return _AUTH_HEADER_SUFFIX
 
 
 def _first_non_empty_line(value: str) -> str:
@@ -66,12 +82,18 @@ def _agent_label_from_enriched_error(detail: str) -> str:
 
 
 def infer_agent_label(*, runner: Any = None, error: str = "", model: Any = None) -> str:
-    """Best-effort display name for the local agent behind a run."""
+    """Best-effort display name for the local agent behind a run.
 
-    for value in [model, error]:
-        label = _match_agent_label(str(value or ""))
-        if label:
-            return label
+    Structured, runner-scoped signals (the model id, the runner's declared
+    capabilities, its name/host label) are checked before the raw error
+    text. The error string can incidentally mention an unrelated agent —
+    a path like ``/Users/claude/...`` or a URL — which would otherwise
+    misattribute the run; it is only consulted as a last resort.
+    """
+
+    label = _match_agent_label(str(model or ""))
+    if label:
+        return label
 
     capabilities = getattr(runner, "capabilities", None)
     for value in _iter_text_values(capabilities):
@@ -84,7 +106,7 @@ def infer_agent_label(*, runner: Any = None, error: str = "", model: Any = None)
         if label:
             return label
 
-    return ""
+    return _match_agent_label(str(error or ""))
 
 
 def _runner_location(runner: Any = None) -> str:
@@ -120,7 +142,7 @@ def enrich_run_error(error: str, *, runner: Any = None, model: Any = None) -> st
     auth_subject = f"{agent_label} auth" if agent_label else "AI agent auth"
     agent_command = agent_label or "the AI agent"
     return (
-        f"{_AGENT_AUTH_HEADER}\n"
+        f"{_auth_header(detail)}\n"
         f"AI agent: {auth_subject} appears expired or invalid. "
         f"Go to the {_runner_location(runner)} and re-authenticate {agent_command}, "
         "then restart the Pi Dash runner.\n\n"

--- a/apps/api/pi_dash/runner/serializers.py
+++ b/apps/api/pi_dash/runner/serializers.py
@@ -205,6 +205,12 @@ class AgentRunSerializer(serializers.ModelSerializer):
     error_diagnostic = serializers.SerializerMethodField()
 
     def get_error_diagnostic(self, run: AgentRun):
+        # Only the per-run detail drawer renders this block. Skip the
+        # classifier's per-row string scans when serializing a list (the
+        # runs table uses ``many=True``), which would otherwise pay the
+        # cost on every row for data the list view discards.
+        if isinstance(self.parent, serializers.ListSerializer):
+            return None
         return classify_run_error(run.error)
 
     class Meta:

--- a/apps/api/pi_dash/runner/serializers.py
+++ b/apps/api/pi_dash/runner/serializers.py
@@ -18,6 +18,7 @@ from pi_dash.runner.models import (
     Runner,
     RunnerLiveState,
 )
+from pi_dash.runner.diagnostics import classify_run_error
 
 
 # Mirrors the runner-side charset rule in `runner/src/util/runner_name.rs`
@@ -201,6 +202,10 @@ class RunnerEnrollRequestSerializer(serializers.Serializer):
 
 class AgentRunSerializer(serializers.ModelSerializer):
     pod_detail = PodMiniSerializer(source="pod", read_only=True)
+    error_diagnostic = serializers.SerializerMethodField()
+
+    def get_error_diagnostic(self, run: AgentRun):
+        return classify_run_error(run.error)
 
     class Meta:
         model = AgentRun
@@ -222,6 +227,7 @@ class AgentRunSerializer(serializers.ModelSerializer):
             "ended_at",
             "done_payload",
             "error",
+            "error_diagnostic",
             "refusal_category",
             "llm_model",
             "input_tokens",

--- a/apps/api/pi_dash/runner/services/run_lifecycle.py
+++ b/apps/api/pi_dash/runner/services/run_lifecycle.py
@@ -23,6 +23,7 @@ from uuid import UUID
 from django.db import transaction
 from django.utils import timezone
 
+from pi_dash.runner.diagnostics import enrich_run_error
 from pi_dash.runner.models import (
     AgentRun,
     AgentRunStatus,
@@ -423,6 +424,7 @@ def finalize_run_terminal(
         updates["done_payload"] = done_payload
         updates["error"] = ""
     if new_status == AgentRunStatus.FAILED and error_detail:
+        error_detail = enrich_run_error(error_detail, runner=runner, model=model)
         updates["error"] = error_detail[:16000]
     if new_status == AgentRunStatus.REFUSED:
         # A safety-classifier decline. Record the category (always set, so the

--- a/apps/api/pi_dash/tests/unit/runner/test_failure_comment.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_failure_comment.py
@@ -237,6 +237,32 @@ def test_cloud_stall_reconciler_failure_does_not_post_comment(
 
 
 @pytest.mark.unit
+def test_agent_auth_failure_persists_actionable_cloud_error(
+    db, create_user, workspace, pod, issue
+):
+    runner = _make_runner(create_user, workspace, pod, name="workx_claude01")
+    runner.capabilities = ["agent:claude_code"]
+    runner.save(update_fields=["capabilities"])
+    run = _make_run(create_user, workspace, pod, runner, issue)
+    raw = "Failed to authenticate. API Error: 401 Invalid authentication credentials"
+
+    finalize_run_terminal(
+        runner,
+        run.id,
+        AgentRunStatus.FAILED,
+        error_detail=raw,
+    )
+
+    run.refresh_from_db()
+    assert run.error.startswith("401 authentication_failed\n")
+    assert (
+        'AI agent: Claude Code auth appears expired or invalid. Go to the dev machine for runner "workx_claude01" '
+        "and re-authenticate Claude Code"
+    ) in run.error
+    assert f"Raw agent error:\n{raw}" in run.error
+
+
+@pytest.mark.unit
 def test_completed_finalize_does_not_post_comment(
     db, create_user, workspace, pod, issue
 ):

--- a/apps/api/pi_dash/tests/unit/runner/test_run_diagnostics.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_run_diagnostics.py
@@ -21,6 +21,43 @@ def test_classify_agent_authentication_error():
     assert diagnostic["summary"] == "Failed to authenticate. API Error: 401 Invalid authentication credentials"
 
 
+def test_enrich_non_401_auth_error_does_not_claim_401():
+    """A 403 (or code-less) auth failure must not be relabeled as a 401."""
+    raw = "Failed to authenticate. API Error: 403 Forbidden"
+
+    enriched = enrich_run_error(raw)
+
+    assert enriched.startswith("403 authentication_failed\n")
+    assert "401" not in enriched.splitlines()[0]
+
+
+def test_enrich_codeless_auth_error_uses_neutral_header():
+    raw = "Failed to authenticate: token refresh returned no credentials"
+
+    enriched = enrich_run_error(raw)
+
+    assert enriched.startswith("authentication_failed\n")
+
+
+def test_infer_agent_label_prefers_runner_over_error_mention():
+    """An unrelated 'claude' in the error text must not mislabel a Codex run."""
+    runner = SimpleNamespace(
+        name="workx_codex01",
+        host_label="mini-build",
+        capabilities=["agent:codex"],
+        dev_machine=None,
+    )
+    # Error references a path that merely contains "claude".
+    raw = "Failed to authenticate. Check /Users/claude/.codex/auth.json"
+
+    enriched = enrich_run_error(raw, runner=runner)
+
+    assert "re-authenticate Codex" in enriched
+    diagnostic = classify_run_error(enriched)
+    assert diagnostic is not None
+    assert diagnostic["source_label"] == "Codex"
+
+
 def test_classify_agent_model_access_error():
     diagnostic = classify_run_error("Selected model 'claude-fable-5' may not exist or you may not have access to it.")
 

--- a/apps/api/pi_dash/tests/unit/runner/test_run_diagnostics.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_run_diagnostics.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+from types import SimpleNamespace
+
+import pytest
+
+from pi_dash.runner.diagnostics import classify_run_error, enrich_run_error
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_classify_agent_authentication_error():
+    diagnostic = classify_run_error("Failed to authenticate. API Error: 401 Invalid authentication credentials")
+
+    assert diagnostic is not None
+    assert diagnostic["source"] == "agent"
+    assert diagnostic["kind"] == "agent_authentication"
+    assert diagnostic["summary"] == "Failed to authenticate. API Error: 401 Invalid authentication credentials"
+
+
+def test_classify_agent_model_access_error():
+    diagnostic = classify_run_error("Selected model 'claude-fable-5' may not exist or you may not have access to it.")
+
+    assert diagnostic is not None
+    assert diagnostic["source"] == "agent"
+    assert diagnostic["kind"] == "agent_model_access"
+
+
+def test_classify_pidash_cloud_runner_registration_error():
+    diagnostic = classify_run_error('{"detail":"runner_not_found"}')
+
+    assert diagnostic is not None
+    assert diagnostic["source"] == "pidash_cloud"
+    assert diagnostic["kind"] == "runner_registration"
+
+
+def test_empty_error_has_no_diagnostic():
+    assert classify_run_error("") is None
+
+
+def test_enrich_agent_authentication_error_adds_actionable_cloud_log_message():
+    runner = SimpleNamespace(
+        name="workx_claude01",
+        host_label="mini-build",
+        capabilities=["agent:claude_code"],
+        dev_machine=SimpleNamespace(label="Mac Mini", host_label="mac-mini.local"),
+    )
+    raw = "Failed to authenticate. API Error: 401 Invalid authentication credentials"
+
+    enriched = enrich_run_error(raw, runner=runner)
+
+    assert enriched.startswith("401 authentication_failed\n")
+    assert (
+        'AI agent: Claude Code auth appears expired or invalid. Go to the dev machine "Mac Mini" '
+        'for runner "workx_claude01" and re-authenticate Claude Code'
+    ) in enriched
+    assert "Raw agent error:\nFailed to authenticate. API Error: 401 Invalid authentication credentials" in enriched
+
+    diagnostic = classify_run_error(enriched)
+    assert diagnostic is not None
+    assert diagnostic["source"] == "agent"
+    assert diagnostic["source_label"] == "Claude Code"
+    assert diagnostic["summary"] == "401 authentication_failed"

--- a/apps/api/pi_dash/tests/unit/runner/test_runs_views.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_runs_views.py
@@ -155,6 +155,27 @@ def test_get_runs_lists_by_created_by(db, session_client, workspace, project):
     assert "not mine" not in prompts
 
 
+@pytest.mark.unit
+def test_get_run_detail_exposes_error_diagnostic(db, session_client, workspace, project):
+    error = "Failed to authenticate. API Error: 401 Invalid authentication credentials"
+    run = AgentRun.objects.create(
+        workspace=workspace,
+        created_by=workspace.owner,
+        pod=Pod.default_for_project(project),
+        prompt="broken auth",
+        status=AgentRunStatus.FAILED,
+        error=error,
+    )
+
+    resp = session_client.get(f"/api/runners/runs/{run.id}/")
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["error"] == error
+    assert resp.data["error_diagnostic"]["source"] == "agent"
+    assert resp.data["error_diagnostic"]["kind"] == "agent_authentication"
+    assert resp.data["error_diagnostic"]["summary"] == error
+
+
 # ---------------------------------------------------------------------------
 # GET /api/runners/runs/ — broadened "involved with" scope.
 #

--- a/apps/web/app/(all)/[workspaceSlug]/runners/runs/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/runs/page.tsx
@@ -11,7 +11,7 @@ import useSWR from "swr";
 import { useTranslation } from "@pi-dash/i18n";
 import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
 import { RunnerService } from "@pi-dash/services";
-import type { IAgentRun, TAgentRunStatus } from "@pi-dash/types";
+import type { IAgentRun, TAgentRunErrorSource, TAgentRunStatus } from "@pi-dash/types";
 import { AGENT_RUN_TERMINAL_STATUSES } from "@pi-dash/types";
 import type { TBadgeVariant } from "@pi-dash/ui";
 import { AlertModalCore, Badge, Button, Spinner } from "@pi-dash/ui";
@@ -47,6 +47,13 @@ const RUN_STATUS_I18N_LABELS: Record<TAgentRunStatus, string> = {
   completed: "completed",
   failed: "failed",
   cancelled: "cancelled",
+};
+
+const ERROR_SOURCE_BADGE_VARIANT: Record<TAgentRunErrorSource, TBadgeVariant> = {
+  agent: "accent-warning",
+  pidash_runner: "accent-primary",
+  pidash_cloud: "accent-primary",
+  unknown: "accent-neutral",
 };
 
 function isTerminal(status: TAgentRunStatus): boolean {
@@ -193,6 +200,24 @@ export const RunnerRunsPage = observer(function RunnerRunsPage() {
               {detail.error && (
                 <div className="text-13">
                   <div className="text-danger-primary">{t("Error")}</div>
+                  {detail.error_diagnostic && (
+                    <div className="mt-1 rounded border border-warning-subtle bg-layer-1 p-3">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="text-secondary">{t("Failure source")}</span>
+                        <Badge
+                          variant={ERROR_SOURCE_BADGE_VARIANT[detail.error_diagnostic.source]}
+                          size="sm"
+                        >
+                          {detail.error_diagnostic.source_label}
+                        </Badge>
+                        <span className="font-mono text-11 text-secondary">{detail.error_diagnostic.kind}</span>
+                      </div>
+                      <div className="mt-2 text-primary">{detail.error_diagnostic.summary}</div>
+                      {detail.error_diagnostic.action && (
+                        <div className="mt-1 text-secondary">{detail.error_diagnostic.action}</div>
+                      )}
+                    </div>
+                  )}
                   <pre className="mt-1 rounded bg-danger-subtle p-2 text-11 whitespace-pre-wrap">{detail.error}</pre>
                 </div>
               )}

--- a/apps/web/app/(all)/[workspaceSlug]/runners/runs/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/runs/page.tsx
@@ -56,6 +56,27 @@ const ERROR_SOURCE_BADGE_VARIANT: Record<TAgentRunErrorSource, TBadgeVariant> = 
   unknown: "accent-neutral",
 };
 
+// Map the diagnostic's internal category token to a human-readable,
+// translatable label. Unknown/new tokens fall back to the raw value.
+function errorKindLabel(kind: string, t: (text: string) => string): string {
+  switch (kind) {
+    case "agent_authentication":
+      return t("Authentication");
+    case "agent_model_access":
+      return t("Model access");
+    case "runner_registration":
+      return t("Runner registration");
+    case "runner_lifecycle":
+      return t("Runner lifecycle");
+    case "agent_stalled":
+      return t("Agent stalled");
+    case "unknown":
+      return t("Unknown");
+    default:
+      return kind;
+  }
+}
+
 function isTerminal(status: TAgentRunStatus): boolean {
   return AGENT_RUN_TERMINAL_STATUSES.includes(status);
 }
@@ -204,13 +225,12 @@ export const RunnerRunsPage = observer(function RunnerRunsPage() {
                     <div className="mt-1 rounded border border-warning-subtle bg-layer-1 p-3">
                       <div className="flex flex-wrap items-center gap-2">
                         <span className="text-secondary">{t("Failure source")}</span>
-                        <Badge
-                          variant={ERROR_SOURCE_BADGE_VARIANT[detail.error_diagnostic.source]}
-                          size="sm"
-                        >
+                        <Badge variant={ERROR_SOURCE_BADGE_VARIANT[detail.error_diagnostic.source]} size="sm">
                           {detail.error_diagnostic.source_label}
                         </Badge>
-                        <span className="font-mono text-11 text-secondary">{detail.error_diagnostic.kind}</span>
+                        <span className="text-11 text-secondary">
+                          {errorKindLabel(detail.error_diagnostic.kind, t)}
+                        </span>
                       </div>
                       <div className="mt-2 text-primary">{detail.error_diagnostic.summary}</div>
                       {detail.error_diagnostic.action && (

--- a/apps/web/core/components/issues/issue-detail/agent-status.tsx
+++ b/apps/web/core/components/issues/issue-detail/agent-status.tsx
@@ -233,15 +233,21 @@ function getRunView(
         icon: CircleAlert,
         iconClassName: "text-warning-primary",
       };
-    case "failed":
+    case "failed": {
+      const failureDetail = run.error_diagnostic
+        ? `${run.error_diagnostic.source_label}: ${truncate(run.error_diagnostic.summary)}`
+        : run.error
+          ? truncate(run.error)
+          : t("The latest run did not complete.");
       return {
         title: t("AI agent run failed"),
-        detail: run.error ? truncate(run.error) : t("The latest run did not complete."),
+        detail: failureDetail,
         badge: t("Failed"),
         badgeVariant: "danger",
         icon: CircleAlert,
         iconClassName: "text-danger-primary",
       };
+    }
     case "cancelled":
       return {
         title: t("AI agent run was cancelled"),

--- a/apps/web/core/components/runners/runner-models.ts
+++ b/apps/web/core/components/runners/runner-models.ts
@@ -65,7 +65,6 @@ const CODEX_OPTIONS: IRunnerModelOption[] = CODEX_MODELS.flatMap((m) =>
 // variant.
 const CLAUDE_OPTIONS: IRunnerModelOption[] = [
   { id: "claude-opus-4-8", label: "Opus 4.8", model: "claude-opus-4-8" },
-  { id: "claude-fable-5", label: "Fable 5", model: "claude-fable-5" },
   { id: "claude-sonnet-4-6", label: "Sonnet 4.6", model: "claude-sonnet-4-6" },
   { id: "claude-sonnet-4-6-1m", label: "Sonnet 4.6 (1M context)", model: "claude-sonnet-4-6[1m]" },
 ];
@@ -104,12 +103,13 @@ export const RUNNER_MODEL_OPTIONS: Record<TRunnerAgent, IRunnerModelOption[]> = 
 };
 
 /**
- * Pre-selected model option id per agent in the "Add runner" form. All agents
- * fall back to the agent's own built-in model (the ``"default"`` sentinel).
+ * Pre-selected model option id per agent in the "Add runner" form. Claude Code
+ * is pinned to Opus 4.8 so the generated command does not inherit a stale
+ * Claude global default; other agents use the agent's built-in default.
  * The id must exist in that agent's `RUNNER_MODEL_OPTIONS` list.
  */
 export const DEFAULT_MODEL_BY_AGENT: Record<TRunnerAgent, string> = {
-  "claude-code": DEFAULT_MODEL_ID,
+  "claude-code": "claude-opus-4-8",
   codex: DEFAULT_MODEL_ID,
   "cursor-agent": DEFAULT_MODEL_ID,
   "open-claw": DEFAULT_MODEL_ID,

--- a/packages/types/src/issues/issue.ts
+++ b/packages/types/src/issues/issue.ts
@@ -5,7 +5,7 @@
  */
 
 import type { TIssuePriorities } from "../issues";
-import type { IRunnerLiveState, TAgentRunStatus } from "../runner";
+import type { IAgentRunErrorDiagnostic, IRunnerLiveState, TAgentRunStatus } from "../runner";
 import type { TStateGroups } from "../state";
 import type { TIssuePublicComment } from "./activity/issue_comment";
 import type { TIssueAttachment } from "./issue_attachment";
@@ -126,6 +126,7 @@ export type TIssueAgentRunSummary = {
   ended_at: string | null;
   done_payload: Record<string, unknown> | null;
   error: string;
+  error_diagnostic: IAgentRunErrorDiagnostic | null;
   llm_model: string;
   input_tokens: number | null;
   output_tokens: number | null;

--- a/packages/types/src/runner.ts
+++ b/packages/types/src/runner.ts
@@ -124,6 +124,16 @@ export interface IAgentRunEvent {
   created_at: string;
 }
 
+export type TAgentRunErrorSource = "agent" | "pidash_runner" | "pidash_cloud" | "unknown";
+
+export interface IAgentRunErrorDiagnostic {
+  source: TAgentRunErrorSource;
+  source_label: string;
+  kind: string;
+  summary: string;
+  action: string;
+}
+
 export interface IAgentRun {
   id: string;
   status: TAgentRunStatus;
@@ -143,6 +153,7 @@ export interface IAgentRun {
   ended_at: string | null;
   done_payload: Record<string, unknown> | null;
   error: string;
+  error_diagnostic: IAgentRunErrorDiagnostic | null;
   llm_model: string;
   input_tokens: number | null;
   output_tokens: number | null;

--- a/runner/src/tui/app.rs
+++ b/runner/src/tui/app.rs
@@ -1207,6 +1207,15 @@ impl App {
 
     fn select_runner_by_name(&mut self, name: &str) {
         if !self.data.select_runner_by_name(name) {
+            // The name came from the live daemon-status list, which can
+            // include a runner that is no longer in config_working (e.g.
+            // deleted from config but still reported until restart). Such a
+            // runner can't become the picker selection, so re-anchor the
+            // list highlight to the committed picker — otherwise the cursor
+            // strands on the unselectable row while the settings/live-state
+            // panels and the delete action still target the previous runner.
+            self.runner_status.reconcile(&self.data);
+            self.frame.schedule_frame();
             return;
         }
         self.runner_status.reconcile(&self.data);

--- a/runner/src/tui/app.rs
+++ b/runner/src/tui/app.rs
@@ -42,9 +42,9 @@ use super::input::keymap::{self, Action, Context, KeymapRegistry, Resolution};
 use super::ipc_client::TuiIpc;
 use super::tui_runtime::{FrameRequester, Tui, TuiEvent};
 use super::view::tab::TabCtx;
+use super::view::tab::{Tab as TabTrait, TabKind};
 use super::view::{FocusPath, KeyHandled, View, ViewCompletion, ViewCtx};
 use super::views::{ApprovalsTab, GeneralTab, RunnerStatusTab, RunsTab};
-use super::view::tab::{Tab as TabTrait, TabKind};
 use crate::util::paths::Paths;
 
 /// Public re-export so `cli/tui.rs` keeps using `tui::app::Tab`.
@@ -71,8 +71,10 @@ pub struct AppData {
     pub last_approval_count: usize,
     pub service_state: Option<String>,
     pub service_action_msg: Option<String>,
-    /// Index into `config_working.runners` chosen by the runner picker.
-    pub runner_picker_idx: usize,
+    /// Runner identity chosen by the picker. Views may present runners in
+    /// different orders, so selection must be stored by name and resolved back
+    /// to the current config index only at mutation/render boundaries.
+    pub selected_runner_name: Option<String>,
     /// In-flight gates so a slow IPC call doesn't pile up across ticks.
     pub ipc_status_in_flight: bool,
     pub ipc_approvals_in_flight: bool,
@@ -105,7 +107,7 @@ impl AppData {
             last_approval_count: 0,
             service_state: None,
             service_action_msg: None,
-            runner_picker_idx: 0,
+            selected_runner_name: None,
             ipc_status_in_flight: false,
             ipc_approvals_in_flight: false,
             ipc_runs_in_flight: false,
@@ -115,29 +117,61 @@ impl AppData {
         }
     }
 
-    /// Resolve the current picker index to a runner *name* (the IPC
+    /// Resolve the current picker identity to a runner *name* (the IPC
     /// scope key). Returns `None` for "use the daemon's default."
     pub fn picker_runner_name(&self) -> Option<String> {
+        let runners = &self.config_working.as_ref()?.runners;
+        if runners.is_empty() {
+            return None;
+        }
+        if let Some(name) = self.selected_runner_name.as_deref()
+            && runners.iter().any(|r| r.name == name)
+        {
+            return Some(name.to_string());
+        }
+        runners.first().map(|r| r.name.clone())
+    }
+
+    pub fn picker_runner_index(&self) -> Option<usize> {
+        let name = self.picker_runner_name()?;
+        self.runner_index_by_name(&name)
+    }
+
+    pub fn runner_index_by_name(&self, name: &str) -> Option<usize> {
         self.config_working
+            .as_ref()?
+            .runners
+            .iter()
+            .position(|r| r.name == name)
+    }
+
+    pub fn select_runner_by_name(&mut self, name: &str) -> bool {
+        if self.runner_index_by_name(name).is_none() {
+            return false;
+        }
+        self.selected_runner_name = Some(name.to_string());
+        self.sync_picker_to_ipc();
+        true
+    }
+
+    pub fn select_runner_by_index(&mut self, idx: usize) -> bool {
+        let Some(name) = self
+            .config_working
             .as_ref()
-            .and_then(|c| c.runners.get(self.runner_picker_idx))
+            .and_then(|c| c.runners.get(idx))
             .map(|r| r.name.clone())
+        else {
+            return false;
+        };
+        self.selected_runner_name = Some(name);
+        self.sync_picker_to_ipc();
+        true
     }
 
     pub fn sync_picker_to_ipc(&mut self) {
-        let total = self
-            .config_working
-            .as_ref()
-            .map(|c| c.runners.len())
-            .unwrap_or(0);
-        if total == 0 {
-            self.ipc.selected_runner = None;
-            return;
-        }
-        if self.runner_picker_idx >= total {
-            self.runner_picker_idx = total - 1;
-        }
-        self.ipc.selected_runner = self.picker_runner_name();
+        let selected = self.picker_runner_name();
+        self.selected_runner_name = selected.clone();
+        self.ipc.selected_runner = selected;
     }
 }
 
@@ -573,8 +607,7 @@ impl App {
                             self.quit = true;
                         }
                         Err(e) => {
-                            self.data.config_edit_error =
-                                Some(format!("save failed: {e:#}"));
+                            self.data.config_edit_error = Some(format!("save failed: {e:#}"));
                             self.frame.schedule_frame();
                         }
                     }
@@ -594,20 +627,11 @@ impl App {
                 self.event_tx.send(AppEvent::Refresh);
                 self.frame.schedule_frame();
             }
-            AppEvent::SelectRunner(idx) => {
-                let total = self
-                    .data
-                    .config_working
-                    .as_ref()
-                    .map(|c| c.runners.len())
-                    .unwrap_or(0);
-                if total > 0 && idx < total {
-                    self.data.runner_picker_idx = idx;
-                    self.data.sync_picker_to_ipc();
-                    self.data.suppress_approval_alert = true;
-                    self.event_tx.send(AppEvent::Refresh);
-                    self.frame.schedule_frame();
-                }
+            AppEvent::SelectRunnerByIndex(idx) => {
+                self.select_runner_by_config_index(idx);
+            }
+            AppEvent::SelectRunnerByName(name) => {
+                self.select_runner_by_name(&name);
             }
         }
         Ok(())
@@ -774,10 +798,9 @@ impl App {
     /// (empty tree) and for keys the layered model doesn't claim
     /// (those continue down the legacy path / keymap).
     fn dispatch_focus_key(&mut self, key: KeyEvent) -> KeyHandled {
-        use super::view::focus::{locate, next_sibling, parent_siblings, FocusNode, NavDir};
+        use super::view::focus::{FocusNode, NavDir, locate, next_sibling, parent_siblings};
 
-        let tree = self
-            .with_tab_ctx(|tab, ctx| tab.focus_tree(ctx.data));
+        let tree = self.with_tab_ctx(|tab, ctx| tab.focus_tree(ctx.data));
         if tree.is_empty() {
             return KeyHandled::NotConsumed;
         }
@@ -872,8 +895,7 @@ impl App {
                 // an internal list cursor on the Runs tab). If it
                 // declines, consume anyway so the legacy keymap (Tabs
                 // ←/→) doesn't switch tabs out from under the user.
-                let inner =
-                    self.with_tab_ctx(|tab, ctx| tab.handle_item_key(key, ctx, &focus));
+                let inner = self.with_tab_ctx(|tab, ctx| tab.handle_item_key(key, ctx, &focus));
                 if matches!(inner, KeyHandled::Consumed) {
                     self.frame.schedule_frame();
                 }
@@ -896,8 +918,7 @@ impl App {
                         }
                         FocusNode::Item { id, .. } => {
                             let id = *id;
-                            let _ = self
-                                .with_tab_ctx(|tab, ctx| tab.activate_item(id, ctx));
+                            let _ = self.with_tab_ctx(|tab, ctx| tab.activate_item(id, ctx));
                             self.frame.schedule_frame();
                         }
                     }
@@ -905,8 +926,7 @@ impl App {
                 KeyHandled::Consumed
             }
             KeyCode::Esc => {
-                let consumed =
-                    self.with_tab_ctx(|tab, ctx| tab.handle_item_key(key, ctx, &focus));
+                let consumed = self.with_tab_ctx(|tab, ctx| tab.handle_item_key(key, ctx, &focus));
                 if matches!(consumed, KeyHandled::Consumed) {
                     self.frame.schedule_frame();
                     return KeyHandled::Consumed;
@@ -1014,9 +1034,7 @@ impl App {
         match action {
             Action::Quit => {
                 let dirty = match (&self.data.config_loaded, &self.data.config_working) {
-                    (Some(loaded), Some(working)) => {
-                        super::views::config::differs(loaded, working)
-                    }
+                    (Some(loaded), Some(working)) => super::views::config::differs(loaded, working),
                     _ => false,
                 };
                 let v = super::views::modals::confirm::ConfirmExitView::new(dirty);
@@ -1047,22 +1065,34 @@ impl App {
 
             Action::ListUp => {
                 self.with_tab_ctx(|tab, ctx| {
-                    tab.handle_key(KeyEvent::new(KeyCode::Up, crossterm::event::KeyModifiers::NONE), ctx);
+                    tab.handle_key(
+                        KeyEvent::new(KeyCode::Up, crossterm::event::KeyModifiers::NONE),
+                        ctx,
+                    );
                 });
             }
             Action::ListDown => {
                 self.with_tab_ctx(|tab, ctx| {
-                    tab.handle_key(KeyEvent::new(KeyCode::Down, crossterm::event::KeyModifiers::NONE), ctx);
+                    tab.handle_key(
+                        KeyEvent::new(KeyCode::Down, crossterm::event::KeyModifiers::NONE),
+                        ctx,
+                    );
                 });
             }
             Action::ListAccept => {
                 self.with_tab_ctx(|tab, ctx| {
-                    tab.handle_key(KeyEvent::new(KeyCode::Enter, crossterm::event::KeyModifiers::NONE), ctx);
+                    tab.handle_key(
+                        KeyEvent::new(KeyCode::Enter, crossterm::event::KeyModifiers::NONE),
+                        ctx,
+                    );
                 });
             }
             Action::ListCancel => {
                 self.with_tab_ctx(|tab, ctx| {
-                    tab.handle_key(KeyEvent::new(KeyCode::Esc, crossterm::event::KeyModifiers::NONE), ctx);
+                    tab.handle_key(
+                        KeyEvent::new(KeyCode::Esc, crossterm::event::KeyModifiers::NONE),
+                        ctx,
+                    );
                 });
             }
 
@@ -1122,7 +1152,7 @@ impl App {
 
             Action::RunnerPickerPrev => self.move_picker(-1),
             Action::RunnerPickerNext => self.move_picker(1),
-            Action::RunnerPickerJump(i) => self.event_tx.send(AppEvent::SelectRunner(i)),
+            Action::RunnerPickerJump(i) => self.event_tx.send(AppEvent::SelectRunnerByIndex(i)),
 
             Action::SaveConfig => self.event_tx.send(AppEvent::SaveConfig),
             Action::DiscardEdits => self.event_tx.send(AppEvent::DiscardConfigEdits),
@@ -1160,9 +1190,29 @@ impl App {
             return;
         }
         let n = total as isize;
-        let cur = self.data.runner_picker_idx as isize;
+        let cur = self.data.picker_runner_index().unwrap_or(0) as isize;
         let next = (cur + delta).rem_euclid(n) as usize;
-        self.event_tx.send(AppEvent::SelectRunner(next));
+        self.event_tx.send(AppEvent::SelectRunnerByIndex(next));
+    }
+
+    fn select_runner_by_config_index(&mut self, idx: usize) {
+        if !self.data.select_runner_by_index(idx) {
+            return;
+        }
+        self.runner_status.reconcile(&self.data);
+        self.data.suppress_approval_alert = true;
+        self.event_tx.send(AppEvent::Refresh);
+        self.frame.schedule_frame();
+    }
+
+    fn select_runner_by_name(&mut self, name: &str) {
+        if !self.data.select_runner_by_name(name) {
+            return;
+        }
+        self.runner_status.reconcile(&self.data);
+        self.data.suppress_approval_alert = true;
+        self.event_tx.send(AppEvent::Refresh);
+        self.frame.schedule_frame();
     }
 
     pub fn handle_tui_event(&mut self, ev: TuiEvent) -> Result<bool> {

--- a/runner/src/tui/event.rs
+++ b/runner/src/tui/event.rs
@@ -111,10 +111,14 @@ pub enum AppEvent {
     /// Result of restart_and_verify after a save.
     ReloadOutcomeUpdated(ReloadOutcome),
 
-    /// IPC-scoped runner-picker change. `runners[idx]` becomes the
-    /// scope for read endpoints; `IpcStatusUpdated` etc. will pick it
-    /// up on the next refresh.
-    SelectRunner(usize),
+    /// IPC-scoped runner-picker change by config-file index.
+    /// `config_working.runners[idx]` becomes the scope for read endpoints;
+    /// `IpcStatusUpdated` etc. will pick it up on the next refresh.
+    SelectRunnerByIndex(usize),
+    /// IPC-scoped runner-picker change by runner name. Used when the
+    /// visible list is built from live daemon status, whose order can differ
+    /// from `config.toml`.
+    SelectRunnerByName(String),
 }
 
 impl std::fmt::Debug for AppEvent {
@@ -141,19 +145,29 @@ impl std::fmt::Debug for AppEvent {
                 .finish(),
             AppEvent::ServiceStart => f.write_str("ServiceStart"),
             AppEvent::ServiceStop => f.write_str("ServiceStop"),
-            AppEvent::ServiceActionResult(s) => f.debug_tuple("ServiceActionResult").field(s).finish(),
+            AppEvent::ServiceActionResult(s) => {
+                f.debug_tuple("ServiceActionResult").field(s).finish()
+            }
             AppEvent::Refresh => f.write_str("Refresh"),
             AppEvent::SubmitRegister => f.write_str("SubmitRegister"),
-            AppEvent::EnrollOutcome { reload, .. } => {
-                f.debug_struct("EnrollOutcome").field("ok", &reload.ok).finish()
-            }
+            AppEvent::EnrollOutcome { reload, .. } => f
+                .debug_struct("EnrollOutcome")
+                .field("ok", &reload.ok)
+                .finish(),
             AppEvent::EnrollFailed(s) => f.debug_tuple("EnrollFailed").field(s).finish(),
-            AppEvent::SubmitRemoveRunner(n) => f.debug_tuple("SubmitRemoveRunner").field(n).finish(),
+            AppEvent::SubmitRemoveRunner(n) => {
+                f.debug_tuple("SubmitRemoveRunner").field(n).finish()
+            }
             AppEvent::SaveConfig => f.write_str("SaveConfig"),
             AppEvent::SaveAndQuit => f.write_str("SaveAndQuit"),
             AppEvent::DiscardConfigEdits => f.write_str("DiscardConfigEdits"),
             AppEvent::ReloadOutcomeUpdated(_) => f.write_str("ReloadOutcomeUpdated"),
-            AppEvent::SelectRunner(i) => f.debug_tuple("SelectRunner").field(i).finish(),
+            AppEvent::SelectRunnerByIndex(i) => {
+                f.debug_tuple("SelectRunnerByIndex").field(i).finish()
+            }
+            AppEvent::SelectRunnerByName(name) => {
+                f.debug_tuple("SelectRunnerByName").field(name).finish()
+            }
         }
     }
 }

--- a/runner/src/tui/views/config.rs
+++ b/runner/src/tui/views/config.rs
@@ -430,7 +430,7 @@ pub fn runner_picker_bar(data: &AppData) -> Paragraph<'static> {
         );
     };
     let total = working.runners.len();
-    let picked = data.runner_picker_idx.min(total.saturating_sub(1));
+    let picked = data.picker_runner_index().unwrap_or(0).min(total.saturating_sub(1));
     let mut spans: Vec<Span<'static>> = Vec::new();
     for (i, r) in working.runners.iter().enumerate() {
         let label = format!(" {}. {} ", i + 1, r.name);

--- a/runner/src/tui/views/general.rs
+++ b/runner/src/tui/views/general.rs
@@ -414,10 +414,16 @@ impl GeneralTab {
             return;
         };
         let text = buf.text().to_string();
+        let runner_idx = ctx.data.picker_runner_index().unwrap_or(0);
         let Some(cfg) = ctx.data.config_working.as_mut() else {
             return;
         };
-        match fields::set_text_value(cfg, fields::FieldId::LogRetentionDays, &text, ctx.data.runner_picker_idx) {
+        match fields::set_text_value(
+            cfg,
+            fields::FieldId::LogRetentionDays,
+            &text,
+            runner_idx,
+        ) {
             Ok(()) => {
                 ctx.data.config_edit_error = None;
             }

--- a/runner/src/tui/views/runner_status.rs
+++ b/runner/src/tui/views/runner_status.rs
@@ -24,11 +24,11 @@ use ratatui::widgets::{
 use super::super::app::AppData;
 use super::super::event::AppEvent;
 use super::super::input::keymap::Context;
+use super::super::view::KeyHandled;
 use super::super::view::focus::{
-    border_style, dived_marker, is_focused, is_in_path, FocusNode, FocusPath,
+    FocusNode, FocusPath, border_style, dived_marker, is_focused, is_in_path,
 };
 use super::super::view::tab::{Tab, TabCtx, TabKind};
-use super::super::view::KeyHandled;
 use super::super::widgets::{SelectableList, TextArea};
 use super::config as fields;
 
@@ -62,18 +62,18 @@ impl RunnerStatusTab {
             Some(s) => s.runners.iter().map(|r| r.name.clone()).collect(),
             None => Vec::new(),
         };
+        if let Some(name) = data.picker_runner_name()
+            && let Some(idx) = ids.iter().position(|id| id == &name)
+        {
+            self.list.jump_to(idx, &ids);
+            return;
+        }
         self.list.reconcile(&ids);
     }
 
     pub fn selected_runner_name(&self, data: &AppData) -> Option<String> {
-        if let Some(id) = self.list.selected_id() {
-            return Some(id.clone());
-        }
-        let working = data.config_working.as_ref()?;
-        working
-            .runners
-            .get(data.runner_picker_idx)
-            .map(|r| r.name.clone())
+        data.picker_runner_name()
+            .or_else(|| self.list.selected_id().cloned())
     }
 
     /// Index of the field currently selected at Layer 2 (for the
@@ -224,15 +224,15 @@ impl Tab for RunnerStatusTab {
             match key.code {
                 KeyCode::Char('j') | KeyCode::Down => {
                     self.list.move_down(&runner_ids);
-                    if let Some(idx) = self.list.selected_index() {
-                        ctx.tx.send(AppEvent::SelectRunner(idx));
+                    if let Some(name) = self.list.selected_id() {
+                        ctx.tx.send(AppEvent::SelectRunnerByName(name.clone()));
                     }
                     return KeyHandled::Consumed;
                 }
                 KeyCode::Char('k') | KeyCode::Up => {
                     self.list.move_up(&runner_ids);
-                    if let Some(idx) = self.list.selected_index() {
-                        ctx.tx.send(AppEvent::SelectRunner(idx));
+                    if let Some(name) = self.list.selected_id() {
+                        ctx.tx.send(AppEvent::SelectRunnerByName(name.clone()));
                     }
                     return KeyHandled::Consumed;
                 }
@@ -262,16 +262,22 @@ impl Tab for RunnerStatusTab {
         }
     }
 
-    fn activate_item(&mut self, item_id: super::super::view::CardId, ctx: &mut TabCtx<'_>) -> KeyHandled {
+    fn activate_item(
+        &mut self,
+        item_id: super::super::view::CardId,
+        ctx: &mut TabCtx<'_>,
+    ) -> KeyHandled {
         // Only settings fields are activatable items in this tab.
         let Some(field_id) = fields::FieldId::from_id_str(item_id) else {
+            return KeyHandled::NotConsumed;
+        };
+        let Some(runner_idx) = ctx.data.picker_runner_index() else {
             return KeyHandled::NotConsumed;
         };
         let Some(cfg) = ctx.data.config_working.as_mut() else {
             return KeyHandled::NotConsumed;
         };
         ctx.data.config_edit_error = None;
-        let runner_idx = ctx.data.runner_picker_idx;
         let spec = fields::FIELDS
             .iter()
             .find(|s| s.id == field_id)
@@ -313,10 +319,12 @@ impl RunnerStatusTab {
             return;
         };
         let text = buf.text().to_string();
+        let Some(runner_idx) = ctx.data.picker_runner_index() else {
+            return;
+        };
         let Some(cfg) = ctx.data.config_working.as_mut() else {
             return;
         };
-        let runner_idx = ctx.data.runner_picker_idx;
         match fields::set_text_value(cfg, id, &text, runner_idx) {
             Ok(()) => {
                 ctx.data.config_edit_error = None;
@@ -345,7 +353,11 @@ impl RunnerStatusTab {
             p.render(area, buf);
             return;
         }
-        let picked_idx = self.list.selected_index().unwrap_or(0).min(runners.len() - 1);
+        let picked_idx = self
+            .list
+            .selected_index()
+            .unwrap_or(0)
+            .min(runners.len() - 1);
         let items: Vec<ListItem<'_>> = runners
             .iter()
             .enumerate()
@@ -404,7 +416,13 @@ impl RunnerStatusTab {
         StatefulWidget::render(list, area, buf, &mut lstate);
     }
 
-    fn render_settings_panel(&self, area: Rect, buf: &mut Buffer, data: &AppData, focus: &FocusPath) {
+    fn render_settings_panel(
+        &self,
+        area: Rect,
+        buf: &mut Buffer,
+        data: &AppData,
+        focus: &FocusPath,
+    ) {
         let Some(working) = data.config_working.as_ref() else {
             return;
         };
@@ -452,7 +470,7 @@ impl RunnerStatusTab {
             working,
             &loaded,
             self.focused_field_idx(focus),
-            data.runner_picker_idx,
+            data.picker_runner_index().unwrap_or(0),
             edit_buffer_str.as_deref(),
         ))
         .block(
@@ -510,8 +528,8 @@ fn render_live_state_panel(
     selected_name: Option<&str>,
     focused: bool,
 ) {
-    let snapshot = selected_name
-        .and_then(|n| data.status.as_ref().and_then(|s| s.runner_by_name(n)));
+    let snapshot =
+        selected_name.and_then(|n| data.status.as_ref().and_then(|s| s.runner_by_name(n)));
     let mut lines: Vec<Line<'static>> = Vec::new();
     let Some(r) = snapshot else {
         lines.push(Line::from(Span::styled(
@@ -529,7 +547,10 @@ fn render_live_state_panel(
             .render(area, buf);
         return;
     };
-    let pod = r.pod_id.map(|p| p.to_string()).unwrap_or_else(|| "(unassigned)".into());
+    let pod = r
+        .pod_id
+        .map(|p| p.to_string())
+        .unwrap_or_else(|| "(unassigned)".into());
     lines.push(field_kv("Pod", &pod));
     lines.push(field_kv("Heartbeat", &fmt_age(r.last_heartbeat)));
     let current_run = match &r.current_run {
@@ -586,10 +607,7 @@ fn render_live_state_panel(
 
 fn field_kv(label: &str, value: &str) -> Line<'static> {
     Line::from(vec![
-        Span::styled(
-            format!("{label:<11} "),
-            Style::default().fg(Color::Cyan),
-        ),
+        Span::styled(format!("{label:<11} "), Style::default().fg(Color::Cyan)),
         Span::raw(value.to_string()),
     ])
 }
@@ -609,5 +627,114 @@ fn fmt_age(ts: Option<chrono::DateTime<chrono::Utc>>) -> String {
                 format!("{}h{}m ago", secs / 3600, (secs % 3600) / 60)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cloud::protocol::RunnerStatus;
+    use crate::config::schema::{Config, DaemonConfig, RunnerConfig, WorkspaceSection};
+    use crate::ipc::protocol::{DaemonInfo, RunnerStatusSnapshot, StatusSnapshot};
+    use crate::util::paths::Paths;
+    use std::path::PathBuf;
+    use uuid::Uuid;
+
+    fn paths() -> Paths {
+        let root = tempfile::tempdir().expect("tempdir").keep();
+        Paths {
+            config_dir: root.join("config"),
+            data_dir: root.join("data"),
+            runtime_dir: root.join("runtime"),
+        }
+    }
+
+    fn runner(name: &str) -> RunnerConfig {
+        RunnerConfig {
+            name: name.into(),
+            runner_id: Uuid::new_v4(),
+            workspace_slug: Some("acme".into()),
+            project_slug: Some("TEST".into()),
+            pod_id: None,
+            workspace: WorkspaceSection {
+                working_dir: PathBuf::from("/tmp/pidash-test"),
+            },
+            workdir: None,
+            agent: Default::default(),
+            codex: Default::default(),
+            claude_code: Default::default(),
+            cursor_agent: Default::default(),
+            openclaw: Default::default(),
+            approval_policy: Default::default(),
+        }
+    }
+
+    fn config(runners: Vec<RunnerConfig>) -> Config {
+        Config {
+            version: 2,
+            daemon: DaemonConfig {
+                cloud_url: "https://pidash.example".into(),
+                dev_machine_id: None,
+                log_level: "info".into(),
+                log_retention_days: 14,
+                agent_observability_v1: false,
+                auto_update: true,
+            },
+            runners,
+            workdirs: vec![],
+            cli: None,
+        }
+    }
+
+    fn snapshot(name: &str) -> RunnerStatusSnapshot {
+        RunnerStatusSnapshot {
+            runner_id: Uuid::new_v4(),
+            name: name.into(),
+            project_slug: Some("TEST".into()),
+            pod_id: None,
+            status: RunnerStatus::Idle,
+            connected: true,
+            current_run: None,
+            approvals_pending: 0,
+            last_heartbeat: None,
+            last_session_open: None,
+            consecutive_bootstrap_failures: 0,
+            observability: None,
+        }
+    }
+
+    fn status(names: &[&str]) -> StatusSnapshot {
+        StatusSnapshot {
+            daemon: DaemonInfo {
+                cloud_url: "https://pidash.example".into(),
+                connected: true,
+                uptime_secs: 0,
+                update: None,
+            },
+            runners: names.iter().map(|name| snapshot(name)).collect(),
+            pools: vec![],
+        }
+    }
+
+    #[test]
+    fn reconcile_anchors_live_list_to_config_selected_runner_name() {
+        let mut data = AppData::new(paths());
+        data.config_working = Some(config(vec![
+            runner("claude_macmini01"),
+            runner("ai_assistant"),
+        ]));
+        data.config_loaded = data.config_working.clone();
+        data.status = Some(status(&["ai_assistant", "claude_macmini01"]));
+        data.selected_runner_name = Some("claude_macmini01".to_string());
+
+        let mut tab = RunnerStatusTab::new();
+        tab.reconcile(&data);
+
+        assert_eq!(
+            tab.list.selected_id(),
+            Some(&"claude_macmini01".to_string())
+        );
+        assert_eq!(tab.list.selected_index(), Some(1));
+        assert_eq!(data.runner_index_by_name("claude_macmini01"), Some(0));
     }
 }

--- a/runner/src/tui/views/runner_status.rs
+++ b/runner/src/tui/views/runner_status.rs
@@ -737,4 +737,32 @@ mod tests {
         assert_eq!(tab.list.selected_index(), Some(1));
         assert_eq!(data.runner_index_by_name("claude_macmini01"), Some(0));
     }
+
+    #[test]
+    fn rejected_select_reanchors_highlight_to_committed_picker() {
+        // A runner still in daemon status but no longer in config ("stale_c")
+        // can't become the picker selection. After the rejected commit, the
+        // list highlight must snap back to the committed picker instead of
+        // stranding on the unselectable row (mirrors App::select_runner_by_name).
+        let mut data = AppData::new(paths());
+        data.config_working = Some(config(vec![runner("alpha"), runner("beta")]));
+        data.config_loaded = data.config_working.clone();
+        data.status = Some(status(&["alpha", "beta", "stale_c"]));
+        data.selected_runner_name = Some("alpha".to_string());
+
+        let mut tab = RunnerStatusTab::new();
+        let live_ids: Vec<String> = vec!["alpha".into(), "beta".into(), "stale_c".into()];
+        // User navigates the live list onto the daemon-only runner.
+        tab.list.jump_to(2, &live_ids);
+        assert_eq!(tab.list.selected_id(), Some(&"stale_c".to_string()));
+
+        // Commit is rejected: the name isn't in config.
+        assert!(!data.select_runner_by_name("stale_c"));
+
+        // The fix's recovery step: reconcile back to the committed picker.
+        tab.reconcile(&data);
+
+        assert_eq!(tab.list.selected_id(), Some(&"alpha".to_string()));
+        assert_eq!(data.picker_runner_name(), Some("alpha".to_string()));
+    }
 }


### PR DESCRIPTION
## Summary
- classify persisted agent-run errors by source and expose `error_diagnostic` on run APIs and issue agent-run summaries
- enrich new agent auth failures with actionable cloud-visible guidance, including the agent and dev-machine re-auth step
- show diagnostic source/action in the runner run detail UI and issue agent status
- make TUI runner selection identity-based (`selected_runner_name`) and derive config indices only at mutation/render boundaries, so live-status order changes cannot save settings to the wrong runner
- pin new Claude Code runners to `claude-opus-4-8` by default and remove Fable 5 from the Add Runner Claude model catalog

## Verification
- `python3 -m ruff check pi_dash/runner/diagnostics.py pi_dash/runner/services/run_lifecycle.py pi_dash/tests/unit/runner/test_run_diagnostics.py pi_dash/tests/unit/runner/test_failure_comment.py`
- `python3 -m ruff format --check pi_dash/runner/diagnostics.py pi_dash/tests/unit/runner/test_run_diagnostics.py`
- `python3 -m py_compile pi_dash/runner/diagnostics.py pi_dash/runner/services/run_lifecycle.py pi_dash/runner/serializers.py pi_dash/app/serializers/issue.py pi_dash/tests/unit/runner/test_run_diagnostics.py`
- `cargo test --package pidash tui::views::runner_status::tests::reconcile_anchors_live_list_to_config_selected_runner_name`
- `cargo test --package pidash tui::widgets::selectable_list`
- `pnpm --filter @pi-dash/types check:types`
- `pnpm --filter @pi-dash/types build`
- `pnpm --filter web check:lint` exits 0 with existing warnings

Known local blockers:
- `python3 -m pytest ...` does not collect because this local Python env is missing `celery`
- `pnpm --filter web check:types` still fails on existing unrelated errors around dev-machine/assistant/scheduler/git-provider exports and `TStateGroups` mismatches
- `cargo fmt --check` could not be rerun after the Rust toolchain in this temp worktree reported missing `rustfmt`; the focused Rust tests compile and pass
