### PR TITLE
PDASHOSS01-32 Update Pidash's web metadata

### DIFF
--- a/apps/admin/app/root.tsx
+++ b/apps/admin/app/root.tsx
@@ -24,9 +24,9 @@ import "@fontsource/material-symbols-rounded";
 // eslint-disable-next-line import/no-unassigned-import
 import "@fontsource/ibm-plex-mono";
 
-const APP_TITLE = "Pi Dash | Simple, extensible, open-source project management tool.";
+const APP_TITLE = "Pi Dash | Open-source AI agent orchestration platform";
 const APP_DESCRIPTION =
-  "Open-source project management tool to manage work items, sprints, and product roadmaps with peace of mind.";
+  "Pi Dash is an open-source AI agent orchestration platform built for As Coding — define what needs to be built and let coding agents handle the implementation in the background.";
 
 export const links: LinksFunction = () => [
   { rel: "apple-touch-icon", sizes: "180x180", href: appleTouchIcon },

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -10,7 +10,7 @@ import Script from "next/script";
 // eslint-disable-next-line import/no-unassigned-import
 import "@/styles/globals.css";
 
-import { SITE_DESCRIPTION, SITE_NAME } from "@pi-dash/constants";
+import { SITE_DESCRIPTION, SITE_KEYWORDS, SITE_NAME, SITE_TITLE } from "@pi-dash/constants";
 
 // helpers
 import { cn } from "@pi-dash/utils";
@@ -26,34 +26,33 @@ import icon512 from "@/app/assets/icons/icon-512x512.png?url";
 import { AppProvider } from "./provider";
 
 export const meta = () => [
-  { title: "Pi Dash | Simple, extensible, open-source project management tool." },
+  { title: SITE_TITLE },
   { name: "description", content: SITE_DESCRIPTION },
   {
     name: "keywords",
-    content:
-      "software development, plan, ship, software, accelerate, code management, release management, project management, work item tracking, agile, scrum, kanban, collaboration",
+    content: SITE_KEYWORDS,
   },
   {
     name: "viewport",
     content:
       "width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover",
   },
-  { property: "og:title", content: "Pi Dash | Simple, extensible, open-source project management tool." },
+  { property: "og:title", content: SITE_TITLE },
   {
     property: "og:description",
-    content: "Open-source project management tool to manage work items, cycles, and product roadmaps easily",
+    content: SITE_DESCRIPTION,
   },
   { property: "og:url", content: "https://airepublic.com/" },
   { property: "og:image", content: "https://airepublic.com/og-image.png" },
   { property: "og:image:width", content: "1200" },
   { property: "og:image:height", content: "630" },
-  { property: "og:image:alt", content: "Pi Dash - Modern project management" },
+  { property: "og:image:alt", content: "Pi Dash - AI agent orchestration platform" },
   { name: "twitter:site", content: "@ai_republic" },
   { name: "twitter:card", content: "summary_large_image" },
   { name: "twitter:image", content: "https://airepublic.com/og-image.png" },
   { name: "twitter:image:width", content: "1200" },
   { name: "twitter:image:height", content: "630" },
-  { name: "twitter:image:alt", content: "Pi Dash - Modern project management" },
+  { name: "twitter:image:alt", content: "Pi Dash - AI agent orchestration platform" },
 ];
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -10,7 +10,7 @@ import { Links, Meta, Outlet, Scripts } from "react-router";
 import type { LinksFunction } from "react-router";
 import { ThemeProvider } from "next-themes";
 // pi dash imports
-import { SITE_DESCRIPTION, SITE_NAME } from "@pi-dash/constants";
+import { SITE_DESCRIPTION, SITE_KEYWORDS, SITE_NAME, SITE_TITLE } from "@pi-dash/constants";
 import { cn } from "@pi-dash/utils";
 // types
 // assets
@@ -34,7 +34,7 @@ import "@fontsource/material-symbols-rounded";
 // eslint-disable-next-line import/no-unassigned-import
 import "@fontsource/ibm-plex-mono";
 
-const APP_TITLE = "Pi Dash | Simple, extensible, open-source project management tool.";
+const APP_TITLE = SITE_TITLE;
 
 export const links: LinksFunction = () => [
   { rel: "icon", type: "image/png", sizes: "32x32", href: favicon32 },
@@ -101,24 +101,23 @@ export const meta: Route.MetaFunction = () => [
   { property: "og:title", content: APP_TITLE },
   {
     property: "og:description",
-    content: "Open-source project management tool to manage work items, cycles, and product roadmaps easily",
+    content: SITE_DESCRIPTION,
   },
   { property: "og:url", content: "https://airepublic.com/" },
   { property: "og:image", content: ogImage },
   { property: "og:image:width", content: "1200" },
   { property: "og:image:height", content: "630" },
-  { property: "og:image:alt", content: "Pi Dash - Modern project management" },
+  { property: "og:image:alt", content: "Pi Dash - AI agent orchestration platform" },
   {
     name: "keywords",
-    content:
-      "software development, plan, ship, software, accelerate, code management, release management, project management, work item tracking, agile, scrum, kanban, collaboration",
+    content: SITE_KEYWORDS,
   },
   { name: "twitter:site", content: "@ai_republic" },
   { name: "twitter:card", content: "summary_large_image" },
   { name: "twitter:image", content: ogImage },
   { name: "twitter:image:width", content: "1200" },
   { name: "twitter:image:height", content: "630" },
-  { name: "twitter:image:alt", content: "Pi Dash - Modern project management" },
+  { name: "twitter:image:alt", content: "Pi Dash - AI agent orchestration platform" },
 ];
 
 export default function Root() {

--- a/apps/web/core/components/core/page-title.tsx
+++ b/apps/web/core/components/core/page-title.tsx
@@ -6,6 +6,8 @@
 
 import { useEffect } from "react";
 
+import { SITE_TITLE } from "@pi-dash/constants";
+
 type PageHeadTitleProps = {
   title?: string;
   description?: string;
@@ -16,7 +18,7 @@ export function PageHead(props: PageHeadTitleProps) {
 
   useEffect(() => {
     if (title) {
-      document.title = title ?? "Pi Dash | Simple, extensible, open-source project management tool.";
+      document.title = title ?? SITE_TITLE;
     }
   }, [title]);
 

--- a/apps/web/manifest.json
+++ b/apps/web/manifest.json
@@ -4,9 +4,9 @@
   "display": "standalone",
   "scope": "/",
   "start_url": "/",
-  "name": "Pi Dash | Accelerate software development with peace.",
+  "name": "Pi Dash | Open-source AI agent orchestration platform",
   "short_name": "Pi Dash",
-  "description": "Pi Dash accelerated the software development by order of magnitude for agencies and product companies.",
+  "description": "Pi Dash is an open-source AI agent orchestration platform built for As Coding — define what needs to be built and let coding agents handle the implementation in the background.",
   "icons": [
     {
       "src": "/icon-192x192.png",

--- a/packages/constants/src/metadata.ts
+++ b/packages/constants/src/metadata.ts
@@ -4,14 +4,14 @@
  * See the LICENSE file for details.
  */
 
-export const SITE_NAME = "Pi Dash | Simple, extensible, open-source project management tool.";
-export const SITE_TITLE = "Pi Dash | Simple, extensible, open-source project management tool.";
+export const SITE_NAME = "Pi Dash | Open-source AI agent orchestration platform";
+export const SITE_TITLE = "Pi Dash | Open-source AI agent orchestration platform";
 export const SITE_DESCRIPTION =
-  "Open-source project management tool to manage work items, cycles, and product roadmaps easily";
+  "Pi Dash is an open-source AI agent orchestration platform built for As Coding — define what needs to be built and let coding agents handle the implementation in the background.";
 export const SITE_KEYWORDS =
-  "software development, plan, ship, software, accelerate, code management, release management, project management, work items tracking, agile, scrum, kanban, collaboration";
+  "AI agent orchestration, asynchronous vibe coding, as coding, coding agents, Claude Code, Codex, autonomous agents, software development, project management, open source, developer tools";
 export const SITE_URL = "https://airepublic.com/";
-export const TWITTER_USER_NAME = "Pi Dash | Simple, extensible, open-source project management tool.";
+export const TWITTER_USER_NAME = "ai_republic";
 
 // Pi Dash Sites Metadata
 export const SPACE_SITE_NAME = "Pi Dash Publish | Make your Pi Dash boards and roadmaps pubic with just one-click. ";


### PR DESCRIPTION
## What

Pi Dash's web tab metadata (browser title, meta description, keywords, Open Graph / Twitter tags, PWA manifest) still carried Plane's inherited framing:

> Pi Dash | Simple, extensible, open-source project management tool.

Pi Dash is not "only a project management tool" — per the README it is an **open-source AI agent orchestration platform built for As Coding (asynchronous vibe coding)**. This PR replaces the inherited tagline/description with copy sourced from the README so the platform's own identity shows in the browser tab and in link previews.

## Changes

- **`packages/constants/src/metadata.ts`** (source of truth):
  - `SITE_NAME` / `SITE_TITLE` → `Pi Dash | Open-source AI agent orchestration platform`
  - `SITE_DESCRIPTION` → README-derived one-liner about As Coding
  - `SITE_KEYWORDS` → AI-orchestration terms
  - `TWITTER_USER_NAME` → `ai_republic` (was mistakenly set to the full title string)
- **`apps/web/app/layout.tsx`** & **`apps/web/app/root.tsx`**: title / description / keywords / OG tags now reference the shared constants instead of hardcoded Plane strings; OG image alt text updated.
- **`apps/web/core/components/core/page-title.tsx`**: fallback document title uses `SITE_TITLE`.
- **`apps/web/manifest.json`**: PWA `name` / `description` updated.
- **`apps/admin/app/root.tsx`**: the same inherited tagline replaced for consistency.

## Validation

- `oxlint` on all changed `.tsx` files → 0 errors; `metadata.ts` lint → 0 errors.
- Rebuilt `@pi-dash/constants` locally and confirmed the new `SITE_TITLE` / `SITE_NAME` propagate.
- `grep` confirms no remaining "Simple, extensible…" / "Modern project management" strings in source.
- Note: `check:types` in `packages/constants` surfaces a pre-existing, unrelated error (`lucide-react` in `src/settings/profile.ts`) not touched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
