### PR TITLE
PDASHOSS01-61 Auto-suggest user timezone from browser in project creation

### DIFF
--- a/apps/web/ce/components/projects/create/utils.ts
+++ b/apps/web/ce/components/projects/create/utils.ts
@@ -8,8 +8,23 @@ import { RANDOM_EMOJI_CODES } from "@pi-dash/constants";
 import type { IProject } from "@pi-dash/types";
 import { getRandomCoverImage } from "@/helpers/cover-image.helper";
 
+// Detect the user's local IANA timezone from the browser so new projects
+// default to it instead of always defaulting to UTC. Modern browsers
+// canonicalize the value returned by `resolvedOptions().timeZone`
+// (e.g. "Asia/Calcutta" -> "Asia/Kolkata"), so it lines up with the backend's
+// `pytz.common_timezones` choices. If detection is unavailable or throws, fall
+// back to UTC.
+const getBrowserTimezone = (): string => {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+  } catch {
+    return "UTC";
+  }
+};
+
 export const getProjectFormValues = (): Partial<IProject> => ({
   cover_image_url: getRandomCoverImage(),
+  timezone: getBrowserTimezone(),
   description: "",
   logo_props: {
     in_use: "emoji",


### PR DESCRIPTION
## What

New projects now default their **Project Timezone** to the user's browser-detected local timezone instead of always defaulting to UTC.

## Why

`PDASHOSS01-61` — when creating a project the timezone was always UTC (the create form never sent a `timezone`, so the backend fell back to the workspace/UTC default). Users then had to manually fix it in project settings.

## How

- `apps/web/ce/components/projects/create/utils.ts`: `getProjectFormValues()` now sets `timezone` from `Intl.DateTimeFormat().resolvedOptions().timeZone`, wrapped in a small `getBrowserTimezone()` helper that falls back to `"UTC"` if detection is unavailable or throws.
- Modern browsers canonicalize the returned zone id (e.g. `Asia/Calcutta` → `Asia/Kolkata`), so the value aligns with the backend `Project.timezone` choices (`pytz.common_timezones`). The submitted value is still user-editable in project settings.
- Mirrors the existing pattern already used in `scheduler-bindings/install-binding-modal.tsx`.

## Notes

- The CE create form does not render a visible timezone field (that field lives in project *settings*); this sets the default value that gets submitted at creation, satisfying "auto-suggest the local timezone as the default." No new UI field was added.

## Validation

- `oxlint` + `oxfmt` on the changed file: clean.
- `npm run check:types`: no new errors from this change (the only failures are pre-existing, in `tests/runners/*`, unrelated to this file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
