### PR TITLE
PDASHOSS01-29 add "this issue belongs to project" prefix for project context in issue prompt

### DIFF
--- a/apps/api/pi_dash/prompting/sections/intro.md
+++ b/apps/api/pi_dash/prompting/sections/intro.md
@@ -15,7 +15,7 @@ Issue context:
 - URL: {{ issue.url }}
 {% if issue.target_date %}- Target date: {{ issue.target_date }}{% endif %}
 
-Project: {{ project.name }} ({{ project.identifier }})
+This issue belongs to the Project: {{ project.name }} ({{ project.identifier }})
 {% if project.description %}
 {{ project.description }}
 {% endif %}


### PR DESCRIPTION
## What

Prefix the project line in the issue-run prompt so the agent understands the relationship between an issue and its project.

The issue-run prompt is composed from `apps/api/pi_dash/prompting/sections/intro.md`. The line that names the project previously read:

```
Project: {{ project.name }} ({{ project.identifier }})
```

It now reads:

```
This issue belongs to the Project: {{ project.name }} ({{ project.identifier }})
```

## Why

Per PDASHOSS01-29: a small copy nudge to help the AI agent understand that the issue it is working on belongs to the named project.

## Scope / notes

- Only the issue-scoped intro (`sections/intro.md`) is changed. `sections/scheduler-intro.md` is left as-is — scheduled runs are project-scoped and not tied to a single issue, so "this issue belongs to" would be inaccurate there.
- `fragments/01_intro.md` is intentionally untouched: `fragments/` + `seed.py` are legacy (kept only for historical-migration replay, per `prompting/apps.py`). The live default prompt is resolved from `sections/` via `registry.py` / `composer.py`.

## Validation

- No unit test asserts the exact `Project:` line text, so nothing breaks.
- Verified the edited section still parses: front-matter is unchanged and both `{{ project.name }}` / `{{ project.identifier }}` placeholders are intact after front-matter stripping.

Resolves PDASHOSS01-29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
