### PR TITLE
PDASHOSS01-70 Change review state tick cadence to every 8 hours

### DIFF
--- a/apps/api/pi_dash/db/migrations/0156_review_interval_8h.py
+++ b/apps/api/pi_dash/db/migrations/0156_review_interval_8h.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Lengthen the default In Review ticking interval from 3 h to 8 h.
+
+Per PDASHOSS01-70 the review-phase cadence is stretched so the runner
+re-reviews an In Review issue every 8 h instead of every 3 h. Each review
+tick is a full re-read of the thread and PR; a wider gap leaves more room
+for a human to weigh in between passes without exhausting the review
+budget prematurely.
+
+Only the project-level default changes; per-issue
+``IssueAgentTicker.review_interval_seconds`` overrides are untouched, and
+the In Progress cadence (``agent_default_interval_seconds`` = 10800) is
+unchanged. As with 0155, a data migration is intentionally *not* run:
+projects created before this change already materialized ``10800`` into
+their row, and silently rewriting an operator's stored value is more
+surprising than leaving it. New projects created after this migration get
+``28800``.
+"""
+
+from __future__ import annotations
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("db", "0155_reduce_review_max_ticks"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="project",
+            name="agent_review_default_interval_seconds",
+            field=models.IntegerField(default=28800),
+        ),
+    ]

--- a/apps/api/pi_dash/db/models/project.py
+++ b/apps/api/pi_dash/db/models/project.py
@@ -149,8 +149,8 @@ class Project(BaseModel):
     # phases respect it.
     agent_default_interval_seconds = models.IntegerField(default=10800)  # 3 h
     agent_default_max_ticks = models.IntegerField(default=24)            # 3 days
-    agent_review_default_interval_seconds = models.IntegerField(default=10800)  # 3 h
-    agent_review_default_max_ticks = models.IntegerField(default=4)             # 12 h window
+    agent_review_default_interval_seconds = models.IntegerField(default=28800)  # 8 h
+    agent_review_default_max_ticks = models.IntegerField(default=4)             # 32 h window
     agent_ticking_enabled = models.BooleanField(default=True)
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
## What

Change the default **In Review** ticking cadence from every 3 h to every 8 h.

- `Project.agent_review_default_interval_seconds`: `10800` (3 h) → `28800` (8 h)
- New migration `0156_review_interval_8h.py` alters the field to match

## Why

For the In Review state the runner should re-review less often, leaving more room for a human to weigh in between passes.

## Notes

- **No data backfill** — mirrors the sibling change `0155_reduce_review_max_ticks.py` (PDASHOSS01-68): projects created before this change already materialized `10800` into their row, and silently rewriting an operator's stored value is more surprising than leaving it. New projects get `28800`.
- In Progress cadence (`agent_default_interval_seconds`) is unchanged.
- Fixed the now-stale `agent_review_default_max_ticks` comment (4 ticks × 8 h = 32 h window).

## Validation

This runner has no project Python venv (system Python lacks `corsheaders`), so `makemigrations --check`/pytest can't boot Django settings here. Validated statically: byte-compile OK; model default == migration default (28800); clean linear migration leaf (0155 → 0156); existing ticker tests set the value explicitly so they're unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)