### PR TITLE
feat(web/auth): extract sign-out into an overridable seam

### DIFF
--- a/apps/web/core/services/auth-signout.ts
+++ b/apps/web/core/services/auth-signout.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+// types
+import type { ICsrfTokenData } from "@pi-dash/types";
+
+/**
+ * The minimal slice of ``AuthService`` the sign-out strategy needs. Declared
+ * structurally (not the concrete class) so an alternate edition can supply a
+ * different strategy without depending on the whole service.
+ */
+export interface SignOutClient {
+  requestCSRFToken(): Promise<ICsrfTokenData>;
+}
+
+/**
+ * Default (self-hosted) sign-out: fetch a CSRF token and submit a hidden form
+ * POST to Django's ``/auth/sign-out/`` session-logout endpoint, which clears
+ * the session cookie and redirects.
+ *
+ * This is the overridable seam for downstream editions (e.g. a hosted OIDC
+ * edition whose logout is a JSON request that returns an upstream logout URL).
+ * Editions override sign-out by replacing this file wholesale — keep the
+ * exported ``performSignOut`` name and signature stable so ``AuthService``
+ * keeps resolving it.
+ */
+export async function performSignOut(client: SignOutClient, baseUrl: string): Promise<void> {
+  const data = await client.requestCSRFToken();
+  const csrfToken = data?.csrf_token;
+
+  if (!csrfToken) throw new Error("CSRF token not found");
+
+  const form = document.createElement("form");
+  const input = document.createElement("input");
+
+  form.method = "POST";
+  form.action = `${baseUrl}/auth/sign-out/`;
+
+  input.value = csrfToken;
+  input.name = "csrfmiddlewaretoken";
+  input.type = "hidden";
+  form.appendChild(input);
+
+  document.body.appendChild(form);
+
+  form.submit();
+}

--- a/apps/web/core/services/auth.service.ts
+++ b/apps/web/core/services/auth.service.ts
@@ -10,6 +10,7 @@ import type { ICsrfTokenData, IEmailCheckData, IEmailCheckResponse } from "@pi-d
 // helpers
 // services
 import { APIService } from "@/services/api.service";
+import { performSignOut } from "@/services/auth-signout";
 
 export class AuthService extends APIService {
   constructor() {
@@ -59,26 +60,10 @@ export class AuthService extends APIService {
       });
   }
 
-  async signOut(baseUrl: string): Promise<any> {
-    await this.requestCSRFToken().then((data) => {
-      const csrfToken = data?.csrf_token;
-
-      if (!csrfToken) throw Error("CSRF token not found");
-
-      const form = document.createElement("form");
-      const element1 = document.createElement("input");
-
-      form.method = "POST";
-      form.action = `${baseUrl}/auth/sign-out/`;
-
-      element1.value = csrfToken;
-      element1.name = "csrfmiddlewaretoken";
-      element1.type = "hidden";
-      form.appendChild(element1);
-
-      document.body.appendChild(form);
-
-      form.submit();
-    });
+  // Sign-out is delegated to an overridable seam (``./auth-signout``) so hosted
+  // editions can swap the strategy — e.g. an OIDC edition whose logout is a
+  // JSON request — without forking this whole service. See auth-signout.ts.
+  async signOut(baseUrl: string): Promise<void> {
+    await performSignOut(this, baseUrl);
   }
 }


### PR DESCRIPTION
## What

`AuthService.signOut` hard-coded a Django session-logout **form POST** to `/auth/sign-out/`. Any downstream edition with a different logout mechanism had to fork the entire `auth.service.ts` to change that one method.

This extracts the sign-out logic into `core/services/auth-signout.ts` behind a stable `performSignOut(client, baseUrl)` export, and has `AuthService.signOut` delegate to it — mirroring the existing `core/hooks/oauth/extended.tsx` extension seam.

## Why

Self-hosted behavior is **unchanged** (same CSRF fetch + hidden-form POST). The point is extensibility: an edition can now override sign-out by replacing just `auth-signout.ts` instead of copying the whole service (which risks silent drift of the un-touched methods).

## Changes
- `apps/web/core/services/auth-signout.ts` (new) — default form-POST strategy + `SignOutClient` structural interface.
- `apps/web/core/services/auth.service.ts` — `signOut` now `await performSignOut(this, baseUrl)`; no other methods touched.

## Testing
- `oxlint` / `oxfmt` clean (pre-commit).
- Behavior-preserving refactor; self-hosted sign-out path identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)