### PR TITLE
[codex] fix runner add auto-pool migration

### DIFF
--- a/runner/src/cli/runner.rs
+++ b/runner/src/cli/runner.rs
@@ -12,7 +12,7 @@ use clap::{Args as ClapArgs, Subcommand};
 use std::io::IsTerminal;
 use std::path::PathBuf;
 
-use crate::cli::runner_ops::{self, AppliedWorkdir, RunnerWorkdirPlan};
+use crate::cli::runner_ops::{self, AppliedWorkdir, ApplyEnrollOptions, RunnerWorkdirPlan};
 use crate::cloud::http::{CreateRunnerRequest, SharedHttpTransport, create_runner};
 use crate::cloud::runners::{delete_runner, probe_cloud_reachable};
 use crate::config::file;
@@ -244,11 +244,13 @@ pub async fn add(args: AddArgs, paths: &Paths) -> Result<RunnerConfig> {
         paths,
         &resp,
         &cloud_url,
-        args.working_dir.clone(),
-        args.agent,
-        args.model.as_deref(),
-        args.reasoning_effort.as_deref(),
-        workdir_plan,
+        ApplyEnrollOptions {
+            working_dir: args.working_dir.clone(),
+            agent_kind: args.agent,
+            model: args.model.as_deref(),
+            reasoning_effort: args.reasoning_effort.as_deref(),
+            workdir_plan,
+        },
     )
     .await
     {

--- a/runner/src/cli/runner.rs
+++ b/runner/src/cli/runner.rs
@@ -12,14 +12,11 @@ use clap::{Args as ClapArgs, Subcommand};
 use std::io::IsTerminal;
 use std::path::PathBuf;
 
-use crate::cli::runner_ops;
+use crate::cli::runner_ops::{self, AppliedWorkdir, RunnerWorkdirPlan};
 use crate::cloud::http::{CreateRunnerRequest, SharedHttpTransport, create_runner};
 use crate::cloud::runners::{delete_runner, probe_cloud_reachable};
 use crate::config::file;
-use crate::config::schema::{
-    AgentKind, CleanMode, Config, DEFAULT_POOL_SIZE, MAX_RUNNERS_PER_DAEMON, RunnerConfig,
-    WorkdirConfig,
-};
+use crate::config::schema::{AgentKind, DEFAULT_POOL_SIZE, MAX_RUNNERS_PER_DAEMON, RunnerConfig};
 use crate::util::confirm::maybe_confirm;
 use crate::util::paths::Paths;
 use crate::util::runner_name;
@@ -233,6 +230,16 @@ pub async fn add(args: AddArgs, paths: &Paths) -> Result<RunnerConfig> {
     // The rollback uses the same X-Api-Key surface as `pidash runner
     // remove` (cascade so any daemon already polling tears down too); a
     // failed rollback is logged but does not mask the original error.
+    let workdir_plan = if let Some(workdir_name) = args.workdir.as_deref() {
+        RunnerWorkdirPlan::Existing {
+            name: workdir_name.to_string(),
+        }
+    } else if args.no_pool {
+        RunnerWorkdirPlan::Legacy
+    } else {
+        RunnerWorkdirPlan::AutoPoolIfGit
+    };
+
     let applied = match runner_ops::apply_enroll_response(
         paths,
         &resp,
@@ -241,6 +248,7 @@ pub async fn add(args: AddArgs, paths: &Paths) -> Result<RunnerConfig> {
         args.agent,
         args.model.as_deref(),
         args.reasoning_effort.as_deref(),
+        workdir_plan,
     )
     .await
     {
@@ -271,125 +279,63 @@ pub async fn add(args: AddArgs, paths: &Paths) -> Result<RunnerConfig> {
         }
     };
 
-    // Bind the runner to a shared work dir if requested: it then leases
-    // worktrees from that pool instead of using its own working_dir. Done as a
-    // follow-up mutate so the existing enroll path stays untouched; validates
-    // the reference and re-runs config validation before writing.
-    if let Some(workdir_name) = args.workdir.as_deref() {
-        let runner_id = applied.runner.runner_id;
-        let name = workdir_name.to_string();
-        file::mutate_config(paths, move |cfg| {
-            if !cfg.workdirs.iter().any(|w| w.name == name) {
-                anyhow::bail!(
-                    "no work dir named {name:?}; add it first with `pidash workdir add --name {name} --path <repo>`"
-                );
-            }
-            if let Some(r) = cfg.runners.iter_mut().find(|r| r.runner_id == runner_id) {
-                r.workdir = Some(name.clone());
-            }
-            cfg.validate()
-                .map_err(|e| anyhow::anyhow!("invalid config after binding workdir: {e}"))?;
-            Ok(())
-        })?;
-        println!("Runner bound to work dir {workdir_name:?} (leases worktrees from its pool).");
-    } else if !args.no_pool {
-        // Default to a pooled runner: auto-provision (or reuse) a worktree pool
-        // from this runner's working_dir so lane-isolation features — notably
-        // concurrent chat during an issue run (#239) — work without a separate
-        // `pidash workdir add`. `--no-pool` keeps the legacy single-dir mode.
-        // Back-compat is preserved at the *parse* layer (a missing `workdir`
-        // still deserializes to `None`), so existing configs are untouched;
-        // this only changes what a *new* `runner add` writes.
-        //
-        // Pooling requires a canonical git clone. The default working_dir is a
-        // data-dir path the daemon clones lazily and isn't a repo yet at
-        // add-time — in that case we leave the runner non-pooled rather than
-        // fail. When the operator pointed --working-dir at an existing repo
-        // (where concurrency actually matters today), we pool it.
-        let working_dir = std::path::absolute(&applied.runner.workspace.working_dir)
-            .unwrap_or_else(|_| applied.runner.workspace.working_dir.clone());
-        if !crate::workspace::git::is_git_repo(&working_dir) {
+    match &applied.workdir {
+        Some(AppliedWorkdir::Existing {
+            name,
+            migrated_legacy_runners,
+        }) => {
             println!(
-                "Runner added non-pooled: working_dir {} is not a git repo yet. \
-                 Once it's cloned, enable concurrent chat by pooling it: \
-                 `pidash workdir add --name <n> --path {0}` then rebind with `--workdir <n>`.",
-                working_dir.display()
+                "Runner bound to work dir {name:?} (leases worktrees from its pool){}.",
+                migration_note(migrated_legacy_runners)
             );
-        } else {
-            let runner_id = applied.runner.runner_id;
-            let seed = applied.runner.name.clone();
-            let wd = working_dir.clone();
-            let pooled = file::mutate_config(paths, move |cfg| {
-                // Reuse a pool already pointed at this path so two runners on the
-                // same repo share one pool (the original pooling use case);
-                // otherwise mint a fresh, uniquely-named pool.
-                let existing = cfg.workdirs.iter().find(|w| w.path == wd).map(|w| w.name.clone());
-                let name = match existing {
-                    Some(n) => n,
-                    None => {
-                        let n = unique_workdir_name(cfg, &seed);
-                        cfg.workdirs.push(WorkdirConfig {
-                            name: n.clone(),
-                            path: wd.clone(),
-                            pool_size: DEFAULT_POOL_SIZE,
-                            clean_mode: CleanMode::default(),
-                            keep_paths: Vec::new(),
-                            setup_command: None,
-                            worktrees_dir: None,
-                        });
-                        n
-                    }
-                };
-                if let Some(r) = cfg.runners.iter_mut().find(|r| r.runner_id == runner_id) {
-                    r.workdir = Some(name);
-                }
-                cfg.validate()
-                    .map_err(|e| anyhow::anyhow!("invalid config after auto-pool: {e}"))?;
-                Ok(())
-            });
-            match pooled {
-                Ok(cfg_after) => {
-                    let chosen = cfg_after
-                        .runners
-                        .iter()
-                        .find(|r| r.runner_id == runner_id)
-                        .and_then(|r| r.workdir.clone())
-                        .unwrap_or_default();
-                    // A pooled canonical clone should sit on a detached HEAD so
-                    // leased worktrees (incl. the chat lane's) can check out any
-                    // branch. Best-effort: a branch left checked out only makes
-                    // runs that pin it wait, so never fail the add over it.
-                    match crate::workspace::git::current_branch(&working_dir).await {
-                        Ok(Some(branch)) => {
-                            match crate::workspace::git::detach_head(&working_dir).await {
-                                Ok(()) => println!(
-                                    "Auto-pooled runner via work dir {chosen:?} (pool_size \
-                                     {DEFAULT_POOL_SIZE}); detached the canonical clone off \
-                                     {branch} so worktrees lease freely. Pass --no-pool for the \
-                                     legacy single-dir mode."
-                                ),
-                                Err(e) => println!(
-                                    "Auto-pooled runner via work dir {chosen:?} (pool_size \
-                                     {DEFAULT_POOL_SIZE}). Note: couldn't detach the canonical \
-                                     clone off {branch} ({e}); runs pinning {branch} will wait \
-                                     until you run `git -C {} checkout --detach`.",
-                                    working_dir.display()
-                                ),
-                            }
-                        }
-                        _ => println!(
-                            "Auto-pooled runner via work dir {chosen:?} (pool_size \
-                             {DEFAULT_POOL_SIZE}). Pass --no-pool for the legacy single-dir mode."
-                        ),
-                    }
-                }
-                Err(e) => println!(
-                    "Runner added, but auto-pooling failed ({e}); left as a non-pooled \
-                     (legacy single-dir) runner. Pool it later with `pidash workdir add` + \
-                     `pidash runner add --workdir <n>`."
+        }
+        Some(AppliedWorkdir::AutoPool {
+            name,
+            path,
+            created,
+            migrated_legacy_runners,
+        }) => {
+            // A pooled canonical clone should sit on a detached HEAD so leased
+            // worktrees (incl. the chat lane's) can check out any branch.
+            // Best-effort: a branch left checked out only makes runs that pin
+            // it wait, so never fail the add over it.
+            match crate::workspace::git::current_branch(path).await {
+                Ok(Some(branch)) => match crate::workspace::git::detach_head(path).await {
+                    Ok(()) => println!(
+                        "Auto-pooled runner via work dir {name:?}{}{}; detached the canonical clone off \
+                         {branch} so worktrees lease freely. Pass --no-pool for the legacy single-dir mode.",
+                        pool_note(*created),
+                        migration_note(migrated_legacy_runners)
+                    ),
+                    Err(e) => println!(
+                        "Auto-pooled runner via work dir {name:?}{}{}. Note: couldn't detach the canonical \
+                         clone off {branch} ({e}); runs pinning {branch} will wait until you run \
+                         `git -C {} checkout --detach`.",
+                        pool_note(*created),
+                        migration_note(migrated_legacy_runners),
+                        path.display()
+                    ),
+                },
+                _ => println!(
+                    "Auto-pooled runner via work dir {name:?}{}{}. Pass --no-pool for the legacy single-dir mode.",
+                    pool_note(*created),
+                    migration_note(migrated_legacy_runners)
                 ),
             }
         }
+        None if !args.no_pool && args.workdir.is_none() => {
+            let working_dir = std::path::absolute(&applied.runner.workspace.working_dir)
+                .unwrap_or_else(|_| applied.runner.workspace.working_dir.clone());
+            if !crate::workspace::git::is_git_repo(&working_dir) {
+                println!(
+                    "Runner added non-pooled: working_dir {} is not a git repo yet. \
+                     Once it's cloned, enable concurrent chat by pooling it: \
+                     `pidash workdir add --name <n> --path {0}` then rebind with `--workdir <n>`.",
+                    working_dir.display()
+                );
+            }
+        }
+        None => {}
     }
 
     println!(
@@ -477,36 +423,20 @@ async fn ensure_cli_token(
         })
 }
 
-/// Derive a unique `[[workdir]]` name for an auto-provisioned pool, seeded from
-/// the runner's name. Non-identifier chars are folded to `-`; collisions get a
-/// numeric suffix so repeated `runner add`s never clash.
-fn unique_workdir_name(cfg: &Config, seed: &str) -> String {
-    let base: String = seed
-        .chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
-                c
-            } else {
-                '-'
-            }
-        })
-        .collect();
-    let base = base.trim_matches('-').to_string();
-    let base = if base.is_empty() {
-        "pool".to_string()
+fn pool_note(created: bool) -> String {
+    if created {
+        format!(" (pool_size {DEFAULT_POOL_SIZE})")
     } else {
-        base
-    };
-    if !cfg.workdirs.iter().any(|w| w.name == base) {
-        return base;
+        String::new()
     }
-    for n in 2.. {
-        let cand = format!("{base}-{n}");
-        if !cfg.workdirs.iter().any(|w| w.name == cand) {
-            return cand;
-        }
+}
+
+fn migration_note(names: &[String]) -> String {
+    if names.is_empty() {
+        String::new()
+    } else {
+        format!("; migrated existing legacy runner(s): {}", names.join(", "))
     }
-    unreachable!("an unbounded search always finds a free name")
 }
 
 fn hostname_or_unknown() -> String {

--- a/runner/src/cli/runner.rs
+++ b/runner/src/cli/runner.rs
@@ -74,13 +74,13 @@ pub struct AddArgs {
     #[arg(long)]
     pub workdir: Option<String>,
 
-    /// Opt out of the default worktree pool and create a legacy runner that
-    /// executes the agent directly in `working_dir`. Without this flag,
-    /// `runner add` auto-provisions (or reuses) a pool from `working_dir` so
-    /// lane-isolation features — notably concurrent chat during an issue run —
-    /// work out of the box. Ignored when `--workdir` is given (that already
-    /// selects a pool). Old configs are unaffected; this only changes what a
-    /// *new* `runner add` writes.
+    /// Deprecated: opt out of the default worktree pool and create a legacy
+    /// runner that executes the agent directly in `working_dir`. Without this
+    /// flag, `runner add` auto-provisions (or reuses) a pool from `working_dir`
+    /// so lane-isolation features — notably concurrent chat during an issue
+    /// run — work out of the box. Ignored when `--workdir` is given (that
+    /// already selects a pool). Old configs are unaffected; this only changes
+    /// what a *new* `runner add` writes.
     #[arg(long)]
     pub no_pool: bool,
 
@@ -174,6 +174,11 @@ pub async fn add(args: AddArgs, paths: &Paths) -> Result<RunnerConfig> {
                  `pidash workdir add --name {workdir_name} --path <repo>`"
             );
         }
+    }
+    if args.no_pool && args.workdir.is_none() {
+        eprintln!(
+            "Warning: `pidash runner add --no-pool` is deprecated. New runners should use the default worktree pool mode or `--workdir <name>`."
+        );
     }
 
     let api_token = ensure_cli_token(paths, args.url.as_deref(), args.workspace.as_deref()).await?;

--- a/runner/src/cli/runner_ops.rs
+++ b/runner/src/cli/runner_ops.rs
@@ -8,13 +8,14 @@
 //! shared dev-machine token in `[cli].token`.
 
 use anyhow::{Context, Result};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::cloud::http::{EnrollResponse, RunnerCredentials, write_runner_credentials};
 use crate::config::file;
 use crate::config::schema::{
-    AgentKind, AgentSection, ApprovalPolicySection, ClaudeCodeSection, CursorAgentSection,
-    CliSection, CodexSection, Config, DaemonConfig, OpenClawSection, RunnerConfig, WorkspaceSection,
+    AgentKind, AgentSection, ApprovalPolicySection, ClaudeCodeSection, CleanMode, CliSection,
+    CodexSection, Config, CursorAgentSection, DEFAULT_POOL_SIZE, DaemonConfig, OpenClawSection,
+    RunnerConfig, WorkdirConfig, WorkspaceSection,
 };
 use crate::util::paths::Paths;
 use std::io::IsTerminal;
@@ -66,7 +67,9 @@ fn model_applies_to_agent(kind: AgentKind, model: &str) -> bool {
         AgentKind::ClaudeCode => has("claude-"),
         // `o3` / `o4` are valid bare model names; the dash-terminated
         // families (`gpt-`, `codex`) require a suffix.
-        AgentKind::Codex => has("gpt-") || m == "o3" || m == "o4" || has("o3-") || has("o4-") || has("codex"),
+        AgentKind::Codex => {
+            has("gpt-") || m == "o3" || m == "o4" || has("o3-") || has("o4-") || has("codex")
+        }
         AgentKind::CursorAgent | AgentKind::OpenClaw => !m.is_empty(),
     }
 }
@@ -310,6 +313,36 @@ pub fn clear_cli_token(paths: &Paths) -> Result<()> {
 pub struct AppliedRunner {
     pub runner: RunnerConfig,
     pub is_first_runner: bool,
+    pub workdir: Option<AppliedWorkdir>,
+}
+
+/// How `pidash runner add` wants the new runner bound locally.
+#[derive(Debug, Clone, Default)]
+pub enum RunnerWorkdirPlan {
+    /// Legacy mode: the runner executes directly in `workspace.working_dir`.
+    #[default]
+    Legacy,
+    /// Bind to an already configured `[[workdir]]`.
+    Existing { name: String },
+    /// If `workspace.working_dir` is already a git repo, create or reuse a
+    /// pool for it and bind the new runner to that pool. Non-git paths stay
+    /// legacy so first-run bootstrap remains permissive.
+    AutoPoolIfGit,
+}
+
+/// Workdir binding that was actually written to config.toml.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AppliedWorkdir {
+    Existing {
+        name: String,
+        migrated_legacy_runners: Vec<String>,
+    },
+    AutoPool {
+        name: String,
+        path: PathBuf,
+        created: bool,
+        migrated_legacy_runners: Vec<String>,
+    },
 }
 
 /// Apply an `EnrollResponse` (from either the legacy enroll endpoint or
@@ -331,6 +364,7 @@ pub async fn apply_enroll_response(
     agent_kind: AgentKind,
     model: Option<&str>,
     reasoning_effort: Option<&str>,
+    workdir_plan: RunnerWorkdirPlan,
 ) -> Result<AppliedRunner> {
     let working_dir =
         working_dir.unwrap_or_else(|| paths.runner_dir(resp.runner_id).join("workspace"));
@@ -381,8 +415,10 @@ pub async fn apply_enroll_response(
     // `mutate_config_or_init` would race with a concurrent `auth login
     // --url <different>` that may be rewriting `[cli]` at the same time.
     let new_runner_for_closure = new_runner.clone();
+    let runner_id = new_runner.runner_id;
     let mut is_first_runner = false;
-    file::mutate_config_or_init(paths, init_cfg, |cfg| {
+    let mut applied_workdir = None;
+    let cfg_after = file::mutate_config_or_init(paths, init_cfg, |cfg| {
         if !cfg.daemon.cloud_url.is_empty() && cfg.daemon.cloud_url != cloud_url {
             anyhow::bail!(
                 "this host is enrolled with cloud {} — refusing to add a runner pointing at {}",
@@ -394,10 +430,18 @@ pub async fn apply_enroll_response(
             cfg.daemon.cloud_url = cloud_url.to_string();
         }
         is_first_runner = cfg.runners.is_empty();
-        cfg.runners.push(new_runner_for_closure);
+        let mut runner = new_runner_for_closure;
+        applied_workdir = apply_workdir_plan(cfg, &mut runner, &workdir_plan)?;
+        cfg.runners.push(runner);
         Ok(())
     })
-    .map_err(|e| anyhow::anyhow!("persisting [[runner]] block under config lock: {e}"))?;
+    .context("persisting [[runner]] block under config lock")?;
+    let new_runner = cfg_after
+        .runners
+        .iter()
+        .find(|runner| runner.runner_id == runner_id)
+        .cloned()
+        .unwrap_or(new_runner);
 
     // Credentials write happens AFTER config so a config-write failure
     // (cloud-URL mismatch, validation error, IO) doesn't leave an orphan
@@ -431,6 +475,7 @@ pub async fn apply_enroll_response(
         return Ok(AppliedRunner {
             runner: new_runner,
             is_first_runner,
+            workdir: applied_workdir,
         });
     }
     write_runner_credentials(
@@ -448,7 +493,121 @@ pub async fn apply_enroll_response(
     Ok(AppliedRunner {
         runner: new_runner,
         is_first_runner,
+        workdir: applied_workdir,
     })
+}
+
+fn apply_workdir_plan(
+    cfg: &mut Config,
+    runner: &mut RunnerConfig,
+    plan: &RunnerWorkdirPlan,
+) -> Result<Option<AppliedWorkdir>> {
+    match plan {
+        RunnerWorkdirPlan::Legacy => Ok(None),
+        RunnerWorkdirPlan::Existing { name } => {
+            let path = cfg
+                .workdirs
+                .iter()
+                .find(|w| w.name == *name)
+                .map(|w| w.path.clone())
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "no work dir named {name:?}; add it first with `pidash workdir add --name {name} --path <repo>`"
+                    )
+                })?;
+            let migrated_legacy_runners = migrate_exact_legacy_runners(cfg, &path, name);
+            runner.workdir = Some(name.clone());
+            Ok(Some(AppliedWorkdir::Existing {
+                name: name.clone(),
+                migrated_legacy_runners,
+            }))
+        }
+        RunnerWorkdirPlan::AutoPoolIfGit => {
+            let path = absolute_path(&runner.workspace.working_dir);
+            if !crate::workspace::git::is_git_repo(&path) {
+                return Ok(None);
+            }
+            let (name, created) = match cfg.workdirs.iter().find(|w| same_path(&w.path, &path)) {
+                Some(existing) => (existing.name.clone(), false),
+                None => {
+                    let name = unique_workdir_name(cfg, &runner.name);
+                    cfg.workdirs.push(WorkdirConfig {
+                        name: name.clone(),
+                        path: path.clone(),
+                        pool_size: DEFAULT_POOL_SIZE,
+                        clean_mode: CleanMode::default(),
+                        keep_paths: Vec::new(),
+                        setup_command: None,
+                        worktrees_dir: None,
+                    });
+                    (name, true)
+                }
+            };
+            let migrated_legacy_runners = migrate_exact_legacy_runners(cfg, &path, &name);
+            runner.workdir = Some(name.clone());
+            Ok(Some(AppliedWorkdir::AutoPool {
+                name,
+                path,
+                created,
+                migrated_legacy_runners,
+            }))
+        }
+    }
+}
+
+fn migrate_exact_legacy_runners(
+    cfg: &mut Config,
+    workdir_path: &Path,
+    workdir_name: &str,
+) -> Vec<String> {
+    let mut migrated = Vec::new();
+    for runner in &mut cfg.runners {
+        if runner.workdir.is_none() && same_path(&runner.workspace.working_dir, workdir_path) {
+            runner.workdir = Some(workdir_name.to_string());
+            migrated.push(runner.name.clone());
+        }
+    }
+    migrated
+}
+
+fn same_path(a: &Path, b: &Path) -> bool {
+    absolute_path(a) == absolute_path(b)
+}
+
+fn absolute_path(path: &Path) -> PathBuf {
+    std::path::absolute(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// Derive a unique `[[workdir]]` name for an auto-provisioned pool, seeded from
+/// the runner's name. Non-identifier chars are folded to `-`; collisions get a
+/// numeric suffix so repeated `runner add`s never clash.
+fn unique_workdir_name(cfg: &Config, seed: &str) -> String {
+    let base: String = seed
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    let base = base.trim_matches('-').to_string();
+    let base = if base.is_empty() {
+        "pool".to_string()
+    } else {
+        base
+    };
+    if !cfg.workdirs.iter().any(|w| w.name == base) {
+        return base;
+    }
+    for n in 2.. {
+        let cand = format!("{base}-{n}");
+        if !cfg.workdirs.iter().any(|w| w.name == cand) {
+            return cand;
+        }
+    }
+    unreachable!("an unbounded search always finds a free name")
 }
 
 #[cfg(test)]
@@ -495,16 +654,18 @@ mod tests {
 
     #[test]
     fn unknown_codex_effort_is_dropped() {
-        let (codex, _, _, _) =
-            agent_sections_for(AgentKind::Codex, Some("gpt-5.5"), Some("turbo"));
+        let (codex, _, _, _) = agent_sections_for(AgentKind::Codex, Some("gpt-5.5"), Some("turbo"));
         assert_eq!(codex.model_default.as_deref(), Some("gpt-5.5"));
         assert_eq!(codex.effort_default, None);
     }
 
     #[test]
     fn cursor_accepts_any_nonempty_slug() {
-        let (_, _, cursor, _) =
-            agent_sections_for(AgentKind::CursorAgent, Some("claude-opus-4-8-thinking-high"), None);
+        let (_, _, cursor, _) = agent_sections_for(
+            AgentKind::CursorAgent,
+            Some("claude-opus-4-8-thinking-high"),
+            None,
+        );
         assert_eq!(
             cursor.model_default.as_deref(),
             Some("claude-opus-4-8-thinking-high")
@@ -577,6 +738,10 @@ mod tests {
         }
     }
 
+    fn mark_git_repo(path: &std::path::Path) {
+        std::fs::create_dir_all(path.join(".git")).unwrap();
+    }
+
     fn sample_response(runner_name: &str) -> EnrollResponse {
         EnrollResponse {
             runner_id: Uuid::new_v4(),
@@ -608,6 +773,7 @@ mod tests {
             AgentKind::Codex,
             None,
             None,
+            RunnerWorkdirPlan::Legacy,
         )
         .await
         .unwrap();
@@ -631,6 +797,7 @@ mod tests {
             AgentKind::Codex,
             None,
             None,
+            RunnerWorkdirPlan::Legacy,
         )
         .await
         .unwrap();
@@ -644,12 +811,125 @@ mod tests {
             AgentKind::Codex,
             None,
             None,
+            RunnerWorkdirPlan::Legacy,
         )
         .await
         .unwrap();
         assert!(!applied.is_first_runner);
         let cfg = file::load_config(&paths).unwrap();
         assert_eq!(cfg.runners.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn auto_pool_migrates_existing_legacy_runner_with_same_working_dir() {
+        let tmp = tempdir().unwrap();
+        let paths = paths_for(tmp.path());
+        let repo = tmp.path().join("repo");
+        mark_git_repo(&repo);
+
+        let existing = sample_response("existing_claude");
+        apply_enroll_response(
+            &paths,
+            &existing,
+            "https://example.com",
+            Some(repo.clone()),
+            AgentKind::ClaudeCode,
+            None,
+            None,
+            RunnerWorkdirPlan::Legacy,
+        )
+        .await
+        .unwrap();
+
+        let added = sample_response("new_codex");
+        let applied = apply_enroll_response(
+            &paths,
+            &added,
+            "https://example.com",
+            Some(repo.clone()),
+            AgentKind::Codex,
+            None,
+            None,
+            RunnerWorkdirPlan::AutoPoolIfGit,
+        )
+        .await
+        .unwrap();
+
+        let AppliedWorkdir::AutoPool {
+            name,
+            created,
+            migrated_legacy_runners,
+            ..
+        } = applied.workdir.expect("new runner should be auto-pooled")
+        else {
+            panic!("expected auto-pool binding");
+        };
+        assert_eq!(name, "new_codex");
+        assert!(created);
+        assert_eq!(migrated_legacy_runners, vec!["existing_claude"]);
+
+        let cfg = file::load_config(&paths).unwrap();
+        cfg.validate().unwrap();
+        assert_eq!(cfg.workdirs.len(), 1);
+        assert_eq!(
+            cfg.workdirs[0].path,
+            std::path::absolute(&repo).unwrap_or(repo)
+        );
+        assert_eq!(
+            cfg.runners
+                .iter()
+                .find(|r| r.runner_id == existing.runner_id)
+                .and_then(|r| r.workdir.as_deref()),
+            Some("new_codex")
+        );
+        assert_eq!(
+            cfg.runners
+                .iter()
+                .find(|r| r.runner_id == added.runner_id)
+                .and_then(|r| r.workdir.as_deref()),
+            Some("new_codex")
+        );
+    }
+
+    #[tokio::test]
+    async fn legacy_add_still_rejects_duplicate_working_dir() {
+        let tmp = tempdir().unwrap();
+        let paths = paths_for(tmp.path());
+        let repo = tmp.path().join("repo");
+        mark_git_repo(&repo);
+
+        let r1 = sample_response("r1");
+        apply_enroll_response(
+            &paths,
+            &r1,
+            "https://example.com",
+            Some(repo.clone()),
+            AgentKind::Codex,
+            None,
+            None,
+            RunnerWorkdirPlan::Legacy,
+        )
+        .await
+        .unwrap();
+
+        let r2 = sample_response("r2");
+        let err = apply_enroll_response(
+            &paths,
+            &r2,
+            "https://example.com",
+            Some(repo),
+            AgentKind::Codex,
+            None,
+            None,
+            RunnerWorkdirPlan::Legacy,
+        )
+        .await
+        .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("share") && msg.contains("working_dir"),
+            "unexpected duplicate-working-dir error: {msg}"
+        );
     }
 
     #[tokio::test]
@@ -669,6 +949,7 @@ mod tests {
             AgentKind::Codex,
             None,
             None,
+            RunnerWorkdirPlan::Legacy,
         )
         .await
         .unwrap();
@@ -682,10 +963,11 @@ mod tests {
             AgentKind::Codex,
             None,
             None,
+            RunnerWorkdirPlan::Legacy,
         )
         .await
         .unwrap_err();
-        assert!(format!("{err}").contains("refusing to add a runner pointing at"));
+        assert!(format!("{err:#}").contains("refusing to add a runner pointing at"));
         // No credentials file should exist for r2 — the bail happened
         // before the write.
         let r2_creds = paths.for_runner(r2.runner_id).credentials_path();

--- a/runner/src/cli/runner_ops.rs
+++ b/runner/src/cli/runner_ops.rs
@@ -15,7 +15,7 @@ use crate::config::file;
 use crate::config::schema::{
     AgentKind, AgentSection, ApprovalPolicySection, ClaudeCodeSection, CleanMode, CliSection,
     CodexSection, Config, CursorAgentSection, DEFAULT_POOL_SIZE, DaemonConfig, OpenClawSection,
-    RunnerConfig, WorkdirConfig, WorkspaceSection,
+    RunnerConfig, WorkdirConfig, WorkspaceSection, canonical_for_compare,
 };
 use crate::util::paths::Paths;
 use std::io::IsTerminal;
@@ -579,7 +579,7 @@ fn migrate_exact_legacy_runners(
 }
 
 fn same_path(a: &Path, b: &Path) -> bool {
-    absolute_path(a) == absolute_path(b)
+    canonical_for_compare(a) == canonical_for_compare(b)
 }
 
 fn absolute_path(path: &Path) -> PathBuf {

--- a/runner/src/cli/runner_ops.rs
+++ b/runner/src/cli/runner_ops.rs
@@ -345,6 +345,15 @@ pub enum AppliedWorkdir {
     },
 }
 
+#[derive(Debug, Clone)]
+pub struct ApplyEnrollOptions<'a> {
+    pub working_dir: Option<PathBuf>,
+    pub agent_kind: AgentKind,
+    pub model: Option<&'a str>,
+    pub reasoning_effort: Option<&'a str>,
+    pub workdir_plan: RunnerWorkdirPlan,
+}
+
 /// Apply an `EnrollResponse` (from either the legacy enroll endpoint or
 /// the new CLI-initiated create endpoint) to local disk:
 ///
@@ -360,17 +369,14 @@ pub async fn apply_enroll_response(
     paths: &Paths,
     resp: &EnrollResponse,
     cloud_url: &str,
-    working_dir: Option<PathBuf>,
-    agent_kind: AgentKind,
-    model: Option<&str>,
-    reasoning_effort: Option<&str>,
-    workdir_plan: RunnerWorkdirPlan,
+    options: ApplyEnrollOptions<'_>,
 ) -> Result<AppliedRunner> {
-    let working_dir =
-        working_dir.unwrap_or_else(|| paths.runner_dir(resp.runner_id).join("workspace"));
+    let working_dir = options
+        .working_dir
+        .unwrap_or_else(|| paths.runner_dir(resp.runner_id).join("workspace"));
 
     let (codex, claude_code, cursor_agent, openclaw) =
-        agent_sections_for(agent_kind, model, reasoning_effort);
+        agent_sections_for(options.agent_kind, options.model, options.reasoning_effort);
     let new_runner = RunnerConfig {
         name: resp.runner_name.clone(),
         runner_id: resp.runner_id,
@@ -379,7 +385,9 @@ pub async fn apply_enroll_response(
         pod_id: None,
         workspace: WorkspaceSection { working_dir },
         workdir: None,
-        agent: AgentSection { kind: agent_kind },
+        agent: AgentSection {
+            kind: options.agent_kind,
+        },
         codex,
         claude_code,
         cursor_agent,
@@ -431,7 +439,7 @@ pub async fn apply_enroll_response(
         }
         is_first_runner = cfg.runners.is_empty();
         let mut runner = new_runner_for_closure;
-        applied_workdir = apply_workdir_plan(cfg, &mut runner, &workdir_plan)?;
+        applied_workdir = apply_workdir_plan(cfg, &mut runner, &options.workdir_plan)?;
         cfg.runners.push(runner);
         Ok(())
     })
@@ -738,6 +746,20 @@ mod tests {
         }
     }
 
+    fn enroll_options(
+        working_dir: PathBuf,
+        agent_kind: AgentKind,
+        workdir_plan: RunnerWorkdirPlan,
+    ) -> ApplyEnrollOptions<'static> {
+        ApplyEnrollOptions {
+            working_dir: Some(working_dir),
+            agent_kind,
+            model: None,
+            reasoning_effort: None,
+            workdir_plan,
+        }
+    }
+
     fn mark_git_repo(path: &std::path::Path) {
         std::fs::create_dir_all(path.join(".git")).unwrap();
     }
@@ -769,11 +791,11 @@ mod tests {
             &paths,
             &resp,
             "https://example.com",
-            Some(tmp.path().join("wd")),
-            AgentKind::Codex,
-            None,
-            None,
-            RunnerWorkdirPlan::Legacy,
+            enroll_options(
+                tmp.path().join("wd"),
+                AgentKind::Codex,
+                RunnerWorkdirPlan::Legacy,
+            ),
         )
         .await
         .unwrap();
@@ -793,11 +815,11 @@ mod tests {
             &paths,
             &r1,
             "https://example.com",
-            Some(tmp.path().join("wd1")),
-            AgentKind::Codex,
-            None,
-            None,
-            RunnerWorkdirPlan::Legacy,
+            enroll_options(
+                tmp.path().join("wd1"),
+                AgentKind::Codex,
+                RunnerWorkdirPlan::Legacy,
+            ),
         )
         .await
         .unwrap();
@@ -807,11 +829,11 @@ mod tests {
             &paths,
             &r2,
             "https://example.com",
-            Some(tmp.path().join("wd2")),
-            AgentKind::Codex,
-            None,
-            None,
-            RunnerWorkdirPlan::Legacy,
+            enroll_options(
+                tmp.path().join("wd2"),
+                AgentKind::Codex,
+                RunnerWorkdirPlan::Legacy,
+            ),
         )
         .await
         .unwrap();
@@ -832,11 +854,11 @@ mod tests {
             &paths,
             &existing,
             "https://example.com",
-            Some(repo.clone()),
-            AgentKind::ClaudeCode,
-            None,
-            None,
-            RunnerWorkdirPlan::Legacy,
+            enroll_options(
+                repo.clone(),
+                AgentKind::ClaudeCode,
+                RunnerWorkdirPlan::Legacy,
+            ),
         )
         .await
         .unwrap();
@@ -846,11 +868,11 @@ mod tests {
             &paths,
             &added,
             "https://example.com",
-            Some(repo.clone()),
-            AgentKind::Codex,
-            None,
-            None,
-            RunnerWorkdirPlan::AutoPoolIfGit,
+            enroll_options(
+                repo.clone(),
+                AgentKind::Codex,
+                RunnerWorkdirPlan::AutoPoolIfGit,
+            ),
         )
         .await
         .unwrap();
@@ -903,11 +925,7 @@ mod tests {
             &paths,
             &r1,
             "https://example.com",
-            Some(repo.clone()),
-            AgentKind::Codex,
-            None,
-            None,
-            RunnerWorkdirPlan::Legacy,
+            enroll_options(repo.clone(), AgentKind::Codex, RunnerWorkdirPlan::Legacy),
         )
         .await
         .unwrap();
@@ -917,11 +935,7 @@ mod tests {
             &paths,
             &r2,
             "https://example.com",
-            Some(repo),
-            AgentKind::Codex,
-            None,
-            None,
-            RunnerWorkdirPlan::Legacy,
+            enroll_options(repo, AgentKind::Codex, RunnerWorkdirPlan::Legacy),
         )
         .await
         .unwrap_err();
@@ -945,11 +959,11 @@ mod tests {
             &paths,
             &r1,
             "https://cloud-a.example.com",
-            Some(tmp.path().join("wd1")),
-            AgentKind::Codex,
-            None,
-            None,
-            RunnerWorkdirPlan::Legacy,
+            enroll_options(
+                tmp.path().join("wd1"),
+                AgentKind::Codex,
+                RunnerWorkdirPlan::Legacy,
+            ),
         )
         .await
         .unwrap();
@@ -959,11 +973,11 @@ mod tests {
             &paths,
             &r2,
             "https://cloud-b.example.com",
-            Some(tmp.path().join("wd2")),
-            AgentKind::Codex,
-            None,
-            None,
-            RunnerWorkdirPlan::Legacy,
+            enroll_options(
+                tmp.path().join("wd2"),
+                AgentKind::Codex,
+                RunnerWorkdirPlan::Legacy,
+            ),
         )
         .await
         .unwrap_err();

--- a/runner/src/config/schema.rs
+++ b/runner/src/config/schema.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 use uuid::Uuid;
 
@@ -519,6 +519,20 @@ pub struct Credentials {
 /// number; the cloud rejects `Hello` beyond it as well.
 pub const MAX_RUNNERS_PER_DAEMON: usize = 50;
 
+/// Normalize a path for *physical-identity* comparison. When the path exists we
+/// `canonicalize` it, resolving symlinks and (on case-insensitive filesystems)
+/// casing so two spellings of one directory — a symlinked `~/repo`, or `C:\repo`
+/// vs `c:\repo` — compare equal. When it does not yet exist (a canonical clone
+/// the daemon creates lazily, or a unit-test fixture path) we fall back to
+/// lexical absolutization, preserving the old behavior. Every "same or nested
+/// working dir" collision check routes through this so config validation and
+/// `runner add`'s auto-pool dedup agree on what "the same repo" means.
+pub(crate) fn canonical_for_compare(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path)
+        .or_else(|_| std::path::absolute(path))
+        .unwrap_or_else(|_| path.to_path_buf())
+}
+
 impl Config {
     /// First configured runner, or `None` for a freshly enrolled connection
     /// that has no runners yet. Callers that need a panic-on-absent
@@ -604,14 +618,15 @@ impl Config {
                 }
                 let ap = &a.workspace.working_dir;
                 let bp = &b.workspace.working_dir;
-                if ap == bp {
+                let (apc, bpc) = (canonical_for_compare(ap), canonical_for_compare(bp));
+                if apc == bpc {
                     return Err(ConfigError::DuplicateWorkingDir {
                         runner_a: a.name.clone(),
                         runner_b: b.name.clone(),
                         path: ap.display().to_string(),
                     });
                 }
-                if ap.starts_with(bp) || bp.starts_with(ap) {
+                if apc.starts_with(&bpc) || bpc.starts_with(&apc) {
                     return Err(ConfigError::NestedWorkingDir {
                         runner_a: a.name.clone(),
                         path_a: ap.display().to_string(),
@@ -651,7 +666,10 @@ impl Config {
         // corrupt git state exactly as two legacy runners sharing a dir would.
         // (Default worktrees_dirs live under `data_dir/worktrees/<name>` and
         // cannot collide: names are unique.)
-        let collide = |x: &PathBuf, y: &PathBuf| x == y || x.starts_with(y) || y.starts_with(x);
+        let collide = |x: &PathBuf, y: &PathBuf| {
+            let (x, y) = (canonical_for_compare(x), canonical_for_compare(y));
+            x == y || x.starts_with(&y) || y.starts_with(&x)
+        };
         let claimed = |w: &WorkdirConfig| -> Vec<PathBuf> {
             let mut v = vec![w.path.clone()];
             if let Some(wt) = &w.worktrees_dir {
@@ -1013,6 +1031,45 @@ mod tests {
         assert!(msg.contains("\"a\""), "message: {msg}");
         assert!(msg.contains("\"b\""), "message: {msg}");
         assert!(msg.contains("/work/shared"), "message: {msg}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn canonical_for_compare_resolves_symlinks() {
+        let tmp = tempfile::tempdir().unwrap();
+        let real = tmp.path().join("repo");
+        std::fs::create_dir(&real).unwrap();
+        let link = tmp.path().join("repo-link");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+        // A directory and a symlink pointing at it normalize to one path.
+        assert_eq!(canonical_for_compare(&real), canonical_for_compare(&link));
+        // A path that doesn't exist yet still normalizes deterministically
+        // (lexical fallback) so it stays comparable with itself.
+        let ghost = tmp.path().join("not-created-yet");
+        assert_eq!(canonical_for_compare(&ghost), canonical_for_compare(&ghost));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn validate_rejects_legacy_runners_sharing_a_dir_via_symlink() {
+        // Two spellings of one physical directory — a real path and a symlink
+        // to it — must collide, or two legacy runners would silently trample
+        // each other's git state. Lexical comparison missed this; the
+        // canonicalize-based check catches it.
+        let tmp = tempfile::tempdir().unwrap();
+        let real = tmp.path().join("repo");
+        std::fs::create_dir(&real).unwrap();
+        let link = tmp.path().join("repo-link");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+        let cfg = config_with(vec![
+            runner("a", real.to_str().unwrap()),
+            runner("b", link.to_str().unwrap()),
+        ]);
+        let err = cfg.validate().unwrap_err();
+        assert!(
+            matches!(err, ConfigError::DuplicateWorkingDir { .. }),
+            "expected symlinked working dirs to collide, got {err:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes a `pidash runner add` regression introduced by worktree pooling. The add flow was persisting a new runner as a legacy direct-working-dir runner first, then attempting to bind it to a pool in a later mutation. If an existing legacy runner already used the same repo path, config validation rejected the intermediate state before pooling could happen.

This change moves workdir planning into the initial local persistence step so the config is written in its final valid shape. Default pooled adds now create or reuse a `[[workdir]]`, bind the new runner to it, and migrate exact-path legacy runners into that pool in the same locked mutation. Explicit `--no-pool` legacy adds still reject duplicate direct `working_dir` usage.

## Impact

Users with existing pre-pool runners can add a second runner for the same repo without manually editing config or cloning a second checkout. The old safety rule remains for true legacy direct execution.

## Validation

- `cargo test --manifest-path runner/Cargo.toml runner_ops::tests`
- `cargo test --manifest-path runner/Cargo.toml --test pidash_runner_add_auth`