### PR TITLE
PDASHOSS01-41 new user has to create workspace?

### DIFF
--- a/apps/api/pi_dash/app/views/workspace/join_request.py
+++ b/apps/api/pi_dash/app/views/workspace/join_request.py
@@ -14,7 +14,7 @@ from rest_framework import status
 from rest_framework.response import Response
 
 # Module imports
-from pi_dash.app.permissions import WorkSpaceAdminPermission
+from pi_dash.app.permissions import WorkspaceOwnerPermission
 from pi_dash.app.serializers import (
     UserWorkspaceJoinRequestSerializer,
     WorkspaceJoinRequestSerializer,
@@ -82,6 +82,23 @@ class UserWorkspaceJoinRequestViewSet(BaseViewSet):
         )
         target_workspace_ids -= already_member_ids
 
+        # The typed email administers only workspace(s) the requester already
+        # belongs to, and nothing else. Recording a pending request here would
+        # strand them: it targets no new workspace, so an admin can never approve
+        # it. Route them straight into their existing workspace instead. Safe to
+        # name the slug — they are already a member, so it leaks nothing.
+        if not target_workspace_ids and already_member_ids:
+            slug = (
+                Workspace.objects.filter(id__in=already_member_ids)
+                .order_by("created_at")
+                .values_list("slug", flat=True)
+                .first()
+            )
+            return Response(
+                {"message": "You are already a member of this workspace", "workspace_slug": slug},
+                status=status.HTTP_200_OK,
+            )
+
         if target_workspace_ids:
             for workspace_id in target_workspace_ids:
                 # Idempotent: do not duplicate a pending request to a workspace.
@@ -144,7 +161,9 @@ class WorkspaceJoinRequestViewSet(BaseViewSet):
 
     serializer_class = WorkspaceJoinRequestSerializer
     model = WorkspaceJoinRequest
-    permission_classes = [WorkSpaceAdminPermission]
+    # Admin-only: only a workspace Admin (not a regular Member) may review join
+    # requests. WorkspaceOwnerPermission gates on role == Admin.
+    permission_classes = [WorkspaceOwnerPermission]
 
     def get_queryset(self):
         return self.filter_queryset(

--- a/apps/api/pi_dash/tests/contract/app/test_workspace_join_request_app.py
+++ b/apps/api/pi_dash/tests/contract/app/test_workspace_join_request_app.py
@@ -116,6 +116,21 @@ class TestCreateJoinRequest:
         )
 
     @pytest.mark.django_db
+    def test_already_member_is_routed_in_not_stranded(self, session_client, create_user, admin_workspace):
+        """If the typed email administers only workspace(s) the requester already
+        belongs to, don't strand them in an un-approvable pending request — route
+        them into the existing workspace instead."""
+        WorkspaceMember.objects.create(workspace=admin_workspace, member=create_user, role=MEMBER_ROLE)
+
+        url = reverse("user-workspace-join-requests")
+        response = session_client.post(url, {"admin_email": "admin@example.com"}, format="json")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["workspace_slug"] == admin_workspace.slug
+        # No phantom request is recorded.
+        assert WorkspaceJoinRequest.objects.count() == 0
+
+    @pytest.mark.django_db
     def test_requires_authentication(self, api_client, admin_workspace):
         url = reverse("user-workspace-join-requests")
         response = api_client.post(url, {"admin_email": "admin@example.com"}, format="json")
@@ -195,6 +210,18 @@ class TestAdminListJoinRequests:
         response = session_client.get(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
+    @pytest.mark.django_db
+    def test_regular_member_cannot_list(self, session_client, create_user, admin_workspace):
+        """A regular (non-admin) member may not review join requests — admin only."""
+        WorkspaceMember.objects.create(workspace=admin_workspace, member=create_user, role=MEMBER_ROLE)
+        requester = User.objects.create(email="requester@example.com", username="requester_user")
+        WorkspaceJoinRequest.objects.create(
+            requester=requester, workspace=admin_workspace, admin_email="admin@example.com"
+        )
+        url = reverse("workspace-join-requests", kwargs={"slug": admin_workspace.slug})
+        response = session_client.get(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
 
 @pytest.mark.contract
 class TestApproveDenyJoinRequest:
@@ -255,3 +282,17 @@ class TestApproveDenyJoinRequest:
         url = reverse("workspace-join-request-approve", kwargs={"slug": admin_workspace.slug, "pk": jr.id})
         response = session_client.post(url, {}, format="json")
         assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.django_db
+    def test_regular_member_cannot_approve(self, session_client, create_user, admin_workspace):
+        """A regular (non-admin) member may not approve join requests — admin only."""
+        WorkspaceMember.objects.create(workspace=admin_workspace, member=create_user, role=MEMBER_ROLE)
+        requester = User.objects.create(email="requester@example.com", username="requester_user")
+        jr = WorkspaceJoinRequest.objects.create(
+            requester=requester, workspace=admin_workspace, admin_email="admin@example.com"
+        )
+        url = reverse("workspace-join-request-approve", kwargs={"slug": admin_workspace.slug, "pk": jr.id})
+        response = session_client.post(url, {}, format="json")
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        jr.refresh_from_db()
+        assert jr.status == WorkspaceJoinRequest.Status.PENDING


### PR DESCRIPTION
## What

Two follow-up backend fixes to the merged join-request feature (#279), landing the product decisions Rich confirmed on PDASHOSS01-41:

1. **Admin-only review.** The admin-facing list / approve / deny endpoint (`WorkspaceJoinRequestViewSet`) now uses `WorkspaceOwnerPermission` (role == Admin) instead of `WorkSpaceAdminPermission` (Admin **or** Member). A regular member can no longer approve or deny join requests.

2. **Already-a-member routing.** When the typed admin email resolves *only* to workspace(s) the requester already belongs to, the endpoint now returns `200 {"message": "You are already a member of this workspace", "workspace_slug": <slug>}` and expects the frontend to route them into that workspace — instead of recording a phantom unresolved (`workspace=None`) request that no admin could ever approve, which would strand them in the pending step.

## Why

Both were flagged in the review of #279 as open product decisions:
- Approver scope — the thread framed it as "admin approves", so we lock it to admins for now.
- The already-member edge would leave a user permanently parked on the pending onboarding step with an un-approvable request.

Revealing the workspace slug in the already-member response leaks nothing: the requester is already a member of that workspace.

## Tests

Added contract tests (all 17 in the file pass):
- `test_already_member_is_routed_in_not_stranded` — already-member email → 200 + slug, no `WorkspaceJoinRequest` recorded.
- `test_regular_member_cannot_list` / `test_regular_member_cannot_approve` — a role-15 member is forbidden (403); request stays PENDING.

Validation: `pytest test_workspace_join_request_app.py` → 17 passed; `ruff check` + `ruff format --check` clean; `manage.py check` clean. Postgres 15 + Redis 7 via Docker.

## Scope

This is the backend of the 3-part feature. Still to come as separate PRs: (2) requester onboarding UX (the "join by admin email" entry + Pending-approval step), and (3) admin approve/deny UI under Members.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
