### PR TITLE
PDASHOSS01-54 Reveal associated PRs to AI agent in issue details

### DIFF
--- a/apps/api/pi_dash/prompting/context.py
+++ b/apps/api/pi_dash/prompting/context.py
@@ -278,6 +278,31 @@ def _repo_context(project, issue: Issue) -> Dict[str, Any]:
     return repo
 
 
+def _code_reviews_context(issue: Issue) -> list[Dict[str, Any]]:
+    """Return the git code reviews (PRs/MRs) attached to ``issue``.
+
+    Surfaces the ``GitCodeReviewLink`` rows created via ``pidash issue
+    attach-review`` or provider webhooks so the agent learns an issue already
+    has associated PRs before it opens a new one. Provider-neutral — the same
+    shape describes a GitHub pull request, a GitLab merge request, etc. The
+    reverse relation uses the model's default (soft-delete-filtering) manager,
+    so removed links never leak into the prompt. Ordered newest-first, matching
+    ``GitCodeReviewLink.Meta.ordering``.
+    """
+    return [
+        {
+            "url": cr.url,
+            "title": cr.title or "",
+            "state": cr.state,
+            "merged": bool(cr.merged),
+            "draft": bool(cr.draft),
+            "provider": cr.provider,
+            "external_iid": cr.external_iid,
+        }
+        for cr in issue.git_code_reviews.all()
+    ]
+
+
 def build_context(issue: Issue, run: AgentRun) -> Dict[str, Any]:
     """Build the dict passed into Jinja.
 
@@ -337,6 +362,10 @@ def build_context(issue: Issue, run: AgentRun) -> Dict[str, Any]:
             "description": project.description or "",
         },
         "repo": _repo_context(project, issue),
+        # Git PRs / code reviews already attached to this issue (empty list
+        # when none). Lets the template tell the agent about associated PRs so
+        # it can build on prior work and avoid opening a duplicate review.
+        "code_reviews": _code_reviews_context(issue),
         "parent": (
             {
                 "identifier": _issue_identifier(parent),

--- a/apps/api/pi_dash/prompting/sections/intro.md
+++ b/apps/api/pi_dash/prompting/sections/intro.md
@@ -58,3 +58,11 @@ Repository:
 {% else %}
 - Work in the runner's configured working directory. Do not clone or touch any other path.
 {% endif %}
+{% if code_reviews %}
+
+Associated {{ repo.code_review_term }}s (git PRs/MRs already linked to this issue):
+{% for cr in code_reviews %}
+- {{ cr.title or cr.url }} — {{ cr.url }} (state: {{ cr.state }}{% if cr.merged %}, merged{% endif %}{% if cr.draft %}, draft{% endif %})
+{% endfor %}
+These are existing code reviews already attached to this issue. Inspect any that are relevant before starting — your task may build on this prior work. When you open a new {{ repo.code_review_term }}, do not duplicate one that is already open here; reuse it instead.
+{% endif %}

--- a/apps/api/pi_dash/prompting/validation.py
+++ b/apps/api/pi_dash/prompting/validation.py
@@ -78,6 +78,17 @@ def _issue_sample(kind: str, *, populated: bool) -> Dict[str, Any]:
                 "full_name": "sample-org/sample-repo",
                 "code_review_term": "pull request",
             },
+            "code_reviews": [
+                {
+                    "url": "https://github.com/sample-org/sample-repo/pull/7",
+                    "title": "Sample PR title",
+                    "state": "open",
+                    "merged": False,
+                    "draft": False,
+                    "provider": "github",
+                    "external_iid": "7",
+                },
+            ],
             "parent": {
                 "identifier": "SAMPLE-0",
                 "title": "Parent issue",
@@ -136,6 +147,7 @@ def _issue_sample(kind: str, *, populated: bool) -> Dict[str, Any]:
             "full_name": None,
             "code_review_term": "code review",
         },
+        "code_reviews": [],
         "parent": None,
         "lineage": None,
         "run": {

--- a/apps/api/pi_dash/tests/unit/prompting/test_context.py
+++ b/apps/api/pi_dash/tests/unit/prompting/test_context.py
@@ -89,6 +89,62 @@ def test_context_attempt_increments_on_follow_up(
 
 
 @pytest.mark.unit
+def test_context_code_reviews_empty_when_none_attached(issue, run):
+    ctx = build_context(issue, run)
+    assert ctx["code_reviews"] == []
+
+
+@pytest.mark.unit
+def test_context_includes_attached_code_reviews(issue, run):
+    from pi_dash.db.models import GitCodeReviewLink
+
+    GitCodeReviewLink.objects.create(
+        issue=issue,
+        project=issue.project,
+        workspace=issue.workspace,
+        provider="github",
+        host_url="https://github.com",
+        namespace="acme",
+        repo_name="web",
+        external_iid="42",
+        url="https://github.com/acme/web/pull/42",
+        title="Add feature",
+        state="open",
+        draft=True,
+    )
+    ctx = build_context(issue, run)
+    assert len(ctx["code_reviews"]) == 1
+    cr = ctx["code_reviews"][0]
+    assert cr["url"] == "https://github.com/acme/web/pull/42"
+    assert cr["title"] == "Add feature"
+    assert cr["state"] == "open"
+    assert cr["merged"] is False
+    assert cr["draft"] is True
+    assert cr["provider"] == "github"
+    assert cr["external_iid"] == "42"
+
+
+@pytest.mark.unit
+def test_context_code_reviews_excludes_soft_deleted(issue, run):
+    from pi_dash.db.models import GitCodeReviewLink
+
+    link = GitCodeReviewLink.objects.create(
+        issue=issue,
+        project=issue.project,
+        workspace=issue.workspace,
+        provider="github",
+        host_url="https://github.com",
+        namespace="acme",
+        repo_name="web",
+        external_iid="43",
+        url="https://github.com/acme/web/pull/43",
+    )
+    link.delete()  # soft delete
+    ctx = build_context(issue, run)
+    assert ctx["code_reviews"] == []
+
+
+@pytest.mark.unit
 def test_context_includes_git_work_branch_when_set(issue, run):
     issue.git_work_branch = "feat/pinned-branch"
     issue.save(update_fields=["git_work_branch"])


### PR DESCRIPTION
## What & why

Resolves **PDASHOSS01-54**.

When an issue is delegated to a coding agent, the first-turn prompt (built by `apps/api/pi_dash/prompting/context.py::build_context` and rendered through the locked `sections/intro.md`) **did not** surface the git PRs / code reviews already attached to the issue via `pidash issue attach-review` (or provider webhooks). The agent therefore had no way to know an issue already had associated PRs — it could open a duplicate review or miss prior work it should build on.

The `GitCodeReviewLink` model and the `issue.git_code_reviews` reverse relation already existed; this change just wires them into the prompt.

## Changes

- **`prompting/context.py`** — new `_code_reviews_context(issue)` helper returning a provider-neutral list (`url`, `title`, `state`, `merged`, `draft`, `provider`, `external_iid`) from `issue.git_code_reviews.all()`, added to `build_context` as the `code_reviews` key. Uses the model's default (soft-delete-filtering) manager, so removed links never leak in.
- **`prompting/sections/intro.md`** — renders an "Associated <pull requests/merge requests/code reviews>" block after the Repository section, listing each linked review with its state/merged/draft flags. Omitted entirely when none are attached.
- **`prompting/validation.py`** — added `code_reviews` to both the populated and minimal `_issue_sample` contexts so the `StrictUndefined` renderer and the sample-context sync tests stay green.
- **`tests/unit/prompting/test_context.py`** — new unit tests: empty when none attached, populated shape from a `GitCodeReviewLink`, and soft-deleted links excluded.

## Validation

The full DB-backed pytest suite could not run in this runner (Python 3.9 / no Postgres / pinned deps require a newer Python), so the two failure modes that a template+context change can introduce were validated in isolation:

- Rendered `intro.md` through the exact `SandboxedEnvironment(undefined=StrictUndefined, ...)` config against both the populated and minimal sample contexts — the block renders correctly (title/url fallback, `merged`/`draft` flags) and is absent when `code_reviews` is empty. No undefined-variable errors.
- Verified the sample-context key-sync invariants that `test_validation.py` enforces (populated sample covers every nested builder path; both samples carry the top-level `code_reviews` key).

The added `test_context.py` cases exercise the ORM path and follow the verified `GitCodeReviewLink` schema; they should be run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
