### PR TITLE
PDASHOSS01-69 Fix PR state sync from GitHub to pidash

### DIFF
--- a/apps/api/pi_dash/app/views/integration/github.py
+++ b/apps/api/pi_dash/app/views/integration/github.py
@@ -890,10 +890,23 @@ class GithubAppWebhookEndpoint(BaseAPIView):
                 "status": GithubWebhookDelivery.Status.RECEIVED,
             },
         )
-        if not created:
+        # GitHub reuses the same X-GitHub-Delivery GUID for automatic retries
+        # (on timeout / 5xx) and for a manual "Redeliver". Only fast-return when a
+        # prior attempt reached a terminal-success outcome; a delivery left in
+        # RECEIVED (the request was interrupted mid-processing — e.g. a deploy or
+        # pod restart) or FAILED (an exception was caught below) must be
+        # reprocessed so the snapshot can still converge. Reprocessing is safe:
+        # `_refresh_pr_links` is idempotent and guarded against out-of-order
+        # payloads by the PR's `updated_at`. Without this, a single dropped
+        # `pull_request` (merge) delivery leaves the PR stuck showing "open".
+        if not created and delivery.status in {
+            GithubWebhookDelivery.Status.PROCESSED,
+            GithubWebhookDelivery.Status.SKIPPED,
+        }:
             return Response({"status": delivery.status}, status=status.HTTP_202_ACCEPTED)
 
         try:
+            delivery.error = ""
             if event == "ping":
                 delivery.status = GithubWebhookDelivery.Status.PROCESSED
             elif event == "pull_request":
@@ -922,7 +935,7 @@ class GithubAppWebhookEndpoint(BaseAPIView):
             else:
                 delivery.status = GithubWebhookDelivery.Status.SKIPPED
             delivery.processed_at = timezone.now()
-            delivery.save(update_fields=["status", "processed_at", "updated_at"])
+            delivery.save(update_fields=["status", "error", "processed_at", "updated_at"])
         except Exception as e:
             log_exception(e)
             delivery.status = GithubWebhookDelivery.Status.FAILED

--- a/apps/api/pi_dash/tests/contract/app/test_github_pr_webhook.py
+++ b/apps/api/pi_dash/tests/contract/app/test_github_pr_webhook.py
@@ -52,13 +52,13 @@ def _pr_payload(*, action="closed", state="closed", merged=True, updated_at="202
     }
 
 
-def _post(api_client, payload, event="pull_request"):
+def _post(api_client, payload, event="pull_request", delivery_id=None):
     with patch("pi_dash.app.views.integration.github.verify_webhook_signature", return_value=True):
         return api_client.post(
             reverse("github-app-webhook"),
             data=json.dumps(payload),
             content_type="application/json",
-            HTTP_X_GITHUB_DELIVERY=str(uuid4()),
+            HTTP_X_GITHUB_DELIVERY=str(delivery_id or uuid4()),
             HTTP_X_GITHUB_EVENT=event,
             HTTP_X_HUB_SIGNATURE_256="sha256=valid",
         )
@@ -114,3 +114,58 @@ def test_pull_request_draft_reflected(api_client, link):
     assert link.draft is True
     assert link.merged is False
     assert link.state == "open"
+
+
+@pytest.mark.parametrize(
+    "prior_status",
+    [GithubWebhookDelivery.Status.RECEIVED, GithubWebhookDelivery.Status.FAILED],
+)
+def test_redelivery_reprocesses_non_terminal_delivery(api_client, link, prior_status):
+    """A delivery that never terminally succeeded — left RECEIVED (the request was
+    interrupted mid-processing) or FAILED (an exception was caught) — must be
+    re-applied when GitHub redelivers the same X-GitHub-Delivery GUID. Otherwise a
+    single dropped merge event leaves the PR stuck showing "open"."""
+    delivery_id = uuid4()
+    GithubWebhookDelivery.objects.create(
+        delivery_id=delivery_id,
+        event="pull_request",
+        action="closed",
+        status=prior_status,
+        error="boom" if prior_status == GithubWebhookDelivery.Status.FAILED else "",
+    )
+
+    response = _post(api_client, _pr_payload(), delivery_id=delivery_id)
+
+    assert response.status_code == status.HTTP_202_ACCEPTED
+    assert response.data == {"status": GithubWebhookDelivery.Status.PROCESSED}
+    link.refresh_from_db()
+    assert link.state == "closed"
+    assert link.merged is True
+    # a successful reprocess clears any stale error from the prior failed attempt
+    delivery = GithubWebhookDelivery.objects.get(delivery_id=delivery_id)
+    assert delivery.status == GithubWebhookDelivery.Status.PROCESSED
+    assert delivery.error == ""
+
+
+@pytest.mark.parametrize(
+    "prior_status",
+    [GithubWebhookDelivery.Status.PROCESSED, GithubWebhookDelivery.Status.SKIPPED],
+)
+def test_redelivery_of_terminal_delivery_is_not_reprocessed(api_client, link, prior_status):
+    """A delivery that already reached a terminal-success outcome fast-returns and
+    does not touch the snapshot again — preserving idempotency for GitHub's normal
+    at-least-once duplicate deliveries."""
+    delivery_id = uuid4()
+    GithubWebhookDelivery.objects.create(
+        delivery_id=delivery_id,
+        event="pull_request",
+        action="closed",
+        status=prior_status,
+    )
+
+    response = _post(api_client, _pr_payload(), delivery_id=delivery_id)
+
+    assert response.status_code == status.HTTP_202_ACCEPTED
+    assert response.data == {"status": prior_status}
+    link.refresh_from_db()
+    assert link.state == "open"  # snapshot untouched — no reprocessing


### PR DESCRIPTION
## Problem

PR links on Pi Dash work items show a stale state — e.g. a PR shows **open** in Pi Dash while it is actually **merged** on GitHub.

## Root cause

PR display state is refreshed **only** by the GitHub App `pull_request` webhook (`_refresh_pr_links`); there is no reconciliation/polling fallback. The webhook endpoint (`GithubAppWebhookEndpoint.post`) recorded the `GithubWebhookDelivery` row with status `RECEIVED` **before** processing, and then short-circuited **every** duplicate `X-GitHub-Delivery` with a 202 — regardless of whether the prior attempt actually applied the update:

```python
if not created:
    return Response({"status": delivery.status}, status=202)
```

GitHub reuses the same delivery GUID for automatic retries (on timeout / 5xx) and for a manual **Redeliver**. So a delivery whose first attempt was:
- **interrupted** mid-request (deploy / pod restart → row stuck `RECEIVED`), or
- **threw** (caught → `FAILED`),

was never re-applied — the redelivery was swallowed with 202. And because the endpoint always returns 202, GitHub never sees an error to retry against either. A single dropped merge (`closed` + `merged`) event therefore leaves the PR stuck showing **open** indefinitely, matching the reported symptom.

The state-mapping logic itself (`pr_snapshot_from_payload` → `_refresh_pr_links`) is correct; the bug is purely in idempotency handling.

## Fix

Only fast-return when the prior attempt reached a **terminal-success** outcome (`PROCESSED` / `SKIPPED`); **reprocess** `RECEIVED` and `FAILED` deliveries on redelivery. Reprocessing is safe: `_refresh_pr_links` is idempotent and guarded against out-of-order payloads by the PR's `updated_at`. A successful reprocess also clears any stale `error` from the prior failed attempt. This preserves idempotency for GitHub's normal at-least-once duplicate deliveries while letting a missed update recover.

## Tests

Added contract tests in `test_github_pr_webhook.py`:
- redelivery of a `RECEIVED`/`FAILED` prior delivery reprocesses and applies the snapshot (and clears stale error);
- redelivery of a `PROCESSED`/`SKIPPED` prior delivery fast-returns and leaves the snapshot untouched.

Full run: **26 passed** (`test_github_pr_webhook.py`, `test_github_pr_link_app.py`, `test_github_pr_link.py`).

## Follow-up (not in this PR — needs a design decision)

There is still no reconciliation path, so drift cannot self-heal if a webhook is **never delivered** (app not subscribed to `pull_request`, event dropped entirely, or the app was down when the event fired). Recommended follow-up: a periodic Celery refresh or an on-render best-effort fetch, reusing existing building blocks (`best_effort_snapshot`, `GithubClient.get_pull_request`, adapter `get_code_review`). Per the issue, this ticket is intentionally kept open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)