### PR TITLE
Fix chat sessions closed by runner chat-runtime swaps (chat_session_closed)

### DIFF
--- a/apps/web/app/(all)/[workspaceSlug]/runners/chat/[runnerId]/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/chat/[runnerId]/page.tsx
@@ -111,6 +111,12 @@ const RunnerChatPage = observer(function RunnerChatPage() {
   const [draft, setDraft] = useState("");
   const [sending, setSending] = useState(false);
   const [creatingChat, setCreatingChat] = useState(false);
+  // Bridges the gap between choosing a session (panel click / New chat) and
+  // the ?sessionId param landing: setSearchParams is transition-deferred, so
+  // without this the memo below can transiently re-resolve the OLD session
+  // and the warm effect re-warms it — which used to bounce the runner's chat
+  // runtime back and forth between the two sessions.
+  const [pendingSessionId, setPendingSessionId] = useState<string | null>(null);
   const [events, setEvents] = useState<IAgentChatEvent[]>([]);
   const [liveMessages, setLiveMessages] = useState<IAgentChatMessage[]>([]);
   const warmSessionRef = useRef<string | null>(null);
@@ -129,19 +135,29 @@ const RunnerChatPage = observer(function RunnerChatPage() {
 
   const session = useMemo(() => {
     const available = sessions ?? [];
-    // An explicit ?sessionId (chosen from the history panel) wins, even for a
-    // closed session so the user can read it back. A stale/unknown id (e.g. a
-    // shared link to a session on another runner) falls through to auto-select.
-    if (requestedSessionId) {
-      const requested = available.find((s) => s.id === requestedSessionId);
-      if (requested) return requested;
+    // An explicit selection (panel click / New chat, tracked in
+    // pendingSessionId until ?sessionId lands) wins, even for a closed session
+    // so the user can read it back. A stale/unknown id (e.g. a shared link to
+    // a session on another runner) falls through to auto-select.
+    const requested = pendingSessionId ?? requestedSessionId;
+    if (requested) {
+      const match = available.find((s) => s.id === requested);
+      if (match) return match;
+      // A session created by New chat can be selected before the SWR list
+      // catches up; the ref is set before pendingSessionId, so it's current.
+      const precreated = precreatedSessionRef.current;
+      if (precreated?.id === requested) return precreated;
     }
     return (
       available.find((s) => s.status === "open" && s.last_message_at !== null) ??
       available.find((s) => s.status === "open") ??
       null
     );
-  }, [sessions, requestedSessionId]);
+  }, [sessions, requestedSessionId, pendingSessionId]);
+
+  useEffect(() => {
+    if (pendingSessionId && requestedSessionId === pendingSessionId) setPendingSessionId(null);
+  }, [requestedSessionId, pendingSessionId]);
 
   useEffect(() => {
     if (!sessions) return;
@@ -155,6 +171,7 @@ const RunnerChatPage = observer(function RunnerChatPage() {
     warmSessionRef.current = null;
     createWarmKeyRef.current = null;
     precreatedSessionRef.current = null;
+    setPendingSessionId(null);
     setEvents([]);
   }, [runnerId]);
 
@@ -188,7 +205,7 @@ const RunnerChatPage = observer(function RunnerChatPage() {
       // Explicitly viewing a resolved session from the history panel (which may
       // be closed): don't silently spin up a brand-new session behind the user's
       // back. A stale ?sessionId (session?.id won't match) still auto-creates.
-      if (session && session.id === requestedSessionId) return;
+      if (session && session.id === (pendingSessionId ?? requestedSessionId)) return;
       if (!sessions) return;
       const key = `${workspaceId}:${runnerId}`;
       if (createWarmKeyRef.current === key) return;
@@ -217,7 +234,7 @@ const RunnerChatPage = observer(function RunnerChatPage() {
     return () => {
       cancelled = true;
     };
-  }, [mutateSessions, requestedSessionId, runner, runnerId, session, sessions, workspaceId]);
+  }, [mutateSessions, pendingSessionId, requestedSessionId, runner, runnerId, session, sessions, workspaceId]);
 
   const { data: messages, mutate: mutateMessages } = useSWR<IAgentChatMessage[]>(
     session?.id ? ["runner-chat-messages", session.id] : null,
@@ -313,6 +330,7 @@ const RunnerChatPage = observer(function RunnerChatPage() {
   }
 
   function selectSession(sessionId: string) {
+    setPendingSessionId(sessionId);
     setSearchParams(
       (prev) => {
         const next = new URLSearchParams(prev);
@@ -330,6 +348,9 @@ const RunnerChatPage = observer(function RunnerChatPage() {
       const created = await service.createChatSession({ workspace: workspaceId, runner: runnerId });
       precreatedSessionRef.current = created;
       warmSessionRef.current = created.id;
+      // Select before mutating so no render can resolve (and re-warm) the old
+      // session between the list update and the ?sessionId change.
+      setPendingSessionId(created.id);
       await mutateSessions((current) => {
         const currentSessions = current ?? [];
         return currentSessions.some((item) => item.id === created.id) ? currentSessions : [created, ...currentSessions];

--- a/runner/src/daemon/supervisor.rs
+++ b/runner/src/daemon/supervisor.rs
@@ -819,6 +819,12 @@ enum ChatCommand {
     Message(ChatTurn),
     Cancel { reason: Option<String> },
     Close { reason: Option<String> },
+    /// Tear down this runtime to make room for another session (or to free a
+    /// non-pooled runner's working dir for an assign) WITHOUT closing the
+    /// cloud session: it stays open and a later warm/message revives it via
+    /// `local_thread_id`. Contrast with `Shutdown`, which emits a terminal
+    /// `ChatClosed`.
+    Release,
     Shutdown,
 }
 
@@ -856,7 +862,10 @@ impl RunnerLoop {
         let Some(mut chat) = self.current_chat.take() else {
             return;
         };
-        let _ = chat.tx.send(ChatCommand::Shutdown).await;
+        // Release, not Shutdown: swapping the runtime to another session must
+        // not close the old session in the cloud — the user may switch back to
+        // it from the chat history panel, and a warm/message revives it.
+        let _ = chat.tx.send(ChatCommand::Release).await;
         let _ = tokio::time::timeout(Duration::from_secs(5), &mut chat.done_rx).await;
     }
 
@@ -1755,6 +1764,12 @@ impl ChatWorker {
                         .await;
                     break;
                 }
+                ChatCommand::Release => {
+                    // Runtime swap (see `stop_idle_chat_runtime`). No terminal
+                    // `ChatClosed` — the cloud session stays open for revival.
+                    // The post-loop persist below still commits + pushes.
+                    break;
+                }
                 ChatCommand::Shutdown => {
                     // RemoveRunner / teardown. Emit a terminal `ChatClosed` so
                     // the cloud session doesn't linger in "active turn" state.
@@ -2092,7 +2107,10 @@ impl ChatWorker {
                             close_after_turn = true;
                             break;
                         }
-                        Some(ChatCommand::Shutdown) | None => {
+                        // Release shouldn't arrive mid-turn (the supervisor
+                        // only swaps idle runtimes), but treat it like a
+                        // shutdown of this turn if it ever does.
+                        Some(ChatCommand::Release | ChatCommand::Shutdown) | None => {
                             bridge.interrupt().await.ok();
                             final_status = "cancelled".into();
                             break;


### PR DESCRIPTION
## Summary

Follow-up to #317. With the chat history panel in place, switching sessions or starting a New Chat frequently killed sessions: the next send failed with `409 chat_session_closed`.

Two compounding bugs:

1. **Runner**: `stop_idle_chat_runtime()` (used when the supervisor swaps its single chat runtime to another session, and when a non-pooled runner frees its working dir for an assign) sent `ChatCommand::Shutdown`, whose handler emits a terminal `ChatClosed`. The cloud unconditionally marks the session closed on that frame — so every session switch permanently closed the previous session, defeating the history panel's revive flow (which demonstrably works via `local_thread_id`).
2. **Web**: `setSearchParams` is transition-deferred, so after selecting a session the page could transiently re-resolve the old session and re-warm it. Combined with (1), a single New Chat produced a warm ping-pong that closed *both* sessions within ~2s (observed: `chat_closed {reason: runner_closed}` on a session 1s after creation).

## Changes

- `runner`: new `ChatCommand::Release` — identical local teardown to `Shutdown` (bridge shutdown + chat-worktree commit/push) but no terminal `ChatClosed`. `stop_idle_chat_runtime` now sends `Release`; `Shutdown` keeps its semantics for `RemoveRunner`/daemon teardown. A defensive `Release` arm in the mid-turn handler mirrors `Shutdown` (the supervisor only swaps idle runtimes).
- `web`: explicit selections (panel click / New chat) are tracked in `pendingSessionId` state that wins over `?sessionId` until the param catches up, with a `precreatedSessionRef` fallback so a just-created session resolves before the SWR list updates. The auto-create guard honors it too, so clicking a closed session mid-transition can't spawn a surprise session.

## Validation

- `cargo clippy -- -D warnings` and `cargo test` — clean.
- `oxlint --deny-warnings` + `oxfmt --check` on the touched page — clean; web vitest suite 52/52.
- Reproduced the failure locally (event trail showed the close ping-pong), then verified against a live runner + codex that warm → New chat → switch back → send keeps every session open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)