### PR TITLE
PDASHOSS01-52 Add chat history panel and new-chat capability to AI runner chat page

### DIFF
--- a/apps/web/app/(all)/[workspaceSlug]/runners/approvals/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/approvals/page.tsx
@@ -60,7 +60,7 @@ export const ApprovalsPage = observer(function ApprovalsPage() {
   const rows = approvals ?? [];
 
   return (
-    <div className="flex flex-col gap-6">
+    <div className="flex flex-col gap-6 p-6">
       <PageHead title={pageTitle} />
       <RunnersTabs />
       {rows.length === 0 ? (

--- a/apps/web/app/(all)/[workspaceSlug]/runners/chat/[runnerId]/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/chat/[runnerId]/page.tsx
@@ -376,7 +376,7 @@ const RunnerChatPage = observer(function RunnerChatPage() {
     ));
 
   return (
-    <div className="flex min-h-[640px] w-full overflow-hidden rounded-md border border-subtle">
+    <div className="flex h-full min-h-[640px] w-full overflow-hidden">
       <ChatHistoryPanel
         heading="Chats"
         items={historyItems}

--- a/apps/web/app/(all)/[workspaceSlug]/runners/chat/[runnerId]/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/chat/[runnerId]/page.tsx
@@ -389,7 +389,7 @@ const RunnerChatPage = observer(function RunnerChatPage() {
       {/* The chat internals (header/list/composer) carry no horizontal padding —
           the host provides it (see the assistant thread page). Without this the
           content sits flush against the history panel's border. */}
-      <div className="flex min-w-0 flex-1 flex-col overflow-hidden px-4">
+      <div className="flex min-w-0 flex-1 flex-col overflow-hidden px-4 pb-4">
         <ChatContainer
           className="min-h-0 flex-1"
           header={

--- a/apps/web/app/(all)/[workspaceSlug]/runners/chat/[runnerId]/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/chat/[runnerId]/page.tsx
@@ -386,7 +386,10 @@ const RunnerChatPage = observer(function RunnerChatPage() {
         busy={creatingChat}
         emptyState={<div className="px-2 py-4 text-12 text-tertiary">No chats yet.</div>}
       />
-      <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+      {/* The chat internals (header/list/composer) carry no horizontal padding —
+          the host provides it (see the assistant thread page). Without this the
+          content sits flush against the history panel's border. */}
+      <div className="flex min-w-0 flex-1 flex-col overflow-hidden px-4">
         <ChatContainer
           className="min-h-0 flex-1"
           header={

--- a/apps/web/app/(all)/[workspaceSlug]/runners/chat/[runnerId]/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/chat/[runnerId]/page.tsx
@@ -7,14 +7,16 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { observer } from "mobx-react";
 import { X } from "lucide-react";
-import { useParams } from "react-router";
+import { useParams, useSearchParams } from "react-router";
 import useSWR from "swr";
 import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
 import { RunnerService, getRunnerDetail } from "@pi-dash/services";
 import type { IAgentChatEvent, IAgentChatMessage, IAgentChatSession, IRunner } from "@pi-dash/types";
 import { Badge, Button } from "@pi-dash/ui";
+import { calculateTimeAgo, renderFormattedDate } from "@pi-dash/utils";
 import { ChatComposer } from "@/components/chat/composer";
 import { ChatContainer } from "@/components/chat/container";
+import { type ChatHistoryItem, ChatHistoryPanel } from "@/components/chat/history-panel";
 import { ChatMessage } from "@/components/chat/message";
 import { useAgentChatEvents } from "@/components/runners/chat/use-agent-chat-events";
 import { useWorkspace } from "@/hooks/store/use-workspace";
@@ -89,12 +91,26 @@ function disabledReason(runner?: IRunner, session?: IAgentChatSession | null): s
   return null;
 }
 
+function sessionHistoryItem(session: IAgentChatSession, activeId: string | undefined): ChatHistoryItem {
+  // Sessions have no title/first-message field, so entries are labelled by
+  // their last activity time. renderFormattedDate falls back gracefully on a
+  // freshly-created session that has no last_message_at yet.
+  const stamp = session.last_message_at ?? session.created_at;
+  const title = renderFormattedDate(stamp, "MMM dd, HH:mm") ?? "New chat";
+  const statusSuffix = session.status === "open" ? "" : ` · ${session.status}`;
+  const subtitle = session.last_message_at ? `${calculateTimeAgo(stamp)}${statusSuffix}` : `New chat${statusSuffix}`;
+  return { id: session.id, title, subtitle, active: session.id === activeId };
+}
+
 const RunnerChatPage = observer(function RunnerChatPage() {
   const { runnerId } = useParams<{ runnerId: string }>();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const requestedSessionId = searchParams.get("sessionId");
   const { currentWorkspace } = useWorkspace();
   const workspaceId = currentWorkspace?.id;
   const [draft, setDraft] = useState("");
   const [sending, setSending] = useState(false);
+  const [creatingChat, setCreatingChat] = useState(false);
   const [events, setEvents] = useState<IAgentChatEvent[]>([]);
   const [liveMessages, setLiveMessages] = useState<IAgentChatMessage[]>([]);
   const warmSessionRef = useRef<string | null>(null);
@@ -111,13 +127,21 @@ const RunnerChatPage = observer(function RunnerChatPage() {
     () => service.listChatSessions(workspaceId!, runnerId)
   );
 
-  const session = useMemo(
-    () =>
-      (sessions ?? []).find((s) => s.status === "open" && s.last_message_at !== null) ??
-      (sessions ?? []).find((s) => s.status === "open") ??
-      null,
-    [sessions]
-  );
+  const session = useMemo(() => {
+    const available = sessions ?? [];
+    // An explicit ?sessionId (chosen from the history panel) wins, even for a
+    // closed session so the user can read it back. A stale/unknown id (e.g. a
+    // shared link to a session on another runner) falls through to auto-select.
+    if (requestedSessionId) {
+      const requested = available.find((s) => s.id === requestedSessionId);
+      if (requested) return requested;
+    }
+    return (
+      available.find((s) => s.status === "open" && s.last_message_at !== null) ??
+      available.find((s) => s.status === "open") ??
+      null
+    );
+  }, [sessions, requestedSessionId]);
 
   useEffect(() => {
     if (!sessions) return;
@@ -161,6 +185,10 @@ const RunnerChatPage = observer(function RunnerChatPage() {
         }
         return;
       }
+      // Explicitly viewing a resolved session from the history panel (which may
+      // be closed): don't silently spin up a brand-new session behind the user's
+      // back. A stale ?sessionId (session?.id won't match) still auto-creates.
+      if (session && session.id === requestedSessionId) return;
       if (!sessions) return;
       const key = `${workspaceId}:${runnerId}`;
       if (createWarmKeyRef.current === key) return;
@@ -189,7 +217,7 @@ const RunnerChatPage = observer(function RunnerChatPage() {
     return () => {
       cancelled = true;
     };
-  }, [mutateSessions, runner, runnerId, session, sessions, workspaceId]);
+  }, [mutateSessions, requestedSessionId, runner, runnerId, session, sessions, workspaceId]);
 
   const { data: messages, mutate: mutateMessages } = useSWR<IAgentChatMessage[]>(
     session?.id ? ["runner-chat-messages", session.id] : null,
@@ -284,6 +312,54 @@ const RunnerChatPage = observer(function RunnerChatPage() {
     mutateSessions();
   }
 
+  function selectSession(sessionId: string) {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.set("sessionId", sessionId);
+        return next;
+      },
+      { replace: true }
+    );
+  }
+
+  async function newChat() {
+    if (!workspaceId || !runnerId || creatingChat) return;
+    setCreatingChat(true);
+    try {
+      const created = await service.createChatSession({ workspace: workspaceId, runner: runnerId });
+      precreatedSessionRef.current = created;
+      warmSessionRef.current = created.id;
+      await mutateSessions((current) => {
+        const currentSessions = current ?? [];
+        return currentSessions.some((item) => item.id === created.id) ? currentSessions : [created, ...currentSessions];
+      }, false);
+      // Warm in the background; the session is usable without waiting for it.
+      service.warmChatSession(created.id).catch(() => {});
+      selectSession(created.id);
+    } catch (e: unknown) {
+      const err = e as { error?: string } | null;
+      setToast({
+        type: TOAST_TYPE.ERROR,
+        title: "Unable to start chat",
+        message: err?.error ?? "Could not create a new chat session",
+      });
+    } finally {
+      setCreatingChat(false);
+    }
+  }
+
+  const historyItems = useMemo(() => {
+    // Copy before sorting so we never mutate the SWR-cached sessions array.
+    // eslint-disable-next-line unicorn/no-array-sort -- toSorted() isn't in the project's TS lib target
+    const sorted = [...(sessions ?? [])].sort((a, b) => {
+      const aTime = Date.parse(a.last_message_at ?? a.created_at);
+      const bTime = Date.parse(b.last_message_at ?? b.created_at);
+      return bTime - aTime;
+    });
+    return sorted.map((item) => sessionHistoryItem(item, session?.id));
+  }, [sessions, session?.id]);
+
   const reason = disabledReason(runner, session);
   const rows = liveMessages;
   const busy = !!(session?.active_message_id || session?.active_turn_id);
@@ -300,43 +376,58 @@ const RunnerChatPage = observer(function RunnerChatPage() {
     ));
 
   return (
-    <ChatContainer
-      className="min-h-[640px]"
-      header={
-        <div className="flex h-12 shrink-0 items-center justify-between border-b border-subtle">
-          <div className="min-w-0">
-            <div className="text-15 truncate font-semibold text-primary">{runner?.name ?? "Runner"}</div>
-            <div className="text-12 text-secondary">{runner?.pod_detail?.name ?? runner?.status ?? ""}</div>
-          </div>
-          <div className="flex items-center gap-2">
-            {runner && (
-              <Badge variant={runner.status === "online" ? "accent-success" : "accent-neutral"}>{runner.status}</Badge>
-            )}
-            {session && (
-              <Button variant="neutral-primary" size="sm" onClick={close}>
-                <X className="size-4" />
-              </Button>
-            )}
-          </div>
-        </div>
-      }
-      messages={rows}
-      renderMessage={(m) => <ChatMessage role={m.role} content={m.content} status={m.status} />}
-      emptyState={<div className="py-16 text-center text-13 text-secondary">No messages</div>}
-      listFooter={eventStrip.length > 0 ? <>{eventStrip}</> : undefined}
-      composer={
-        <ChatComposer
-          draft={draft}
-          onDraftChange={setDraft}
-          onSend={send}
-          onStop={stop}
-          busy={busy}
-          sending={sending}
-          disabledReason={reason}
-          placeholder="Message this runner…"
+    <div className="flex min-h-[640px] w-full overflow-hidden rounded-md border border-subtle">
+      <ChatHistoryPanel
+        heading="Chats"
+        items={historyItems}
+        onSelect={selectSession}
+        onNewChat={newChat}
+        newChatLabel="New chat"
+        busy={creatingChat}
+        emptyState={<div className="px-2 py-4 text-12 text-tertiary">No chats yet.</div>}
+      />
+      <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+        <ChatContainer
+          className="min-h-0 flex-1"
+          header={
+            <div className="flex h-12 shrink-0 items-center justify-between border-b border-subtle">
+              <div className="min-w-0">
+                <div className="text-15 truncate font-semibold text-primary">{runner?.name ?? "Runner"}</div>
+                <div className="text-12 text-secondary">{runner?.pod_detail?.name ?? runner?.status ?? ""}</div>
+              </div>
+              <div className="flex items-center gap-2">
+                {runner && (
+                  <Badge variant={runner.status === "online" ? "accent-success" : "accent-neutral"}>
+                    {runner.status}
+                  </Badge>
+                )}
+                {session && (
+                  <Button variant="neutral-primary" size="sm" onClick={close}>
+                    <X className="size-4" />
+                  </Button>
+                )}
+              </div>
+            </div>
+          }
+          messages={rows}
+          renderMessage={(m) => <ChatMessage role={m.role} content={m.content} status={m.status} />}
+          emptyState={<div className="py-16 text-center text-13 text-secondary">No messages</div>}
+          listFooter={eventStrip.length > 0 ? <>{eventStrip}</> : undefined}
+          composer={
+            <ChatComposer
+              draft={draft}
+              onDraftChange={setDraft}
+              onSend={send}
+              onStop={stop}
+              busy={busy}
+              sending={sending}
+              disabledReason={reason}
+              placeholder="Message this runner…"
+            />
+          }
         />
-      }
-    />
+      </div>
+    </div>
   );
 });
 

--- a/apps/web/app/(all)/[workspaceSlug]/runners/detail/[runnerId]/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/detail/[runnerId]/page.tsx
@@ -46,7 +46,7 @@ const RunnerDetailPage = observer(function RunnerDetailPage() {
   });
 
   return (
-    <div className="flex flex-col gap-6">
+    <div className="flex flex-col gap-6 p-6">
       <PageHead title={runner?.name ? t("Runner {name}", { name: runner.name }) : t("Runner detail")} />
 
       <div className="flex items-center justify-between gap-3">

--- a/apps/web/app/(all)/[workspaceSlug]/runners/layout.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/layout.tsx
@@ -104,7 +104,9 @@ const RunnersLayout = observer(function RunnersLayout() {
               ))}
             </nav>
           </aside>
-          <main className="min-w-0 flex-1 overflow-auto p-6">
+          {/* Pages pad themselves (p-6) so full-bleed surfaces like the runner
+              chat can span edge-to-edge. */}
+          <main className="min-w-0 flex-1 overflow-auto">
             <Outlet />
           </main>
         </div>

--- a/apps/web/app/(all)/[workspaceSlug]/runners/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/page.tsx
@@ -100,7 +100,7 @@ const RunnersListPage = observer(function RunnersListPage() {
   }
 
   return (
-    <div className="flex flex-col gap-6">
+    <div className="flex flex-col gap-6 p-6">
       <PageHead title={pageTitle} />
 
       <RunnersTabs />

--- a/apps/web/app/(all)/[workspaceSlug]/runners/runs/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/runs/page.tsx
@@ -166,7 +166,7 @@ export const RunnerRunsPage = observer(function RunnerRunsPage() {
     : t("AI Agents");
 
   return (
-    <div className="flex h-full min-h-0 flex-col gap-6">
+    <div className="flex h-full min-h-0 flex-col gap-6 p-6">
       <PageHead title={pageTitle} />
       <RunnersTabs />
       <div className="grid min-h-0 flex-1 grid-cols-[400px_1fr] gap-4 overflow-hidden">

--- a/apps/web/core/components/chat/history-panel.tsx
+++ b/apps/web/core/components/chat/history-panel.tsx
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import type { ReactNode } from "react";
+import { MessageSquare, SquarePen } from "lucide-react";
+import { cn } from "@pi-dash/utils";
+
+export interface ChatHistoryItem {
+  id: string;
+  /** Primary label for the entry (e.g. chat title, first message, or a date). */
+  title: string;
+  /** Secondary line — typically a timestamp or status. */
+  subtitle?: string;
+  /** Whether this entry is the currently loaded conversation. */
+  active?: boolean;
+}
+
+interface ChatHistoryPanelProps {
+  /** Section heading shown above the list (e.g. "Chats"). */
+  heading: string;
+  items: ChatHistoryItem[];
+  onSelect: (id: string) => void;
+  onNewChat: () => void;
+  newChatLabel?: string;
+  /** Rendered in place of the list when there are no items. */
+  emptyState?: ReactNode;
+  /** Disables the New Chat button while a session is being created. */
+  busy?: boolean;
+  className?: string;
+}
+
+/**
+ * Left-column chat history panel shared by the Pi Dash AI and AI runner chat
+ * pages. Lists prior conversations (clickable to load) and exposes a New Chat
+ * action. Purely presentational — the host owns session state and data fetching.
+ */
+export function ChatHistoryPanel({
+  heading,
+  items,
+  onSelect,
+  onNewChat,
+  newChatLabel = "New chat",
+  emptyState,
+  busy = false,
+  className,
+}: ChatHistoryPanelProps) {
+  return (
+    <aside className={cn("flex w-64 shrink-0 flex-col border-r border-subtle bg-surface-1", className)}>
+      <div className="shrink-0 p-2">
+        <button
+          type="button"
+          onClick={onNewChat}
+          disabled={busy}
+          className="flex h-9 w-full items-center gap-2 rounded px-2 text-13 text-secondary hover:bg-layer-1 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <SquarePen className="size-4 shrink-0" />
+          <span>{newChatLabel}</span>
+        </button>
+      </div>
+      <nav className="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto p-2 pt-0">
+        <div className="px-2 py-1 text-11 font-medium text-tertiary uppercase">{heading}</div>
+        {items.map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            onClick={() => onSelect(item.id)}
+            className={cn(
+              "flex min-h-9 items-center gap-2 rounded px-2 py-2 text-left text-13",
+              item.active ? "bg-layer-1 font-medium text-primary" : "text-secondary hover:bg-layer-1"
+            )}
+          >
+            <MessageSquare className="size-4 shrink-0" />
+            <span className="flex min-w-0 flex-1 flex-col">
+              <span className="truncate">{item.title}</span>
+              {item.subtitle && <span className="truncate text-11 text-tertiary">{item.subtitle}</span>}
+            </span>
+          </button>
+        ))}
+        {items.length === 0 &&
+          (emptyState ?? <div className="px-2 py-4 text-12 text-tertiary">No conversations yet.</div>)}
+      </nav>
+    </aside>
+  );
+}

--- a/apps/web/tests/chat/history-panel.test.tsx
+++ b/apps/web/tests/chat/history-panel.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// Mock the lightweight class-name helper so the test doesn't pull the full
+// @pi-dash/utils barrel (which transitively imports @pi-dash/constants).
+vi.mock("@pi-dash/utils", () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}));
+
+import { type ChatHistoryItem, ChatHistoryPanel } from "@/components/chat/history-panel";
+
+const items: ChatHistoryItem[] = [
+  { id: "s1", title: "Jul 23, 14:05", subtitle: "2 minutes ago", active: true },
+  { id: "s2", title: "Jul 22, 09:30", subtitle: "1 day ago · closed" },
+];
+
+function renderPanel(overrides: Partial<Parameters<typeof ChatHistoryPanel>[0]> = {}) {
+  const onSelect = vi.fn();
+  const onNewChat = vi.fn();
+  render(<ChatHistoryPanel heading="Chats" items={items} onSelect={onSelect} onNewChat={onNewChat} {...overrides} />);
+  return { onSelect, onNewChat };
+}
+
+describe("ChatHistoryPanel", () => {
+  it("renders the heading and one entry per item", () => {
+    renderPanel();
+    expect(screen.getByText("Chats")).toBeTruthy();
+    expect(screen.getByText("Jul 23, 14:05")).toBeTruthy();
+    expect(screen.getByText("Jul 22, 09:30")).toBeTruthy();
+    expect(screen.getByText("1 day ago · closed")).toBeTruthy();
+  });
+
+  it("invokes onSelect with the item id when an entry is clicked", () => {
+    const { onSelect } = renderPanel();
+    fireEvent.click(screen.getByText("Jul 22, 09:30"));
+    expect(onSelect).toHaveBeenCalledWith("s2");
+  });
+
+  it("invokes onNewChat when the New chat button is clicked", () => {
+    const { onNewChat } = renderPanel();
+    fireEvent.click(screen.getByText("New chat"));
+    expect(onNewChat).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the New chat button while busy", () => {
+    const { onNewChat } = renderPanel({ busy: true });
+    const button = screen.getByText("New chat").closest("button");
+    expect(button?.disabled).toBe(true);
+    fireEvent.click(button!);
+    expect(onNewChat).not.toHaveBeenCalled();
+  });
+
+  it("shows an empty state when there are no items", () => {
+    render(
+      <ChatHistoryPanel
+        heading="Chats"
+        items={[]}
+        onSelect={vi.fn()}
+        onNewChat={vi.fn()}
+        emptyState={<div>No chats yet.</div>}
+      />
+    );
+    expect(screen.getByText("No chats yet.")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a **chat history side panel** and a **New Chat** button to the AI runner chat page (`runners/chat/:runnerId`), closing PDASHOSS01-52. Previously the page auto-selected a single session with no way to browse past conversations or explicitly start a fresh one.

## Changes

- **New shared component** `apps/web/core/components/chat/history-panel.tsx` — a presentational `ChatHistoryPanel` (New Chat action + clickable session list + empty state), designed to be reusable across the Pi Dash AI and runner chat surfaces per the parent unification work (PDASHOSS01-51).
- **Runner chat page** now:
  - Renders the panel as a left column beside the shared `ChatContainer`.
  - Selects the active session from a `?sessionId` search param (chosen from the panel), falling back to the existing "most recent open session" auto-select when the id is absent or stale (e.g. a shared link).
  - Guards the existing auto-warm effect so an explicitly opened session (including a closed one being read back) isn't silently replaced by a new one.
  - Adds a **New Chat** handler that creates + warms a session and switches the view to it.
- Sessions carry no title/first-message field, so each entry is labelled by its last-activity timestamp (`renderFormattedDate` + `calculateTimeAgo`) with a status suffix for non-open sessions. A first-message preview would need backend support — noted as a follow-up.

## Acceptance criteria

- [x] Chat history side panel visible on the runner chat page.
- [x] Each entry is clickable and loads the corresponding conversation.
- [x] "New Chat" button creates a fresh session and switches to it.
- [x] Built with the shared chat UI components from the parent issue.

## Validation

- `oxlint --deny-warnings` on all touched files — 0 warnings, 0 errors.
- `pnpm --filter=web check:types` — clean for touched files (one pre-existing, unrelated error in `tests/runners/runner-runs-page.test.tsx` also present on `main`).
- `vitest run tests/chat/history-panel.test.tsx` — 5/5 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
