### PR TITLE
chore: ignore local runtime cache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,8 @@ package-lock.json
 
 .secrets
 tmp/
+.pidash/
+.pnpm-store/
 
 ## packages
 dist


### PR DESCRIPTION
## Summary
- Ignore local `.pidash/` runtime/context files.
- Ignore local `.pnpm-store/` package cache output.

## Validation
- `git diff --check -- .gitignore`