### PR TITLE
PDASHOSS01-42 Is AgentRun card reflecting the manual trigger run and comment and run?

### DIFF
--- a/apps/web/core/components/issues/issue-detail-widgets/action-buttons.tsx
+++ b/apps/web/core/components/issues/issue-detail-widgets/action-buttons.tsx
@@ -93,7 +93,7 @@ export function IssueDetailWidgetActionButtons(props: Props) {
           issueServiceType={issueServiceType}
         />
       )}
-      <RunAIActionButton workspaceSlug={workspaceSlug} issueId={issueId} disabled={disabled} />
+      <RunAIActionButton workspaceSlug={workspaceSlug} projectId={projectId} issueId={issueId} disabled={disabled} />
       <WorkItemAdditionalWidgetActionButtons
         disabled={disabled}
         hideWidgets={hideWidgets ?? []}

--- a/apps/web/core/components/issues/issue-detail-widgets/run-ai/comment-and-run-button.tsx
+++ b/apps/web/core/components/issues/issue-detail-widgets/run-ai/comment-and-run-button.tsx
@@ -16,6 +16,7 @@ import { useCreateAgentRun } from "./use-create-agent-run";
 
 type Props = {
   workspaceSlug: string;
+  projectId: string;
   issueId: string;
   /** Posts the comment currently typed in the composer and returns it (or
    * ``undefined`` when empty / on failure). Supplied by ``CommentCreate`` via
@@ -33,7 +34,7 @@ type Props = {
 };
 
 export const CommentAndRunActionButton = observer(function CommentAndRunActionButton(props: Props) {
-  const { workspaceSlug, issueId, submitComment, disabled = false, size = "lg", className } = props;
+  const { workspaceSlug, projectId, issueId, submitComment, disabled = false, size = "lg", className } = props;
   const { t } = useTranslation();
   const { triggerRun, isSubmitting: isRunning } = useCreateAgentRun();
 
@@ -44,7 +45,7 @@ export const CommentAndRunActionButton = observer(function CommentAndRunActionBu
     // immediately dispatch the run. No second dialog.
     const comment = await submitComment();
     if (!comment) return;
-    await triggerRun({ workspaceSlug, issueId, mode: "comment_and_run" });
+    await triggerRun({ workspaceSlug, projectId, issueId, mode: "comment_and_run" });
   };
 
   return (

--- a/apps/web/core/components/issues/issue-detail-widgets/run-ai/run-ai-button.tsx
+++ b/apps/web/core/components/issues/issue-detail-widgets/run-ai/run-ai-button.tsx
@@ -17,12 +17,13 @@ import { useCreateAgentRun } from "./use-create-agent-run";
 
 type Props = {
   workspaceSlug: string;
+  projectId: string;
   issueId: string;
   disabled?: boolean;
 };
 
 export const RunAIActionButton = observer(function RunAIActionButton(props: Props) {
-  const { workspaceSlug, issueId, disabled = false } = props;
+  const { workspaceSlug, projectId, issueId, disabled = false } = props;
   const { t } = useTranslation();
   const { isMobile } = usePlatformOS();
   const { triggerRun, isSubmitting } = useCreateAgentRun();
@@ -30,7 +31,7 @@ export const RunAIActionButton = observer(function RunAIActionButton(props: Prop
   const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     e.stopPropagation();
-    triggerRun({ workspaceSlug, issueId, mode: "run_ai" });
+    triggerRun({ workspaceSlug, projectId, issueId, mode: "run_ai" });
   };
 
   return (

--- a/apps/web/core/components/issues/issue-detail-widgets/run-ai/use-create-agent-run.ts
+++ b/apps/web/core/components/issues/issue-detail-widgets/run-ai/use-create-agent-run.ts
@@ -8,6 +8,7 @@ import { useCallback, useState } from "react";
 import { useTranslation } from "@pi-dash/i18n";
 import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
 // hooks
+import { useIssueDetail } from "@/hooks/store/use-issue-detail";
 import { useWorkspace } from "@/hooks/store/use-workspace";
 // services
 import { AgentRunService } from "@/services/runner";
@@ -16,6 +17,7 @@ const agentRunService = new AgentRunService();
 
 type CreateRunArgs = {
   workspaceSlug: string;
+  projectId: string;
   issueId: string;
   /** Selects the dispatch path. Both modes have the prompt rendered
    * server-side from the issue's phase template (``coding-task`` for
@@ -29,11 +31,12 @@ type CreateRunArgs = {
 
 export function useCreateAgentRun() {
   const workspaceStore = useWorkspace();
+  const { fetchIssue } = useIssueDetail();
   const { t } = useTranslation();
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const triggerRun = useCallback(
-    async ({ workspaceSlug, issueId, mode }: CreateRunArgs) => {
+    async ({ workspaceSlug, projectId, issueId, mode }: CreateRunArgs) => {
       const workspace = workspaceStore.getWorkspaceBySlug(workspaceSlug);
       if (!workspace?.id) {
         setToast({
@@ -61,6 +64,15 @@ export function useCreateAgentRun() {
           title: t("Agent run started"),
           message: t("The AI agent will pick up this work item shortly."),
         });
+        // Re-fetch the issue so the AgentRun status card reflects the run we
+        // just started (it lands as ``queued`` — an active status — which also
+        // kicks off the card's live poller). Best-effort: a refresh failure
+        // must not turn the successful trigger into an error.
+        try {
+          await fetchIssue(workspaceSlug, projectId, issueId);
+        } catch {
+          // ignore — the card will catch up on its next scheduled refresh
+        }
         return run;
       } catch (error: unknown) {
         const message = (error as { error?: string })?.error ?? t("Could not start the agent run. Please try again.");
@@ -74,7 +86,7 @@ export function useCreateAgentRun() {
         setIsSubmitting(false);
       }
     },
-    [workspaceStore, t]
+    [workspaceStore, fetchIssue, t]
   );
 
   return { triggerRun, isSubmitting };

--- a/apps/web/core/components/issues/issue-detail/issue-activity/root.tsx
+++ b/apps/web/core/components/issues/issue-detail/issue-activity/root.tsx
@@ -106,6 +106,7 @@ export const IssueActivity = observer(function IssueActivity(props: TIssueActivi
         extraToolbarActions={({ isEmpty, isSubmitting, submitComment }) => (
           <CommentAndRunActionButton
             workspaceSlug={workspaceSlug}
+            projectId={projectId}
             issueId={issueId}
             submitComment={submitComment}
             disabled={disabled || isEmpty || isSubmitting}


### PR DESCRIPTION
## What & why

Issue PDASHOSS01-42: manually triggering a run via **Run AI** or **Comment & Run** did not update the AgentRun status card on the issue detail page — the run only showed up after a manual reload.

### Root cause

The backend was never the problem. Both buttons `POST /api/runners/runs/` → `scheduling.dispatch_run_ai_run` / `dispatch_continuation_run`, which create a full `AgentRun` row, and the card's serializer (`IssueDetailSerializer.get_agent_status`) queries **all** runs on the issue with no trigger filter. The data is there.

The gap is purely frontend:

- After `triggerRun` succeeds, nothing re-fetched the issue, so the store's `issue.agent_status` stayed stale.
- `IssueAgentStatusPanel`'s 15s live poller only starts once `agent_status.active_run` is already an active status in local state — which never became true without a refresh.

So the newly-created run stayed invisible until the user reloaded the page.

### Fix

Re-fetch the issue detail after a successful trigger. The new run lands as `queued` (an `ACTIVE_RUN_STATUS`), so the card renders it immediately and the poller starts tracking it to completion. `projectId` is threaded through the two trigger buttons so the shared `useCreateAgentRun` hook can call `fetchIssue`. The re-fetch is best-effort — a refresh failure won't turn a successful trigger into an error toast; the card catches up on its next scheduled refresh.

### Files

- `use-create-agent-run.ts` — accept `projectId`, `fetchIssue` after success
- `run-ai-button.tsx`, `action-buttons.tsx` — thread `projectId`
- `comment-and-run-button.tsx`, `issue-activity/root.tsx` — thread `projectId`

## Validation

- `pnpm turbo run check:types --filter=web` — passes
- `pnpm turbo run check:lint --filter=web` — 0 errors
- Reasoning trace of the refresh path (no runner available in-session for a live UI test). Suggested manual check: trigger a run on an idle issue and confirm the card flips to "Working"/"Queued" without reloading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
