### PR TITLE
Route the LLM-config precheck through the ee model-provider seam

### DIFF
--- a/apps/api/pi_dash/assistant/views/messages.py
+++ b/apps/api/pi_dash/assistant/views/messages.py
@@ -19,7 +19,7 @@ from pi_dash.assistant.models import (
     TurnStatus,
 )
 from pi_dash.assistant.runtime import events
-from pi_dash.assistant.runtime.llm import get_config
+from pi_dash.ee.assistant.model_provider import has_usable_llm_config
 from pi_dash.assistant.serializers import AssistantThreadSerializer
 from pi_dash.assistant.tasks import cancel_key, run_assistant_turn
 from pi_dash.assistant.views._base import AssistantBaseView
@@ -74,8 +74,7 @@ class AssistantMessageListCreateEndpoint(AssistantBaseView):
         if len(content) > MAX_MESSAGE_CHARS:
             return Response({"error": "message_too_long"}, status=status.HTTP_400_BAD_REQUEST)
 
-        cfg = get_config(request.user)
-        if cfg is None or not cfg.has_api_key:
+        if not has_usable_llm_config(request.user):
             return Response(
                 {"error": "llm_config_missing", "detail": "Configure your AI provider in Settings."},
                 status=status.HTTP_422_UNPROCESSABLE_ENTITY,

--- a/apps/api/pi_dash/ee/assistant/model_provider.py
+++ b/apps/api/pi_dash/ee/assistant/model_provider.py
@@ -14,8 +14,19 @@ instead of BYOK direct helpers, so the overlay is the single switch point.
 
 from __future__ import annotations
 
-from pi_dash.assistant.runtime.llm import resolve_byok_model
+from pi_dash.assistant.runtime.llm import get_config, resolve_byok_model
 from pi_dash.assistant.runtime.title import generate_byok_title_for_user
+
+
+def has_usable_llm_config(user) -> bool:
+    """True when ``user`` has a usable LLM configuration (CE: a BYOK key).
+
+    Cheap presence check for request-time gating (e.g. rejecting a chat
+    message before enqueueing a turn) — must not build a model or decrypt
+    anything. The cloud overlay also accepts its platform credentials here.
+    """
+    cfg = get_config(user)
+    return bool(cfg and cfg.has_api_key)
 
 
 def resolve_model_for_user(user):


### PR DESCRIPTION
## What

Adds `has_usable_llm_config(user)` to the `pi_dash/ee/assistant/model_provider.py` seam and routes the send-message precheck in `assistant/views/messages.py` through it, replacing the direct `UserLLMConfig` lookup.

## Why

Everything else in the assistant (model resolution, title generation) already goes through the ee seam, so an edition that supplies LLM credentials outside the BYOK table works at runtime — but message sends were still gated on the raw BYOK row and 422'd with `llm_config_missing` ("Configure your AI provider in Settings"). This surfaced in the cloud edition when a user's only connection was an OpenAI subscription credential.

## Behavior

- **CE/self-hosted: unchanged.** The seam's default is exactly the old check — a stored BYOK key.
- The cloud overlay overrides the seam to also accept its platform credentials (companion change on `private-pi-dash` PR #97, which depends on this merging first).

## Testing

- Assistant contract suite passes (`pi_dash/tests/contract/assistant/`).
- Exercised end-to-end in the cloud dev stack: with no BYOK row and only the overlay credential, sends now 202 and turns complete; with neither, still 422 `llm_config_missing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)