### PR TITLE
PDASHOSS01-57 Integrate the Test state group across the issue lifecycle

### DIFF
--- a/apps/api/pi_dash/api/views/issue.py
+++ b/apps/api/pi_dash/api/views/issue.py
@@ -82,13 +82,13 @@ from pi_dash.db.models import (
     Project,
     ProjectMember,
     CycleIssue,
-    StateGroup,
     Workspace,
 )
 from pi_dash.settings.storage import S3Storage
 from pi_dash.bgtasks.storage_metadata_task import get_asset_object_metadata
 from .base import BaseAPIView
 from pi_dash.utils.host import base_host
+from pi_dash.utils.constants import CLOSED_STATE_GROUPS, OPEN_STATE_GROUPS, STATE_GROUP_ORDER
 from pi_dash.utils.issue_relation_mapper import get_actual_relation
 from pi_dash.search.issue import extract_snippet, issue_search_queryset
 from pi_dash.utils.issue_move import move_work_item_to_project, IssueMoveError
@@ -334,7 +334,7 @@ class IssueListCreateAPIEndpoint(BaseAPIView):
 
         # Custom ordering for priority and state
         priority_order = ["urgent", "high", "medium", "low", "none"]
-        state_order = ["backlog", "unstarted", "started", "review", "completed", "cancelled"]
+        state_order = STATE_GROUP_ORDER
 
         order_by_param = request.GET.get("order_by", "-created_at")
 
@@ -2348,17 +2348,12 @@ class IssueAdvancedSearchEndpoint(BaseAPIView):
     # primary because users hit them right after creating issues.
     use_read_replica = True
 
-    _CLOSED_STATE_GROUPS = (StateGroup.COMPLETED.value, StateGroup.CANCELLED.value)
+    _CLOSED_STATE_GROUPS = CLOSED_STATE_GROUPS
     # Positive list — modelling "open" as `state__group IN (open)` instead
     # of `NOT IN (closed)` keeps stateless issues (state IS NULL) visible:
     # SQL `NULL NOT IN (...)` evaluates to NULL → row dropped, which would
     # silently hide just-created or state-less issues from `?status=open`.
-    _OPEN_STATE_GROUPS = (
-        StateGroup.BACKLOG.value,
-        StateGroup.UNSTARTED.value,
-        StateGroup.STARTED.value,
-        StateGroup.REVIEW.value,
-    )
+    _OPEN_STATE_GROUPS = OPEN_STATE_GROUPS
     _SORT_OPTIONS = {
         "rank": ("-_rank", "-created_at"),
         "-created": ("-created_at",),

--- a/apps/api/pi_dash/app/views/analytic/base.py
+++ b/apps/api/pi_dash/app/views/analytic/base.py
@@ -30,6 +30,7 @@ from pi_dash.db.models import (
 )
 
 from pi_dash.utils.analytics_plot import build_graph_plot, VALID_ANALYTICS_FIELDS, VALID_YAXIS
+from pi_dash.utils.constants import CLOSED_STATE_GROUPS, OPEN_STATE_GROUPS
 from pi_dash.utils.issue_filters import issue_filters
 from pi_dash.app.permissions import allow_permission, ROLE
 
@@ -262,8 +263,7 @@ class DefaultAnalyticsEndpoint(BaseAPIView):
             state_groups.values("state_group").annotate(state_count=Count("state_group")).order_by("state_group")
         )
 
-        open_issues_groups = ["backlog", "unstarted", "started", "review"]
-        open_issues_queryset = state_groups.filter(state__group__in=open_issues_groups)
+        open_issues_queryset = state_groups.filter(state__group__in=OPEN_STATE_GROUPS)
 
         open_issues = open_issues_queryset.count()
         open_issues_classified = (
@@ -421,7 +421,7 @@ class ProjectStatsEndpoint(BaseAPIView):
 
         if "completed_issues" in requested_fields:
             annotations["completed_issues"] = (
-                Issue.issue_objects.filter(project_id=OuterRef("pk"), state__group__in=["completed", "cancelled"])
+                Issue.issue_objects.filter(project_id=OuterRef("pk"), state__group__in=CLOSED_STATE_GROUPS)
                 .order_by()
                 .annotate(count=Func(F("id"), function="Count"))
                 .values("count")

--- a/apps/api/pi_dash/app/views/issue/archive.py
+++ b/apps/api/pi_dash/app/views/issue/archive.py
@@ -38,6 +38,7 @@ from pi_dash.utils.grouper import (
     issue_queryset_grouper,
 )
 from pi_dash.utils.issue_filters import issue_filters
+from pi_dash.utils.constants import CLOSED_STATE_GROUPS
 from pi_dash.utils.order_queryset import order_issue_queryset
 from pi_dash.utils.paginator import GroupedOffsetPaginator, SubGroupedOffsetPaginator
 from pi_dash.app.permissions import allow_permission, ROLE
@@ -256,7 +257,7 @@ class IssueArchiveViewSet(BaseViewSet):
     @allow_permission([ROLE.ADMIN, ROLE.MEMBER])
     def archive(self, request, slug, project_id, pk=None):
         issue = Issue.issue_objects.get(workspace__slug=slug, project_id=project_id, pk=pk)
-        if issue.state.group not in ["completed", "cancelled"]:
+        if issue.state.group not in CLOSED_STATE_GROUPS:
             return Response(
                 {"error": "Can only archive completed or cancelled state group issue"},
                 status=status.HTTP_400_BAD_REQUEST,

--- a/apps/api/pi_dash/app/views/workspace/base.py
+++ b/apps/api/pi_dash/app/views/workspace/base.py
@@ -43,7 +43,7 @@ from pi_dash.db.models import (
     Profile,
 )
 from pi_dash.app.permissions import ROLE, allow_permission
-from pi_dash.utils.constants import RESTRICTED_WORKSPACE_SLUGS
+from pi_dash.utils.constants import CLOSED_STATE_GROUPS, RESTRICTED_WORKSPACE_SLUGS
 from pi_dash.license.utils.instance_value import get_configuration_value
 from pi_dash.bgtasks.workspace_seed_task import workspace_seed
 from pi_dash.bgtasks.event_tracking_task import track_event
@@ -292,7 +292,7 @@ class UserWorkspaceDashboardEndpoint(BaseAPIView):
         assigned_issues = Issue.issue_objects.filter(workspace__slug=slug, assignees__in=[request.user]).count()
 
         pending_issues_count = Issue.issue_objects.filter(
-            ~Q(state__group__in=["completed", "cancelled"]),
+            ~Q(state__group__in=CLOSED_STATE_GROUPS),
             workspace__slug=slug,
             assignees__in=[request.user],
         ).count()
@@ -317,7 +317,7 @@ class UserWorkspaceDashboardEndpoint(BaseAPIView):
         )
 
         overdue_issues = Issue.issue_objects.filter(
-            ~Q(state__group__in=["completed", "cancelled"]),
+            ~Q(state__group__in=CLOSED_STATE_GROUPS),
             workspace__slug=slug,
             assignees__in=[request.user],
             target_date__lt=timezone.now(),
@@ -325,7 +325,7 @@ class UserWorkspaceDashboardEndpoint(BaseAPIView):
         ).values("id", "name", "workspace__slug", "project_id", "target_date")
 
         upcoming_issues = Issue.issue_objects.filter(
-            ~Q(state__group__in=["completed", "cancelled"]),
+            ~Q(state__group__in=CLOSED_STATE_GROUPS),
             start_date__gte=timezone.now(),
             workspace__slug=slug,
             assignees__in=[request.user],

--- a/apps/api/pi_dash/app/views/workspace/user.py
+++ b/apps/api/pi_dash/app/views/workspace/user.py
@@ -58,6 +58,7 @@ from pi_dash.utils.grouper import (
     issue_on_results,
     issue_queryset_grouper,
 )
+from pi_dash.utils.constants import CLOSED_STATE_GROUPS
 from pi_dash.utils.issue_filters import issue_filters
 from pi_dash.utils.order_queryset import order_issue_queryset
 from pi_dash.utils.paginator import GroupedOffsetPaginator, SubGroupedOffsetPaginator
@@ -458,7 +459,7 @@ class WorkspaceUserProfileStatsEndpoint(BaseAPIView):
 
         pending_issues_count = (
             Issue.issue_objects.filter(
-                ~Q(state__group__in=["completed", "cancelled"]),
+                ~Q(state__group__in=CLOSED_STATE_GROUPS),
                 (Q(assignees__in=[user_id]) & Q(issue_assignee__deleted_at__isnull=True)),
                 workspace__slug=slug,
                 project__project_projectmember__member=request.user,

--- a/apps/api/pi_dash/bgtasks/issue_automation_task.py
+++ b/apps/api/pi_dash/bgtasks/issue_automation_task.py
@@ -16,6 +16,7 @@ from django.utils import timezone
 # Module imports
 from pi_dash.bgtasks.issue_activities_task import issue_activity
 from pi_dash.db.models import Issue, Project, State
+from pi_dash.utils.constants import CLOSED_STATE_GROUPS, OPEN_STATE_GROUPS
 from pi_dash.utils.exception_logger import log_exception
 
 
@@ -40,7 +41,7 @@ def archive_old_issues():
                     project=project_id,
                     archived_at__isnull=True,
                     updated_at__lte=(timezone.now() - timedelta(days=archive_in * 30)),
-                    state__group__in=["completed", "cancelled"],
+                    state__group__in=CLOSED_STATE_GROUPS,
                 ),
                 Q(issue_cycle__isnull=True)
                 | (Q(issue_cycle__cycle__end_date__lt=timezone.now()) & Q(issue_cycle__isnull=False)),
@@ -101,7 +102,7 @@ def close_old_issues():
                     project=project_id,
                     archived_at__isnull=True,
                     updated_at__lte=(timezone.now() - timedelta(days=close_in * 30)),
-                    state__group__in=["backlog", "unstarted", "started", "review"],
+                    state__group__in=OPEN_STATE_GROUPS,
                 ),
                 Q(issue_cycle__isnull=True)
                 | (Q(issue_cycle__cycle__end_date__lt=timezone.now()) & Q(issue_cycle__isnull=False)),

--- a/apps/api/pi_dash/space/utils/grouper.py
+++ b/apps/api/pi_dash/space/utils/grouper.py
@@ -22,6 +22,7 @@ from pi_dash.db.models import (
     State,
     WorkspaceMember,
 )
+from pi_dash.utils.constants import STATE_GROUP_ORDER
 
 
 def issue_queryset_grouper(
@@ -227,7 +228,7 @@ def issue_group_values(
     if field == "priority":
         return ["low", "medium", "high", "urgent", "none"]
     if field == "state__group":
-        return ["backlog", "unstarted", "started", "review", "completed", "cancelled"]
+        return list(STATE_GROUP_ORDER)
     if field == "target_date":
         queryset = queryset.values_list("target_date", flat=True).distinct()
         if project_id:

--- a/apps/api/pi_dash/tests/unit/orchestration/test_agent_phases.py
+++ b/apps/api/pi_dash/tests/unit/orchestration/test_agent_phases.py
@@ -64,6 +64,14 @@ def test_is_ticking_state_true_for_started_in_progress():
 
 
 @pytest.mark.unit
+def test_test_group_is_manual_and_does_not_tick():
+    state = _StubState(StateGroup.TEST.value, "In Test")
+
+    assert StateGroup.TEST.value not in agent_phases.PHASES
+    assert agent_phases.is_ticking_state(state) is False
+
+
+@pytest.mark.unit
 def test_is_ticking_state_false_for_started_with_custom_name():
     # Workspaces with custom state names within a ticking group still
     # do not tick — the registry pins the literal state name per group.

--- a/apps/api/pi_dash/tests/unit/utils/test_state_groups.py
+++ b/apps/api/pi_dash/tests/unit/utils/test_state_groups.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Regression coverage for lifecycle-wide state-group integrations."""
+
+import pytest
+
+from pi_dash.api.views.issue import IssueAdvancedSearchEndpoint
+from pi_dash.db.models.state import DEFAULT_STATES, StateGroup
+from pi_dash.space.utils.grouper import issue_group_values as space_issue_group_values
+from pi_dash.utils.constants import (
+    ACTIVE_STATE_GROUPS,
+    CLOSED_STATE_GROUPS,
+    OPEN_STATE_GROUPS,
+    STATE_GROUP_ORDER,
+)
+from pi_dash.utils.filters.converters import LegacyToRichFiltersConverter
+from pi_dash.utils.grouper import issue_group_values
+from pi_dash.utils.issue_filters import filter_issue_state_type
+from pi_dash.utils.order_queryset import STATE_ORDER
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_test_group_is_in_the_canonical_lifecycle_order():
+    assert STATE_GROUP_ORDER == (
+        "backlog",
+        "unstarted",
+        "started",
+        "review",
+        "test",
+        "completed",
+        "cancelled",
+    )
+    assert tuple(group.value for group in StateGroup if group is not StateGroup.TRIAGE) == STATE_GROUP_ORDER
+    assert tuple(state["group"] for state in DEFAULT_STATES if state["group"] != StateGroup.TRIAGE) == STATE_GROUP_ORDER
+
+
+def test_test_group_is_open_and_active_but_not_closed():
+    assert StateGroup.TEST in OPEN_STATE_GROUPS
+    assert StateGroup.TEST in ACTIVE_STATE_GROUPS
+    assert StateGroup.TEST not in CLOSED_STATE_GROUPS
+
+
+@pytest.mark.parametrize("method", ["GET", "POST"])
+def test_legacy_issue_type_filters_keep_test_issues_visible(method):
+    all_filter = {}
+    filter_issue_state_type({"type": "all"}, all_filter, method)
+    assert all_filter["state__group__in"] == list(STATE_GROUP_ORDER)
+
+    active_filter = {}
+    filter_issue_state_type({"type": "active"}, active_filter, method)
+    assert active_filter["state__group__in"] == list(ACTIVE_STATE_GROUPS)
+
+
+def test_state_group_sorting_grouping_and_conversion_share_the_canonical_order():
+    assert STATE_ORDER == list(STATE_GROUP_ORDER)
+    assert issue_group_values("state__group", "workspace") == list(STATE_GROUP_ORDER)
+    assert space_issue_group_values("state__group", "workspace") == list(STATE_GROUP_ORDER)
+    assert LegacyToRichFiltersConverter.DEFAULT_VALID_CHOICES["state_group"] == list(STATE_GROUP_ORDER)
+
+
+def test_advanced_search_treats_test_issues_as_open():
+    assert IssueAdvancedSearchEndpoint._OPEN_STATE_GROUPS == OPEN_STATE_GROUPS
+    assert IssueAdvancedSearchEndpoint._CLOSED_STATE_GROUPS == CLOSED_STATE_GROUPS

--- a/apps/api/pi_dash/utils/constants.py
+++ b/apps/api/pi_dash/utils/constants.py
@@ -69,3 +69,20 @@ RESTRICTED_WORKSPACE_SLUGS = [
     "instances",
     "instance",
 ]
+
+# Lifecycle ordering shared by API sorting, grouping, filtering, analytics,
+# and maintenance tasks. Triage is intentionally excluded because it has its
+# own manager and intake workflow.
+STATE_GROUP_ORDER = (
+    "backlog",
+    "unstarted",
+    "started",
+    "review",
+    "test",
+    "completed",
+    "cancelled",
+)
+
+OPEN_STATE_GROUPS = STATE_GROUP_ORDER[:-2]
+ACTIVE_STATE_GROUPS = STATE_GROUP_ORDER[1:-2]
+CLOSED_STATE_GROUPS = STATE_GROUP_ORDER[-2:]

--- a/apps/api/pi_dash/utils/cycle_transfer_issues.py
+++ b/apps/api/pi_dash/utils/cycle_transfer_issues.py
@@ -29,6 +29,7 @@ from pi_dash.db.models import (
 )
 from pi_dash.utils.analytics_plot import burndown_plot
 from pi_dash.bgtasks.issue_activities_task import issue_activity
+from pi_dash.utils.constants import OPEN_STATE_GROUPS
 from pi_dash.utils.host import base_host
 
 
@@ -438,7 +439,7 @@ def transfer_cycle_issues(
         workspace__slug=slug,
         issue__archived_at__isnull=True,
         issue__is_draft=False,
-        issue__state__group__in=["backlog", "unstarted", "started", "review"],
+        issue__state__group__in=OPEN_STATE_GROUPS,
     )
 
     updated_cycles = []

--- a/apps/api/pi_dash/utils/filters/converters.py
+++ b/apps/api/pi_dash/utils/filters/converters.py
@@ -9,6 +9,8 @@ from typing import Any, Dict, List, Union
 
 from dateutil.parser import parse as dateutil_parse
 
+from pi_dash.utils.constants import STATE_GROUP_ORDER
+
 
 class LegacyToRichFiltersConverter:
     # Default mapping from legacy filter names to new rich filter field names
@@ -41,7 +43,7 @@ class LegacyToRichFiltersConverter:
 
     # Default valid choices for choice fields
     DEFAULT_VALID_CHOICES = {
-        "state_group": ["backlog", "unstarted", "started", "review", "completed", "cancelled"],
+        "state_group": list(STATE_GROUP_ORDER),
         "priority": ["urgent", "high", "medium", "low", "none"],
     }
 

--- a/apps/api/pi_dash/utils/grouper.py
+++ b/apps/api/pi_dash/utils/grouper.py
@@ -24,6 +24,8 @@ from pi_dash.db.models import (
 )
 from typing import Optional, Dict, Tuple, Any, Union, List
 
+from pi_dash.utils.constants import STATE_GROUP_ORDER
+
 
 def issue_queryset_grouper(
     queryset: QuerySet[Issue],
@@ -191,7 +193,7 @@ def issue_group_values(
         return ["low", "medium", "high", "urgent", "none"]
 
     if field == "state__group":
-        return ["backlog", "unstarted", "started", "review", "completed", "cancelled"]
+        return list(STATE_GROUP_ORDER)
 
     if field == "target_date":
         queryset = queryset.values_list("target_date", flat=True).distinct()

--- a/apps/api/pi_dash/utils/issue_filters.py
+++ b/apps/api/pi_dash/utils/issue_filters.py
@@ -8,6 +8,8 @@ from datetime import timedelta
 
 from django.utils import timezone
 
+from pi_dash.utils.constants import ACTIVE_STATE_GROUPS, STATE_GROUP_ORDER
+
 # The date from pattern
 pattern = re.compile(r"\d+_(weeks|months)$")
 
@@ -295,12 +297,12 @@ def filter_completed_at(params, issue_filter, method, prefix=""):
 
 def filter_issue_state_type(params, issue_filter, method, prefix=""):
     type = params.get("type", "all")
-    group = ["backlog", "unstarted", "started", "review", "completed", "cancelled"]
+    group = list(STATE_GROUP_ORDER)
     if type == "backlog":
         group = ["backlog"]
     if type == "active":
-        # In Review issues are active work — same as Started for activity-list purposes.
-        group = ["unstarted", "started", "review"]
+        # Review and test issues are active work for activity-list purposes.
+        group = list(ACTIVE_STATE_GROUPS)
 
     issue_filter[f"{prefix}state__group__in"] = group
     return issue_filter

--- a/apps/api/pi_dash/utils/openapi/parameters.py
+++ b/apps/api/pi_dash/utils/openapi/parameters.py
@@ -340,7 +340,7 @@ ORDER_BY_PARAMETER = OpenApiParameter(
         OpenApiExample(
             name="State group",
             value="state__group",
-            description="Order by state group (backlog, unstarted, started, completed, cancelled)",  # noqa: E501
+            description="Order by state group (backlog, unstarted, started, review, test, completed, cancelled)",  # noqa: E501
         ),
         OpenApiExample(
             name="Assignee name",

--- a/apps/api/pi_dash/utils/order_queryset.py
+++ b/apps/api/pi_dash/utils/order_queryset.py
@@ -4,9 +4,11 @@
 
 from django.db.models import Case, CharField, Min, Value, When
 
+from pi_dash.utils.constants import STATE_GROUP_ORDER
+
 # Custom ordering for priority and state
 PRIORITY_ORDER = ["urgent", "high", "medium", "low", "none"]
-STATE_ORDER = ["backlog", "unstarted", "started", "review", "completed", "cancelled"]
+STATE_ORDER = list(STATE_GROUP_ORDER)
 
 
 def order_issue_queryset(issue_queryset, order_by_param="-created_at"):

--- a/packages/utils/tests/state.test.ts
+++ b/packages/utils/tests/state.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { IState, TStateGroups } from "@pi-dash/types";
+
+import { orderStateGroups, sortStates } from "../src/work-item/state";
+
+const makeState = (group: TStateGroups, sequence: number): IState => ({
+  id: `${group}-${sequence}`,
+  color: "#000000",
+  default: false,
+  description: "",
+  group,
+  name: group,
+  project_id: "project-id",
+  sequence,
+  workspace_id: "workspace-id",
+  order: sequence,
+});
+
+describe("state-group ordering", () => {
+  it("creates an empty Test bucket in lifecycle order", () => {
+    const ordered = orderStateGroups({ completed: [makeState("completed", 1)] });
+
+    expect(Object.keys(ordered ?? {})).toEqual([
+      "backlog",
+      "unstarted",
+      "started",
+      "review",
+      "test",
+      "completed",
+      "cancelled",
+    ]);
+    expect(ordered?.test).toEqual([]);
+  });
+
+  it("sorts Test between Review and Completed without mutating the input", () => {
+    const states = [makeState("completed", 1), makeState("test", 2), makeState("review", 3), makeState("test", 1)];
+
+    const sorted = sortStates(states);
+
+    expect(sorted?.map((state) => `${state.group}:${state.sequence}`)).toEqual([
+      "review:3",
+      "test:1",
+      "test:2",
+      "completed:1",
+    ]);
+    expect(states.map((state) => `${state.group}:${state.sequence}`)).toEqual([
+      "completed:1",
+      "test:2",
+      "review:3",
+      "test:1",
+    ]);
+  });
+});


### PR DESCRIPTION
## What

Follow-up to #304, which added the `test` state group and its default "In Test" state. The group lists consumed across the app were still hardcoded from before the group existed, so In Test issues fell through the cracks everywhere the lifecycle is enumerated.

This PR defines the lifecycle **once** in `pi_dash/utils/constants.py`:

```python
STATE_GROUP_ORDER   = ("backlog", "unstarted", "started", "review", "test", "completed", "cancelled")
OPEN_STATE_GROUPS   = STATE_GROUP_ORDER[:-2]
ACTIVE_STATE_GROUPS = STATE_GROUP_ORDER[1:-2]
CLOSED_STATE_GROUPS = STATE_GROUP_ORDER[-2:]
```

(triage is deliberately excluded — it has its own manager and intake workflow) and replaces every hardcoded enumeration with it.

## User-visible bugs this fixes

Without this, an issue in "In Test":
- disappears from `?status=open` advanced search (open was hardcoded through `review`)
- is **left behind by cycle transfer** as if it were done
- is never auto-closed by the staleness automation
- is excluded from the "open issues" analytics count
- sorts/groups unpredictably in group-by-state views
- doesn't count as active in legacy `type=active` filters

## Also swept

- Remaining `["completed", "cancelled"]` literals on `state__group` sites (workspace stats, analytics, archive guard) → `CLOSED_STATE_GROUPS`. Behavior identical today; future group additions inherit correctness.
- OpenAPI parameter description for state-group ordering now lists the real lifecycle.

## Deliberately unchanged

- The "pending issues" stat (backend `workspace/user.py` + web `dashboard.helper.ts`) keeps its historical `backlog/unstarted/started` definition — it has excluded `review` since that group shipped, so this PR doesn't unilaterally redefine it.
- Agent phase ticking: a new regression test pins that In Test does **not** auto-tick (matches #304's design).

## Tests

- New `pi_dash/tests/unit/utils/test_state_groups.py`: canonical order matches `StateGroup`/`DEFAULT_STATES`, test group is open+active+not closed, legacy filters/groupers/search/converters all share the canonical order — 25 unit tests pass.
- New `packages/utils/tests/state.test.ts`: `orderStateGroups` creates the Test bucket in lifecycle position; `sortStates` sorts Test between Review and Completed (17 vitest tests pass).
- Frontend canonical constants (`@pi-dash/types`, `@pi-dash/constants`) already carry `test` from #304 — verified, no source changes needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Known follow-up (pre-existing, out of scope)

Cycle/module **progress payloads** enumerate per-group counts for only the classic five groups (`backlog/unstarted/started/completed/cancelled` in `module/base.py`, `cycle/base.py`, cycle serializers, and progress snapshots). They have **never included `review_issues`** — a gap dating to when the review group shipped — and this PR keeps `test` consistent with that: review/test issues are counted in totals but not broken out per group. Extending the progress shape (serializers + snapshot format + web progress components) is its own change and should be a separate PR.
