### PR TITLE
PDASHOSS01-33 add grok  build support

### DIFF
--- a/apps/web/core/components/runners/add-runner-modal.tsx
+++ b/apps/web/core/components/runners/add-runner-modal.tsx
@@ -35,7 +35,7 @@ type Props = {
 
 // Mirrors the runner CLI's ``--agent`` value-enum (kebab-case). Keep in
 // sync with runner/src/config/schema.rs:AgentKind.
-const AGENT_OPTIONS = ["claude-code", "codex", "cursor-agent", "open-claw"] as const;
+const AGENT_OPTIONS = ["claude-code", "codex", "cursor-agent", "open-claw", "grok"] as const;
 type TAgent = (typeof AGENT_OPTIONS)[number];
 const DEFAULT_AGENT: TAgent = "claude-code";
 const RUNNER_NAME_WHITESPACE_RE = /\s/;
@@ -226,6 +226,7 @@ export const AddRunnerModal = observer(function AddRunnerModal(props: Props) {
     if (value === "claude-code") return t("Claude Code");
     if (value === "cursor-agent") return t("Cursor");
     if (value === "open-claw") return t("OpenClaw");
+    if (value === "grok") return t("Grok");
     return t("Codex");
   };
 

--- a/apps/web/core/components/runners/runner-models.ts
+++ b/apps/web/core/components/runners/runner-models.ts
@@ -18,7 +18,7 @@
  */
 
 // Mirrors the runner CLI's ``--agent`` value-enum (kebab-case).
-export type TRunnerAgent = "claude-code" | "codex" | "cursor-agent" | "open-claw";
+export type TRunnerAgent = "claude-code" | "codex" | "cursor-agent" | "open-claw" | "grok";
 
 export interface IRunnerModelOption {
   /** Unique select value within an agent's list. */
@@ -96,11 +96,20 @@ const CURSOR_OPTIONS: IRunnerModelOption[] = [
   { id: "grok-4.3", label: "Grok 4.3", model: "grok-4.3" },
 ];
 
+// Grok: xAI's Grok CLI drives its own model catalog; a small curated subset.
+// The runner accepts any non-empty slug and falls back to grok's default, so a
+// stale entry downgrades gracefully. Update as xAI's lineup changes.
+const GROK_OPTIONS: IRunnerModelOption[] = [
+  { id: "grok-4.3", label: "Grok 4.3", model: "grok-4.3" },
+  { id: "grok-code-fast-1", label: "Grok Code Fast 1", model: "grok-code-fast-1" },
+];
+
 export const RUNNER_MODEL_OPTIONS: Record<TRunnerAgent, IRunnerModelOption[]> = {
   "claude-code": [DEFAULT_OPTION, ...CLAUDE_OPTIONS],
   codex: [DEFAULT_OPTION, ...CODEX_OPTIONS],
   "cursor-agent": [DEFAULT_OPTION, ...CURSOR_OPTIONS],
   "open-claw": [DEFAULT_OPTION],
+  grok: [DEFAULT_OPTION, ...GROK_OPTIONS],
 };
 
 /**
@@ -114,6 +123,7 @@ export const DEFAULT_MODEL_BY_AGENT: Record<TRunnerAgent, string> = {
   codex: DEFAULT_MODEL_ID,
   "cursor-agent": DEFAULT_MODEL_ID,
   "open-claw": DEFAULT_MODEL_ID,
+  grok: DEFAULT_MODEL_ID,
 };
 
 /** Look up a selected option's label; falls back to the default label. */

--- a/runner/src/agent/mod.rs
+++ b/runner/src/agent/mod.rs
@@ -270,6 +270,7 @@ pub enum AgentBridge {
     ClaudeCode(crate::claude_code::bridge::Bridge),
     CursorAgent(crate::cursor_agent::bridge::Bridge),
     OpenClaw(crate::openclaw::bridge::Bridge),
+    Grok(crate::grok::bridge::Bridge),
 }
 
 /// Per-run cursor, paired with an `AgentBridge`. Holds agent-specific frame
@@ -279,6 +280,7 @@ pub enum AgentCursor {
     ClaudeCode(crate::claude_code::bridge::BridgeCursor),
     CursorAgent(crate::cursor_agent::bridge::BridgeCursor),
     OpenClaw(crate::openclaw::bridge::BridgeCursor),
+    Grok(crate::grok::bridge::BridgeCursor),
 }
 
 impl AgentCursor {
@@ -288,6 +290,7 @@ impl AgentCursor {
             AgentCursor::ClaudeCode(c) => c.run_id,
             AgentCursor::CursorAgent(c) => c.run_id,
             AgentCursor::OpenClaw(c) => c.run_id,
+            AgentCursor::Grok(c) => c.run_id,
         }
     }
 
@@ -297,6 +300,7 @@ impl AgentCursor {
             AgentCursor::ClaudeCode(c) => &c.thread_id,
             AgentCursor::CursorAgent(c) => &c.thread_id,
             AgentCursor::OpenClaw(c) => &c.thread_id,
+            AgentCursor::Grok(c) => &c.thread_id,
         }
     }
 
@@ -306,6 +310,7 @@ impl AgentCursor {
             AgentCursor::ClaudeCode(c) => c.model.as_deref(),
             AgentCursor::CursorAgent(c) => c.model.as_deref(),
             AgentCursor::OpenClaw(c) => c.model.as_deref(),
+            AgentCursor::Grok(c) => c.model.as_deref(),
         }
     }
 }
@@ -369,6 +374,16 @@ impl AgentBridge {
                 .await?;
                 Ok(AgentBridge::OpenClaw(b))
             }
+            AgentKind::Grok => {
+                let b = crate::grok::bridge::Bridge::spawn_with_resume(
+                    &runner.grok.binary,
+                    cwd,
+                    selected_model(model_override, runner.grok.model_default.clone()),
+                    resume_session_id,
+                )
+                .await?;
+                Ok(AgentBridge::Grok(b))
+            }
         }
     }
 
@@ -378,6 +393,7 @@ impl AgentBridge {
             AgentBridge::ClaudeCode(b) => Ok(AgentCursor::ClaudeCode(b.run(payload, cwd).await?)),
             AgentBridge::CursorAgent(b) => Ok(AgentCursor::CursorAgent(b.run(payload, cwd).await?)),
             AgentBridge::OpenClaw(b) => Ok(AgentCursor::OpenClaw(b.run(payload, cwd).await?)),
+            AgentBridge::Grok(b) => Ok(AgentCursor::Grok(b.run(payload, cwd).await?)),
         }
     }
 
@@ -393,6 +409,7 @@ impl AgentBridge {
             AgentBridge::OpenClaw(b) => {
                 Ok(AgentCursor::OpenClaw(b.run_one_shot(payload, cwd).await?))
             }
+            AgentBridge::Grok(b) => Ok(AgentCursor::Grok(b.run_one_shot(payload, cwd).await?)),
         }
     }
 
@@ -407,6 +424,7 @@ impl AgentBridge {
             AgentBridge::ClaudeCode(b) => b.warm(cwd).await,
             AgentBridge::CursorAgent(b) => b.warm(cwd).await,
             AgentBridge::OpenClaw(b) => b.warm(cwd).await,
+            AgentBridge::Grok(b) => b.warm(cwd).await,
         }
     }
 
@@ -422,6 +440,7 @@ impl AgentBridge {
             (AgentBridge::ClaudeCode(b), AgentCursor::ClaudeCode(c)) => b.next_events(c).await,
             (AgentBridge::CursorAgent(b), AgentCursor::CursorAgent(c)) => b.next_events(c).await,
             (AgentBridge::OpenClaw(b), AgentCursor::OpenClaw(c)) => b.next_events(c).await,
+            (AgentBridge::Grok(b), AgentCursor::Grok(c)) => b.next_events(c).await,
             // These pairings are constructed together by `run`, so a mismatch
             // is a programmer error — fail loudly.
             _ => panic!("agent bridge and cursor variants mismatched"),
@@ -438,6 +457,7 @@ impl AgentBridge {
             AgentBridge::ClaudeCode(b) => b.send_approval(approval_id, decision).await,
             AgentBridge::CursorAgent(b) => b.send_approval(approval_id, decision).await,
             AgentBridge::OpenClaw(b) => b.send_approval(approval_id, decision).await,
+            AgentBridge::Grok(b) => b.send_approval(approval_id, decision).await,
         }
     }
 
@@ -447,6 +467,7 @@ impl AgentBridge {
             AgentBridge::ClaudeCode(b) => b.interrupt().await,
             AgentBridge::CursorAgent(b) => b.interrupt().await,
             AgentBridge::OpenClaw(b) => b.interrupt().await,
+            AgentBridge::Grok(b) => b.interrupt().await,
         }
     }
 
@@ -456,6 +477,7 @@ impl AgentBridge {
             AgentBridge::ClaudeCode(b) => b.shutdown(grace).await,
             AgentBridge::CursorAgent(b) => b.shutdown(grace).await,
             AgentBridge::OpenClaw(b) => b.shutdown(grace).await,
+            AgentBridge::Grok(b) => b.shutdown(grace).await,
         }
     }
 
@@ -469,6 +491,7 @@ impl AgentBridge {
             AgentBridge::ClaudeCode(b) => b.process_handle(),
             AgentBridge::CursorAgent(b) => b.process_handle(),
             AgentBridge::OpenClaw(b) => b.process_handle(),
+            AgentBridge::Grok(b) => b.process_handle(),
         }
     }
 
@@ -483,6 +506,7 @@ impl AgentBridge {
             AgentBridge::ClaudeCode(b) => b.recent_stderr().await,
             AgentBridge::CursorAgent(b) => b.recent_stderr().await,
             AgentBridge::OpenClaw(b) => b.recent_stderr().await,
+            AgentBridge::Grok(b) => b.recent_stderr().await,
         }
     }
 }

--- a/runner/src/api_client.rs
+++ b/runner/src/api_client.rs
@@ -330,6 +330,7 @@ mod resolve_tests {
                 claude_code: ClaudeCodeSection::default(),
                 cursor_agent: CursorAgentSection::default(),
                 openclaw: Default::default(),
+                grok: Default::default(),
                 approval_policy: ApprovalPolicySection::default(),
             }],
             workdirs: vec![],

--- a/runner/src/cli/connect.rs
+++ b/runner/src/cli/connect.rs
@@ -190,11 +190,12 @@ pub async fn run(args: Args, paths: &Paths) -> Result<()> {
         .unwrap_or_else(|| paths.runner_dir(resp.runner_id).join("workspace"));
 
     let agent_kind = args.agent.unwrap_or_default();
-    let (codex, claude_code, cursor_agent, openclaw) = crate::cli::runner_ops::agent_sections_for(
-        agent_kind,
-        args.model.as_deref(),
-        args.reasoning_effort.as_deref(),
-    );
+    let (codex, claude_code, cursor_agent, openclaw, grok) =
+        crate::cli::runner_ops::agent_sections_for(
+            agent_kind,
+            args.model.as_deref(),
+            args.reasoning_effort.as_deref(),
+        );
     let new_runner_block = RunnerConfig {
         name: resp.runner_name.clone(),
         runner_id: resp.runner_id,
@@ -208,6 +209,7 @@ pub async fn run(args: Args, paths: &Paths) -> Result<()> {
         claude_code,
         cursor_agent,
         openclaw,
+        grok,
         approval_policy: Default::default(),
     };
 
@@ -525,6 +527,7 @@ pub async fn enroll_additional_runner(
         claude_code: Default::default(),
         cursor_agent: Default::default(),
         openclaw: Default::default(),
+        grok: Default::default(),
         approval_policy: Default::default(),
     };
     cfg.runners.push(new_runner.clone());
@@ -667,6 +670,7 @@ mod tests {
             claude_code: ClaudeCodeSection::default(),
             cursor_agent: CursorAgentSection::default(),
             openclaw: crate::config::schema::OpenClawSection::default(),
+            grok: crate::config::schema::GrokSection::default(),
             approval_policy: ApprovalPolicySection::default(),
         }
     }

--- a/runner/src/cli/doctor.rs
+++ b/runner/src/cli/doctor.rs
@@ -107,6 +107,7 @@ pub async fn execute(paths: &Paths, runner_filter: Option<&str>) -> Result<Repor
             "claude",
             "cursor-agent",
             "acpx",
+            "grok",
         )
         .await;
     } else {
@@ -120,6 +121,7 @@ pub async fn execute(paths: &Paths, runner_filter: Option<&str>) -> Result<Repor
                 &r.claude_code.binary,
                 &r.cursor_agent.binary,
                 &r.openclaw.binary,
+                &r.grok.binary,
             )
             .await;
         }
@@ -166,6 +168,10 @@ pub async fn execute(paths: &Paths, runner_filter: Option<&str>) -> Result<Repor
 /// in multi-runner installs so the report distinguishes which runner failed
 /// — `codex@laptop` vs `codex@build-box` — and `None` in the single-runner
 /// case to keep output identical to the pre-multi-runner format.
+// One `&str` binary name per supported agent, so the arity grows with the
+// agent list; a struct wrapper would add ceremony without clarifying the call
+// sites, which pass the runner's per-agent binaries positionally.
+#[allow(clippy::too_many_arguments)]
 async fn run_agent_checks(
     checks: &mut Vec<Check>,
     prefix: Option<&str>,
@@ -174,6 +180,7 @@ async fn run_agent_checks(
     claude_binary: &str,
     cursor_binary: &str,
     openclaw_binary: &str,
+    grok_binary: &str,
 ) {
     let tag = |base: &str| match prefix {
         Some(p) => format!("{base}@{p}"),
@@ -304,6 +311,34 @@ async fn run_agent_checks(
                 blocker: false,
             });
         }
+        crate::config::schema::AgentKind::Grok => {
+            match check_version(grok_binary).await {
+                Ok(detail) => checks.push(Check {
+                    name: tag("grok"),
+                    ok: true,
+                    detail,
+                    blocker: true,
+                }),
+                Err(e) => checks.push(Check {
+                    name: tag("grok"),
+                    ok: false,
+                    detail: e.to_string(),
+                    blocker: true,
+                }),
+            }
+            // grok auth is via the `XAI_API_KEY` env var or an interactive
+            // `grok` login; there's no cheap non-interactive probe, so surface
+            // a hint rather than block.
+            checks.push(Check {
+                name: tag("grok-auth"),
+                ok: true,
+                detail: format!(
+                    "assumed ok (set XAI_API_KEY or run `{grok_binary}` login if runs \
+                     fail with auth errors)"
+                ),
+                blocker: false,
+            });
+        }
     }
 }
 
@@ -376,7 +411,7 @@ mod tests {
     use super::*;
     use crate::config::schema::{
         AgentKind, ClaudeCodeSection, CursorAgentSection, CodexSection, Config, DaemonConfig,
-        OpenClawSection, RunnerConfig, WorkspaceSection,
+        GrokSection, OpenClawSection, RunnerConfig, WorkspaceSection,
     };
     use std::path::PathBuf;
     use uuid::Uuid;
@@ -411,6 +446,7 @@ mod tests {
             claude_code: ClaudeCodeSection::default(),
             cursor_agent: CursorAgentSection::default(),
             openclaw: OpenClawSection::default(),
+            grok: GrokSection::default(),
             approval_policy: Default::default(),
         }
     }
@@ -528,6 +564,7 @@ mod tests {
         let mut claude_checks: Vec<Check> = Vec::new();
         let mut cursor_checks: Vec<Check> = Vec::new();
         let mut openclaw_checks: Vec<Check> = Vec::new();
+        let mut grok_checks: Vec<Check> = Vec::new();
         run_agent_checks(
             &mut codex_checks,
             None,
@@ -536,6 +573,7 @@ mod tests {
             "claude-missing",
             "cursor-missing",
             "acpx-missing",
+            "grok-missing",
         )
         .await;
         run_agent_checks(
@@ -546,6 +584,7 @@ mod tests {
             "claude-missing",
             "cursor-missing",
             "acpx-missing",
+            "grok-missing",
         )
         .await;
         run_agent_checks(
@@ -556,6 +595,7 @@ mod tests {
             "claude-missing",
             "cursor-missing",
             "acpx-missing",
+            "grok-missing",
         )
         .await;
         run_agent_checks(
@@ -566,6 +606,18 @@ mod tests {
             "claude-missing",
             "cursor-missing",
             "acpx-missing",
+            "grok-missing",
+        )
+        .await;
+        run_agent_checks(
+            &mut grok_checks,
+            None,
+            AgentKind::Grok,
+            "codex-missing",
+            "claude-missing",
+            "cursor-missing",
+            "acpx-missing",
+            "grok-missing",
         )
         .await;
         assert!(codex_checks.iter().any(|c| c.name == "codex"));
@@ -576,5 +628,7 @@ mod tests {
         assert!(cursor_checks.iter().any(|c| c.name == "cursor-auth"));
         assert!(openclaw_checks.iter().any(|c| c.name == "acpx"));
         assert!(openclaw_checks.iter().any(|c| c.name == "openclaw"));
+        assert!(grok_checks.iter().any(|c| c.name == "grok"));
+        assert!(grok_checks.iter().any(|c| c.name == "grok-auth"));
     }
 }

--- a/runner/src/cli/runner_ops.rs
+++ b/runner/src/cli/runner_ops.rs
@@ -14,8 +14,8 @@ use crate::cloud::http::{EnrollResponse, RunnerCredentials, write_runner_credent
 use crate::config::file;
 use crate::config::schema::{
     AgentKind, AgentSection, ApprovalPolicySection, ClaudeCodeSection, CleanMode, CliSection,
-    CodexSection, Config, CursorAgentSection, DEFAULT_POOL_SIZE, DaemonConfig, OpenClawSection,
-    RunnerConfig, WorkdirConfig, WorkspaceSection, canonical_for_compare,
+    CodexSection, Config, CursorAgentSection, DEFAULT_POOL_SIZE, DaemonConfig, GrokSection,
+    OpenClawSection, RunnerConfig, WorkdirConfig, WorkspaceSection, canonical_for_compare,
 };
 use crate::util::paths::Paths;
 use std::io::IsTerminal;
@@ -70,7 +70,10 @@ fn model_applies_to_agent(kind: AgentKind, model: &str) -> bool {
         AgentKind::Codex => {
             has("gpt-") || m == "o3" || m == "o4" || has("o3-") || has("o4-") || has("codex")
         }
-        AgentKind::CursorAgent | AgentKind::OpenClaw => !m.is_empty(),
+        // Cursor, OpenClaw, and Grok pull their model slug from their own
+        // provider's catalog; accept any non-empty value and let the agent
+        // reject unknown slugs.
+        AgentKind::CursorAgent | AgentKind::OpenClaw | AgentKind::Grok => !m.is_empty(),
     }
 }
 
@@ -89,6 +92,7 @@ pub fn agent_sections_for(
     ClaudeCodeSection,
     CursorAgentSection,
     OpenClawSection,
+    GrokSection,
 ) {
     let model = model.map(str::trim).filter(|s| !s.is_empty());
     let effort = reasoning_effort.map(str::trim).filter(|s| !s.is_empty());
@@ -145,6 +149,7 @@ pub fn agent_sections_for(
     let mut claude_code = ClaudeCodeSection::default();
     let mut cursor_agent = CursorAgentSection::default();
     let mut openclaw = OpenClawSection::default();
+    let mut grok = GrokSection::default();
     match agent_kind {
         AgentKind::Codex => {
             codex.model_default = model;
@@ -153,8 +158,9 @@ pub fn agent_sections_for(
         AgentKind::ClaudeCode => claude_code.model_default = model,
         AgentKind::CursorAgent => cursor_agent.model_default = model,
         AgentKind::OpenClaw => openclaw.model_default = model,
+        AgentKind::Grok => grok.model_default = model,
     }
-    (codex, claude_code, cursor_agent, openclaw)
+    (codex, claude_code, cursor_agent, openclaw, grok)
 }
 
 /// Read the user's CLI token from `[cli].token` in `config.toml`.
@@ -375,7 +381,7 @@ pub async fn apply_enroll_response(
         .working_dir
         .unwrap_or_else(|| paths.runner_dir(resp.runner_id).join("workspace"));
 
-    let (codex, claude_code, cursor_agent, openclaw) =
+    let (codex, claude_code, cursor_agent, openclaw, grok) =
         agent_sections_for(options.agent_kind, options.model, options.reasoning_effort);
     let new_runner = RunnerConfig {
         name: resp.runner_name.clone(),
@@ -392,6 +398,7 @@ pub async fn apply_enroll_response(
         claude_code,
         cursor_agent,
         openclaw,
+        grok,
         approval_policy: ApprovalPolicySection::default(),
     };
 
@@ -627,7 +634,7 @@ mod tests {
 
     #[test]
     fn model_routes_to_selected_agent_section() {
-        let (codex, claude, cursor, openclaw) =
+        let (codex, claude, cursor, openclaw, _) =
             agent_sections_for(AgentKind::ClaudeCode, Some("claude-opus-4-8"), None);
         assert_eq!(claude.model_default.as_deref(), Some("claude-opus-4-8"));
         assert_eq!(codex.model_default, None);
@@ -637,7 +644,7 @@ mod tests {
 
     #[test]
     fn codex_model_and_effort_are_applied_together() {
-        let (codex, _, _, _) = agent_sections_for(AgentKind::Codex, Some("gpt-5.5"), Some("High"));
+        let (codex, _, _, _, _) = agent_sections_for(AgentKind::Codex, Some("gpt-5.5"), Some("High"));
         assert_eq!(codex.model_default.as_deref(), Some("gpt-5.5"));
         // Effort is normalized to lowercase.
         assert_eq!(codex.effort_default.as_deref(), Some("high"));
@@ -648,13 +655,14 @@ mod tests {
         // The user's example: a Codex model handed to the Claude agent.
         // Non-fatal — the model is dropped (warning printed) and the
         // section is left at its default (None).
-        let (_, claude, _, _) = agent_sections_for(AgentKind::ClaudeCode, Some("gpt-5.5"), None);
+        let (_, claude, _, _, _) =
+ agent_sections_for(AgentKind::ClaudeCode, Some("gpt-5.5"), None);
         assert_eq!(claude.model_default, None);
     }
 
     #[test]
     fn effort_ignored_for_non_codex_agents() {
-        let (_, claude, _, _) =
+        let (_, claude, _, _, _) =
             agent_sections_for(AgentKind::ClaudeCode, Some("claude-opus-4-8"), Some("high"));
         // Model still applies; effort has no home on the claude section.
         assert_eq!(claude.model_default.as_deref(), Some("claude-opus-4-8"));
@@ -662,14 +670,14 @@ mod tests {
 
     #[test]
     fn unknown_codex_effort_is_dropped() {
-        let (codex, _, _, _) = agent_sections_for(AgentKind::Codex, Some("gpt-5.5"), Some("turbo"));
+        let (codex, _, _, _, _) = agent_sections_for(AgentKind::Codex, Some("gpt-5.5"), Some("turbo"));
         assert_eq!(codex.model_default.as_deref(), Some("gpt-5.5"));
         assert_eq!(codex.effort_default, None);
     }
 
     #[test]
     fn cursor_accepts_any_nonempty_slug() {
-        let (_, _, cursor, _) = agent_sections_for(
+        let (_, _, cursor, _, _) = agent_sections_for(
             AgentKind::CursorAgent,
             Some("claude-opus-4-8-thinking-high"),
             None,
@@ -684,7 +692,7 @@ mod tests {
     fn openclaw_accepts_any_nonempty_slug() {
         // OpenClaw's model space is provider-agnostic (resolved by the
         // Gateway), so any non-empty slug routes to its section.
-        let (codex, claude, cursor, openclaw) =
+        let (codex, claude, cursor, openclaw, _) =
             agent_sections_for(AgentKind::OpenClaw, Some("anthropic/claude-opus-4-8"), None);
         assert_eq!(
             openclaw.model_default.as_deref(),
@@ -697,7 +705,7 @@ mod tests {
 
     #[test]
     fn blank_model_is_treated_as_unset() {
-        let (codex, _, _, _) = agent_sections_for(AgentKind::Codex, Some("   "), None);
+        let (codex, _, _, _, _) = agent_sections_for(AgentKind::Codex, Some("   "), None);
         assert_eq!(codex.model_default, None);
     }
 
@@ -705,7 +713,7 @@ mod tests {
     fn codex_effort_dropped_when_model_inapplicable() {
         // A Claude model handed to codex: the model is dropped, and the
         // effort meant for it must not survive onto codex's default model.
-        let (codex, _, _, _) =
+        let (codex, _, _, _, _) =
             agent_sections_for(AgentKind::Codex, Some("claude-opus-4-8"), Some("high"));
         assert_eq!(codex.model_default, None);
         assert_eq!(codex.effort_default, None);
@@ -715,7 +723,7 @@ mod tests {
     fn codex_effort_dropped_without_a_model() {
         // Effort is meaningless without an explicit model (see the
         // CodexSection::effort_default contract).
-        let (codex, _, _, _) = agent_sections_for(AgentKind::Codex, None, Some("high"));
+        let (codex, _, _, _, _) = agent_sections_for(AgentKind::Codex, None, Some("high"));
         assert_eq!(codex.model_default, None);
         assert_eq!(codex.effort_default, None);
     }
@@ -724,9 +732,10 @@ mod tests {
     fn bare_prefix_models_are_rejected() {
         // A dash-terminated prefix with nothing after it is an incomplete
         // slug, not a model — it must not become a bogus model_default.
-        let (_, claude, _, _) = agent_sections_for(AgentKind::ClaudeCode, Some("claude-"), None);
+        let (_, claude, _, _, _) =
+ agent_sections_for(AgentKind::ClaudeCode, Some("claude-"), None);
         assert_eq!(claude.model_default, None);
-        let (codex, _, _, _) = agent_sections_for(AgentKind::Codex, Some("gpt-"), None);
+        let (codex, _, _, _, _) = agent_sections_for(AgentKind::Codex, Some("gpt-"), None);
         assert_eq!(codex.model_default, None);
     }
 
@@ -734,7 +743,7 @@ mod tests {
     fn bare_openai_reasoning_models_are_accepted() {
         // `o3` / `o4` are valid bare model names; the bare-prefix guard
         // must not reject them.
-        let (codex, _, _, _) = agent_sections_for(AgentKind::Codex, Some("o3"), None);
+        let (codex, _, _, _, _) = agent_sections_for(AgentKind::Codex, Some("o3"), None);
         assert_eq!(codex.model_default.as_deref(), Some("o3"));
     }
 
@@ -1077,6 +1086,7 @@ mod tests {
             claude_code: ClaudeCodeSection::default(),
             cursor_agent: CursorAgentSection::default(),
             openclaw: OpenClawSection::default(),
+            grok: GrokSection::default(),
             approval_policy: ApprovalPolicySection::default(),
         });
         file::write_config(&paths, &cfg).unwrap();

--- a/runner/src/config/file.rs
+++ b/runner/src/config/file.rs
@@ -243,6 +243,7 @@ mod tests {
             claude_code: Default::default(),
             cursor_agent: Default::default(),
             openclaw: Default::default(),
+            grok: Default::default(),
             approval_policy: Default::default(),
         }
     }

--- a/runner/src/config/schema.rs
+++ b/runner/src/config/schema.rs
@@ -174,6 +174,11 @@ pub struct RunnerConfig {
     /// `agent.kind == open_claw`.
     #[serde(default)]
     pub openclaw: OpenClawSection,
+    /// Grok settings. Missing section falls back to `GrokSection::default()`
+    /// so existing `config.toml` files (written before Grok support) still
+    /// parse. Only consulted when `agent.kind == grok`.
+    #[serde(default)]
+    pub grok: GrokSection,
     /// Missing section falls back to `ApprovalPolicySection::default()` so
     /// a minimal `config.toml` doesn't have to spell out every knob.
     #[serde(default)]
@@ -313,6 +318,9 @@ pub enum AgentKind {
     /// (`acpx --format json openclaw exec`), which drives OpenClaw over the
     /// Agent Client Protocol.
     OpenClaw,
+    /// xAI Grok via its native ACP server (`grok agent stdio`), which the
+    /// runner drives directly over the Agent Client Protocol.
+    Grok,
 }
 
 impl AgentKind {
@@ -341,9 +349,11 @@ impl AgentKind {
             // OpenClaw (driven via acpx), like Cursor and Claude, can be silent
             // for the full duration of a single tool call with no intra-tool
             // progress on the ACP stream. Use the same 15-minute envelope.
-            AgentKind::ClaudeCode | AgentKind::CursorAgent | AgentKind::OpenClaw => {
-                Duration::from_secs(15 * 60)
-            }
+            // Grok, also driven over ACP, has the same quiet-tool-call profile.
+            AgentKind::ClaudeCode
+            | AgentKind::CursorAgent
+            | AgentKind::OpenClaw
+            | AgentKind::Grok => Duration::from_secs(15 * 60),
         }
     }
 
@@ -355,6 +365,7 @@ impl AgentKind {
             AgentKind::ClaudeCode => "Claude Code",
             AgentKind::CursorAgent => "Cursor",
             AgentKind::OpenClaw => "OpenClaw",
+            AgentKind::Grok => "Grok",
         }
     }
 
@@ -370,6 +381,9 @@ impl AgentKind {
             // OpenClaw is driven through the `acpx` ACP client, so that's the
             // binary the runner invokes and `pidash runner add` probes for.
             AgentKind::OpenClaw => "acpx",
+            // Grok is its own ACP server (`grok agent stdio`), so the runner
+            // invokes `grok` directly.
+            AgentKind::Grok => "grok",
         }
     }
 
@@ -382,6 +396,7 @@ impl AgentKind {
             AgentKind::ClaudeCode => "https://docs.claude.com/en/docs/claude-code/setup",
             AgentKind::CursorAgent => "https://cursor.com/download",
             AgentKind::OpenClaw => "https://github.com/openclaw/acpx",
+            AgentKind::Grok => "https://x.ai/cli",
         }
     }
 }
@@ -453,6 +468,30 @@ impl Default for OpenClawSection {
     fn default() -> Self {
         Self {
             binary: default_openclaw_binary(),
+            model_default: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GrokSection {
+    /// The `grok` CLI binary the runner spawns as an ACP server (`grok agent
+    /// stdio`). Per-field default so a partial `[grok]` block (e.g. only
+    /// `model_default`) still parses without spelling out `binary = "grok"`.
+    #[serde(default = "default_grok_binary")]
+    pub binary: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_default: Option<String>,
+}
+
+fn default_grok_binary() -> String {
+    "grok".to_string()
+}
+
+impl Default for GrokSection {
+    fn default() -> Self {
+        Self {
+            binary: default_grok_binary(),
             model_default: None,
         }
     }
@@ -926,6 +965,7 @@ mod tests {
             claude_code: Default::default(),
             cursor_agent: Default::default(),
             openclaw: Default::default(),
+            grok: Default::default(),
             approval_policy: Default::default(),
         }
     }
@@ -1128,6 +1168,7 @@ mod tests {
             AgentKind::OpenClaw.default_binary(),
             OpenClawSection::default().binary
         );
+        assert_eq!(AgentKind::Grok.default_binary(), GrokSection::default().binary);
     }
 
     #[test]
@@ -1139,6 +1180,7 @@ mod tests {
             AgentKind::ClaudeCode,
             AgentKind::CursorAgent,
             AgentKind::OpenClaw,
+            AgentKind::Grok,
         ] {
             let url = kind.install_page_url();
             assert!(url.starts_with("https://"), "{kind:?} url not https: {url}");

--- a/runner/src/daemon/runner_instance.rs
+++ b/runner/src/daemon/runner_instance.rs
@@ -169,6 +169,7 @@ mod tests {
             claude_code: ClaudeCodeSection::default(),
             cursor_agent: CursorAgentSection::default(),
             openclaw: Default::default(),
+            grok: Default::default(),
             approval_policy: ApprovalPolicySection::default(),
         }
     }

--- a/runner/src/daemon/supervisor.rs
+++ b/runner/src/daemon/supervisor.rs
@@ -2633,9 +2633,10 @@ impl AssignWorker {
     fn crash_reason(&self) -> FailureReason {
         match self.runner_config.agent.kind {
             AgentKind::Codex => FailureReason::CodexCrash,
-            AgentKind::ClaudeCode | AgentKind::CursorAgent | AgentKind::OpenClaw => {
-                FailureReason::AgentCrash
-            }
+            AgentKind::ClaudeCode
+            | AgentKind::CursorAgent
+            | AgentKind::OpenClaw
+            | AgentKind::Grok => FailureReason::AgentCrash,
         }
     }
 
@@ -3488,7 +3489,7 @@ mod tests {
     use crate::cloud::protocol::Envelope;
     use crate::config::schema::{
         AgentSection, ApprovalPolicySection, ClaudeCodeSection, CodexSection, CursorAgentSection,
-        OpenClawSection, RunnerConfig, WorkspaceSection,
+        GrokSection, OpenClawSection, RunnerConfig, WorkspaceSection,
     };
     use crate::daemon::state::ExecCommandSnapshot;
     use chrono::TimeZone;
@@ -3517,6 +3518,7 @@ mod tests {
             claude_code: ClaudeCodeSection::default(),
             cursor_agent: CursorAgentSection::default(),
             openclaw: OpenClawSection::default(),
+            grok: GrokSection::default(),
             approval_policy: ApprovalPolicySection::default(),
         }
     }

--- a/runner/src/grok/bridge.rs
+++ b/runner/src/grok/bridge.rs
@@ -1,0 +1,559 @@
+//! Grok bridge. Acts as the ACP *client* for grok's native ACP server
+//! (`grok agent stdio`): it performs the JSON-RPC handshake
+//!
+//! ```text
+//! initialize → session/new {cwd} → session/prompt {sessionId, prompt}
+//! ```
+//!
+//! then streams the server's `session/update` notifications as
+//! [`crate::agent::BridgeEvent::Raw`] and ends the turn on the
+//! `session/prompt` response's `stopReason`. Inbound frames are parsed with
+//! OpenClaw's shared [`AcpMessage`]; outbound requests are built in
+//! [`crate::grok::schema`].
+//!
+//! The public surface mirrors the other bridges so the agent dispatch layer
+//! (`crate::agent::AgentBridge`) can treat all agents uniformly. Unlike the
+//! one-shot cursor / acpx bridges, the grok process is a persistent server, so
+//! `initialize` + `session/new` happen once (in `warm`) and multiple turns can
+//! reuse the same session.
+//!
+//! MVP limitations (tracked as follow-ups):
+//! - **Approvals bypass**: a `session/request_permission` request is answered
+//!   automatically by selecting an "allow" option (see
+//!   [`schema::select_allow_option`]). Real per-tool approval — routing the
+//!   request through `runner/src/approval` — is the documented next step.
+//! - **Stateless turns**: each fresh bridge does a new `session/new`; a resume
+//!   session id only seeds the run's thread id, it does not `session/load`
+//!   prior conversation state.
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use std::collections::VecDeque;
+use std::path::Path;
+use std::time::Duration;
+use uuid::Uuid;
+
+use crate::agent::{AgentProcessHandle, BridgeEvent, RunPayload, StderrSnapshot};
+use crate::cloud::protocol::{ApprovalDecision, FailureReason};
+use crate::grok::process::GrokProcess;
+use crate::grok::schema;
+use crate::openclaw::schema::AcpMessage;
+
+/// How long to wait for grok to answer a handshake request (`initialize` /
+/// `session/new`) before giving up on run setup. Generous: grok has to boot
+/// its ACP server and may authenticate against the xAI API first.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
+
+pub struct Bridge {
+    proc: GrokProcess,
+    model: Option<String>,
+    /// `initialize` completed for this process.
+    initialized: bool,
+    /// A live ACP session exists on this process (via `session/new`).
+    session_ready: bool,
+    /// ACP session id — captured from `session/new`, or seeded from a resume id
+    /// (MVP: seed only; see module docs). Surfaced as the run's thread id.
+    session_id: Option<String>,
+    /// Frames pulled off stdout while awaiting a handshake response that were
+    /// notifications rather than the response — replayed by `next_events` so no
+    /// streamed output is lost.
+    pending: VecDeque<serde_json::Value>,
+}
+
+impl Bridge {
+    pub async fn spawn(binary: &str, cwd: &Path, model_default: Option<String>) -> Result<Self> {
+        Self::spawn_with_resume(binary, cwd, model_default, None).await
+    }
+
+    pub async fn spawn_with_resume(
+        binary: &str,
+        cwd: &Path,
+        model_default: Option<String>,
+        resume_session_id: Option<&str>,
+    ) -> Result<Self> {
+        let proc = GrokProcess::spawn(binary, cwd).await?;
+        Ok(Self::from_process(
+            proc,
+            model_default,
+            resume_session_id.filter(|s| !s.is_empty()).map(ToOwned::to_owned),
+        ))
+    }
+
+    /// Build a bridge over an already-constructed process. Used by tests to
+    /// substitute a fake `grok` subprocess.
+    pub fn from_process(
+        proc: GrokProcess,
+        model_default: Option<String>,
+        resume_session_id: Option<String>,
+    ) -> Self {
+        Self {
+            proc,
+            model: model_default.filter(|s| !s.is_empty()),
+            initialized: false,
+            session_ready: false,
+            session_id: resume_session_id,
+            pending: VecDeque::new(),
+        }
+    }
+
+    /// Prepare the ACP server for a turn: `initialize` (once) then `session/new`
+    /// (once). Returns the live session id so the cloud can anchor the run's
+    /// thread on it before the first turn lands.
+    pub async fn warm(&mut self, cwd: &Path) -> Result<Option<String>> {
+        self.ensure_initialized().await?;
+        self.ensure_session(cwd).await?;
+        Ok(self.session_id.clone())
+    }
+
+    pub async fn run(&mut self, payload: &RunPayload, cwd: &Path) -> Result<BridgeCursor> {
+        if let Some(m) = payload.model.as_deref().filter(|s| !s.is_empty()) {
+            self.model = Some(m.to_string());
+        }
+        self.warm(cwd).await?;
+        let session_id = self
+            .session_id
+            .clone()
+            .context("grok session id missing after warm")?;
+        let id = self.proc.alloc_id();
+        let line = schema::session_prompt_request(id, &session_id, &payload.prompt);
+        self.proc.send_raw(&line).await?;
+        Ok(BridgeCursor {
+            run_id: payload.run_id,
+            thread_id: session_id,
+            model: self.model.clone(),
+            terminal: false,
+            seq: 0,
+        })
+    }
+
+    /// grok's ACP session persists across turns, so one-shot and chat `run` are
+    /// identical at the process level.
+    pub async fn run_one_shot(&mut self, payload: &RunPayload, cwd: &Path) -> Result<BridgeCursor> {
+        self.run(payload, cwd).await
+    }
+
+    async fn ensure_initialized(&mut self) -> Result<()> {
+        if self.initialized {
+            return Ok(());
+        }
+        let id = self.proc.alloc_id();
+        let line = schema::initialize_request(id);
+        self.proc.send_raw(&line).await?;
+        self.await_response(HANDSHAKE_TIMEOUT)
+            .await
+            .context("grok initialize failed")?;
+        self.initialized = true;
+        Ok(())
+    }
+
+    async fn ensure_session(&mut self, cwd: &Path) -> Result<()> {
+        if self.session_ready {
+            return Ok(());
+        }
+        let id = self.proc.alloc_id();
+        let cwd_str = cwd.to_string_lossy();
+        let line = schema::session_new_request(id, &cwd_str, self.model.as_deref());
+        self.proc.send_raw(&line).await?;
+        let result = self
+            .await_response(HANDSHAKE_TIMEOUT)
+            .await
+            .context("grok session/new failed")?;
+        // Prefer the id grok minted; fall back to any seeded resume id so we
+        // still have a stable thread id even if the server omits it.
+        if let Some(sid) = schema::session_id_from_result(&result) {
+            self.session_id = Some(sid);
+        }
+        if self.session_id.is_none() {
+            anyhow::bail!("grok session/new returned no sessionId");
+        }
+        self.session_ready = true;
+        Ok(())
+    }
+
+    /// Pull frames until the next JSON-RPC *response* arrives, returning its
+    /// `result` (or bailing on an `error`). Non-response frames (notifications,
+    /// and any early permission request) are handled along the way — permission
+    /// requests are auto-answered, other notifications are buffered so
+    /// `next_events` replays them. Responses are correlated by arrival order:
+    /// the handshake sends one request at a time and awaits it before the next,
+    /// so the first response we see is the one we asked for.
+    async fn await_response(&mut self, timeout: Duration) -> Result<serde_json::Value> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            let frame = tokio::time::timeout(remaining, self.proc.inbound.recv())
+                .await
+                .context("grok response timed out")?;
+            let Some(value) = frame else {
+                anyhow::bail!("grok stdout closed while awaiting response");
+            };
+            if self.try_auto_approve(&value).await? {
+                continue;
+            }
+            if let Some(err) = value.get("error").filter(|e| !e.is_null()) {
+                let msg = err
+                    .get("message")
+                    .and_then(|m| m.as_str())
+                    .map(ToOwned::to_owned)
+                    .unwrap_or_else(|| err.to_string());
+                anyhow::bail!("grok rpc error: {msg}");
+            }
+            if value.get("result").is_some() {
+                return Ok(value.get("result").cloned().unwrap_or(serde_json::Value::Null));
+            }
+            // A notification (has `method`, no `result`) arrived mid-handshake;
+            // stash it so the turn translator still sees it.
+            self.pending.push_back(value);
+        }
+    }
+
+    /// Pull the next event and translate it. Auto-answers permission requests
+    /// (emitting them as `Raw` for history). Returns `None` once the stream
+    /// closes for good.
+    pub async fn next_events(&mut self, cursor: &mut BridgeCursor) -> Option<Vec<BridgeEvent>> {
+        loop {
+            let value = if let Some(buffered) = self.pending.pop_front() {
+                buffered
+            } else {
+                self.proc.inbound.recv().await?
+            };
+            // A permission request must be answered or the turn deadlocks; do it
+            // and surface the request as Raw so history records the ask.
+            if is_permission_request(&value) {
+                if let Err(e) = self.try_auto_approve(&value).await {
+                    tracing::warn!("grok auto-approve failed: {e}");
+                }
+                let translated = cursor.translate_raw("session/request_permission", value);
+                if !translated.is_empty() {
+                    return Some(translated);
+                }
+                continue;
+            }
+            let msg: AcpMessage = match serde_json::from_value(value.clone()) {
+                Ok(m) => m,
+                Err(e) => {
+                    tracing::warn!("grok emitted unparsable ACP frame ({e}): {value}");
+                    AcpMessage::Unknown(value)
+                }
+            };
+            let translated = cursor.translate(msg);
+            if !translated.is_empty() {
+                return Some(translated);
+            }
+        }
+    }
+
+    /// If `value` is a `session/request_permission` request, answer it by
+    /// selecting an allow option and return `true`. Otherwise `false`.
+    async fn try_auto_approve(&mut self, value: &serde_json::Value) -> Result<bool> {
+        if !is_permission_request(value) {
+            return Ok(false);
+        }
+        let id = value.get("id").cloned().unwrap_or(serde_json::Value::Null);
+        let params = value.get("params").cloned().unwrap_or(serde_json::Value::Null);
+        match schema::select_allow_option(&params) {
+            Some(option_id) => {
+                let line = schema::permission_selected_response(&id, &option_id);
+                self.proc.send_raw(&line).await?;
+            }
+            None => {
+                tracing::warn!(
+                    "grok session/request_permission offered no options; cannot auto-approve"
+                );
+            }
+        }
+        Ok(true)
+    }
+
+    /// Approvals aren't routed for grok in the MVP — `next_events` auto-answers
+    /// every `session/request_permission` inline, so the supervisor never gets
+    /// an `ApprovalRequest` to decide. Reaching this is a programmer error.
+    pub async fn send_approval(
+        &mut self,
+        approval_id: &str,
+        _decision: ApprovalDecision,
+    ) -> Result<()> {
+        tracing::error!(
+            approval_id,
+            "grok bridge received an approval decision but approvals are \
+             auto-answered inline; refusing to silently drop it"
+        );
+        anyhow::bail!("grok bridge received approval {approval_id} but approvals are auto-answered");
+    }
+
+    pub async fn interrupt(&mut self) -> Result<()> {
+        self.proc.interrupt().await
+    }
+
+    pub async fn shutdown(self, grace: Duration) -> Result<()> {
+        self.proc.shutdown(grace).await
+    }
+
+    pub fn process_handle(&self) -> AgentProcessHandle {
+        self.proc.process_handle()
+    }
+
+    pub async fn recent_stderr(&self) -> StderrSnapshot {
+        self.proc.recent_stderr().await
+    }
+}
+
+/// True when `value` is a JSON-RPC *request* (carries an `id`) whose method is
+/// `session/request_permission`.
+fn is_permission_request(value: &serde_json::Value) -> bool {
+    value.get("id").is_some()
+        && value.get("method").and_then(|m| m.as_str()) == Some("session/request_permission")
+}
+
+/// Per-run translation state. Mirrors OpenClaw's cursor: the first turn output
+/// streams as `Raw`, and the `session/prompt` response's `stopReason` (or a
+/// JSON-RPC error) ends the turn.
+pub struct BridgeCursor {
+    pub run_id: Uuid,
+    pub thread_id: String,
+    pub model: Option<String>,
+    /// Flipped once a terminal frame (the `stopReason` response or an error) is
+    /// seen; suppresses any trailing frames.
+    terminal: bool,
+    pub seq: u64,
+}
+
+impl BridgeCursor {
+    /// Emit a raw history event without consuming a translation branch — used
+    /// for the auto-answered permission request.
+    fn translate_raw(&mut self, method: &str, params: serde_json::Value) -> Vec<BridgeEvent> {
+        if self.terminal {
+            return Vec::new();
+        }
+        self.seq = self.seq.saturating_add(1);
+        vec![BridgeEvent::Raw {
+            run_id: self.run_id,
+            method: method.to_string(),
+            params,
+        }]
+    }
+
+    pub fn translate(&mut self, ev: AcpMessage) -> Vec<BridgeEvent> {
+        if self.terminal {
+            return Vec::new();
+        }
+        self.seq = self.seq.saturating_add(1);
+
+        match ev {
+            AcpMessage::Method { method, params } => {
+                let label = if method == "session/update" {
+                    match AcpMessage::session_update_kind(&params) {
+                        Some(kind) => format!("session/update/{kind}"),
+                        None => method,
+                    }
+                } else {
+                    method
+                };
+                vec![BridgeEvent::Raw {
+                    run_id: self.run_id,
+                    method: label,
+                    params,
+                }]
+            }
+            AcpMessage::Response { result } => {
+                match result.get("stopReason").and_then(|s| s.as_str()) {
+                    Some(stop_reason) => {
+                        self.terminal = true;
+                        if is_failure_stop_reason(stop_reason) {
+                            vec![BridgeEvent::Failed {
+                                run_id: self.run_id,
+                                reason: FailureReason::AgentCrash,
+                                detail: Some(format!("grok stopReason: {stop_reason}")),
+                            }]
+                        } else {
+                            let done_payload = serde_json::json!({
+                                "conclusion": stop_reason,
+                                "stop_reason": stop_reason,
+                                "ended_at": Utc::now().to_rfc3339(),
+                            });
+                            vec![BridgeEvent::Completed {
+                                run_id: self.run_id,
+                                done_payload,
+                            }]
+                        }
+                    }
+                    None => vec![BridgeEvent::Raw {
+                        run_id: self.run_id,
+                        method: "response".into(),
+                        params: result,
+                    }],
+                }
+            }
+            AcpMessage::Error { error } => {
+                self.terminal = true;
+                let detail = error
+                    .get("message")
+                    .and_then(|m| m.as_str())
+                    .map(ToOwned::to_owned)
+                    .or_else(|| Some(format!("grok ACP error: {error}")));
+                vec![BridgeEvent::Failed {
+                    run_id: self.run_id,
+                    reason: FailureReason::AgentCrash,
+                    detail,
+                }]
+            }
+            AcpMessage::Unknown(v) => vec![BridgeEvent::Raw {
+                run_id: self.run_id,
+                method: "unknown".into(),
+                params: v,
+            }],
+        }
+    }
+}
+
+/// ACP `stopReason` values meaning the turn did not complete its work:
+/// `cancelled` (interrupted) and `refusal` (the model declined). Everything
+/// else (`end_turn`, `max_tokens`, `max_turn_requests`) is a natural end.
+/// Mirrors the OpenClaw bridge.
+fn is_failure_stop_reason(stop_reason: &str) -> bool {
+    matches!(stop_reason, "cancelled" | "refusal")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn cursor() -> BridgeCursor {
+        BridgeCursor {
+            run_id: Uuid::nil(),
+            thread_id: "s1".into(),
+            model: None,
+            terminal: false,
+            seq: 0,
+        }
+    }
+
+    fn msg(line: &str) -> AcpMessage {
+        serde_json::from_str(line).unwrap()
+    }
+
+    #[test]
+    fn translates_session_update_to_raw_with_kind_label() {
+        let mut c = cursor();
+        let out = c.translate(msg(
+            r#"{"method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"hi"}}}}"#,
+        ));
+        match &out[0] {
+            BridgeEvent::Raw { method, .. } => {
+                assert_eq!(method, "session/update/agent_message_chunk")
+            }
+            other => panic!("expected Raw, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn stop_reason_end_turn_completes_and_is_terminal() {
+        let mut c = cursor();
+        let out = c.translate(msg(r#"{"id":3,"result":{"stopReason":"end_turn"}}"#));
+        assert!(matches!(out[0], BridgeEvent::Completed { .. }));
+        // Terminal: subsequent frames suppressed.
+        assert!(
+            c.translate(msg(r#"{"method":"session/update","params":{}}"#))
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn stop_reason_cancelled_fails() {
+        let mut c = cursor();
+        let out = c.translate(msg(r#"{"id":3,"result":{"stopReason":"cancelled"}}"#));
+        assert!(matches!(out[0], BridgeEvent::Failed { .. }));
+    }
+
+    #[test]
+    fn jsonrpc_error_fails_with_detail() {
+        let mut c = cursor();
+        let out = c.translate(msg(
+            r#"{"id":2,"error":{"code":-32603,"message":"invalid api key"}}"#,
+        ));
+        match &out[0] {
+            BridgeEvent::Failed { detail, .. } => {
+                assert_eq!(detail.as_deref(), Some("invalid api key"))
+            }
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn non_terminal_response_is_raw() {
+        let mut c = cursor();
+        let out = c.translate(msg(r#"{"id":1,"result":{"sessionId":"s1"}}"#));
+        assert!(matches!(out[0], BridgeEvent::Raw { .. }));
+    }
+
+    #[test]
+    fn permission_request_is_detected() {
+        assert!(is_permission_request(&json!({
+            "id": 5, "method": "session/request_permission", "params": {}
+        })));
+        // A notification with the same method but no id is not a request.
+        assert!(!is_permission_request(&json!({
+            "method": "session/request_permission", "params": {}
+        })));
+        // A session/update is not a permission request.
+        assert!(!is_permission_request(&json!({
+            "id": 6, "method": "session/update", "params": {}
+        })));
+    }
+
+    /// Drive the real handshake + translate path against a fake `grok agent
+    /// stdio` that prints canned ACP frames in order and then drains stdin.
+    /// This exercises `initialize` → `session/new` → `session/prompt` and the
+    /// terminal `stopReason` without a real binary.
+    #[tokio::test]
+    async fn end_to_end_handshake_against_fake_grok() {
+        // The fake ignores request ids and just emits, in order: the
+        // initialize response, the session/new response (with a sessionId), a
+        // streamed agent message, and the terminal stopReason. `exec cat` then
+        // keeps the process alive draining our stdin writes so send_raw never
+        // hits a broken pipe.
+        let script = r#"
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":1}}'
+printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"sessionId":"sess-xyz"}}'
+printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"sess-xyz","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"working"}}}}'
+printf '%s\n' '{"jsonrpc":"2.0","id":3,"result":{"stopReason":"end_turn"}}'
+exec cat >/dev/null
+"#;
+        let mut cmd = tokio::process::Command::new("bash");
+        cmd.arg("-c").arg(script);
+        let proc = GrokProcess::spawn_command(cmd).await.expect("spawn fake grok");
+        let mut bridge = Bridge::from_process(proc, None, None);
+
+        let payload = RunPayload {
+            run_id: Uuid::nil(),
+            prompt: "do it".into(),
+            model: None,
+        };
+        let mut cursor = bridge
+            .run(&payload, Path::new("/tmp"))
+            .await
+            .expect("run drives the handshake");
+        assert_eq!(cursor.thread_id, "sess-xyz");
+
+        // Drain events to the terminal Completed.
+        let mut saw_raw = false;
+        let mut completed = false;
+        while let Some(events) = bridge.next_events(&mut cursor).await {
+            for ev in events {
+                match ev {
+                    BridgeEvent::Raw { .. } => saw_raw = true,
+                    BridgeEvent::Completed { .. } => {
+                        completed = true;
+                    }
+                    other => panic!("unexpected event: {other:?}"),
+                }
+            }
+            if completed {
+                break;
+            }
+        }
+        assert!(saw_raw, "expected the streamed session/update as a Raw event");
+        assert!(completed, "expected the stopReason to complete the turn");
+    }
+}

--- a/runner/src/grok/mod.rs
+++ b/runner/src/grok/mod.rs
@@ -1,0 +1,33 @@
+//! Grok integration. Drives xAI's Grok CLI coding agent over the Agent
+//! Client Protocol (ACP) by spawning its native ACP server (`grok agent
+//! stdio`) and speaking JSON-RPC to it directly on stdin/stdout, translating
+//! the emitted ACP traffic into the agent-agnostic
+//! [`crate::agent::BridgeEvent`] shape used by the daemon.
+//!
+//! Unlike the OpenClaw bridge — which shells out to the third-party `acpx`
+//! ACP *client* to drive the `openclaw exec` adapter — Grok is its own ACP
+//! server, so this bridge acts as the ACP client itself: it performs the
+//! `initialize` → `session/new` → `session/prompt` handshake and reads the
+//! streamed `session/update` notifications plus the terminal `stopReason`.
+//! This keeps Grok self-contained (it needs only the `grok` binary, not
+//! `acpx`, which lists no Grok adapter) while reusing OpenClaw's ACP message
+//! schema ([`crate::openclaw::schema::AcpMessage`]) for the load-bearing
+//! frame-parse and turn-end detection.
+//!
+//! Because `grok agent stdio` is a long-lived JSON-RPC server (not a one-shot
+//! process like `cursor-agent` / `acpx exec`), the process wrapper is modelled
+//! on the persistent, stdin-driven `codex::app_server::AppServer` rather than
+//! OpenClaw's argv-only one-shot.
+//!
+//! MVP limitations (tracked as follow-ups), see [`bridge`]:
+//! - **Approvals bypass**: any `session/request_permission` the server sends is
+//!   auto-approved, mirroring the cursor / Claude / OpenClaw bridges' bypass
+//!   posture. Real per-tool approval (answered from `runner/src/approval`) is
+//!   the documented next step.
+//! - **Stateless turns**: each run performs a fresh `session/new`; a known
+//!   resume session id is reused only as the run's thread-id seed, not to
+//!   restore prior conversation state via `session/load`.
+
+pub mod bridge;
+pub mod process;
+pub mod schema;

--- a/runner/src/grok/process.rs
+++ b/runner/src/grok/process.rs
@@ -1,0 +1,269 @@
+//! `grok agent stdio` subprocess wrapper. Grok's ACP server is a long-lived
+//! JSON-RPC endpoint on stdin/stdout, so this is modelled on
+//! `codex::app_server::AppServer` (persistent, owns stdin for outbound
+//! requests) rather than OpenClaw's one-shot argv process.
+//!
+//! Inbound NDJSON is surfaced as raw `serde_json::Value`s rather than parsed
+//! `AcpMessage`s: the bridge needs the untyped value both to translate turns
+//! (via [`crate::openclaw::schema::AcpMessage`]) *and* to read the JSON-RPC
+//! `id` off a `session/request_permission` request so it can answer with a
+//! matching response. Unparsable lines are dropped with a warning, keeping the
+//! reader resilient to any non-JSON chatter grok might emit.
+//!
+//! `Child` is owned exclusively by an internal wait task (as in the Codex
+//! wrapper) because `Child::wait()` and `start_kill()` both need `&mut self`;
+//! the `GrokProcess` keeps only the side-channels to drive it.
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use std::path::Path;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, Command};
+use tokio::sync::{Mutex, mpsc, watch};
+
+use crate::agent::{
+    AgentProcessHandle, ExitSnapshot, STDERR_RING_LINES, StderrBuffer, StderrRing, StderrSnapshot,
+};
+use crate::util::shell::{is_benign_login_shell_warning, login_shell_command};
+
+/// Handles the `grok agent stdio` subprocess lifecycle + ACP JSON-RPC wire.
+pub struct GrokProcess {
+    pid: Option<u32>,
+    stdin: ChildStdin,
+    next_id: AtomicU64,
+    pub inbound: mpsc::Receiver<serde_json::Value>,
+    kill_tx: mpsc::Sender<KillRequest>,
+    exit_rx: watch::Receiver<Option<ExitSnapshot>>,
+    stderr_ring: StderrRing,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum KillRequest {
+    /// Stdin was already half-closed by the caller; just await natural exit and
+    /// force-kill on grace expiry.
+    Graceful,
+    /// Force-kill immediately (the grace-window fallback).
+    Force,
+}
+
+impl GrokProcess {
+    /// Spawn `grok agent stdio` in `cwd` via the platform login-shell helper so
+    /// the probe (`pidash doctor`) and real launch stay aligned.
+    pub async fn spawn(binary: &str, cwd: &Path) -> Result<Self> {
+        let cmd = login_shell_command(binary, &["agent", "stdio"], Some(cwd));
+        Self::spawn_command(cmd).await
+    }
+
+    /// Test-friendly constructor taking a fully-prepared `Command`. Forces the
+    /// stdio disposition the reader / writer tasks expect.
+    pub async fn spawn_command(mut cmd: Command) -> Result<Self> {
+        cmd.stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        let mut child = cmd.spawn().context("spawning grok subprocess")?;
+        let stdin = child.stdin.take().context("grok stdin missing")?;
+        let stdout = child.stdout.take().context("grok stdout missing")?;
+        let stderr = child.stderr.take().context("grok stderr missing")?;
+        let pid = child.id();
+
+        let (tx, rx) = mpsc::channel(128);
+        let stderr_ring: StderrRing = Arc::new(Mutex::new(StderrBuffer::new(STDERR_RING_LINES)));
+        tokio::spawn(read_frames(stdout, tx));
+        tokio::spawn(drain_stderr(stderr, stderr_ring.clone()));
+
+        let (kill_tx, kill_rx) = mpsc::channel::<KillRequest>(2);
+        let (exit_tx, exit_rx) = watch::channel::<Option<ExitSnapshot>>(None);
+        tokio::spawn(wait_task(child, kill_rx, exit_tx));
+
+        Ok(Self {
+            pid,
+            stdin,
+            next_id: AtomicU64::new(1),
+            inbound: rx,
+            kill_tx,
+            exit_rx,
+            stderr_ring,
+        })
+    }
+
+    pub fn pid(&self) -> Option<u32> {
+        self.pid
+    }
+
+    /// Allocate a fresh monotonic JSON-RPC request id.
+    pub fn alloc_id(&self) -> u64 {
+        self.next_id.fetch_add(1, Ordering::Relaxed)
+    }
+
+    /// Write a single JSON-RPC line to grok's stdin (newline-framed).
+    pub async fn send_raw(&mut self, line: &str) -> Result<()> {
+        self.stdin.write_all(line.as_bytes()).await?;
+        self.stdin.write_all(b"\n").await?;
+        self.stdin.flush().await?;
+        Ok(())
+    }
+
+    pub fn process_handle(&self) -> AgentProcessHandle {
+        AgentProcessHandle {
+            pid: self.pid,
+            exit_rx: self.exit_rx.clone(),
+        }
+    }
+
+    pub async fn recent_stderr(&self) -> StderrSnapshot {
+        self.stderr_ring.lock().await.snapshot()
+    }
+
+    /// Best-effort interrupt: SIGINT if we can, else force-kill. We don't hold
+    /// a spec-level `session/cancel` channel in the MVP, so the OS signal is
+    /// the lever (grok cleans up its ACP session on SIGINT).
+    pub async fn interrupt(&mut self) -> Result<()> {
+        #[cfg(unix)]
+        {
+            use nix::sys::signal::{Signal, kill};
+            use nix::unistd::Pid;
+            if let Some(pid) = self.pid {
+                match kill(Pid::from_raw(pid as i32), Signal::SIGINT) {
+                    Ok(()) => return Ok(()),
+                    Err(e) => tracing::warn!("grok SIGINT failed ({e}); falling back to SIGKILL"),
+                }
+            }
+        }
+        self.kill_tx
+            .send(KillRequest::Force)
+            .await
+            .context("failed to send kill request to grok wait task")?;
+        Ok(())
+    }
+
+    pub async fn shutdown(mut self, grace: std::time::Duration) -> Result<()> {
+        // Half-close stdin so grok notices end-of-input and can exit cleanly.
+        drop(self.stdin);
+        let _ = self.kill_tx.send(KillRequest::Graceful).await;
+        match tokio::time::timeout(grace, self.exit_rx.changed()).await {
+            Ok(Ok(())) => {
+                let snap = self.exit_rx.borrow().clone();
+                tracing::debug!(?snap, "grok exited gracefully");
+            }
+            _ => {
+                tracing::warn!("grok did not exit within grace; sending SIGKILL");
+                let _ = self.kill_tx.send(KillRequest::Force).await;
+                let _ = tokio::time::timeout(grace, self.exit_rx.changed()).await;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Owns the `Child` exclusively. Awaits a kill request (force-kill) or natural
+/// exit, then publishes an `ExitSnapshot` and terminates.
+async fn wait_task(
+    mut child: Child,
+    mut kill_rx: mpsc::Receiver<KillRequest>,
+    exit_tx: watch::Sender<Option<ExitSnapshot>>,
+) {
+    let snapshot = loop {
+        tokio::select! {
+            biased;
+            req = kill_rx.recv() => {
+                match req {
+                    Some(KillRequest::Force) => {
+                        let _ = child.start_kill();
+                    }
+                    Some(KillRequest::Graceful) => {
+                        // No-op: wait for natural exit.
+                    }
+                    None => {
+                        // All senders dropped — recv resolves to None every
+                        // iteration; stop polling it and just await exit.
+                        let res = child.wait().await;
+                        break exit_snapshot_from(res.ok());
+                    }
+                }
+            }
+            res = child.wait() => {
+                break exit_snapshot_from(res.ok());
+            }
+        }
+    };
+    let _ = exit_tx.send(Some(snapshot));
+}
+
+fn exit_snapshot_from(status: Option<std::process::ExitStatus>) -> ExitSnapshot {
+    #[cfg(unix)]
+    let signal = {
+        use std::os::unix::process::ExitStatusExt;
+        status.as_ref().and_then(|s| s.signal())
+    };
+    #[cfg(not(unix))]
+    let signal: Option<i32> = None;
+    let status_code = status.as_ref().and_then(|s| s.code());
+    ExitSnapshot {
+        status_code,
+        signal,
+        observed_at: Utc::now(),
+    }
+}
+
+async fn read_frames(stdout: tokio::process::ChildStdout, tx: mpsc::Sender<serde_json::Value>) {
+    let mut reader = BufReader::new(stdout);
+    let mut line = String::new();
+    loop {
+        line.clear();
+        match reader.read_line(&mut line).await {
+            Ok(0) => break,
+            Ok(_) => {
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                match serde_json::from_str::<serde_json::Value>(trimmed) {
+                    Ok(v) => {
+                        if tx.send(v).await.is_err() {
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!("grok emitted non-JSON line ({e}): {trimmed}");
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!("grok stdout read error: {e}");
+                break;
+            }
+        }
+    }
+}
+
+async fn drain_stderr(stderr: tokio::process::ChildStderr, ring: StderrRing) {
+    // grok surfaces auth (missing/invalid XAI_API_KEY), model, and runtime
+    // errors here. At the default level these would be invisible, so every
+    // non-empty line is logged at `warn!` AND buffered into the per-process
+    // ring for RunFailed-detail enrichment. The login-shell wrapper emits two
+    // TTY-less diagnostics before exec; suppress those.
+    let mut reader = BufReader::new(stderr);
+    let mut line = String::new();
+    loop {
+        line.clear();
+        match reader.read_line(&mut line).await {
+            Ok(0) => break,
+            Ok(_) => {
+                let trimmed = line.trim_end();
+                if trimmed.is_empty() || is_benign_login_shell_warning(trimmed) {
+                    continue;
+                }
+                tracing::warn!(target: "grok.stderr", "{trimmed}");
+                ring.lock().await.push(trimmed);
+            }
+            Err(e) => {
+                tracing::warn!("grok stderr read error: {e}");
+                break;
+            }
+        }
+    }
+}

--- a/runner/src/grok/schema.rs
+++ b/runner/src/grok/schema.rs
@@ -1,0 +1,211 @@
+//! Outbound ACP JSON-RPC message builders for the Grok bridge, plus the
+//! small helpers used to interpret the responses grok's ACP server sends
+//! back. Inbound frames are parsed with OpenClaw's shared
+//! [`crate::openclaw::schema::AcpMessage`] — this module only covers the
+//! client → server direction that the OpenClaw bridge never needed (there,
+//! `acpx` is the client and drives the handshake for us).
+//!
+//! ACP is JSON-RPC 2.0 (<https://agentclientprotocol.com>). The handshake is:
+//! `initialize` (capability negotiation) → `session/new` (returns a
+//! `sessionId`) → `session/prompt` (the turn; the server streams
+//! `session/update` notifications then answers with a `stopReason`). While a
+//! turn is in flight the server may send a `session/request_permission`
+//! request, which the client must answer by selecting one of the offered
+//! options; [`select_allow_option`] implements the MVP auto-approve choice.
+
+use serde_json::{Value, json};
+
+/// The ACP protocol major version this client advertises in `initialize`.
+/// ACP is currently at major version 1; a server that speaks a newer version
+/// negotiates down in its `initialize` response.
+pub const ACP_PROTOCOL_VERSION: u64 = 1;
+
+/// Build the `initialize` request line. We advertise a minimal client: no
+/// filesystem or terminal capabilities, so the server does its own I/O and we
+/// stay a thin driver. The `clientInfo` mirrors what the Codex bridge sends so
+/// grok's logs attribute the session to pidash.
+pub fn initialize_request(id: u64) -> String {
+    rpc_request(
+        id,
+        "initialize",
+        json!({
+            "protocolVersion": ACP_PROTOCOL_VERSION,
+            "clientCapabilities": { "fs": { "readTextFile": false, "writeTextFile": false } },
+            "clientInfo": { "name": "pidash", "version": crate::RUNNER_VERSION },
+        }),
+    )
+}
+
+/// Build the `session/new` request line. `cwd` is the absolute working
+/// directory the agent operates in; `model`, when set, rides as an extra field
+/// (grok reads it to pick the model — unknown fields are ignored by
+/// spec-conforming ACP servers, so this is safe if grok ignores it).
+pub fn session_new_request(id: u64, cwd: &str, model: Option<&str>) -> String {
+    let mut params = json!({ "cwd": cwd, "mcpServers": [] });
+    if let Some(m) = model {
+        params["model"] = Value::String(m.to_string());
+    }
+    rpc_request(id, "session/new", params)
+}
+
+/// Build the `session/prompt` request line — the turn itself. The prompt is a
+/// single text content block, matching how the Codex bridge sends turn input.
+pub fn session_prompt_request(id: u64, session_id: &str, prompt: &str) -> String {
+    rpc_request(
+        id,
+        "session/prompt",
+        json!({
+            "sessionId": session_id,
+            "prompt": [ { "type": "text", "text": prompt } ],
+        }),
+    )
+}
+
+/// Build the response to a `session/request_permission` request, selecting the
+/// given option id (see [`select_allow_option`]). ACP expects the outcome to
+/// name the chosen option.
+pub fn permission_selected_response(id: &Value, option_id: &str) -> String {
+    let msg = json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": { "outcome": { "outcome": "selected", "optionId": option_id } },
+    });
+    msg.to_string()
+}
+
+/// Pick the option id to auto-approve from a `session/request_permission`
+/// request's `params.options` array. Prefers a persistent "allow always" over
+/// a one-shot "allow once"; falls back to the first option so we always send
+/// *something* rather than deadlocking the turn. Returns `None` only when no
+/// options are offered at all.
+pub fn select_allow_option(params: &Value) -> Option<String> {
+    let options = params.get("options").and_then(|o| o.as_array())?;
+    let id_of = |opt: &Value| {
+        opt.get("optionId")
+            .and_then(|v| v.as_str())
+            .map(ToOwned::to_owned)
+    };
+    let by_kind = |want: &str| {
+        options
+            .iter()
+            .find(|o| o.get("kind").and_then(|k| k.as_str()) == Some(want))
+            .and_then(id_of)
+    };
+    by_kind("allow_always")
+        .or_else(|| by_kind("allow_once"))
+        .or_else(|| options.first().and_then(id_of))
+}
+
+/// Extract the `sessionId` from a `session/new` response `result`. ACP puts it
+/// at `result.sessionId`; tolerate a snake_case spelling defensively.
+pub fn session_id_from_result(result: &Value) -> Option<String> {
+    result
+        .get("sessionId")
+        .or_else(|| result.get("session_id"))
+        .and_then(|v| v.as_str())
+        .map(ToOwned::to_owned)
+}
+
+/// Serialize a JSON-RPC 2.0 request with an integer id.
+fn rpc_request(id: u64, method: &str, params: Value) -> String {
+    json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params }).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn initialize_request_carries_protocol_version_and_client_info() {
+        let line = initialize_request(1);
+        let v: Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(v["method"], "initialize");
+        assert_eq!(v["id"], 1);
+        assert_eq!(v["params"]["protocolVersion"], ACP_PROTOCOL_VERSION);
+        assert_eq!(v["params"]["clientInfo"]["name"], "pidash");
+    }
+
+    #[test]
+    fn session_new_includes_model_only_when_set() {
+        let with = session_new_request(2, "/work", Some("grok-4.3"));
+        let v: Value = serde_json::from_str(&with).unwrap();
+        assert_eq!(v["params"]["cwd"], "/work");
+        assert_eq!(v["params"]["model"], "grok-4.3");
+
+        let without = session_new_request(2, "/work", None);
+        let v: Value = serde_json::from_str(&without).unwrap();
+        assert!(v["params"].get("model").is_none());
+    }
+
+    #[test]
+    fn session_prompt_wraps_text_content_block() {
+        let line = session_prompt_request(3, "sess-1", "do the thing");
+        let v: Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(v["method"], "session/prompt");
+        assert_eq!(v["params"]["sessionId"], "sess-1");
+        assert_eq!(v["params"]["prompt"][0]["type"], "text");
+        assert_eq!(v["params"]["prompt"][0]["text"], "do the thing");
+    }
+
+    #[test]
+    fn select_allow_option_prefers_allow_always() {
+        let params = json!({
+            "options": [
+                { "optionId": "a", "name": "Reject", "kind": "reject_once" },
+                { "optionId": "b", "name": "Allow once", "kind": "allow_once" },
+                { "optionId": "c", "name": "Always allow", "kind": "allow_always" },
+            ]
+        });
+        assert_eq!(select_allow_option(&params).as_deref(), Some("c"));
+    }
+
+    #[test]
+    fn select_allow_option_falls_back_to_allow_once_then_first() {
+        let allow_once = json!({
+            "options": [
+                { "optionId": "a", "name": "Reject", "kind": "reject_once" },
+                { "optionId": "b", "name": "Allow once", "kind": "allow_once" },
+            ]
+        });
+        assert_eq!(select_allow_option(&allow_once).as_deref(), Some("b"));
+
+        // No kinds we recognize → first option, so we never deadlock the turn.
+        let unknown = json!({
+            "options": [
+                { "optionId": "x", "name": "Whatever" },
+                { "optionId": "y", "name": "Other" },
+            ]
+        });
+        assert_eq!(select_allow_option(&unknown).as_deref(), Some("x"));
+
+        // No options at all → None.
+        assert_eq!(select_allow_option(&json!({ "options": [] })), None);
+        assert_eq!(select_allow_option(&json!({})), None);
+    }
+
+    #[test]
+    fn permission_response_echoes_request_id_and_option() {
+        let line = permission_selected_response(&json!(7), "opt-1");
+        let v: Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(v["id"], 7);
+        assert_eq!(v["result"]["outcome"]["outcome"], "selected");
+        assert_eq!(v["result"]["outcome"]["optionId"], "opt-1");
+        // A string id must round-trip too (ACP ids may be strings).
+        let line = permission_selected_response(&json!("req-9"), "opt-2");
+        let v: Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(v["id"], "req-9");
+    }
+
+    #[test]
+    fn session_id_extracted_from_result() {
+        assert_eq!(
+            session_id_from_result(&json!({ "sessionId": "s1" })).as_deref(),
+            Some("s1")
+        );
+        assert_eq!(
+            session_id_from_result(&json!({ "session_id": "s2" })).as_deref(),
+            Some("s2")
+        );
+        assert_eq!(session_id_from_result(&json!({})), None);
+    }
+}

--- a/runner/src/lib.rs
+++ b/runner/src/lib.rs
@@ -11,6 +11,7 @@ pub mod codex;
 pub mod config;
 pub mod cursor_agent;
 pub mod daemon;
+pub mod grok;
 pub mod history;
 pub mod ipc;
 pub mod openclaw;

--- a/runner/src/tui/views/config.rs
+++ b/runner/src/tui/views/config.rs
@@ -21,7 +21,7 @@ use crate::service::reload::ReloadOutcome;
 
 use super::super::app::AppData;
 
-pub const AGENT_KINDS: &[&str] = &["codex", "claude-code", "cursor-agent", "open-claw"];
+pub const AGENT_KINDS: &[&str] = &["codex", "claude-code", "cursor-agent", "open-claw", "grok"];
 pub const LOG_LEVELS: &[&str] = &["trace", "debug", "info", "warn", "error"];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -37,6 +37,8 @@ pub enum FieldId {
     CursorModelDefault,
     OpenClawBinary,
     OpenClawModelDefault,
+    GrokBinary,
+    GrokModelDefault,
     ApprovalAutoReadonly,
     ApprovalAutoWrites,
     ApprovalAutoNetwork,
@@ -59,6 +61,8 @@ impl FieldId {
             FieldId::CursorModelDefault => "field:cursor_model_default",
             FieldId::OpenClawBinary => "field:openclaw_binary",
             FieldId::OpenClawModelDefault => "field:openclaw_model_default",
+            FieldId::GrokBinary => "field:grok_binary",
+            FieldId::GrokModelDefault => "field:grok_model_default",
             FieldId::ApprovalAutoReadonly => "field:approval_auto_readonly",
             FieldId::ApprovalAutoWrites => "field:approval_auto_writes",
             FieldId::ApprovalAutoNetwork => "field:approval_auto_network",
@@ -80,6 +84,8 @@ impl FieldId {
             "field:cursor_model_default" => FieldId::CursorModelDefault,
             "field:openclaw_binary" => FieldId::OpenClawBinary,
             "field:openclaw_model_default" => FieldId::OpenClawModelDefault,
+            "field:grok_binary" => FieldId::GrokBinary,
+            "field:grok_model_default" => FieldId::GrokModelDefault,
             "field:approval_auto_readonly" => FieldId::ApprovalAutoReadonly,
             "field:approval_auto_writes" => FieldId::ApprovalAutoWrites,
             "field:approval_auto_network" => FieldId::ApprovalAutoNetwork,
@@ -173,6 +179,18 @@ pub const FIELDS: &[FieldSpec] = &[
         kind: FieldKind::Text,
     },
     FieldSpec {
+        id: FieldId::GrokBinary,
+        label: "binary",
+        section: "Grok",
+        kind: FieldKind::Text,
+    },
+    FieldSpec {
+        id: FieldId::GrokModelDefault,
+        label: "model_default",
+        section: "Grok",
+        kind: FieldKind::Text,
+    },
+    FieldSpec {
         id: FieldId::ApprovalAutoReadonly,
         label: "auto_approve_readonly_shell",
         section: "Approval policy",
@@ -209,6 +227,7 @@ pub fn field_agent_kind(id: FieldId) -> Option<AgentKind> {
         FieldId::ClaudeBinary | FieldId::ClaudeModelDefault => Some(AgentKind::ClaudeCode),
         FieldId::CursorBinary | FieldId::CursorModelDefault => Some(AgentKind::CursorAgent),
         FieldId::OpenClawBinary | FieldId::OpenClawModelDefault => Some(AgentKind::OpenClaw),
+        FieldId::GrokBinary | FieldId::GrokModelDefault => Some(AgentKind::Grok),
         _ => None,
     }
 }
@@ -269,6 +288,7 @@ pub fn display_value(cfg: &Config, id: FieldId, runner_idx: usize) -> String {
             AgentKind::ClaudeCode => "claude-code".into(),
             AgentKind::CursorAgent => "cursor-agent".into(),
             AgentKind::OpenClaw => "open-claw".into(),
+            AgentKind::Grok => "grok".into(),
         },
         FieldId::CodexBinary => runner.codex.binary.clone(),
         FieldId::CodexModelDefault => runner.codex.model_default.clone().unwrap_or_default(),
@@ -288,6 +308,8 @@ pub fn display_value(cfg: &Config, id: FieldId, runner_idx: usize) -> String {
         FieldId::OpenClawModelDefault => {
             runner.openclaw.model_default.clone().unwrap_or_default()
         }
+        FieldId::GrokBinary => runner.grok.binary.clone(),
+        FieldId::GrokModelDefault => runner.grok.model_default.clone().unwrap_or_default(),
         FieldId::ApprovalAutoReadonly => runner
             .approval_policy
             .auto_approve_readonly_shell
@@ -380,6 +402,19 @@ pub fn set_text_value(
                 Some(s.to_string())
             };
         }
+        FieldId::GrokBinary => {
+            if s.trim().is_empty() {
+                return Err("binary cannot be empty".into());
+            }
+            runner.grok.binary = s.to_string();
+        }
+        FieldId::GrokModelDefault => {
+            runner.grok.model_default = if s.is_empty() {
+                None
+            } else {
+                Some(s.to_string())
+            };
+        }
         FieldId::AgentKind
         | FieldId::ApprovalAutoReadonly
         | FieldId::ApprovalAutoWrites
@@ -423,7 +458,8 @@ pub fn cycle_enum(cfg: &mut Config, id: FieldId, runner_idx: usize) {
                 AgentKind::Codex => AgentKind::ClaudeCode,
                 AgentKind::ClaudeCode => AgentKind::CursorAgent,
                 AgentKind::CursorAgent => AgentKind::OpenClaw,
-                AgentKind::OpenClaw => AgentKind::Codex,
+                AgentKind::OpenClaw => AgentKind::Grok,
+                AgentKind::Grok => AgentKind::Codex,
             };
         }
         FieldId::LogLevel => {
@@ -577,6 +613,11 @@ pub fn editable_lines(
             "OpenClaw",
             AgentKind::OpenClaw,
             [FieldId::OpenClawBinary, FieldId::OpenClawModelDefault],
+        ),
+        (
+            "Grok",
+            AgentKind::Grok,
+            [FieldId::GrokBinary, FieldId::GrokModelDefault],
         ),
     ] {
         if kind != selected_kind {
@@ -837,6 +878,7 @@ mod tests {
             claude_code: Default::default(),
             cursor_agent: Default::default(),
             openclaw: Default::default(),
+            grok: Default::default(),
             approval_policy: Default::default(),
         };
         runner.agent.kind = kind;

--- a/runner/src/tui/views/general.rs
+++ b/runner/src/tui/views/general.rs
@@ -921,6 +921,7 @@ pub async fn submit_register(
         claude_code: Default::default(),
         cursor_agent: Default::default(),
         openclaw: Default::default(),
+        grok: Default::default(),
         approval_policy: Default::default(),
     };
     let cfg = crate::config::schema::Config {

--- a/runner/src/tui/views/runner_status.rs
+++ b/runner/src/tui/views/runner_status.rs
@@ -693,6 +693,7 @@ mod tests {
             claude_code: Default::default(),
             cursor_agent: Default::default(),
             openclaw: Default::default(),
+            grok: Default::default(),
             approval_policy: Default::default(),
         }
     }


### PR DESCRIPTION
## What & why

Integrates xAI's **Grok** CLI coding agent into Pi Dash's supported-agent list (PDASHOSS01-33), selectable end-to-end exactly like Codex / Claude Code / Cursor / OpenClaw.

Per the issue owner's decision (comment thread), Grok is driven over the **Agent Client Protocol (ACP)**. Rather than route through the third-party `acpx` ACP client (which lists no Grok adapter and is alpha), the runner acts as the ACP **client** itself: it spawns Grok's native ACP server (`grok agent stdio`) and drives the JSON-RPC handshake directly —

```
initialize → session/new {cwd} → session/prompt {sessionId, prompt}
```

Streamed `session/update` notifications become `BridgeEvent::Raw`; the turn ends on the `session/prompt` response's `stopReason`. Inbound frames reuse OpenClaw's shared `AcpMessage` schema (the load-bearing frame-parse + turn-end detection); the persistent, stdin-driven process wrapper is modelled on `codex::app_server` (Grok's `agent stdio` is a long-lived server, not a one-shot).

## Changes

**New module** `runner/src/grok/` — `mod` · `schema` (outbound ACP request builders + permission-option selection) · `process` (persistent `grok agent stdio` wrapper) · `bridge` (ACP client handshake + translate).

**Wiring** (mechanical, mirrors the existing agents):
- `AgentKind::Grok`, `GrokSection` + `RunnerConfig.grok`, `stall_timeout` / `display_name` / `default_binary` (`grok`) / `install_page_url` (`https://x.ai/cli`)
- `AgentBridge::Grok` / `AgentCursor::Grok` dispatch (all match arms)
- TUI runner-config: agent kind, `Grok` binary/model fields
- CLI: `--agent grok`, `model_applies_to_agent`, `agent_sections_for`, doctor binary + auth checks
- supervisor crash-reason mapping (`AgentCrash`)
- web: Add-Runner modal option + `runner-models.ts` (`TRunnerAgent`, Grok model catalog)

## MVP limitations (mirror OpenClaw, tracked as follow-ups)
- **Approvals bypass**: `session/request_permission` requests are auto-approved inline (an "allow" option is selected).
- **Stateless turns**: a fresh `session/new` per run; a resume session id only seeds the thread id (no `session/load` continuity yet).

## Testing
- `cargo build -p pidash` ✅
- `cargo test -p pidash grok` → **14/14** ✅ — schema builders, permission-option selection, translate (Raw / Completed / Failed), terminal `stopReason` detection, and an **end-to-end fake `grok agent stdio` handshake** exercising initialize → session/new → session/prompt → stopReason.
- full `cargo test -p pidash` → 444 pass (1 unrelated pre-existing failure in `workspace::git`, fails identically on `main`).
- `cargo clippy -p pidash` → no new warnings.
- web `runner-models.ts` / `add-runner-modal.tsx` pass format + lint (oxfmt/oxlint `--deny-warnings` via lint-staged).

## ⚠️ Needs a real-binary smoke test before merge
The exact Grok ACP wire schema could **not** be validated against a real `grok` binary in the sandbox (no binary, no `XAI_API_KEY`, paid API off-limits). The translator is forgiving (Unknown catch-all + unparseable-line fallback) and turn-end reuses OpenClaw's proven `stopReason` logic, but a reviewer with a Grok install + `XAI_API_KEY` should confirm: the `session/new` response shape (`result.sessionId`), the terminal `session/prompt` response (`result.stopReason`), and — if Grok emits them — the `session/request_permission` request/response shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
