### PR TITLE
PDASHOSS01-60 enable abort active ai agent run

### DIFF
--- a/apps/web/core/components/issues/issue-detail/agent-status.tsx
+++ b/apps/web/core/components/issues/issue-detail/agent-status.tsx
@@ -6,16 +6,18 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { LucideIcon } from "lucide-react";
-import { CircleAlert, CircleCheck, CirclePause, Clock3, LoaderCircle, RotateCw } from "lucide-react";
+import { CircleAlert, CircleCheck, CirclePause, CircleX, Clock3, LoaderCircle, RotateCw } from "lucide-react";
 import { useTranslation } from "@pi-dash/i18n";
 // pi dash imports
 import { Badge } from "@pi-dash/propel/badge";
 import type { TBadgeVariant } from "@pi-dash/propel/badge";
 import { Button } from "@pi-dash/propel/button";
 import type { TAgentRunStatus, TIssue, TIssueAgentRunSummary, TIssueAgentTicker } from "@pi-dash/types";
+import { AlertModalCore } from "@pi-dash/ui";
 import { cn } from "@pi-dash/utils";
 // local imports
 import type { TIssueOperations } from "./root";
+import { useAbortRun } from "./use-abort-run";
 import { useReTick } from "./use-re-tick";
 
 type TranslationFn = ReturnType<typeof useTranslation>["t"];
@@ -338,6 +340,8 @@ export function IssueAgentStatusPanel({ workspaceSlug, projectId, issueId, issue
   const view = useMemo(() => getAgentStatusView(issue, now, t), [issue, now, t]);
   const canReTick = Boolean(ticker?.can_re_tick);
   const { reTick, isSubmitting: isReTicking } = useReTick();
+  const { abortRun, isSubmitting: isAborting } = useAbortRun();
+  const [showAbortConfirm, setShowAbortConfirm] = useState(false);
 
   const handleReTick = useCallback(async () => {
     const result = await reTick(issueId);
@@ -345,6 +349,16 @@ export function IssueAgentStatusPanel({ workspaceSlug, projectId, issueId, issue
     // when the grant was a no-op (state may have drifted since load).
     if (result) void issueOperations.fetch(workspaceSlug, projectId, issueId);
   }, [reTick, issueId, issueOperations, workspaceSlug, projectId]);
+
+  const handleAbort = useCallback(async () => {
+    if (!activeRun?.id) return;
+    const aborted = await abortRun(activeRun.id);
+    if (aborted) {
+      setShowAbortConfirm(false);
+      // Refresh so the card reflects the now-terminal run.
+      void issueOperations.fetch(workspaceSlug, projectId, issueId);
+    }
+  }, [abortRun, activeRun?.id, issueOperations, workspaceSlug, projectId, issueId]);
 
   useEffect(() => {
     const timer = window.setInterval(() => setNow(Date.now()), 60_000);
@@ -434,6 +448,35 @@ export function IssueAgentStatusPanel({ workspaceSlug, projectId, issueId, issue
           </p>
         </div>
       )}
+
+      {hasActiveAgentRun && activeRun?.id && (
+        <div className="mt-3 flex flex-col gap-1.5">
+          <Button
+            variant="error-outline"
+            size="base"
+            onClick={() => setShowAbortConfirm(true)}
+            disabled={isAborting}
+            loading={isAborting}
+            className="w-full"
+          >
+            <CircleX className="size-3.5 flex-shrink-0" />
+            <span className="text-body-xs-medium">{t("Abort run")}</span>
+          </Button>
+          <p className="text-caption-sm-regular text-tertiary">
+            {t("Signal the runner to stop the current AI agent run.")}
+          </p>
+        </div>
+      )}
+
+      <AlertModalCore
+        isOpen={showAbortConfirm}
+        handleClose={() => (isAborting ? null : setShowAbortConfirm(false))}
+        handleSubmit={handleAbort}
+        isSubmitting={isAborting}
+        title={t("Abort run?")}
+        content={t("The runner will stop this run as soon as it gets the signal.")}
+        primaryButtonText={{ default: t("Abort run"), loading: t("Aborting") }}
+      />
     </section>
   );
 }

--- a/apps/web/core/components/issues/issue-detail/use-abort-run.ts
+++ b/apps/web/core/components/issues/issue-detail/use-abort-run.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useCallback, useState } from "react";
+import { useTranslation } from "@pi-dash/i18n";
+import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
+// services
+import { AgentRunService } from "@/services/runner";
+
+const agentRunService = new AgentRunService();
+
+/**
+ * Drives the "Abort run" affordance on the issue AgentRun card: signals the
+ * associated runner to stop the active run and marks the AgentRun terminal
+ * (``cancelled``) server-side. The runner stops as soon as it receives the
+ * signal; the server rejects an already-terminal run. Returns ``true`` on a
+ * successful abort so the caller can refresh the card.
+ */
+export function useAbortRun() {
+  const { t } = useTranslation();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const abortRun = useCallback(
+    async (runId: string): Promise<boolean> => {
+      setIsSubmitting(true);
+      try {
+        await agentRunService.abortRun(runId, "user");
+        setToast({
+          type: TOAST_TYPE.SUCCESS,
+          title: t("Run aborted"),
+          message: t("The runner will stop this run as soon as it gets the signal."),
+        });
+        return true;
+      } catch (error: unknown) {
+        const message = (error as { error?: string })?.error ?? t("Could not abort this run. Please try again.");
+        setToast({
+          type: TOAST_TYPE.ERROR,
+          title: t("Failed to abort run"),
+          message,
+        });
+        return false;
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [t]
+  );
+
+  return { abortRun, isSubmitting };
+}

--- a/apps/web/core/services/runner/agent-run.service.ts
+++ b/apps/web/core/services/runner/agent-run.service.ts
@@ -113,4 +113,20 @@ export class AgentRunService extends APIService {
         throw error?.response?.data ?? error;
       });
   }
+
+  /**
+   * Abort an in-flight run. Signals the associated runner to stop the run
+   * and marks the AgentRun terminal (``cancelled``) server-side. The server
+   * enforces authorization and rejects an already-terminal run.
+   *
+   * Server-side wiring: ``apps/api/pi_dash/runner/views/runs.py``
+   * ``AgentRunCancelEndpoint``.
+   */
+  async abortRun(runId: string, reason?: string): Promise<TAgentRun> {
+    return this.post(`/api/runners/runs/${runId}/cancel/`, { reason: reason ?? "" })
+      .then((response) => response?.data)
+      .catch((error) => {
+        throw error?.response?.data ?? error;
+      });
+  }
 }

--- a/apps/web/tests/issues/agent-status-abort.test.tsx
+++ b/apps/web/tests/issues/agent-status-abort.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TIssue } from "@pi-dash/types";
+
+const { abortRun, reTick } = vi.hoisted(() => ({
+  abortRun: vi.fn(),
+  reTick: vi.fn(),
+}));
+
+vi.mock("@pi-dash/constants", () => ({
+  API_BASE_URL: "",
+}));
+
+vi.mock("@pi-dash/utils", () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}));
+
+vi.mock("@pi-dash/i18n", () => ({
+  useTranslation: () => ({
+    t: (key: string, vars?: Record<string, unknown>) =>
+      vars ? key.replace(/\{(\w+)\}/g, (_m, k) => String(vars[k] ?? "")) : key,
+  }),
+}));
+
+vi.mock("@pi-dash/propel/toast", () => ({
+  TOAST_TYPE: { SUCCESS: "success", ERROR: "error", INFO: "info" },
+  setToast: vi.fn(),
+}));
+
+vi.mock("@pi-dash/propel/badge", () => ({
+  Badge: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}));
+
+vi.mock("@pi-dash/propel/button", () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button type="button" onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+
+// Surface the confirmation dialog's submit affordance only while open so the
+// test can drive the confirm path without the real modal implementation.
+vi.mock("@pi-dash/ui", () => ({
+  AlertModalCore: ({ isOpen, handleSubmit }: { isOpen: boolean; handleSubmit: () => void }) =>
+    isOpen ? (
+      <button type="button" onClick={handleSubmit}>
+        confirm-abort
+      </button>
+    ) : null,
+}));
+
+// Both use-abort-run and use-re-tick construct an AgentRunService at module
+// load; mock the shared service so the hooks call our spies.
+vi.mock("@/services/runner", () => ({
+  AgentRunService: class {
+    abortRun = abortRun;
+    reTick = reTick;
+  },
+}));
+
+import { IssueAgentStatusPanel } from "../../core/components/issues/issue-detail/agent-status";
+
+const ISSUE_OPS = { fetch: vi.fn() };
+
+function makeIssue(status: string): TIssue {
+  return {
+    id: "issue-1",
+    agent_status: {
+      ticker: null,
+      active_run: {
+        id: "run-1",
+        status,
+        runner: "runner-1",
+        runner_name: "workx_claude01",
+        created_at: "2026-07-21T00:00:00Z",
+        assigned_at: null,
+        started_at: null,
+        ended_at: null,
+        done_payload: null,
+        error: "",
+        error_diagnostic: null,
+        llm_model: "",
+        input_tokens: null,
+        output_tokens: null,
+        total_tokens: null,
+      },
+      latest_run: null,
+      run_count: 1,
+    },
+  } as unknown as TIssue;
+}
+
+function renderPanel(issue: TIssue) {
+  return render(
+    <IssueAgentStatusPanel
+      workspaceSlug="acme"
+      projectId="proj-1"
+      issueId="issue-1"
+      issue={issue}
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      issueOperations={ISSUE_OPS as any}
+    />
+  );
+}
+
+describe("IssueAgentStatusPanel abort run", () => {
+  beforeEach(() => {
+    abortRun.mockReset();
+    reTick.mockReset();
+    ISSUE_OPS.fetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows the abort button while a run is active", () => {
+    renderPanel(makeIssue("running"));
+    expect(screen.getByText("Abort run")).toBeTruthy();
+  });
+
+  it("confirming abort signals the runner and refreshes the card", async () => {
+    abortRun.mockResolvedValue({ id: "run-1", status: "cancelled" });
+    renderPanel(makeIssue("running"));
+
+    fireEvent.click(screen.getByText("Abort run"));
+    fireEvent.click(screen.getByText("confirm-abort"));
+
+    await waitFor(() => expect(abortRun).toHaveBeenCalledWith("run-1", "user"));
+    await waitFor(() => expect(ISSUE_OPS.fetch).toHaveBeenCalledWith("acme", "proj-1", "issue-1"));
+  });
+
+  it("hides the abort button once the run is terminal", () => {
+    renderPanel(makeIssue("cancelled"));
+    expect(screen.queryByText("Abort run")).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Adds a manual **Abort run** button to the AI agent run status card on the issue detail page (`IssueAgentStatusPanel`). While a run is active, the card shows a destructive-styled button; clicking it opens a confirmation dialog, and confirming signals the associated runner to stop the current run and marks the `AgentRun` terminal.

Resolves **PDASHOSS01-60** — *enable abort active ai agent run*.

## How

The abort reuses the existing cancel pipeline end-to-end, so **no backend or runner changes are required**:

- `AgentRunService.abortRun(runId, reason)` posts to `POST /api/runners/runs/{id}/cancel/`.
- The endpoint (`AgentRunCancelEndpoint`) sets `status = cancelled`, stamps `ended_at`, and fans out a `{ type: "cancel", run_id, reason }` control frame to the runner.
- The runner handles `ServerMsg::Cancel` and fires the run's `CancellationToken`, stopping the in-flight agent process.

Frontend pieces:
- `useAbortRun` hook mirrors the existing `useReTick` (success/error toasts).
- `IssueAgentStatusPanel` renders the button (shown only for an active run) plus an `AlertModalCore` confirmation, and refreshes the card via `issueOperations.fetch` on success.

## Design note

The issue asks to mark the run "aborted". I reused the existing terminal **`cancelled`** status rather than introducing a new `aborted` enum value — the whole cancel infrastructure already means "a user stopped this run," and a distinct status would require a Django migration, a Rust runner change, and serializer/type churn for no functional difference. Happy to rename to a dedicated `aborted` status if reviewers prefer a distinct label.

## Testing

- `tests/issues/agent-status-abort.test.tsx` — button visibility for active vs terminal runs, and the confirm → signal-runner → refresh-card flow. 3/3 pass.
- `oxlint` on changed files: clean.
- `check:types`: passes for these files. (Two pre-existing, unrelated failures exist on the branch and are untouched here: a type error in `tests/runners/runner-runs-page.test.tsx` and a module-resolution failure in `tests/runners/add-runner-modal.test.tsx`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
