### PR TITLE
PDASHOSS01-31 paginate the  items in https://pidash.airepublic.com/ai-republic/runners/runs

### DIFF
--- a/apps/api/pi_dash/runner/views/runs.py
+++ b/apps/api/pi_dash/runner/views/runs.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # See the LICENSE file for details.
 
+import math
+
 from django.db import transaction
 from django.db.models import Q
 from django.utils import timezone
@@ -27,6 +29,30 @@ from pi_dash.runner.services.validation import (
     RunCreationError,
     validate_run_creation,
 )
+
+
+DEFAULT_PER_PAGE = 50
+MAX_PER_PAGE = 200
+
+
+def _parse_pagination(query_params) -> tuple[int, int]:
+    """Resolve ``page`` (1-based) and ``per_page`` from query params.
+
+    Invalid or out-of-bounds values fall back to safe defaults rather than
+    erroring: ``page`` clamps to a minimum of 1, ``per_page`` to ``[1,
+    MAX_PER_PAGE]`` with a ``DEFAULT_PER_PAGE`` fallback.
+    """
+
+    def _to_int(value, default):
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return default
+
+    page = max(1, _to_int(query_params.get("page"), 1))
+    per_page = _to_int(query_params.get("per_page"), DEFAULT_PER_PAGE)
+    per_page = max(1, min(per_page, MAX_PER_PAGE))
+    return page, per_page
 
 
 def _can_view_run(user, run: AgentRun) -> bool:
@@ -93,7 +119,28 @@ class AgentRunListEndpoint(APIView):
         workspace_id = request.query_params.get("workspace")
         if workspace_id:
             qs = qs.filter(workspace_id=workspace_id)
-        return Response(AgentRunSerializer(qs[:200], many=True).data)
+
+        # Page-number pagination. The list grew unbounded (previously capped at
+        # a flat 200), so the client now requests one page at a time and only
+        # the first page loads by default. ``page`` is 1-based and reflected in
+        # the runs-view URL so a page is directly linkable. Out-of-range pages
+        # return an empty ``results`` with the real ``total_pages`` so the UI
+        # can recover.
+        page, per_page = _parse_pagination(request.query_params)
+        total_count = qs.count()
+        total_pages = max(1, math.ceil(total_count / per_page))
+        offset = (page - 1) * per_page
+        results = qs[offset : offset + per_page]
+        return Response(
+            {
+                "results": AgentRunSerializer(results, many=True).data,
+                "count": len(results),
+                "total_count": total_count,
+                "total_pages": total_pages,
+                "page": page,
+                "per_page": per_page,
+            }
+        )
 
     def post(self, request):
         triggered_by = (request.data.get("triggered_by") or "").strip()

--- a/apps/api/pi_dash/runner/views/runs.py
+++ b/apps/api/pi_dash/runner/views/runs.py
@@ -31,7 +31,7 @@ from pi_dash.runner.services.validation import (
 )
 
 
-DEFAULT_PER_PAGE = 50
+DEFAULT_PER_PAGE = 30
 MAX_PER_PAGE = 200
 
 

--- a/apps/api/pi_dash/tests/unit/runner/test_runs_views.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_runs_views.py
@@ -355,29 +355,29 @@ def _bulk_create_runs(workspace, project, count, prefix="run"):
 
 
 @pytest.mark.unit
-def test_get_runs_defaults_to_first_page_of_fifty(db, session_client, workspace, project):
-    """With no page param, only the first 50 runs come back and the envelope
+def test_get_runs_defaults_to_first_page_of_thirty(db, session_client, workspace, project):
+    """With no page param, only the first 30 runs come back and the envelope
     reports the true totals."""
     _bulk_create_runs(workspace, project, 60)
     resp = session_client.get("/api/runners/runs/")
     assert resp.status_code == status.HTTP_200_OK
     assert resp.data["page"] == 1
-    assert resp.data["per_page"] == 50
+    assert resp.data["per_page"] == 30
     assert resp.data["total_count"] == 60
     assert resp.data["total_pages"] == 2
-    assert resp.data["count"] == 50
-    assert len(resp.data["results"]) == 50
+    assert resp.data["count"] == 30
+    assert len(resp.data["results"]) == 30
 
 
 @pytest.mark.unit
 def test_get_runs_second_page_returns_remainder(db, session_client, workspace, project):
     """Page 2 returns the remaining items and does not overlap page 1."""
-    _bulk_create_runs(workspace, project, 60)
+    _bulk_create_runs(workspace, project, 45)
     page1 = session_client.get("/api/runners/runs/", {"page": 1})
     page2 = session_client.get("/api/runners/runs/", {"page": 2})
     assert page2.status_code == status.HTTP_200_OK
     assert page2.data["page"] == 2
-    assert len(page2.data["results"]) == 10
+    assert len(page2.data["results"]) == 15
     ids1 = {r["id"] for r in page1.data["results"]}
     ids2 = {r["id"] for r in page2.data["results"]}
     assert ids1.isdisjoint(ids2)

--- a/apps/api/pi_dash/tests/unit/runner/test_runs_views.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_runs_views.py
@@ -150,7 +150,7 @@ def test_get_runs_lists_by_created_by(db, session_client, workspace, project):
     )
     resp = session_client.get("/api/runners/runs/")
     assert resp.status_code == status.HTTP_200_OK
-    prompts = [r["prompt"] for r in resp.data]
+    prompts = [r["prompt"] for r in resp.data["results"]]
     assert "mine" in prompts
     assert "not mine" not in prompts
 
@@ -274,7 +274,7 @@ def test_get_runs_includes_tick_runs_on_issue_user_created(db, session_client, w
     )
     resp = session_client.get("/api/runners/runs/")
     assert resp.status_code == status.HTTP_200_OK
-    assert "tick run on my issue" in [r["prompt"] for r in resp.data]
+    assert "tick run on my issue" in [r["prompt"] for r in resp.data["results"]]
 
 
 @pytest.mark.unit
@@ -293,7 +293,7 @@ def test_get_runs_includes_tick_runs_on_issue_user_assigned(db, session_client, 
     )
     resp = session_client.get("/api/runners/runs/")
     assert resp.status_code == status.HTTP_200_OK
-    assert "tick run on assigned issue" in [r["prompt"] for r in resp.data]
+    assert "tick run on assigned issue" in [r["prompt"] for r in resp.data["results"]]
 
 
 @pytest.mark.unit
@@ -312,7 +312,7 @@ def test_get_runs_excludes_runs_on_unrelated_issues(db, session_client, workspac
     )
     resp = session_client.get("/api/runners/runs/")
     assert resp.status_code == status.HTTP_200_OK
-    assert "run on unrelated issue" not in [r["prompt"] for r in resp.data]
+    assert "run on unrelated issue" not in [r["prompt"] for r in resp.data["results"]]
 
 
 @pytest.mark.unit
@@ -330,8 +330,87 @@ def test_get_runs_does_not_duplicate_when_user_satisfies_multiple_clauses(db, se
     )
     resp = session_client.get("/api/runners/runs/")
     assert resp.status_code == status.HTTP_200_OK
-    prompts = [r["prompt"] for r in resp.data]
+    prompts = [r["prompt"] for r in resp.data["results"]]
     assert prompts.count("multi-match run") == 1
+
+
+# ---------------------------------------------------------------------------
+# GET /api/runners/runs/ — page-number pagination.
+# ---------------------------------------------------------------------------
+
+
+def _bulk_create_runs(workspace, project, count, prefix="run"):
+    pod = Pod.default_for_project(project)
+    AgentRun.objects.bulk_create(
+        [
+            AgentRun(
+                workspace=workspace,
+                created_by=workspace.owner,
+                pod=pod,
+                prompt=f"{prefix}-{i:03d}",
+            )
+            for i in range(count)
+        ]
+    )
+
+
+@pytest.mark.unit
+def test_get_runs_defaults_to_first_page_of_fifty(db, session_client, workspace, project):
+    """With no page param, only the first 50 runs come back and the envelope
+    reports the true totals."""
+    _bulk_create_runs(workspace, project, 60)
+    resp = session_client.get("/api/runners/runs/")
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["page"] == 1
+    assert resp.data["per_page"] == 50
+    assert resp.data["total_count"] == 60
+    assert resp.data["total_pages"] == 2
+    assert resp.data["count"] == 50
+    assert len(resp.data["results"]) == 50
+
+
+@pytest.mark.unit
+def test_get_runs_second_page_returns_remainder(db, session_client, workspace, project):
+    """Page 2 returns the remaining items and does not overlap page 1."""
+    _bulk_create_runs(workspace, project, 60)
+    page1 = session_client.get("/api/runners/runs/", {"page": 1})
+    page2 = session_client.get("/api/runners/runs/", {"page": 2})
+    assert page2.status_code == status.HTTP_200_OK
+    assert page2.data["page"] == 2
+    assert len(page2.data["results"]) == 10
+    ids1 = {r["id"] for r in page1.data["results"]}
+    ids2 = {r["id"] for r in page2.data["results"]}
+    assert ids1.isdisjoint(ids2)
+
+
+@pytest.mark.unit
+def test_get_runs_out_of_range_page_is_empty_with_real_totals(db, session_client, workspace, project):
+    """A page beyond the last returns an empty result set but keeps the real
+    total_pages so the UI can recover."""
+    _bulk_create_runs(workspace, project, 10)
+    resp = session_client.get("/api/runners/runs/", {"page": 99})
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["results"] == []
+    assert resp.data["total_count"] == 10
+    assert resp.data["total_pages"] == 1
+
+
+@pytest.mark.unit
+def test_get_runs_per_page_is_capped(db, session_client, workspace, project):
+    """per_page above the cap is clamped rather than honored verbatim."""
+    resp = session_client.get("/api/runners/runs/", {"per_page": 100000})
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["per_page"] == 200
+
+
+@pytest.mark.unit
+def test_get_runs_invalid_page_falls_back_to_one(db, session_client, workspace, project):
+    """Garbage or non-positive page values fall back to page 1 instead of
+    erroring."""
+    for bad in ("abc", "0", "-3", ""):
+        resp = session_client.get("/api/runners/runs/", {"page": bad})
+        assert resp.status_code == status.HTTP_200_OK
+        assert resp.data["page"] == 1
 
 
 # ---------------------------------------------------------------------------

--- a/apps/web/app/(all)/[workspaceSlug]/runners/runs/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/runs/page.tsx
@@ -6,12 +6,12 @@
 
 import { useState } from "react";
 import { observer } from "mobx-react";
-import { useNavigate, useParams } from "react-router";
+import { useNavigate, useParams, useSearchParams } from "react-router";
 import useSWR from "swr";
 import { useTranslation } from "@pi-dash/i18n";
 import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
 import { RunnerService } from "@pi-dash/services";
-import type { IAgentRun, TAgentRunErrorSource, TAgentRunStatus } from "@pi-dash/types";
+import type { IAgentRun, IAgentRunPage, TAgentRunErrorSource, TAgentRunStatus } from "@pi-dash/types";
 import { AGENT_RUN_TERMINAL_STATUSES } from "@pi-dash/types";
 import type { TBadgeVariant } from "@pi-dash/ui";
 import { AlertModalCore, Badge, Button, Spinner } from "@pi-dash/ui";
@@ -86,14 +86,31 @@ export const RunnerRunsPage = observer(function RunnerRunsPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { workspaceSlug, runId } = useParams<{ workspaceSlug: string; runId?: string }>();
+  const [searchParams, setSearchParams] = useSearchParams();
   const workspaceId = currentWorkspace?.id;
   const selected = runId ?? null;
 
-  const { data: runs, mutate } = useSWR<IAgentRun[]>(
-    workspaceId ? ["runner-runs", workspaceId] : null,
-    () => service.listRuns(workspaceId),
+  // Current page comes from the URL (`?page=N`, 1-based) so a specific page is
+  // directly linkable; missing/invalid values fall back to page 1.
+  const parsedPage = Number.parseInt(searchParams.get("page") ?? "", 10);
+  const page = Number.isFinite(parsedPage) && parsedPage > 0 ? parsedPage : 1;
+
+  const { data: runsPage, mutate } = useSWR<IAgentRunPage>(
+    workspaceId ? ["runner-runs", workspaceId, page] : null,
+    () => service.listRuns(workspaceId, page),
     { refreshInterval: 5_000 }
   );
+
+  const runs = runsPage?.results;
+  const totalPages = runsPage?.total_pages ?? 1;
+  const totalCount = runsPage?.total_count ?? 0;
+
+  function goToPage(next: number) {
+    const params = new URLSearchParams(searchParams);
+    if (next <= 1) params.delete("page");
+    else params.set("page", String(next));
+    setSearchParams(params, { replace: true });
+  }
 
   const { data: detail, error: detailError } = useSWR<IAgentRun>(
     selected ? ["runner-run-detail", selected] : null,
@@ -109,7 +126,9 @@ export const RunnerRunsPage = observer(function RunnerRunsPage() {
 
   function selectRun(id: string) {
     if (!workspaceSlug) return;
-    navigate(`/${workspaceSlug}/runners/runs/${id}`, { replace: true });
+    // Preserve the `?page=` query so selecting a run doesn't reset pagination.
+    const search = searchParams.toString();
+    navigate(`/${workspaceSlug}/runners/runs/${id}${search ? `?${search}` : ""}`, { replace: true });
   }
 
   async function confirmCancel() {
@@ -140,42 +159,62 @@ export const RunnerRunsPage = observer(function RunnerRunsPage() {
       <PageHead title={pageTitle} />
       <RunnersTabs />
       <div className="grid min-h-0 flex-1 grid-cols-[400px_1fr] gap-4 overflow-hidden">
-        <div className="overflow-auto rounded-md border border-subtle">
-          <table className="w-full text-13">
-            <thead className="sticky top-0 z-10 bg-layer-1 text-left text-secondary">
-              <tr>
-                <th className="px-3 py-2">{t("Started")}</th>
-                <th className="px-3 py-2">{t("Status")}</th>
-                <th className="px-3 py-2">{t("Prompt")}</th>
-              </tr>
-            </thead>
-            <tbody>
-              {(runs ?? []).map((r) => (
-                <tr
-                  key={r.id}
-                  onClick={() => selectRun(r.id)}
-                  className={`cursor-pointer border-t border-subtle ${
-                    selected === r.id ? "bg-accent-subtle" : "hover:bg-layer-1"
-                  }`}
-                >
-                  <td className="px-3 py-2 whitespace-nowrap">{new Date(r.created_at).toLocaleString()}</td>
-                  <td className="px-3 py-2">
-                    <Badge variant={STATUS_BADGE_VARIANT[r.status]} size="sm">
-                      {t(RUN_STATUS_I18N_LABELS[r.status])}
-                    </Badge>
-                  </td>
-                  <td className="font-mono max-w-[180px] truncate px-3 py-2 text-11">{r.prompt}</td>
-                </tr>
-              ))}
-              {(runs ?? []).length === 0 && (
+        <div className="flex min-h-0 flex-col rounded-md border border-subtle">
+          <div className="min-h-0 flex-1 overflow-auto">
+            <table className="w-full text-13">
+              <thead className="sticky top-0 z-10 bg-layer-1 text-left text-secondary">
                 <tr>
-                  <td colSpan={3} className="px-3 py-8 text-center text-secondary">
-                    {t("No runs yet.")}
-                  </td>
+                  <th className="px-3 py-2">{t("Started")}</th>
+                  <th className="px-3 py-2">{t("Status")}</th>
+                  <th className="px-3 py-2">{t("Prompt")}</th>
                 </tr>
-              )}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {(runs ?? []).map((r) => (
+                  <tr
+                    key={r.id}
+                    onClick={() => selectRun(r.id)}
+                    className={`cursor-pointer border-t border-subtle ${
+                      selected === r.id ? "bg-accent-subtle" : "hover:bg-layer-1"
+                    }`}
+                  >
+                    <td className="px-3 py-2 whitespace-nowrap">{new Date(r.created_at).toLocaleString()}</td>
+                    <td className="px-3 py-2">
+                      <Badge variant={STATUS_BADGE_VARIANT[r.status]} size="sm">
+                        {t(RUN_STATUS_I18N_LABELS[r.status])}
+                      </Badge>
+                    </td>
+                    <td className="font-mono max-w-[180px] truncate px-3 py-2 text-11">{r.prompt}</td>
+                  </tr>
+                ))}
+                {(runs ?? []).length === 0 && (
+                  <tr>
+                    <td colSpan={3} className="px-3 py-8 text-center text-secondary">
+                      {t("No runs yet.")}
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+          {totalCount > 0 && (
+            <div className="flex items-center justify-between gap-2 border-t border-subtle bg-layer-1 px-3 py-2 text-11 text-secondary">
+              <span>{t("Page {page} of {total}", { page, total: totalPages })}</span>
+              <div className="flex items-center gap-2">
+                <Button variant="neutral-primary" size="sm" disabled={page <= 1} onClick={() => goToPage(page - 1)}>
+                  {t("Previous")}
+                </Button>
+                <Button
+                  variant="neutral-primary"
+                  size="sm"
+                  disabled={page >= totalPages}
+                  onClick={() => goToPage(page + 1)}
+                >
+                  {t("Next")}
+                </Button>
+              </div>
+            </div>
+          )}
         </div>
 
         <div className="overflow-auto rounded-md border border-subtle p-4">

--- a/packages/services/src/runner/runner.service.ts
+++ b/packages/services/src/runner/runner.service.ts
@@ -111,7 +111,7 @@ export class RunnerService extends APIService {
 
   /**
    * List agent runs one page at a time. ``page`` is 1-based; the server
-   * defaults to 50 items per page. Returns the paginated envelope so callers
+   * defaults to 30 items per page. Returns the paginated envelope so callers
    * can render page controls and only the requested page is loaded.
    */
   async listRuns(workspaceId?: string, page = 1, perPage?: number): Promise<IAgentRunPage> {

--- a/packages/services/src/runner/runner.service.ts
+++ b/packages/services/src/runner/runner.service.ts
@@ -7,6 +7,7 @@
 import { API_BASE_URL } from "@pi-dash/constants";
 import type {
   IAgentRun,
+  IAgentRunPage,
   IAgentChatApprovalRequest,
   IAgentChatMessage,
   IAgentChatSession,
@@ -108,9 +109,16 @@ export class RunnerService extends APIService {
       });
   }
 
-  async listRuns(workspaceId?: string): Promise<IAgentRun[]> {
-    const params = workspaceId ? { params: { workspace: workspaceId } } : {};
-    return this.get("/api/runners/runs/", params)
+  /**
+   * List agent runs one page at a time. ``page`` is 1-based; the server
+   * defaults to 50 items per page. Returns the paginated envelope so callers
+   * can render page controls and only the requested page is loaded.
+   */
+  async listRuns(workspaceId?: string, page = 1, perPage?: number): Promise<IAgentRunPage> {
+    const params: Record<string, string | number> = { page };
+    if (workspaceId) params.workspace = workspaceId;
+    if (perPage !== undefined) params.per_page = perPage;
+    return this.get("/api/runners/runs/", { params })
       .then((r) => r?.data)
       .catch((e) => {
         throw e?.response?.data;

--- a/packages/types/src/runner.ts
+++ b/packages/types/src/runner.ts
@@ -164,6 +164,20 @@ export interface IAgentRun {
   events?: IAgentRunEvent[];
 }
 
+/** One page of agent runs from `GET /api/runners/runs/`. */
+export interface IAgentRunPage {
+  results: IAgentRun[];
+  /** Number of items on this page. */
+  count: number;
+  /** Total items across all pages. */
+  total_count: number;
+  /** Total number of pages (at least 1, even when empty). */
+  total_pages: number;
+  /** Current 1-based page. */
+  page: number;
+  per_page: number;
+}
+
 export type TApprovalKind = "command_execution" | "file_change" | "network_access" | "other";
 export type TApprovalDecision = "accept" | "decline" | "accept_for_session";
 export type TApprovalStatus = "pending" | "accepted" | "declined" | "expired";


### PR DESCRIPTION
## What & why

The runner runs view (`/:workspaceSlug/runners/runs`) loaded **every** run on each 5s poll (server capped the list at a flat 200, the client rendered all of them), so load time grew as the run count grew. This paginates the list: **30 per page**, only the **first page** loads by default, and the **current page is reflected in the URL** so a specific page is directly linkable.

Resolves PDASHOSS01-31.

## Changes

- **API** (`apps/api/pi_dash/runner/views/runs.py`): `AgentRunListEndpoint.get` now returns a page envelope `{results, count, total_count, total_pages, page, per_page}`. `page` is 1-based; `per_page` defaults to 30 and is capped at 200. Invalid/non-positive `page` falls back to 1; an out-of-range page returns empty `results` with the real `total_pages` so the UI can recover. Workspace scoping and the "involved with" filter are unchanged.
- **types** (`packages/types/src/runner.ts`): add `IAgentRunPage`.
- **services** (`packages/services/src/runner/runner.service.ts`): `RunnerService.listRuns(workspaceId, page = 1, perPage?)` now returns the envelope.
- **web** (`.../runners/runs/page.tsx`): reads/writes `?page=` via react-router `useSearchParams`, keys SWR by page (so polling only refetches the current page), renders `Previous`/`Next` + "Page X of Y", and preserves `?page=` when a run is selected.

## Testing

- `apps/api`: 35 pass in `test_runs_views.py`, including 5 new pagination tests (default first page of 30, second-page remainder with no overlap, out-of-range → empty with real totals, `per_page` cap, invalid `page` → 1). Existing list tests updated to read `results`.
- Repo: `pnpm check:types` and `pnpm check:lint` green (0 errors); oxfmt + ruff format clean.

## Notes

- Chose page-number pagination over the cursor-based `BasePaginator` (which the runner module doesn't use) for clean, directly-linkable `?page=N` URLs, matching the issue's "visit a specific page by URL" requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)