### PR TITLE
PDASHOSS01-43 change the UI of "Run AI" into "Manually Run AI"

### DIFF
--- a/apps/web/core/components/issues/issue-detail-widgets/run-ai/run-ai-button.tsx
+++ b/apps/web/core/components/issues/issue-detail-widgets/run-ai/run-ai-button.tsx
@@ -49,7 +49,7 @@ export const RunAIActionButton = observer(function RunAIActionButton(props: Prop
           loading={isSubmitting}
         >
           <AiIcon className="h-3.5 w-3.5 flex-shrink-0" />
-          <span className="text-body-xs-medium">{t("Run AI")}</span>
+          <span className="text-body-xs-medium">{t("Manually Run AI")}</span>
         </Button>
       </span>
     </Tooltip>

--- a/packages/i18n/src/locales/en/translations.ts
+++ b/packages/i18n/src/locales/en/translations.ts
@@ -897,6 +897,7 @@ export default {
   Manual: "Manual",
   "Manually or through automation, you can archive work items that are completed or cancelled. Find them here once archived.":
     "Manually or through automation, you can archive work items that are completed or cancelled. Find them here once archived.",
+  "Manually Run AI": "Manually Run AI",
   "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)":
     "Manually trigger an extra AI agent run. (Issues in the In Progress state already tick an agent run every few hours.)",
   "Map your project goals to Modules and track easily.": "Map your project goals to Modules and track easily.",
@@ -1289,7 +1290,6 @@ export default {
   Rotate: "Rotate",
   "Rotate dev machine token?": "Rotate dev machine token?",
   "Run {runId} · requested {at}": "Run {runId} · requested {at}",
-  "Run AI": "Run AI",
   "Run an installer on the machine that will host your AI agent. The wrapper commands download the latest signed binary, drop `pidash` on your PATH, and walk you through the device-code login.":
     "Run an installer on the machine that will host your AI agent. The wrapper commands download the latest signed binary, drop `pidash` on your PATH, and walk you through the device-code login.",
   "Run this on the machine that will host the runner:": "Run this on the machine that will host the runner:",


### PR DESCRIPTION
## Summary

Renames the manual agent-run trigger button in the issue detail view from **"Run AI"** to **"Manually Run AI"** to make its purpose clearer (it manually triggers an extra run, on top of the automatic ticks that already fire for in-progress issues).

## Changes

- `apps/web/core/components/issues/issue-detail-widgets/run-ai/run-ai-button.tsx` — button label now uses `t("Manually Run AI")`.
- `packages/i18n/src/locales/en/translations.ts` — added the `"Manually Run AI"` key and removed the now-unused `"Run AI"` key (the button was its only usage).

## Validation

- `pnpm turbo run check:types --filter=@pi-dash/i18n --filter=web` — passes (12 tasks successful).
- Grep confirms no remaining `t("Run AI")` usages.

Resolves PDASHOSS01-43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
