### PR TITLE
PDASHOSS01-39 allow re-ticking for "in progress", "in review" state

### DIFF
--- a/apps/api/pi_dash/api/urls/work_item.py
+++ b/apps/api/pi_dash/api/urls/work_item.py
@@ -12,6 +12,7 @@ from pi_dash.api.views import (
     IssueListCreateAPIEndpoint,
     IssueDetailAPIEndpoint,
     IssueMoveAPIEndpoint,
+    IssueReTickAPIEndpoint,
     IssueLinkListCreateAPIEndpoint,
     IssueLinkDetailAPIEndpoint,
     IssueCommentListCreateAPIEndpoint,
@@ -122,6 +123,11 @@ new_url_patterns = [
         "workspaces/<str:slug>/projects/<str:project_id>/work-items/<uuid:pk>/move/",
         IssueMoveAPIEndpoint.as_view(http_method_names=["post"]),
         name="work-item-move",
+    ),
+    path(
+        "workspaces/<str:slug>/projects/<str:project_id>/work-items/<uuid:pk>/re-tick/",
+        IssueReTickAPIEndpoint.as_view(http_method_names=["post"]),
+        name="work-item-re-tick",
     ),
     path(
         "workspaces/<str:slug>/projects/<str:project_id>/work-items/<uuid:issue_id>/links/",

--- a/apps/api/pi_dash/api/views/__init__.py
+++ b/apps/api/pi_dash/api/views/__init__.py
@@ -19,6 +19,7 @@ from .issue import (
     IssueListCreateAPIEndpoint,
     IssueDetailAPIEndpoint,
     IssueMoveAPIEndpoint,
+    IssueReTickAPIEndpoint,
     LabelListCreateAPIEndpoint,
     LabelDetailAPIEndpoint,
     IssueLinkListCreateAPIEndpoint,

--- a/apps/api/pi_dash/api/views/issue.py
+++ b/apps/api/pi_dash/api/views/issue.py
@@ -1022,6 +1022,47 @@ class IssueMoveAPIEndpoint(BaseAPIView):
         return Response(IssueSerializer(issue).data, status=status.HTTP_200_OK)
 
 
+class IssueReTickAPIEndpoint(BaseAPIView):
+    """Re-grant a fresh tick budget to an exhausted issue ticker.
+
+    The CLI-facing sibling of the web ``AgentReTickEndpoint``. Grants an
+    extra phase-sized budget and re-arms the ticker **only** when the
+    issue is still in a ticking state (In Progress / In Review) and the
+    current budget is exhausted; otherwise it is a no-op that reports
+    ``granted = false`` with a machine-readable ``reason``. See
+    ``pi_dash.orchestration.scheduling.re_tick_ticker`` for the rules.
+    """
+
+    model = Issue
+    permission_classes = [ProjectEntityPermission]
+
+    def post(self, request, slug, project_id, pk):
+        from pi_dash.orchestration import scheduling
+
+        issue = (
+            Issue.objects.select_related("project", "workspace", "state")
+            .filter(workspace__slug=slug, project_id=project_id, pk=pk)
+            .first()
+        )
+        if issue is None:
+            return Response({"error": "Work item not found"}, status=status.HTTP_404_NOT_FOUND)
+
+        result = scheduling.re_tick_ticker(issue)
+        ticker = result["ticker"]
+        payload = {
+            "granted": result["granted"],
+            "reason": result["reason"],
+        }
+        if ticker is not None:
+            payload["tick_count"] = ticker.tick_count
+            payload["max_ticks"] = ticker.effective_max_ticks()
+            payload["enabled"] = ticker.enabled
+            payload["next_run_at"] = (
+                ticker.next_run_at.isoformat() if ticker.next_run_at else None
+            )
+        return Response(payload, status=status.HTTP_200_OK)
+
+
 class LabelListCreateAPIEndpoint(BaseAPIView):
     """Label List and Create Endpoint"""
 

--- a/apps/api/pi_dash/api/views/issue.py
+++ b/apps/api/pi_dash/api/views/issue.py
@@ -8,7 +8,7 @@ import uuid
 
 # Django imports
 from django.core.serializers.json import DjangoJSONEncoder
-from django.http import Http404, HttpResponseRedirect
+from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.dateparse import parse_datetime
 from django.db import IntegrityError, connection, transaction

--- a/apps/api/pi_dash/app/serializers/issue.py
+++ b/apps/api/pi_dash/app/serializers/issue.py
@@ -1175,6 +1175,16 @@ class IssueDetailSerializer(IssueSerializer):
 
         if ticker is None:
             return None
+        # ``can_re_tick`` is the single source of truth for the "re-tick"
+        # affordance: true only when a fresh budget grant would actually do
+        # something — the issue is still in a ticking state AND the current
+        # budget is exhausted. Mirrors the guardrails in
+        # ``scheduling.re_tick_ticker`` so the button never appears when the
+        # server would no-op (e.g. a cap-hit issue already auto-paused out
+        # of a ticking state).
+        from pi_dash.orchestration.agent_phases import is_ticking_state
+
+        can_re_tick = is_ticking_state(obj.state) and ticker.cap_reached()
         return {
             "enabled": ticker.enabled,
             "user_disabled": ticker.user_disabled,
@@ -1184,6 +1194,7 @@ class IssueDetailSerializer(IssueSerializer):
             "next_run_at": ticker.next_run_at.isoformat() if ticker.next_run_at else None,
             "last_tick_at": ticker.last_tick_at.isoformat() if ticker.last_tick_at else None,
             "disarm_reason": ticker.disarm_reason,
+            "can_re_tick": can_re_tick,
         }
 
     def _serialize_agent_live_state(self, state):

--- a/apps/api/pi_dash/app/serializers/issue.py
+++ b/apps/api/pi_dash/app/serializers/issue.py
@@ -81,7 +81,10 @@ def _comment_is_actively_synced(comment) -> bool:
         return False
     from pi_dash.db.models import GitCommentSync, GithubCommentSync
 
-    return GitCommentSync.objects.filter(comment=comment).exists() or GithubCommentSync.objects.filter(comment=comment).exists()
+    return (
+        GitCommentSync.objects.filter(comment=comment).exists()
+        or GithubCommentSync.objects.filter(comment=comment).exists()
+    )
 
 
 class IssueFlatSerializer(BaseSerializer):

--- a/apps/api/pi_dash/orchestration/scheduling.py
+++ b/apps/api/pi_dash/orchestration/scheduling.py
@@ -391,7 +391,7 @@ def re_tick_ticker(issue: Issue) -> dict:
         # transition out of a ticking state (e.g. to Done) could race the
         # re-arm and leave the ticker enabled for a non-ticking issue.
         locked_issue = (
-            Issue.all_objects.select_for_update()
+            Issue.all_objects.select_for_update(of=("self",))
             .select_related("state", "project")
             .filter(pk=issue.pk)
             .first()

--- a/apps/api/pi_dash/orchestration/scheduling.py
+++ b/apps/api/pi_dash/orchestration/scheduling.py
@@ -385,19 +385,37 @@ def re_tick_ticker(issue: Issue) -> dict:
     cap-hit pause (§6.1 / §4.4.1).
     """
     with transaction.atomic():
+        # Re-fetch and lock the issue inside the transaction so the state
+        # guard below sees the latest committed state, not a possibly-stale
+        # instance handed in by the caller. Without this, a concurrent
+        # transition out of a ticking state (e.g. to Done) could race the
+        # re-arm and leave the ticker enabled for a non-ticking issue.
+        locked_issue = (
+            Issue.all_objects.select_for_update()
+            .select_related("state", "project")
+            .filter(pk=issue.pk)
+            .first()
+        )
+        if locked_issue is None:
+            return {"granted": False, "reason": "no_issue", "ticker": None}
+
         sched = (
             IssueAgentTicker.objects.select_for_update()
-            .filter(issue=issue)
+            .filter(issue=locked_issue)
             .first()
         )
         if sched is None:
             return {"granted": False, "reason": "no_ticker", "ticker": None}
-        if not is_ticking_state(issue.state):
+        # Bind the freshly-locked issue so phase-aware methods
+        # (``_is_review_phase``/``effective_max_ticks``) resolve against the
+        # current state rather than lazy-loading a fresh copy.
+        sched.issue = locked_issue
+        if not is_ticking_state(locked_issue.state):
             return {"granted": False, "reason": "not_ticking_state", "ticker": sched}
         if not sched.cap_reached():
             return {"granted": False, "reason": "budget_not_exhausted", "ticker": sched}
 
-        grant = _project_default_max_ticks(issue)
+        grant = _project_default_max_ticks(locked_issue)
         review = sched._is_review_phase()
         new_cap = sched.effective_max_ticks() + grant
         if review:
@@ -407,7 +425,7 @@ def re_tick_ticker(issue: Issue) -> dict:
 
         # Re-arm: clear the disarm cause and restart the clock unless the
         # user disabled ticking on this issue or the project suppresses it.
-        suppress = sched.user_disabled or not _project_ticking_enabled(issue)
+        suppress = sched.user_disabled or not _project_ticking_enabled(locked_issue)
         sched.enabled = not suppress
         sched.disarm_reason = TickerDisarmReason.NONE
         sched.next_run_at = _compute_next_run_at(sched.effective_interval_seconds())
@@ -422,7 +440,7 @@ def re_tick_ticker(issue: Issue) -> dict:
         )
     logger.info(
         "agent_ticker: re-ticked issue=%s new_cap=%s enabled=%s next_run_at=%s",
-        issue.pk,
+        locked_issue.pk,
         new_cap,
         sched.enabled,
         sched.next_run_at,

--- a/apps/api/pi_dash/orchestration/scheduling.py
+++ b/apps/api/pi_dash/orchestration/scheduling.py
@@ -349,6 +349,87 @@ def reset_ticker_after_comment_and_run(issue: Issue) -> Optional[IssueAgentTicke
     return sched
 
 
+def re_tick_ticker(issue: Issue) -> dict:
+    """Grant a fresh phase-sized tick budget to an exhausted ticker and re-arm.
+
+    Manual "re-ticking". When a ticker has burned through its budget
+    (``cap_reached()``) while the issue is still in a ticking state
+    (In Progress / In Review), the user can re-grant budget so the
+    continuation clock resumes. Unlike
+    :func:`reset_ticker_after_comment_and_run` (which zeroes
+    ``tick_count``), re-ticking **grows** the cap by one fresh phase
+    budget and leaves ``tick_count`` intact — the issue detail card keeps
+    showing cumulative progress ("Tick 24 of 48") rather than resetting to
+    "Tick 0 of 24".
+
+    The grant amount is the project default for the issue's *current*
+    phase (In Progress vs In Review), so re-ticking In Review re-grants the
+    In-Review budget and re-ticking In Progress re-grants the In-Progress
+    budget. Because ``tick_count == effective_max_ticks()`` at exhaustion,
+    ``new_cap = effective_max_ticks() + grant`` yields exactly ``grant``
+    fresh ticks. Using the phase's *project default* as the grant unit
+    keeps repeated re-ticks granting a stable amount even though the grant
+    is persisted by bumping the phase cap override.
+
+    Returns ``{"granted": bool, "reason": str, "ticker": IssueAgentTicker|None}``.
+    All three guardrails below must hold or the call is a no-op with
+    ``granted = False`` and no mutation:
+
+    * a ticker row exists (``reason = "no_ticker"``),
+    * the issue is currently in a ticking state (``reason =
+      "not_ticking_state"``),
+    * the budget is actually exhausted (``reason =
+      "budget_not_exhausted"``).
+
+    ``select_for_update`` serializes against ``fire_tick`` and the deferred
+    cap-hit pause (§6.1 / §4.4.1).
+    """
+    with transaction.atomic():
+        sched = (
+            IssueAgentTicker.objects.select_for_update()
+            .filter(issue=issue)
+            .first()
+        )
+        if sched is None:
+            return {"granted": False, "reason": "no_ticker", "ticker": None}
+        if not is_ticking_state(issue.state):
+            return {"granted": False, "reason": "not_ticking_state", "ticker": sched}
+        if not sched.cap_reached():
+            return {"granted": False, "reason": "budget_not_exhausted", "ticker": sched}
+
+        grant = _project_default_max_ticks(issue)
+        review = sched._is_review_phase()
+        new_cap = sched.effective_max_ticks() + grant
+        if review:
+            sched.review_max_ticks = new_cap
+        else:
+            sched.max_ticks = new_cap
+
+        # Re-arm: clear the disarm cause and restart the clock unless the
+        # user disabled ticking on this issue or the project suppresses it.
+        suppress = sched.user_disabled or not _project_ticking_enabled(issue)
+        sched.enabled = not suppress
+        sched.disarm_reason = TickerDisarmReason.NONE
+        sched.next_run_at = _compute_next_run_at(sched.effective_interval_seconds())
+        sched.save(
+            update_fields=[
+                "review_max_ticks" if review else "max_ticks",
+                "enabled",
+                "disarm_reason",
+                "next_run_at",
+                "updated_at",
+            ]
+        )
+    logger.info(
+        "agent_ticker: re-ticked issue=%s new_cap=%s enabled=%s next_run_at=%s",
+        issue.pk,
+        new_cap,
+        sched.enabled,
+        sched.next_run_at,
+    )
+    return {"granted": True, "reason": "granted", "ticker": sched}
+
+
 # ---------------------------------------------------------------------------
 # Continuation dispatch
 # ---------------------------------------------------------------------------

--- a/apps/api/pi_dash/runner/views/__init__.py
+++ b/apps/api/pi_dash/runner/views/__init__.py
@@ -58,6 +58,7 @@ from .runners import (
     RunnerRevokeEndpoint,
 )
 from .runs import (
+    AgentReTickEndpoint,
     AgentRunCancelEndpoint,
     AgentRunDetailEndpoint,
     AgentRunListEndpoint,
@@ -107,6 +108,7 @@ __all__ = [
     "DevMachineRotateEndpoint",
     "RunnerDetailEndpoint",
     "RunnerListEndpoint",
+    "AgentReTickEndpoint",
     "AgentRunCancelEndpoint",
     "AgentRunDetailEndpoint",
     "AgentRunListEndpoint",

--- a/apps/api/pi_dash/runner/views/runs.py
+++ b/apps/api/pi_dash/runner/views/runs.py
@@ -272,6 +272,8 @@ class AgentReTickEndpoint(APIView):
     permission_classes = [IsAuthenticated]
 
     def post(self, request):
+        import uuid
+
         from pi_dash.db.models.issue import Issue
         from pi_dash.orchestration import scheduling
 
@@ -279,6 +281,15 @@ class AgentReTickEndpoint(APIView):
         if not work_item_id:
             return Response(
                 {"error": "work_item is required for re-tick"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        try:
+            uuid.UUID(str(work_item_id))
+        except (ValueError, TypeError):
+            # A malformed value would make the ``pk=`` lookup raise Django's
+            # ValidationError (an unhandled 500) — return a clean 400 instead.
+            return Response(
+                {"error": "invalid work_item UUID format"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
         issue = Issue.all_objects.filter(pk=work_item_id).first()

--- a/apps/api/pi_dash/runner/views/runs.py
+++ b/apps/api/pi_dash/runner/views/runs.py
@@ -258,6 +258,51 @@ class AgentRunListEndpoint(APIView):
         )
 
 
+class AgentReTickEndpoint(APIView):
+    """Re-grant a fresh tick budget to an exhausted issue ticker.
+
+    Manual "re-ticking" from the issue detail AgentRun card. Body must
+    include ``work_item`` (issue id). Grants an extra phase-sized budget
+    and re-arms the ticker **only** when the issue is still in a ticking
+    state and the current budget is exhausted; otherwise it is a no-op.
+    See ``scheduling.re_tick_ticker`` for the exact rules.
+    """
+
+    authentication_classes = [BaseSessionAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request):
+        from pi_dash.db.models.issue import Issue
+        from pi_dash.orchestration import scheduling
+
+        work_item_id = request.data.get("work_item")
+        if not work_item_id:
+            return Response(
+                {"error": "work_item is required for re-tick"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        issue = Issue.all_objects.filter(pk=work_item_id).first()
+        if issue is None:
+            return Response({"error": "issue not found"}, status=status.HTTP_404_NOT_FOUND)
+        if not is_workspace_member(request.user, issue.workspace_id):
+            return Response({"error": "issue not found"}, status=status.HTTP_404_NOT_FOUND)
+
+        result = scheduling.re_tick_ticker(issue)
+        ticker = result["ticker"]
+        payload = {
+            "granted": result["granted"],
+            "reason": result["reason"],
+        }
+        if ticker is not None:
+            payload["tick_count"] = ticker.tick_count
+            payload["max_ticks"] = ticker.effective_max_ticks()
+            payload["enabled"] = ticker.enabled
+            payload["next_run_at"] = (
+                ticker.next_run_at.isoformat() if ticker.next_run_at else None
+            )
+        return Response(payload, status=status.HTTP_200_OK)
+
+
 class AgentRunDetailEndpoint(APIView):
     authentication_classes = [BaseSessionAuthentication]
     permission_classes = [IsAuthenticated]

--- a/apps/api/pi_dash/runner/web_urls.py
+++ b/apps/api/pi_dash/runner/web_urls.py
@@ -15,6 +15,7 @@ from pi_dash.runner.views import (
     AgentChatSessionDetailEndpoint,
     AgentChatSessionListEndpoint,
     AgentChatWarmEndpoint,
+    AgentReTickEndpoint,
     AgentRunCancelEndpoint,
     AgentRunDetailEndpoint,
     AgentRunListEndpoint,
@@ -88,6 +89,7 @@ urlpatterns = [
     path("projects/", ProjectListEndpoint.as_view(), name="project-list"),
     # Runs
     path("runs/", AgentRunListEndpoint.as_view(), name="runner-runs"),
+    path("re-tick/", AgentReTickEndpoint.as_view(), name="runner-re-tick"),
     path(
         "runs/<uuid:run_id>/",
         AgentRunDetailEndpoint.as_view(),

--- a/apps/api/pi_dash/tests/unit/orchestration/test_scheduling.py
+++ b/apps/api/pi_dash/tests/unit/orchestration/test_scheduling.py
@@ -570,3 +570,99 @@ def test_disarm_ticker_persists_reason(seeded, issue, states):
     out = scheduling.disarm_ticker(issue, reason=TickerDisarmReason.CAP_HIT)
     assert out.enabled is False
     assert out.disarm_reason == TickerDisarmReason.CAP_HIT
+
+
+# ---------------------------------------------------------------------------
+# re_tick_ticker
+# ---------------------------------------------------------------------------
+
+
+def _exhaust(sched, cap):
+    """Drive a ticker to its cap so ``cap_reached()`` is true, mirroring the
+    disarmed state ``fire_tick`` leaves behind on the final tick."""
+    sched.tick_count = cap
+    sched.enabled = False
+    sched.disarm_reason = TickerDisarmReason.CAP_HIT
+    sched.save(update_fields=["tick_count", "enabled", "disarm_reason"])
+
+
+@pytest.mark.unit
+def test_re_tick_grants_extra_budget_when_exhausted(seeded, issue, states):
+    _to_in_progress(issue, states)
+    sched = scheduling.arm_ticker(issue)
+    cap = sched.effective_max_ticks()  # project default (24) for In Progress
+    _exhaust(sched, cap)
+
+    result = scheduling.re_tick_ticker(issue)
+
+    assert result["granted"] is True
+    assert result["reason"] == "granted"
+    ticker = result["ticker"]
+    # Cap grows by one fresh phase budget; tick_count is NOT reset.
+    assert ticker.effective_max_ticks() == cap * 2
+    assert ticker.tick_count == cap
+    assert ticker.cap_reached() is False
+    # Re-armed: enabled, clock restarted, disarm cause cleared.
+    assert ticker.enabled is True
+    assert ticker.disarm_reason == TickerDisarmReason.NONE
+    assert ticker.next_run_at > timezone.now()
+
+
+@pytest.mark.unit
+def test_re_tick_noop_when_budget_not_exhausted(seeded, issue, states):
+    _to_in_progress(issue, states)
+    sched = scheduling.arm_ticker(issue)
+    sched.tick_count = 1  # well under the cap
+    sched.save(update_fields=["tick_count"])
+    before = sched.effective_max_ticks()
+
+    result = scheduling.re_tick_ticker(issue)
+
+    assert result["granted"] is False
+    assert result["reason"] == "budget_not_exhausted"
+    sched.refresh_from_db()
+    assert sched.effective_max_ticks() == before  # unchanged
+    assert sched.tick_count == 1
+
+
+@pytest.mark.unit
+def test_re_tick_noop_when_not_ticking_state(seeded, issue, states):
+    # Issue stays in Todo (not a ticking state) but has an exhausted ticker.
+    sched = scheduling.arm_ticker(issue)
+    _exhaust(sched, sched.effective_max_ticks())
+    before = sched.effective_max_ticks()
+
+    result = scheduling.re_tick_ticker(issue)
+
+    assert result["granted"] is False
+    assert result["reason"] == "not_ticking_state"
+    sched.refresh_from_db()
+    assert sched.effective_max_ticks() == before
+    assert sched.enabled is False  # not re-armed
+
+
+@pytest.mark.unit
+def test_re_tick_noop_when_no_ticker(seeded, issue, states):
+    _to_in_progress(issue, states)
+    result = scheduling.re_tick_ticker(issue)
+    assert result["granted"] is False
+    assert result["reason"] == "no_ticker"
+    assert result["ticker"] is None
+
+
+@pytest.mark.unit
+def test_re_tick_respects_user_disabled(seeded, issue, states):
+    _to_in_progress(issue, states)
+    sched = scheduling.arm_ticker(issue)
+    cap = sched.effective_max_ticks()
+    _exhaust(sched, cap)
+    sched.user_disabled = True
+    sched.save(update_fields=["user_disabled"])
+
+    result = scheduling.re_tick_ticker(issue)
+
+    # Budget is still granted, but ticking stays disabled per user's choice.
+    assert result["granted"] is True
+    ticker = result["ticker"]
+    assert ticker.effective_max_ticks() == cap * 2
+    assert ticker.enabled is False

--- a/apps/web/core/components/issues/issue-detail/agent-status.tsx
+++ b/apps/web/core/components/issues/issue-detail/agent-status.tsx
@@ -4,17 +4,19 @@
  * See the LICENSE file for details.
  */
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import type { LucideIcon } from "lucide-react";
-import { CircleAlert, CircleCheck, CirclePause, Clock3, LoaderCircle } from "lucide-react";
+import { CircleAlert, CircleCheck, CirclePause, Clock3, LoaderCircle, RotateCw } from "lucide-react";
 import { useTranslation } from "@pi-dash/i18n";
 // pi dash imports
 import { Badge } from "@pi-dash/propel/badge";
 import type { TBadgeVariant } from "@pi-dash/propel/badge";
+import { Button } from "@pi-dash/propel/button";
 import type { TAgentRunStatus, TIssue, TIssueAgentRunSummary, TIssueAgentTicker } from "@pi-dash/types";
 import { cn } from "@pi-dash/utils";
 // local imports
 import type { TIssueOperations } from "./root";
+import { useReTick } from "./use-re-tick";
 
 type TranslationFn = ReturnType<typeof useTranslation>["t"];
 
@@ -334,6 +336,15 @@ export function IssueAgentStatusPanel({ workspaceSlug, projectId, issueId, issue
   const activeRunStatus = activeRun?.status;
   const hasActiveAgentRun = Boolean(activeRunStatus && ACTIVE_RUN_STATUSES.has(activeRunStatus));
   const view = useMemo(() => getAgentStatusView(issue, now, t), [issue, now, t]);
+  const canReTick = Boolean(ticker?.can_re_tick);
+  const { reTick, isSubmitting: isReTicking } = useReTick();
+
+  const handleReTick = useCallback(async () => {
+    const result = await reTick(issueId);
+    // Refresh the card so the new budget / re-armed schedule shows even
+    // when the grant was a no-op (state may have drifted since load).
+    if (result) void issueOperations.fetch(workspaceSlug, projectId, issueId);
+  }, [reTick, issueId, issueOperations, workspaceSlug, projectId]);
 
   useEffect(() => {
     const timer = window.setInterval(() => setNow(Date.now()), 60_000);
@@ -402,6 +413,25 @@ export function IssueAgentStatusPanel({ workspaceSlug, projectId, issueId, issue
               <span className="text-primary">{tickBudget}</span>
             </div>
           ) : null}
+        </div>
+      )}
+
+      {canReTick && (
+        <div className="mt-3 flex flex-col gap-1.5">
+          <Button
+            variant="secondary"
+            size="base"
+            onClick={handleReTick}
+            disabled={isReTicking}
+            loading={isReTicking}
+            className="w-full"
+          >
+            <RotateCw className="size-3.5 flex-shrink-0" />
+            <span className="text-body-xs-medium">{t("Re-tick")}</span>
+          </Button>
+          <p className="text-caption-sm-regular text-tertiary">
+            {t("Grant a fresh ticking budget so the AI agent resumes on its schedule.")}
+          </p>
         </div>
       )}
     </section>

--- a/apps/web/core/components/issues/issue-detail/use-re-tick.ts
+++ b/apps/web/core/components/issues/issue-detail/use-re-tick.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useCallback, useState } from "react";
+import { useTranslation } from "@pi-dash/i18n";
+import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
+// services
+import { AgentRunService } from "@/services/runner";
+import type { TReTickResponse } from "@/services/runner";
+
+const agentRunService = new AgentRunService();
+
+/**
+ * Drives the "re-tick" affordance on the issue AgentRun card: re-grants a
+ * fresh ticking budget to an exhausted issue ticker so the periodic agent
+ * runs resume. The server enforces the guardrails (ticking state +
+ * exhausted budget); a ``granted: false`` response is a normal outcome, not
+ * an error, so we surface it as an informational toast rather than a
+ * failure.
+ */
+export function useReTick() {
+  const { t } = useTranslation();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const reTick = useCallback(
+    async (issueId: string): Promise<TReTickResponse | null> => {
+      setIsSubmitting(true);
+      try {
+        const result = await agentRunService.reTick({ work_item: issueId });
+        if (result?.granted) {
+          setToast({
+            type: TOAST_TYPE.SUCCESS,
+            title: t("Ticking restarted"),
+            message: t("Granted a fresh ticking budget. The AI agent will resume on its schedule."),
+          });
+        } else {
+          setToast({
+            type: TOAST_TYPE.INFO,
+            title: t("Nothing to re-tick"),
+            message: t("Re-ticking only applies while the issue is ticking and its budget is used up."),
+          });
+        }
+        return result;
+      } catch (error: unknown) {
+        const message = (error as { error?: string })?.error ?? t("Could not re-tick this issue. Please try again.");
+        setToast({
+          type: TOAST_TYPE.ERROR,
+          title: t("Failed to re-tick"),
+          message,
+        });
+        return null;
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [t]
+  );
+
+  return { reTick, isSubmitting };
+}

--- a/apps/web/core/services/runner/agent-run.service.ts
+++ b/apps/web/core/services/runner/agent-run.service.ts
@@ -48,6 +48,29 @@ export type TAgentRun = {
   // because the UI does not consume them yet.
 };
 
+/**
+ * Re-tick dispatch — re-grants a fresh phase-sized ticking budget to an
+ * issue whose agent-ticker budget is exhausted, and re-arms the ticker.
+ * The server enforces the guardrails (issue must be in a ticking state and
+ * its budget exhausted); when they don't hold it responds ``granted:
+ * false`` with a machine-readable ``reason`` rather than an error.
+ *
+ * Server-side wiring: ``apps/api/pi_dash/runner/views/runs.py``
+ * ``AgentReTickEndpoint``.
+ */
+export type TReTickPayload = {
+  work_item: string;
+};
+
+export type TReTickResponse = {
+  granted: boolean;
+  reason: string;
+  tick_count?: number;
+  max_ticks?: number;
+  enabled?: boolean;
+  next_run_at?: string | null;
+};
+
 export class AgentRunService extends APIService {
   constructor() {
     super(API_BASE_URL);
@@ -72,6 +95,19 @@ export class AgentRunService extends APIService {
    */
   async commentAndRun(data: TCommentAndRunPayload): Promise<TAgentRun> {
     return this.post(`/api/runners/runs/`, { ...data, triggered_by: "comment_and_run" })
+      .then((response) => response?.data)
+      .catch((error) => {
+        throw error?.response?.data ?? error;
+      });
+  }
+
+  /**
+   * Re-grant a fresh ticking budget to an exhausted issue ticker. No-op
+   * (``granted: false``) when the issue is not in a ticking state or its
+   * budget is not exhausted — the server decides, not the client.
+   */
+  async reTick(data: TReTickPayload): Promise<TReTickResponse> {
+    return this.post(`/api/runners/re-tick/`, data)
       .then((response) => response?.data)
       .catch((error) => {
         throw error?.response?.data ?? error;

--- a/packages/types/src/issues/issue.ts
+++ b/packages/types/src/issues/issue.ts
@@ -113,6 +113,11 @@ export type TIssueAgentTicker = {
   next_run_at: string | null;
   last_tick_at: string | null;
   disarm_reason?: "" | "left_ticking_state" | "cap_hit" | "terminal_signal" | "user_disabled";
+  /** True only when re-ticking would actually do something: the issue is
+   * still in a ticking state (In Progress / In Review) AND its current tick
+   * budget is exhausted. Gates the "re-tick" button so it never appears
+   * when the server would no-op. */
+  can_re_tick?: boolean;
 };
 
 export type TIssueAgentRunSummary = {

--- a/runner/src/cli/issue.rs
+++ b/runner/src/cli/issue.rs
@@ -53,6 +53,14 @@ pub enum IssueCommand {
     /// Attach a GitHub pull request to a work item. Alias of `attach-review`
     /// kept for existing scripts.
     AttachPr(AttachReviewArgs),
+    /// Re-grant a fresh ticking budget to an issue whose agent-ticker budget
+    /// is exhausted, so the periodic agent runs resume. No-op (reports
+    /// `granted: false`) unless the issue is currently in a ticking state
+    /// (In Progress / In Review) AND its current budget is used up.
+    ReTick {
+        /// Project-scoped identifier, e.g. `ENG-42`.
+        identifier: String,
+    },
 }
 
 #[derive(Debug, Args)]
@@ -190,6 +198,7 @@ pub async fn run(args: IssueArgs, paths: &crate::util::paths::Paths) -> i32 {
         IssueCommand::Search(s) => cmd_search(&client, s).await,
         IssueCommand::AttachReview(a) => cmd_attach_review(&client, a).await,
         IssueCommand::AttachPr(a) => cmd_attach_review(&client, a).await,
+        IssueCommand::ReTick { identifier } => cmd_re_tick(&client, &identifier).await,
     };
     match result {
         Ok(()) => 0,
@@ -468,6 +477,23 @@ async fn cmd_move(client: &ApiClient, args: MoveArgs) -> Result<(), CliError> {
         client.env.workspace_slug, issue.project_id, issue.id
     );
     let resp = client.post(&path, &body).await?;
+    println!(
+        "{}",
+        serde_json::to_string(&resp).expect("serialize JSON value")
+    );
+    Ok(())
+}
+
+async fn cmd_re_tick(client: &ApiClient, identifier: &str) -> Result<(), CliError> {
+    let issue = resolve_issue(client, identifier).await?;
+    let path = format!(
+        "workspaces/{}/projects/{}/work-items/{}/re-tick/",
+        client.env.workspace_slug, issue.project_id, issue.id
+    );
+    // The server applies the guardrails (ticking state + exhausted budget)
+    // and reports `granted: false` with a reason when nothing changed, so a
+    // no-op is a normal 200 rather than an error.
+    let resp = client.post(&path, &serde_json::json!({})).await?;
     println!(
         "{}",
         serde_json::to_string(&resp).expect("serialize JSON value")


### PR DESCRIPTION
## What & why

When an issue's agent ticker exhausts its budget (`disarm_reason = cap_hit`) while the issue is still **In Progress** / **In Review**, periodic ticking stops. This adds a manual **re-ticking** affordance so the user can re-grant budget and resume ticking without resetting progress.

Resolves PDASHOSS01-39.

## Behaviour

- Re-ticking grants **one fresh phase-sized budget on top of the current cap** — it does **not** reset `tick_count`. The card keeps showing cumulative progress (e.g. `Tick 24 of 48`).
- The grant amount is the project default for the issue's **current phase** — 24 for In Progress, 8 for In Review — so In Review re-grants the In-Review budget and In Progress re-grants the In-Progress budget.
- **No-op** (nothing changes) when the issue is not in a ticking state, or the budget is not exhausted.
- On grant, the ticker is re-armed (`enabled` unless the user disabled ticking, `disarm_reason` cleared, `next_run_at` restarted).

All of the above live in one shared primitive (`scheduling.re_tick_ticker`) so the UI button and the CLI behave identically.

## Changes

**Backend**
- `orchestration/scheduling.py` — `re_tick_ticker(issue)` primitive (row-locked; returns `{granted, reason, ticker}`).
- `app/serializers/issue.py` — expose `agent_ticker.can_re_tick` (true only when a grant would do something) to gate the UI button.
- `runner/views/runs.py` + `runner/web_urls.py` — `AgentReTickEndpoint` at `POST /api/runners/re-tick/` (session auth) for the web card.
- `api/views/issue.py` + `api/urls/work_item.py` — `IssueReTickAPIEndpoint` at `POST .../work-items/<id>/re-tick/` (API-key auth) for the CLI.

**CLI**
- `runner/src/cli/issue.rs` — `pidash issue re-tick <identifier>` (follows the same server-enforced rules; a no-op returns `granted: false` with a reason, not an error).

**Frontend**
- `packages/types` — `TIssueAgentTicker.can_re_tick`.
- `agent-run.service.ts` + `use-re-tick.ts` — service method + hook (success / no-op / error toasts).
- `agent-status.tsx` — "Re-tick" button on the AgentRun card, shown only when `can_re_tick`, refreshes the card after.

## Testing

- Added 5 unit tests for `re_tick_ticker` (grant, budget-not-exhausted no-op, not-ticking-state no-op, no-ticker, user-disabled).
- `cargo check` clean; `pidash issue re-tick --help` verified.
- `pnpm turbo check:types` + `check:lint` (web, types) — 0 errors.

> Note: the full API pytest suite needs Docker + Postgres, which isn't available in this environment; the new tests were verified for import/syntax and follow the existing `test_scheduling.py` fixtures. Please run the API suite in CI.

## Follow-up (not in this PR)

- Granted extra budget is stored by bumping the phase cap override, which persists across a later state re-entry (`arm_ticker` resets `tick_count` but not overrides). Minor pre-existing override semantics; noted for triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
