### PR TITLE
PDASHOSS01-51 Unify Pi Dash AI and AI runner chat to use the same shared UI components

### DIFF
--- a/apps/web/app/(all)/[workspaceSlug]/runners/chat/[runnerId]/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/chat/[runnerId]/page.tsx
@@ -14,8 +14,8 @@ import { RunnerService, getRunnerDetail } from "@pi-dash/services";
 import type { IAgentChatEvent, IAgentChatMessage, IAgentChatSession, IRunner } from "@pi-dash/types";
 import { Badge, Button } from "@pi-dash/ui";
 import { ChatComposer } from "@/components/chat/composer";
+import { ChatContainer } from "@/components/chat/container";
 import { ChatMessage } from "@/components/chat/message";
-import { ChatMessageList } from "@/components/chat/message-list";
 import { useAgentChatEvents } from "@/components/runners/chat/use-agent-chat-events";
 import { useWorkspace } from "@/hooks/store/use-workspace";
 
@@ -300,42 +300,43 @@ const RunnerChatPage = observer(function RunnerChatPage() {
     ));
 
   return (
-    <div className="flex h-full min-h-[640px] flex-col overflow-hidden">
-      <div className="flex h-12 shrink-0 items-center justify-between border-b border-subtle">
-        <div className="min-w-0">
-          <div className="text-15 truncate font-semibold text-primary">{runner?.name ?? "Runner"}</div>
-          <div className="text-12 text-secondary">{runner?.pod_detail?.name ?? runner?.status ?? ""}</div>
+    <ChatContainer
+      className="min-h-[640px]"
+      header={
+        <div className="flex h-12 shrink-0 items-center justify-between border-b border-subtle">
+          <div className="min-w-0">
+            <div className="text-15 truncate font-semibold text-primary">{runner?.name ?? "Runner"}</div>
+            <div className="text-12 text-secondary">{runner?.pod_detail?.name ?? runner?.status ?? ""}</div>
+          </div>
+          <div className="flex items-center gap-2">
+            {runner && (
+              <Badge variant={runner.status === "online" ? "accent-success" : "accent-neutral"}>{runner.status}</Badge>
+            )}
+            {session && (
+              <Button variant="neutral-primary" size="sm" onClick={close}>
+                <X className="size-4" />
+              </Button>
+            )}
+          </div>
         </div>
-        <div className="flex items-center gap-2">
-          {runner && (
-            <Badge variant={runner.status === "online" ? "accent-success" : "accent-neutral"}>{runner.status}</Badge>
-          )}
-          {session && (
-            <Button variant="neutral-primary" size="sm" onClick={close}>
-              <X className="size-4" />
-            </Button>
-          )}
-        </div>
-      </div>
-
-      <ChatMessageList
-        messages={rows}
-        renderMessage={(m) => <ChatMessage role={m.role} content={m.content} status={m.status} />}
-        emptyState={<div className="py-16 text-center text-13 text-secondary">No messages</div>}
-        footer={eventStrip.length > 0 ? <>{eventStrip}</> : undefined}
-      />
-
-      <ChatComposer
-        draft={draft}
-        onDraftChange={setDraft}
-        onSend={send}
-        onStop={stop}
-        busy={busy}
-        sending={sending}
-        disabledReason={reason}
-        placeholder="Message this runner…"
-      />
-    </div>
+      }
+      messages={rows}
+      renderMessage={(m) => <ChatMessage role={m.role} content={m.content} status={m.status} />}
+      emptyState={<div className="py-16 text-center text-13 text-secondary">No messages</div>}
+      listFooter={eventStrip.length > 0 ? <>{eventStrip}</> : undefined}
+      composer={
+        <ChatComposer
+          draft={draft}
+          onDraftChange={setDraft}
+          onSend={send}
+          onStop={stop}
+          busy={busy}
+          sending={sending}
+          disabledReason={reason}
+          placeholder="Message this runner…"
+        />
+      }
+    />
   );
 });
 

--- a/apps/web/core/components/assistant/chat-root.tsx
+++ b/apps/web/core/components/assistant/chat-root.tsx
@@ -8,7 +8,7 @@ import { useEffect, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router";
 import { setToast, TOAST_TYPE } from "@pi-dash/propel/toast";
 import { ChatComposer } from "@/components/chat/composer";
-import { ChatMessageList } from "@/components/chat/message-list";
+import { ChatContainer } from "@/components/chat/container";
 import { AssistantMessage } from "@/components/assistant/assistant-message";
 import { AssistantSetupCard } from "@/components/assistant/setup-card";
 import { useAssistantChat } from "@/components/assistant/use-assistant-chat";
@@ -48,30 +48,30 @@ export function AssistantChatRoot({ slug, threadId }: { slug: string; threadId: 
   };
 
   return (
-    <div className="flex h-full min-h-0 flex-col overflow-hidden">
-      <ChatMessageList
-        messages={messages}
-        renderMessage={(m) => <AssistantMessage message={m} />}
-        emptyState={
-          needsSetup ? (
-            <AssistantSetupCard />
-          ) : (
-            <div className="py-16 text-center text-13 text-secondary">
-              Ask about your issues, create work, or start a coding run.
-            </div>
-          )
-        }
-      />
-      {error && <div className="text-danger mb-2 text-12">{error}</div>}
-      <ChatComposer
-        draft={draft}
-        onDraftChange={setDraft}
-        onSend={onSend}
-        onStop={stop}
-        busy={busy}
-        sending={sending}
-        disabledReason={needsSetup ? API_KEY_REMINDER : null}
-      />
-    </div>
+    <ChatContainer
+      messages={messages}
+      renderMessage={(m) => <AssistantMessage message={m} />}
+      emptyState={
+        needsSetup ? (
+          <AssistantSetupCard />
+        ) : (
+          <div className="py-16 text-center text-13 text-secondary">
+            Ask about your issues, create work, or start a coding run.
+          </div>
+        )
+      }
+      error={error ? <div className="text-danger mb-2 text-12">{error}</div> : undefined}
+      composer={
+        <ChatComposer
+          draft={draft}
+          onDraftChange={setDraft}
+          onSend={onSend}
+          onStop={stop}
+          busy={busy}
+          sending={sending}
+          disabledReason={needsSetup ? API_KEY_REMINDER : null}
+        />
+      }
+    />
   );
 }

--- a/apps/web/core/components/chat/container.tsx
+++ b/apps/web/core/components/chat/container.tsx
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import type { ReactNode } from "react";
+import { cn } from "@pi-dash/utils";
+import { type ChatListItem, ChatMessageList } from "@/components/chat/message-list";
+
+interface ChatContainerProps<M extends ChatListItem> {
+  messages: M[];
+  renderMessage?: (message: M) => ReactNode;
+  emptyState?: ReactNode;
+  /** Extra content rendered after the messages (e.g. a runner debug event strip). */
+  listFooter?: ReactNode;
+  /** Optional header row above the message list (e.g. the runner's title bar). */
+  header?: ReactNode;
+  /** Optional inline notice rendered between the list and the composer (e.g. an error line). */
+  error?: ReactNode;
+  /** The composer element for this surface (each view owns its own props/handlers). */
+  composer: ReactNode;
+  /** Override the outer height/layout when a surface needs it (e.g. a min-height). */
+  className?: string;
+}
+
+/**
+ * Shared chat shell that assembles the message list, an optional header/footer,
+ * an optional inline error, and the composer into the standard full-height
+ * chat layout. Both the Pi Dash AI assistant chat and the runner agent chat
+ * render through this so layout and streaming/scroll behavior improve in one
+ * place; surface-specific differences are supplied via props/slots.
+ */
+export function ChatContainer<M extends ChatListItem>({
+  messages,
+  renderMessage,
+  emptyState,
+  listFooter,
+  header,
+  error,
+  composer,
+  className,
+}: ChatContainerProps<M>) {
+  return (
+    <div className={cn("flex h-full min-h-0 flex-col overflow-hidden", className)}>
+      {header}
+      <ChatMessageList messages={messages} renderMessage={renderMessage} emptyState={emptyState} footer={listFooter} />
+      {error}
+      {composer}
+    </div>
+  );
+}


### PR DESCRIPTION
## PDASHOSS01-51 — Unify Pi Dash AI and AI runner chat UI

### Context

The primitive chat components — `ChatMessage`, `ChatMessageList`, `ChatComposer`, `ChatToolActivity` — were **already extracted and shared** between the Pi Dash AI assistant chat and the runner agent chat (they live in `apps/web/core/components/chat/` and both surfaces import them; that unification landed in #269).

What remained was the top-level `ChatContainer` the issue explicitly calls for: both full chat views still hand-assembled the outer flex-column shell (message list + optional header/footer + inline error + composer), so any layout/scroll/streaming-shell change had to be duplicated across the two files.

### Change

- Add `apps/web/core/components/chat/container.tsx` — a shared `ChatContainer` composable that assembles the message list, an optional `header` slot, an optional `listFooter`, an optional inline `error`, and the `composer` into the standard full-height chat layout.
- Route `AssistantChatRoot` and the runner chat page (`runners/chat/[runnerId]/page.tsx`) through it.
- Surface-specific differences are supplied via props/slots rather than forking the layout:
  - **Runner**: `header` (runner title/pod/status Badge + close button), `listFooter` (debug event strip), `className="min-h-[640px]"`, runner composer props.
  - **Assistant**: setup-card/empty-state, inline `error` line, assistant composer props.

A single change to the chat shell (layout, scroll behavior, error placement) now lands in one place for both surfaces.

### Scope notes

- The assistant landing page (`assistant/page.tsx`) uses only a standalone `ChatComposer` (a centered "start a chat" screen, not a full chat view) and is intentionally left as-is.
- **Follow-up candidate (out of scope):** promoting the shared chat components from `apps/web/core/components/chat/` into `packages/ui` (per the `@pi-dash/ui` convention in AGENTS.md). That is a larger, separable refactor because the components depend on app-level `MarkdownRenderer` and react-router `Link`, which would need to be injected.

### Validation

- `pnpm turbo run check:types --filter=web` — passes.
- `pnpm turbo run check:lint --filter=web` — 0 errors (pre-existing warnings unchanged).
- `oxfmt --check` on all three touched files — clean.
- No behavioral or visual change intended: the exact class strings each view used are preserved (the runner's `min-h-[640px]` overrides the container default via tailwind-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
