### PR TITLE
PDASHOSS01-44 Change the left panel wording

### DIFF
--- a/packages/constants/src/workspace.ts
+++ b/packages/constants/src/workspace.ts
@@ -287,7 +287,7 @@ export const WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS: Record<string, IWorkspac
     href: `/runners/`,
     access: [EUserWorkspaceRoles.ADMIN, EUserWorkspaceRoles.MEMBER],
     highlight: (pathname: string, url: string) => pathname.includes(url),
-    tooltipTranslationKey: "Manage your AI Agent connectivities",
+    tooltipTranslationKey: "Manage your AI Worker connectivities",
   },
   prompts: {
     key: "prompts",

--- a/packages/constants/src/workspace.ts
+++ b/packages/constants/src/workspace.ts
@@ -239,7 +239,7 @@ export const WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS: Record<string, IWorkspac
   },
   assistant: {
     key: "assistant",
-    labelTranslationKey: "AI Assistant",
+    labelTranslationKey: "Pi Dash AI",
     href: `/assistant/`,
     // Guests are excluded (parity with the backend 403).
     access: [EUserWorkspaceRoles.ADMIN, EUserWorkspaceRoles.MEMBER],
@@ -283,7 +283,7 @@ export const WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS: Record<string, IWorkspac
   },
   runners: {
     key: "runners",
-    labelTranslationKey: "AI Agents",
+    labelTranslationKey: "AI Workers",
     href: `/runners/`,
     access: [EUserWorkspaceRoles.ADMIN, EUserWorkspaceRoles.MEMBER],
     highlight: (pathname: string, url: string) => pathname.includes(url),

--- a/packages/i18n/src/locales/en/translations.ts
+++ b/packages/i18n/src/locales/en/translations.ts
@@ -161,6 +161,7 @@ export default {
   "AI Agents": "AI Agents",
   "AI Dev Machines": "AI Dev Machines",
   "AI Prompt Templates": "AI Prompt Templates",
+  "AI Workers": "AI Workers",
   All: "All",
   "All permissions set to true within the workspace.": "All permissions set to true within the workspace.",
   "All Projects": "All Projects",
@@ -1130,6 +1131,7 @@ export default {
   Personal: "Personal",
   "Personal Access Tokens": "Personal Access Tokens",
   "Pi Chat": "Pi Chat",
+  "Pi Dash AI": "Pi Dash AI",
   "Pi Dash default": "Pi Dash default",
   "Pi Dash hands AI agents (Claude Code, Codex, …) the keys to a real dev machine so they can pick up work items, write code, and open changes. Three pieces work together to make that possible:":
     "Pi Dash hands AI agents (Claude Code, Codex, …) the keys to a real dev machine so they can pick up work items, write code, and open changes. Three pieces work together to make that possible:",

--- a/packages/i18n/src/locales/en/translations.ts
+++ b/packages/i18n/src/locales/en/translations.ts
@@ -893,7 +893,7 @@ export default {
   "Make public": "Make public",
   "Manage features": "Manage features",
   "Manage widgets": "Manage widgets",
-  "Manage your AI Agent connectivities": "Manage your AI Agent connectivities",
+  "Manage your AI Worker connectivities": "Manage your AI Worker connectivities",
   Manifest: "Manifest",
   Manual: "Manual",
   "Manually or through automation, you can archive work items that are completed or cancelled. Find them here once archived.":


### PR DESCRIPTION
## What

Renames two left-panel (sidebar) navigation labels:

- **"AI Assistant" → "Pi Dash AI"**
- **"AI Agents" → "AI Workers"**

## Why

Per issue PDASHOSS01-44 — update the wording of these two sidebar items.

## How

- Updated the `labelTranslationKey` for the `assistant` and `runners` entries in `packages/constants/src/workspace.ts` (`WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS`), which the sidebar renders via `t(item.labelTranslationKey)` in `sidebar-item.tsx`.
- Added matching English i18n entries (`"Pi Dash AI"`, `"AI Workers"`) in `packages/i18n/src/locales/en/translations.ts` for consistency (the translation layer falls back to the raw key if an entry is absent).

Scope is limited to the left panel. Page titles for the runners area use separate direct `t("AI Agents")` calls and are intentionally left unchanged; the existing `"AI Agents"` i18n entry is therefore retained.

## Validation

- `pnpm turbo run check:types --filter=@pi-dash/i18n` → pass
- `pnpm turbo run check:lint --filter=@pi-dash/constants --filter=@pi-dash/i18n` → 0 errors

(A pre-existing `lucide-react` type error in `packages/constants/src/settings/profile.ts` is present on the base branch and is unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
