### PR TITLE
PDASHOSS01-38 Pi Dash TUI doesn't support copy paste

### DIFF
--- a/runner/src/tui/app.rs
+++ b/runner/src/tui/app.rs
@@ -1240,7 +1240,8 @@ impl App {
                     };
                     let _ = view.handle_paste(text, &mut ctx);
                 } else {
-                    self.with_tab_ctx(|tab, ctx| tab.handle_paste(text, ctx));
+                    let focus = self.focus_for(self.tab).clone();
+                    self.with_tab_ctx(|tab, ctx| tab.handle_paste(text, ctx, &focus));
                 }
                 self.frame.schedule_frame();
                 Ok(true)

--- a/runner/src/tui/view/tab.rs
+++ b/runner/src/tui/view/tab.rs
@@ -147,8 +147,15 @@ pub trait Tab {
         KeyHandled::NotConsumed
     }
 
-    /// Accept a paste burst (bracketed-paste path). Default: ignore.
-    fn handle_paste(&mut self, _text: String, _ctx: &mut TabCtx<'_>) -> KeyHandled {
+    /// Accept a paste burst (bracketed-paste path). `focus` is the tab's
+    /// current focus path so the tab can route the paste to whichever
+    /// text field is focused. Default: ignore.
+    fn handle_paste(
+        &mut self,
+        _text: String,
+        _ctx: &mut TabCtx<'_>,
+        _focus: &FocusPath,
+    ) -> KeyHandled {
         KeyHandled::NotConsumed
     }
 

--- a/runner/src/tui/views/general.rs
+++ b/runner/src/tui/views/general.rs
@@ -379,15 +379,27 @@ impl Tab for GeneralTab {
         }
     }
 
-    fn handle_paste(&mut self, text: String, _ctx: &mut TabCtx<'_>) -> KeyHandled {
+    fn handle_paste(
+        &mut self,
+        text: String,
+        _ctx: &mut TabCtx<'_>,
+        focus: &FocusPath,
+    ) -> KeyHandled {
+        // Register form: route the paste to whichever text field is
+        // focused (cloud_url / token / host_label). This is the primary
+        // onboarding surface — the token is meant to be pasted, not typed.
+        if let Some(reg) = self.register.as_mut()
+            && let Some(reg_focus) = focus.current().and_then(Self::register_focus_for_item)
+            && let Some(area) = reg.focused_textarea_mut(reg_focus)
+        {
+            area.insert_str(&text);
+            return KeyHandled::Consumed;
+        }
+        // Daemon-settings edit buffer (e.g. log-retention).
         if let Some(buf) = self.edit_buffer.as_mut() {
             buf.insert_str(&text);
             return KeyHandled::Consumed;
         }
-        // Pasting into the register form is best-effort: we don't know
-        // which field is focused without the FocusPath, so paste lands
-        // on whichever TextArea is currently the leaf via insert. The
-        // GeneralTab drops the paste otherwise.
         KeyHandled::NotConsumed
     }
 
@@ -942,4 +954,79 @@ pub async fn submit_register(
         .map_err(|e| format!("writing service unit: {e:#}"))?;
     let outcome = crate::service::reload::restart_and_verify(paths).await;
     Ok((cfg, outcome))
+}
+
+#[cfg(test)]
+mod paste_tests {
+    use super::*;
+    use crate::tui::event::AppEvent;
+    use crate::tui::event_sender::AppEventSender;
+    use crate::tui::input::keymap::KeymapRegistry;
+    use crate::tui::tui_runtime::frame_requester::FrameScheduler;
+    use crate::tui::view::tab::{Tab, TabCtx};
+    use crate::util::paths::Paths;
+    use tokio::sync::mpsc;
+
+    fn paths() -> Paths {
+        let root = tempfile::tempdir().expect("tempdir").keep();
+        Paths {
+            config_dir: root.join("config"),
+            data_dir: root.join("data"),
+            runtime_dir: root.join("runtime"),
+        }
+    }
+
+    #[tokio::test]
+    async fn paste_routes_to_focused_register_token_field() {
+        let mut data = AppData::new(paths());
+        let mut tab = GeneralTab::new();
+        tab.on_config_missing(&data);
+
+        let (tx, _rx) = mpsc::unbounded_channel::<AppEvent>();
+        let sender = AppEventSender::new(tx);
+        let keymap = KeymapRegistry::new();
+        let p = paths();
+        let (frame, _draw) = FrameScheduler::spawn();
+        let mut ctx = TabCtx {
+            tx: &sender,
+            data: &mut data,
+            keymap: &keymap,
+            paths: &p,
+            frame: &frame,
+        };
+
+        let mut focus = FocusPath::default();
+        focus.push(CARD_REGISTER);
+        focus.push(ITEM_REG_TOKEN);
+
+        let h = tab.handle_paste("pasted-token".into(), &mut ctx, &focus);
+        assert_eq!(h, KeyHandled::Consumed);
+        assert_eq!(tab.register_form_snapshot().unwrap().token, "pasted-token");
+    }
+
+    #[tokio::test]
+    async fn paste_routes_to_settings_edit_buffer() {
+        let mut data = AppData::new(paths());
+        let mut tab = GeneralTab::new();
+        tab.edit_buffer = Some(TextArea::with_text("14"));
+
+        let (tx, _rx) = mpsc::unbounded_channel::<AppEvent>();
+        let sender = AppEventSender::new(tx);
+        let keymap = KeymapRegistry::new();
+        let p = paths();
+        let (frame, _draw) = FrameScheduler::spawn();
+        let mut ctx = TabCtx {
+            tx: &sender,
+            data: &mut data,
+            keymap: &keymap,
+            paths: &p,
+            frame: &frame,
+        };
+
+        // No register form, focus empty -> falls through to edit buffer.
+        let focus = FocusPath::default();
+        let h = tab.handle_paste("7".into(), &mut ctx, &focus);
+        assert_eq!(h, KeyHandled::Consumed);
+        assert_eq!(tab.edit_buffer.as_ref().unwrap().text(), "147");
+    }
 }

--- a/runner/src/tui/views/modals/add_runner.rs
+++ b/runner/src/tui/views/modals/add_runner.rs
@@ -252,6 +252,17 @@ impl View for AddRunnerView {
         }
     }
 
+    fn handle_paste(&mut self, text: String, _ctx: &mut ViewCtx<'_>) -> KeyHandled {
+        // Route the paste to the focused field. The token is the whole
+        // reason this modal exists ("paste enrollment token"), so pasting
+        // must land in whichever TextArea currently has focus.
+        if let Some(area) = self.focused_textarea_mut() {
+            area.insert_str(&text);
+            return KeyHandled::Consumed;
+        }
+        KeyHandled::NotConsumed
+    }
+
     fn is_complete(&self) -> bool {
         self.complete
     }
@@ -314,5 +325,75 @@ fn mask_token(raw: &str) -> String {
         "*".repeat(raw.len())
     } else {
         format!("{}…{}", &raw[..2], &raw[raw.len() - 2..])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tui::event::AppEvent;
+    use crate::tui::event_sender::AppEventSender;
+    use crate::tui::input::keymap::KeymapRegistry;
+    use crate::util::paths::Paths;
+    use tokio::sync::mpsc;
+
+    fn paths() -> Paths {
+        let root = tempfile::tempdir().expect("tempdir").keep();
+        Paths {
+            config_dir: root.join("config"),
+            data_dir: root.join("data"),
+            runtime_dir: root.join("runtime"),
+        }
+    }
+
+    fn view() -> AddRunnerView {
+        let data = AppData::new(paths());
+        AddRunnerView::open(&data)
+    }
+
+    fn with_ctx(f: impl FnOnce(&mut ViewCtx<'_>)) {
+        let (tx, _rx) = mpsc::unbounded_channel::<AppEvent>();
+        let sender = AppEventSender::new(tx);
+        let keymap = KeymapRegistry::new();
+        let p = paths();
+        let mut ctx = ViewCtx {
+            tx: &sender,
+            keymap: &keymap,
+            paths: &p,
+        };
+        f(&mut ctx);
+    }
+
+    #[test]
+    fn paste_lands_in_focused_token_field() {
+        let mut v = view();
+        // Default focus is the token field — the whole point of this modal.
+        with_ctx(|ctx| {
+            let h = v.handle_paste("enroll-tok-123".into(), ctx);
+            assert_eq!(h, KeyHandled::Consumed);
+        });
+        assert_eq!(v.token.text(), "enroll-tok-123");
+    }
+
+    #[test]
+    fn paste_follows_focus_to_other_fields() {
+        let mut v = view();
+        v.focus = Focus::HostLabel;
+        v.host_label.clear();
+        with_ctx(|ctx| {
+            assert_eq!(v.handle_paste("mac-mini".into(), ctx), KeyHandled::Consumed);
+        });
+        assert_eq!(v.host_label.text(), "mac-mini");
+        assert_eq!(v.token.text(), "");
+    }
+
+    #[test]
+    fn paste_ignored_when_submit_focused() {
+        let mut v = view();
+        v.focus = Focus::Submit;
+        with_ctx(|ctx| {
+            assert_eq!(v.handle_paste("nope".into(), ctx), KeyHandled::NotConsumed);
+        });
+        assert!(v.token.text().is_empty());
     }
 }

--- a/runner/src/tui/views/runner_status.rs
+++ b/runner/src/tui/views/runner_status.rs
@@ -262,6 +262,21 @@ impl Tab for RunnerStatusTab {
         }
     }
 
+    fn handle_paste(
+        &mut self,
+        text: String,
+        _ctx: &mut TabCtx<'_>,
+        _focus: &FocusPath,
+    ) -> KeyHandled {
+        // Only the settings edit buffer accepts text on this tab; route
+        // the paste there so tokens/paths can be pasted rather than typed.
+        if let Some(buf) = self.edit_buffer.as_mut() {
+            buf.insert_str(&text);
+            return KeyHandled::Consumed;
+        }
+        KeyHandled::NotConsumed
+    }
+
     fn activate_item(
         &mut self,
         item_id: super::super::view::CardId,
@@ -764,5 +779,35 @@ mod tests {
 
         assert_eq!(tab.list.selected_id(), Some(&"alpha".to_string()));
         assert_eq!(data.picker_runner_name(), Some("alpha".to_string()));
+    }
+
+    #[tokio::test]
+    async fn paste_routes_to_settings_edit_buffer() {
+        use crate::tui::event_sender::AppEventSender;
+        use crate::tui::input::keymap::KeymapRegistry;
+        use crate::tui::tui_runtime::frame_requester::FrameScheduler;
+        use tokio::sync::mpsc;
+
+        let mut data = AppData::new(paths());
+        let mut tab = RunnerStatusTab::new();
+        tab.edit_buffer = Some(TextArea::with_text("abc"));
+
+        let (tx, _rx) = mpsc::unbounded_channel::<AppEvent>();
+        let sender = AppEventSender::new(tx);
+        let keymap = KeymapRegistry::new();
+        let p = paths();
+        let (frame, _draw) = FrameScheduler::spawn();
+        let mut ctx = TabCtx {
+            tx: &sender,
+            data: &mut data,
+            keymap: &keymap,
+            paths: &p,
+            frame: &frame,
+        };
+
+        let focus = FocusPath::default();
+        let h = tab.handle_paste("XYZ".into(), &mut ctx, &focus);
+        assert_eq!(h, KeyHandled::Consumed);
+        assert_eq!(tab.edit_buffer.as_ref().unwrap().text(), "abcXYZ");
     }
 }

--- a/runner/src/tui/widgets/textarea.rs
+++ b/runner/src/tui/widgets/textarea.rs
@@ -141,9 +141,15 @@ impl TextArea {
     }
 
     pub fn insert_str(&mut self, s: &str) {
+        // This widget is strictly single-line (flat char cursor, single-Line
+        // render), and typing can never produce a newline. `insert_str` is the
+        // paste entry point, so strip CR/LF here — a trailing newline copied
+        // with a token would otherwise corrupt the layout and be submitted as
+        // part of the value (e.g. an enrollment token that fails validation).
+        let sanitized: String = s.chars().filter(|c| *c != '\r' && *c != '\n').collect();
         let byte = self.byte_index(self.cursor);
-        self.text.insert_str(byte, s);
-        self.cursor += s.chars().count();
+        self.text.insert_str(byte, &sanitized);
+        self.cursor += sanitized.chars().count();
     }
 
     pub fn delete_backward(&mut self) {
@@ -255,6 +261,16 @@ mod tests {
         // Release is filtered (consumed silently — not double-typed).
         assert_eq!(h, KeyHandled::Consumed);
         assert_eq!(t.text(), "");
+    }
+
+    #[test]
+    fn insert_str_strips_newlines() {
+        // Pasting a token with a trailing newline (and an embedded CRLF)
+        // must not leak line breaks into this single-line field.
+        let mut t = TextArea::with_text("tok");
+        t.insert_str("-abc\r\ndef\n");
+        assert_eq!(t.text(), "tok-abcdef");
+        assert_eq!(t.cursor(), t.text().chars().count());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

In the runner TUI, pasting text (Cmd/Ctrl+V) into fields where you're meant to type — the enrollment token, cloud URL, host label, and editable per-runner settings — did nothing. Copy/paste appeared completely unsupported.

## Root cause

The TUI already enables bracketed paste and turns a paste into a `TuiEvent::Paste(text)` that's dispatched to `Tab::handle_paste` / `View::handle_paste`. But those trait methods default to a no-op, and most text-input surfaces never overrode them, so the pasted text was silently dropped. The only override was `GeneralTab`, and it only handled the daemon-settings edit buffer — the register form (the primary "paste enrollment token" onboarding screen) dropped paste too.

## Fix

- Thread the tab's current `FocusPath` into `Tab::handle_paste` so a tab can route the paste to whichever field is focused.
- **`GeneralTab`** — paste into the focused register field (`cloud_url` / `token` / `host_label`), falling back to the settings edit buffer.
- **`RunnerStatusTab`** — paste into the per-runner settings edit buffer.
- **`AddRunnerView`** (legacy add-runner modal) — paste into the focused field; the masked token field is the whole reason the modal exists.

All insertion goes through the existing `TextArea::insert_str`, so the cursor advances correctly and masked fields stay masked.

## Scope / follow-up

This covers terminals with bracketed paste (macOS Terminal, iTerm2, most modern emulators) — the reported environment. Terminals *without* bracketed paste deliver a paste as a rapid burst of `Char` events; a `paste_burst` collapser already exists in the tree but isn't wired into the key dispatcher. Wiring that is a separate, lower-priority robustness improvement and is left as a follow-up.

## Tests

Added unit tests covering each surface:
- register token field receives paste (`general.rs`)
- settings edit buffer receives paste (`general.rs`, `runner_status.rs`)
- add-runner modal paste follows focus and is ignored on the Submit button (`add_runner.rs`)

`cargo test --lib tui::` and `cargo clippy --lib --tests` pass. (One pre-existing, unrelated `workspace::git` test fails on this macOS host due to a `/var` vs `/private/var` symlink path mismatch; it fails identically on the base branch without these changes.)
