### PR TITLE
PDASHOSS01-37 Pidash TUI improvement: somehow runner now shows every agent even it is not relevant

### DIFF
--- a/runner/src/tui/app.rs
+++ b/runner/src/tui/app.rs
@@ -805,6 +805,19 @@ impl App {
             return KeyHandled::NotConsumed;
         }
 
+        // Stale-leaf guard: a tab's focus tree can shrink between frames — e.g.
+        // switching to a runner whose `agent.kind` hides the agent field the
+        // user had dived into. Pop any trailing segments that no longer resolve
+        // in the current tree so navigation never strands on a leaf that isn't
+        // there; the focus settles on the nearest still-present ancestor.
+        loop {
+            let segs = self.focus_for(self.tab).segments().to_vec();
+            if segs.is_empty() || locate(&tree, &segs).is_some() {
+                break;
+            }
+            self.focus_for_mut(self.tab).pop();
+        }
+
         let focus = self.focus_for(self.tab).clone();
         let active_ctxs = self.active_tab().active_contexts(&focus);
         let text_input_only = active_ctxs == [Context::TextInput];

--- a/runner/src/tui/views/config.rs
+++ b/runner/src/tui/views/config.rs
@@ -200,6 +200,41 @@ pub fn field_at(idx: usize) -> &'static FieldSpec {
     &FIELDS[idx.min(FIELDS.len() - 1)]
 }
 
+/// The `AgentKind` an agent-specific config field belongs to, or `None`
+/// for fields that aren't tied to a particular agent (those are always
+/// shown regardless of the runner's selected kind).
+pub fn field_agent_kind(id: FieldId) -> Option<AgentKind> {
+    match id {
+        FieldId::CodexBinary | FieldId::CodexModelDefault => Some(AgentKind::Codex),
+        FieldId::ClaudeBinary | FieldId::ClaudeModelDefault => Some(AgentKind::ClaudeCode),
+        FieldId::CursorBinary | FieldId::CursorModelDefault => Some(AgentKind::CursorAgent),
+        FieldId::OpenClawBinary | FieldId::OpenClawModelDefault => Some(AgentKind::OpenClaw),
+        _ => None,
+    }
+}
+
+/// The agent kind selected by the runner at `runner_idx`, defaulting to
+/// `AgentKind::default()` when no runner exists so the panel still renders a
+/// coherent section.
+fn selected_agent_kind(cfg: &Config, runner_idx: usize) -> AgentKind {
+    runner_at(cfg, runner_idx)
+        .map(|r| r.agent.kind)
+        .unwrap_or_default()
+}
+
+/// Whether a field should be shown (and navigable) for the runner at
+/// `runner_idx`. Agent-specific `binary` / `model_default` fields are visible
+/// only when they belong to that runner's selected `agent.kind`; every other
+/// field is always visible. The Runners-tab render layer and the focus tree
+/// share this predicate so keyboard navigation never lands on a field that
+/// isn't drawn.
+pub fn field_visible(cfg: &Config, id: FieldId, runner_idx: usize) -> bool {
+    match field_agent_kind(id) {
+        None => true,
+        Some(kind) => selected_agent_kind(cfg, runner_idx) == kind,
+    }
+}
+
 fn runner_at(cfg: &Config, idx: usize) -> Option<&crate::config::schema::RunnerConfig> {
     if cfg.runners.is_empty() {
         return None;
@@ -516,28 +551,37 @@ pub fn editable_lines(
     ));
     lines.push(Line::raw(""));
 
-    // Per-agent binary / model_default. Every agent's pair is registered in
-    // `FIELDS` (and therefore in the focus tree), so each must be rendered or
-    // navigation would land on an invisible, un-highlighted field. Rendered in
-    // `FIELDS` order so the index-based selection highlight lines up.
-    for (section, ids) in [
+    // Per-agent binary / model_default. Only the section for the runner's
+    // selected `agent.kind` is drawn; the other agents' fields are hidden here
+    // AND excluded from the focus tree (see `focus_tree` and `field_visible`),
+    // so navigation never lands on an invisible, un-highlighted field. Rendered
+    // in `FIELDS` order so the index-based selection highlight lines up.
+    let selected_kind = selected_agent_kind(working, runner_idx);
+    for (section, kind, ids) in [
         (
             "Codex",
+            AgentKind::Codex,
             [FieldId::CodexBinary, FieldId::CodexModelDefault],
         ),
         (
             "Claude Code",
+            AgentKind::ClaudeCode,
             [FieldId::ClaudeBinary, FieldId::ClaudeModelDefault],
         ),
         (
             "Cursor Agent",
+            AgentKind::CursorAgent,
             [FieldId::CursorBinary, FieldId::CursorModelDefault],
         ),
         (
             "OpenClaw",
+            AgentKind::OpenClaw,
             [FieldId::OpenClawBinary, FieldId::OpenClawModelDefault],
         ),
     ] {
+        if kind != selected_kind {
+            continue;
+        }
         lines.push(section_header(section));
         for id in ids {
             lines.extend(render_editable_row(
@@ -766,4 +810,95 @@ fn index_of(id: FieldId) -> usize {
         .iter()
         .position(|f| f.id == id)
         .expect("FieldId missing from FIELDS table")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::schema::{
+        Config, DaemonConfig, RunnerConfig, WorkspaceSection,
+    };
+    use std::path::PathBuf;
+    use uuid::Uuid;
+
+    fn config_with_kind(kind: AgentKind) -> Config {
+        let mut runner = RunnerConfig {
+            name: "r".into(),
+            runner_id: Uuid::new_v4(),
+            workspace_slug: Some("acme".into()),
+            project_slug: Some("TEST".into()),
+            pod_id: None,
+            workspace: WorkspaceSection {
+                working_dir: PathBuf::from("/tmp/pidash-test"),
+            },
+            workdir: None,
+            agent: Default::default(),
+            codex: Default::default(),
+            claude_code: Default::default(),
+            cursor_agent: Default::default(),
+            openclaw: Default::default(),
+            approval_policy: Default::default(),
+        };
+        runner.agent.kind = kind;
+        Config {
+            version: 2,
+            daemon: DaemonConfig {
+                cloud_url: "https://pidash.example".into(),
+                dev_machine_id: None,
+                log_level: "info".into(),
+                log_retention_days: 14,
+                agent_observability_v1: false,
+                auto_update: true,
+            },
+            runners: vec![runner],
+            workdirs: vec![],
+            cli: None,
+        }
+    }
+
+    fn rendered_text(cfg: &Config) -> String {
+        editable_lines(cfg, &None, 0, 0, None)
+            .iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|s| s.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn editable_lines_shows_only_selected_agent_section() {
+        // Claude Code runner: the Claude section header shows; the other three
+        // agent section headers are absent.
+        let text = rendered_text(&config_with_kind(AgentKind::ClaudeCode));
+        assert!(text.contains("Claude Code"));
+        assert!(!text.contains("Codex"));
+        assert!(!text.contains("Cursor Agent"));
+        assert!(!text.contains("OpenClaw"));
+
+        // Codex runner: mirror the check the other way.
+        let text = rendered_text(&config_with_kind(AgentKind::Codex));
+        assert!(text.contains("Codex"));
+        assert!(!text.contains("Claude Code"));
+        assert!(!text.contains("Cursor Agent"));
+        assert!(!text.contains("OpenClaw"));
+    }
+
+    #[test]
+    fn field_visible_matches_selected_kind() {
+        let cfg = config_with_kind(AgentKind::CursorAgent);
+        // Cursor fields visible; other agents' fields hidden.
+        assert!(field_visible(&cfg, FieldId::CursorBinary, 0));
+        assert!(field_visible(&cfg, FieldId::CursorModelDefault, 0));
+        assert!(!field_visible(&cfg, FieldId::CodexBinary, 0));
+        assert!(!field_visible(&cfg, FieldId::ClaudeBinary, 0));
+        assert!(!field_visible(&cfg, FieldId::OpenClawBinary, 0));
+        // Non-agent fields always visible.
+        assert!(field_visible(&cfg, FieldId::AgentKind, 0));
+        assert!(field_visible(&cfg, FieldId::RunnerName, 0));
+        assert!(field_visible(&cfg, FieldId::ApprovalAutoReadonly, 0));
+    }
 }

--- a/runner/src/tui/views/runner_status.rs
+++ b/runner/src/tui/views/runner_status.rs
@@ -110,9 +110,22 @@ impl Tab for RunnerStatusTab {
             .map(|c| !c.runners.is_empty())
             .unwrap_or(false);
         let settings_children = if runners_present {
+            // Only fields visible for the picked runner are navigable. Agent
+            // `binary` / `model_default` fields for kinds other than the
+            // runner's `agent.kind` are excluded here so up/down skips them,
+            // exactly matching what `editable_lines` draws. `row` keeps the
+            // original `FIELDS` index; `next_sibling` sorts+dedups rows, so the
+            // gaps left by hidden fields navigate correctly.
+            let runner_idx = data.picker_runner_index().unwrap_or(0);
             fields::FIELDS
                 .iter()
                 .enumerate()
+                .filter(|(_, spec)| {
+                    data.config_working
+                        .as_ref()
+                        .map(|cfg| fields::field_visible(cfg, spec.id, runner_idx))
+                        .unwrap_or(true)
+                })
                 .map(|(i, spec)| FocusNode::Item {
                     id: spec.id.id_str(),
                     interactive: true,
@@ -764,5 +777,92 @@ mod tests {
 
         assert_eq!(tab.list.selected_id(), Some(&"alpha".to_string()));
         assert_eq!(data.picker_runner_name(), Some("alpha".to_string()));
+    }
+
+    fn runner_with_kind(name: &str, kind: crate::config::schema::AgentKind) -> RunnerConfig {
+        let mut r = runner(name);
+        r.agent.kind = kind;
+        r
+    }
+
+    /// Collect the leaf ids of the settings card in the focus tree.
+    fn settings_field_ids(tab: &RunnerStatusTab, data: &AppData) -> Vec<&'static str> {
+        tab.focus_tree(data)
+            .into_iter()
+            .find(|n| n.id() == CARD_SETTINGS)
+            .map(|n| n.children().iter().map(|c| c.id()).collect())
+            .unwrap_or_default()
+    }
+
+    #[test]
+    fn focus_tree_hides_non_selected_agent_fields() {
+        use crate::config::schema::AgentKind;
+
+        // Runner uses Claude Code — only Claude's binary/model_default should be
+        // navigable; the other three agents' fields must be excluded.
+        let mut data = AppData::new(paths());
+        data.config_working = Some(config(vec![runner_with_kind(
+            "claude_runner",
+            AgentKind::ClaudeCode,
+        )]));
+        data.config_loaded = data.config_working.clone();
+        data.status = Some(status(&["claude_runner"]));
+        data.selected_runner_name = Some("claude_runner".to_string());
+
+        let tab = RunnerStatusTab::new();
+        let ids = settings_field_ids(&tab, &data);
+
+        assert!(ids.contains(&"field:claude_binary"));
+        assert!(ids.contains(&"field:claude_model_default"));
+        for hidden in [
+            "field:codex_binary",
+            "field:codex_model_default",
+            "field:cursor_binary",
+            "field:cursor_model_default",
+            "field:openclaw_binary",
+            "field:openclaw_model_default",
+        ] {
+            assert!(!ids.contains(&hidden), "{hidden} should be hidden");
+        }
+        // Non-agent fields stay navigable.
+        assert!(ids.contains(&"field:agent_kind"));
+        assert!(ids.contains(&"field:runner_name"));
+    }
+
+    #[test]
+    fn focus_tree_agent_fields_follow_selected_kind() {
+        use crate::config::schema::AgentKind;
+
+        for (kind, want, other) in [
+            (
+                AgentKind::Codex,
+                "field:codex_binary",
+                "field:openclaw_binary",
+            ),
+            (
+                AgentKind::OpenClaw,
+                "field:openclaw_binary",
+                "field:codex_binary",
+            ),
+            (
+                AgentKind::CursorAgent,
+                "field:cursor_binary",
+                "field:claude_binary",
+            ),
+        ] {
+            let mut data = AppData::new(paths());
+            data.config_working = Some(config(vec![runner_with_kind("r", kind)]));
+            data.config_loaded = data.config_working.clone();
+            data.status = Some(status(&["r"]));
+            data.selected_runner_name = Some("r".to_string());
+
+            let tab = RunnerStatusTab::new();
+            let ids = settings_field_ids(&tab, &data);
+            assert!(ids.contains(&want), "{want} should be visible for {kind:?}");
+            assert!(
+                !ids.contains(&other),
+                "{other} should be hidden for {kind:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes the runner TUI Settings panel showing **every** agent's configuration (Codex, Claude Code, Cursor Agent, OpenClaw) regardless of which agent a runner actually drives. Now only the section matching the runner's `agent.kind` is shown — and only its fields are keyboard-navigable.

Resolves **PDASHOSS01-37**.

## The bug

In the Runners tab → Settings panel, all four per-agent sections were rendered unconditionally, and all their fields were registered in the focus tree, so `↑/↓` also stepped through the irrelevant agents' `binary` / `model_default` fields.

## The fix

Filter both the render layer and the focus tree by the picked runner's selected agent kind, using one shared predicate.

- **`runner/src/tui/views/config.rs`** — new `field_agent_kind()` (maps an agent-specific `FieldId` to its `AgentKind`) and public `field_visible()`. `editable_lines()` now draws only the section whose kind equals `runner.agent.kind`.
- **`runner/src/tui/views/runner_status.rs`** — `focus_tree()` excludes hidden agent fields so navigation skips them. Rows keep their original `FIELDS` index; `next_sibling` sorts+dedups rows, so the gaps navigate correctly. Highlight alignment is preserved because `focused_field_idx` resolves the leaf by `id_str` position, independent of tree rows.
- **`runner/src/tui/app.rs`** — `dispatch_focus_key()` gains a stale-leaf guard that pops focus segments no longer present in the current tree. This handles the edge case of switching runners across agent kinds while dived into an agent-specific field (the field the focus pointed at can disappear).

`differs()` is intentionally left untouched — it compares all `FIELDS` for unsaved-change detection, which is correct regardless of visibility.

## Behavior

- Cycling **Agent → kind** (Enter on the always-visible `kind` field) immediately swaps which agent section is shown.
- Editing the visible agent's `binary` / `model_default` still works and saves as before.

## Tests

New unit tests:
- `focus_tree_hides_non_selected_agent_fields`
- `focus_tree_agent_fields_follow_selected_kind`
- `editable_lines_shows_only_selected_agent_section`
- `field_visible_matches_selected_kind`

`cargo build -p pidash` is clean and `cargo test -p pidash --lib tui::` passes. (One pre-existing, environment-specific failure in `workspace::git` — a macOS `/private/var` vs `/var` tmpdir symlink mismatch — also fails on `main` and is unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
