### PR TITLE
PDASHOSS01-55 Add Claude Fable 5 to model list for Claude agent runner

### DIFF
--- a/apps/web/core/components/runners/runner-models.ts
+++ b/apps/web/core/components/runners/runner-models.ts
@@ -64,6 +64,7 @@ const CODEX_OPTIONS: IRunnerModelOption[] = CODEX_MODELS.flatMap((m) =>
 // Claude Code: model ids are Anthropic slugs; `[1m]` selects the 1M-context
 // variant.
 const CLAUDE_OPTIONS: IRunnerModelOption[] = [
+  { id: "claude-fable-5", label: "Fable 5", model: "claude-fable-5" },
   { id: "claude-opus-4-8", label: "Opus 4.8", model: "claude-opus-4-8" },
   { id: "claude-sonnet-4-6", label: "Sonnet 4.6", model: "claude-sonnet-4-6" },
   { id: "claude-sonnet-4-6-1m", label: "Sonnet 4.6 (1M context)", model: "claude-sonnet-4-6[1m]" },


### PR DESCRIPTION
## What

Adds **Fable 5** (`claude-fable-5`) as a selectable model in the **Add Runner** form when **Claude Code** is the chosen agent.

## Why

Resolves PDASHOSS01-55 — operators enrolling a Claude Code runner should be able to pick the latest Fable 5 model from the dropdown.

## Changes

- `apps/web/core/components/runners/runner-models.ts`: add `{ id: "claude-fable-5", label: "Fable 5", model: "claude-fable-5" }` to `CLAUDE_OPTIONS`, placed first as the newest flagship.

Selecting it appends `--model claude-fable-5` to the generated `pidash runner add` command. No backend change needed: `model_applies_to_agent` (`runner/src/cli/runner_ops.rs:62`) already accepts any `claude-*` model for the ClaudeCode agent. The default pre-selection (`DEFAULT_MODEL_BY_AGENT`) is intentionally left at Opus 4.8 — this only adds the option.

## Validation

- `oxlint` on the changed file: 0 warnings, 0 errors.
- Pre-existing `web#check:types` and `add-runner-modal.test.tsx` failures were confirmed to exist identically on `main` and are unrelated to this change (a test-file type mismatch and a vite/lucide-react import transform issue, respectively).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
