### PR TITLE
PDASHOSS01-71 Add labels to prompt sections and receipts

### DIFF
--- a/apps/api/pi_dash/prompting/migrations/0005_prompt_label.py
+++ b/apps/api/pi_dash/prompting/migrations/0005_prompt_label.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Workspace-scoped prompt labels for sections and receipts (PDASHOSS01-71).
+
+Introduces ``PromptLabel`` (a workspace-shared, user-managed label) and
+``PromptLabelAssignment`` (the n:n attachment of a label to a code-defined
+prompt section — keyed by ``section_key`` — or receipt — keyed by prompt
+``kind``). Kept separate from the issue ``Label`` model, which is
+project/issue-coupled and hierarchical.
+"""
+
+import uuid
+
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("db", "0001_initial"),
+        ("prompting", "0004_prompt_section_override"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="PromptLabel",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("name", models.CharField(max_length=64)),
+                ("color", models.CharField(default="#6b7280", max_length=32)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="prompt_labels_created",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "updated_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="prompt_labels_updated",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "workspace",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="prompt_labels",
+                        to="db.workspace",
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "prompt_label",
+                "ordering": ("name",),
+            },
+        ),
+        migrations.CreateModel(
+            name="PromptLabelAssignment",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("target_type", models.CharField(max_length=16)),
+                ("target_key", models.CharField(max_length=64)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="prompt_label_assignments_created",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "label",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="assignments",
+                        to="prompting.promptlabel",
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "prompt_label_assignment",
+            },
+        ),
+        migrations.AddIndex(
+            model_name="promptlabel",
+            index=models.Index(fields=["workspace"], name="prompt_label_ws_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="promptlabelassignment",
+            index=models.Index(
+                fields=["target_type", "target_key"],
+                name="prompt_label_assign_target_idx",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="promptlabel",
+            constraint=models.UniqueConstraint(
+                fields=["workspace", "name"],
+                name="prompt_label_unique_name_per_ws",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="promptlabelassignment",
+            constraint=models.UniqueConstraint(
+                fields=["label", "target_type", "target_key"],
+                name="prompt_label_assignment_unique_target",
+            ),
+        ),
+    ]

--- a/apps/api/pi_dash/prompting/models.py
+++ b/apps/api/pi_dash/prompting/models.py
@@ -141,3 +141,113 @@ class PromptSectionOverride(models.Model):
     @property
     def is_workspace_level(self) -> bool:
         return self.user_id is None
+
+
+#: A label may be attached to a prompt *section* (keyed by ``section_key``) or a
+#: *receipt* (keyed by prompt ``kind``). Sections/receipts are code-defined (see
+#: ``prompting.registry`` / ``prompting.recipes``), not DB rows, so an assignment
+#: references their stable string identifier rather than a foreign key.
+TARGET_SECTION = "section"
+TARGET_RECEIPT = "receipt"
+TARGET_TYPES = frozenset({TARGET_SECTION, TARGET_RECEIPT})
+
+#: Default chip color for a new label (matches the neutral grey used elsewhere).
+DEFAULT_LABEL_COLOR = "#6b7280"
+
+
+class PromptLabel(models.Model):
+    """A workspace-scoped, user-managed label for prompt sections and receipts.
+
+    Labels are shared across the workspace (like ``PromptSectionOverride``) and
+    are deliberately kept separate from the issue ``Label`` model, which is
+    project/issue-coupled and hierarchical. A label attaches to any number of
+    sections/receipts via :class:`PromptLabelAssignment` (n:n).
+
+    See PDASHOSS01-71.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    workspace = models.ForeignKey(
+        "db.Workspace",
+        on_delete=models.CASCADE,
+        related_name="prompt_labels",
+    )
+    name = models.CharField(max_length=64)
+    color = models.CharField(max_length=32, default=DEFAULT_LABEL_COLOR)
+    created_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="prompt_labels_created",
+    )
+    updated_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="prompt_labels_updated",
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        db_table = "prompt_label"
+        ordering = ("name",)
+        constraints = [
+            models.UniqueConstraint(
+                fields=["workspace", "name"],
+                name="prompt_label_unique_name_per_ws",
+            ),
+        ]
+        indexes = [models.Index(fields=["workspace"], name="prompt_label_ws_idx")]
+
+    def __str__(self) -> str:
+        return f"PromptLabel<ws={self.workspace_id}:{self.name}>"
+
+
+class PromptLabelAssignment(models.Model):
+    """A single attachment of a :class:`PromptLabel` to one section or receipt.
+
+    ``target_type`` is ``section`` or ``receipt`` (see :data:`TARGET_TYPES`) and
+    ``target_key`` is the section's ``section_key`` or the receipt's prompt
+    ``kind``. The workspace scope is carried by the parent label.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    label = models.ForeignKey(
+        PromptLabel,
+        on_delete=models.CASCADE,
+        related_name="assignments",
+    )
+    target_type = models.CharField(max_length=16)
+    target_key = models.CharField(max_length=64)
+    created_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="prompt_label_assignments_created",
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        db_table = "prompt_label_assignment"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["label", "target_type", "target_key"],
+                name="prompt_label_assignment_unique_target",
+            ),
+        ]
+        indexes = [
+            models.Index(
+                fields=["target_type", "target_key"],
+                name="prompt_label_assign_target_idx",
+            )
+        ]
+
+    def __str__(self) -> str:
+        return (
+            f"PromptLabelAssignment<label={self.label_id}:"
+            f"{self.target_type}:{self.target_key}>"
+        )

--- a/apps/api/pi_dash/prompting/serializers.py
+++ b/apps/api/pi_dash/prompting/serializers.py
@@ -8,7 +8,11 @@ from __future__ import annotations
 
 from rest_framework import serializers
 
-from pi_dash.prompting.models import PromptSectionOverride
+from pi_dash.prompting.models import (
+    PromptLabel,
+    PromptLabelAssignment,
+    PromptSectionOverride,
+)
 
 
 class PromptSectionOverrideSerializer(serializers.ModelSerializer):
@@ -52,3 +56,38 @@ class ResolvedSectionSerializer(serializers.Serializer):
     # the caller's role to decide which editors to surface.
     editable_at_workspace = serializers.BooleanField()
     editable_at_personal = serializers.BooleanField()
+
+
+class PromptLabelAssignmentSerializer(serializers.ModelSerializer):
+    """One attachment of a label to a section/receipt target."""
+
+    class Meta:
+        model = PromptLabelAssignment
+        fields = ["id", "target_type", "target_key", "created_at"]
+        read_only_fields = fields
+
+
+class PromptLabelSerializer(serializers.ModelSerializer):
+    """A workspace prompt label plus its section/receipt attachments.
+
+    The nested ``targets`` list lets the client build both the per-target chip
+    map (target -> labels) and the click-to-filter map (label -> targets) from a
+    single list response.
+    """
+
+    targets = PromptLabelAssignmentSerializer(source="assignments", many=True, read_only=True)
+
+    class Meta:
+        model = PromptLabel
+        fields = [
+            "id",
+            "workspace",
+            "name",
+            "color",
+            "targets",
+            "created_by",
+            "updated_by",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = ["id", "workspace", "targets", "created_by", "updated_by", "created_at", "updated_at"]

--- a/apps/api/pi_dash/prompting/urls.py
+++ b/apps/api/pi_dash/prompting/urls.py
@@ -6,6 +6,9 @@ from django.urls import path
 
 from pi_dash.prompting.views import (
     PromptCompiledEndpoint,
+    PromptLabelAssignmentEndpoint,
+    PromptLabelDetailEndpoint,
+    PromptLabelListEndpoint,
     PromptPreviewEndpoint,
     PromptSectionDetailEndpoint,
     PromptSectionListEndpoint,
@@ -14,6 +17,21 @@ from pi_dash.prompting.views import (
 app_name = "prompting"
 
 urlpatterns = [
+    path(
+        "workspaces/<slug:slug>/prompt-labels",
+        PromptLabelListEndpoint.as_view(),
+        name="prompt-label-list",
+    ),
+    path(
+        "workspaces/<slug:slug>/prompt-labels/<uuid:label_id>",
+        PromptLabelDetailEndpoint.as_view(),
+        name="prompt-label-detail",
+    ),
+    path(
+        "workspaces/<slug:slug>/prompt-labels/<uuid:label_id>/assignments",
+        PromptLabelAssignmentEndpoint.as_view(),
+        name="prompt-label-assignments",
+    ),
     path(
         "workspaces/<slug:slug>/prompt-sections",
         PromptSectionListEndpoint.as_view(),

--- a/apps/api/pi_dash/prompting/views.py
+++ b/apps/api/pi_dash/prompting/views.py
@@ -46,9 +46,17 @@ from pi_dash.prompting.composer import (
     resolve_section,
 )
 from pi_dash.prompting.context import build_context, build_scheduler_context
-from pi_dash.prompting.models import PromptSectionOverride
+from pi_dash.prompting.models import (
+    TARGET_RECEIPT,
+    TARGET_SECTION,
+    TARGET_TYPES,
+    PromptLabel,
+    PromptLabelAssignment,
+    PromptSectionOverride,
+)
 from pi_dash.prompting.renderer import PromptRenderError
 from pi_dash.prompting.serializers import (
+    PromptLabelSerializer,
     PromptSectionOverrideSerializer,
     ResolvedSectionSerializer,
 )
@@ -491,3 +499,238 @@ class PromptPreviewEndpoint(APIView):
             )
         context = build_scheduler_context(binding, _FakeRun(run_id=uuid.uuid4()))
         return context, binding.project, None
+
+
+# ----------------------------------------------------------------------
+# Prompt labels (PDASHOSS01-71)
+# ----------------------------------------------------------------------
+
+#: Max characters for a label name / color value.
+MAX_LABEL_NAME_LENGTH = 64
+MAX_LABEL_COLOR_LENGTH = 32
+
+
+def _validate_target(target_type, target_key):
+    """Return an error :class:`Response` if ``(target_type, target_key)`` does
+    not reference a real, code-defined section or receipt; otherwise ``None``.
+
+    Sections/receipts are not DB rows, so referential integrity is enforced here
+    against the registry (sections) and recipes (receipts).
+    """
+    if target_type not in TARGET_TYPES:
+        return Response(
+            {"error": f"unknown target_type {target_type!r}", "target_types": sorted(TARGET_TYPES)},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+    if not target_key:
+        return Response({"error": "target_key is required"}, status=status.HTTP_400_BAD_REQUEST)
+    if target_type == TARGET_SECTION and target_key not in registry.REGISTRY:
+        return Response(
+            {"error": f"unknown section {target_key!r}"}, status=status.HTTP_404_NOT_FOUND
+        )
+    if target_type == TARGET_RECEIPT and target_key not in recipes.RECIPES:
+        return Response(
+            {"error": f"unknown receipt kind {target_key!r}", "kinds": list(recipes.all_kinds())},
+            status=status.HTTP_404_NOT_FOUND,
+        )
+    return None
+
+
+def _clean_label_name(raw):
+    """Return a trimmed label name, or ``None`` if empty/invalid."""
+    if raw is None:
+        return None
+    name = str(raw).strip()
+    if not name or len(name) > MAX_LABEL_NAME_LENGTH:
+        return None
+    return name
+
+
+class PromptLabelListEndpoint(APIView):
+    """``GET|POST /api/workspaces/<slug>/prompt-labels``.
+
+    ``GET`` returns every workspace label with its section/receipt targets
+    (member-readable). ``POST`` creates a label (admin-only).
+    """
+
+    permission_classes = [IsAuthenticated]
+    throttle_classes = [UserRateThrottle]
+
+    def get(self, request, slug: str):
+        workspace = _get_workspace_or_404(slug)
+        if workspace is None:
+            return Response({"error": "workspace not found"}, status=status.HTTP_404_NOT_FOUND)
+        if not _is_workspace_member(request.user, workspace):
+            return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
+
+        labels = (
+            PromptLabel.objects.filter(workspace=workspace)
+            .prefetch_related("assignments")
+            .order_by("name")
+        )
+        return Response({"labels": PromptLabelSerializer(labels, many=True).data})
+
+    def post(self, request, slug: str):
+        workspace = _get_workspace_or_404(slug)
+        if workspace is None:
+            return Response({"error": "workspace not found"}, status=status.HTTP_404_NOT_FOUND)
+        if not _is_workspace_admin(request.user, workspace):
+            return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
+
+        name = _clean_label_name(request.data.get("name"))
+        if name is None:
+            return Response(
+                {"error": "a non-empty name of at most 64 characters is required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        color = (request.data.get("color") or "").strip()[:MAX_LABEL_COLOR_LENGTH] or None
+
+        try:
+            label = PromptLabel.objects.create(
+                workspace=workspace,
+                name=name,
+                color=color or PromptLabel._meta.get_field("color").default,
+                created_by=request.user,
+                updated_by=request.user,
+            )
+        except IntegrityError:
+            return Response(
+                {"error": f"a label named {name!r} already exists in this workspace"},
+                status=status.HTTP_409_CONFLICT,
+            )
+        return Response(PromptLabelSerializer(label).data, status=status.HTTP_201_CREATED)
+
+
+class PromptLabelDetailEndpoint(APIView):
+    """``PATCH|DELETE /api/workspaces/<slug>/prompt-labels/<label_id>`` (admin)."""
+
+    permission_classes = [IsAuthenticated]
+    throttle_classes = [UserRateThrottle]
+
+    def _get(self, workspace, label_id):
+        try:
+            return PromptLabel.objects.prefetch_related("assignments").get(
+                id=label_id, workspace=workspace
+            )
+        except (PromptLabel.DoesNotExist, ValueError, DjangoValidationError):
+            return None
+
+    def patch(self, request, slug: str, label_id):
+        workspace = _get_workspace_or_404(slug)
+        if workspace is None:
+            return Response({"error": "workspace not found"}, status=status.HTTP_404_NOT_FOUND)
+        if not _is_workspace_admin(request.user, workspace):
+            return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
+        label = self._get(workspace, label_id)
+        if label is None:
+            return Response({"error": "label not found"}, status=status.HTTP_404_NOT_FOUND)
+
+        update_fields = ["updated_by", "updated_at"]
+        if "name" in request.data:
+            name = _clean_label_name(request.data.get("name"))
+            if name is None:
+                return Response(
+                    {"error": "a non-empty name of at most 64 characters is required"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            label.name = name
+            update_fields.append("name")
+        if "color" in request.data:
+            label.color = (request.data.get("color") or "").strip()[:MAX_LABEL_COLOR_LENGTH] or (
+                PromptLabel._meta.get_field("color").default
+            )
+            update_fields.append("color")
+
+        label.updated_by = request.user
+        try:
+            label.save(update_fields=update_fields)
+        except IntegrityError:
+            return Response(
+                {"error": f"a label named {label.name!r} already exists in this workspace"},
+                status=status.HTTP_409_CONFLICT,
+            )
+        label.refresh_from_db()
+        return Response(PromptLabelSerializer(label).data, status=status.HTTP_200_OK)
+
+    def delete(self, request, slug: str, label_id):
+        workspace = _get_workspace_or_404(slug)
+        if workspace is None:
+            return Response({"error": "workspace not found"}, status=status.HTTP_404_NOT_FOUND)
+        if not _is_workspace_admin(request.user, workspace):
+            return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
+        label = self._get(workspace, label_id)
+        if label is None:
+            return Response({"error": "label not found"}, status=status.HTTP_404_NOT_FOUND)
+        label.delete()  # cascades to assignments
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class PromptLabelAssignmentEndpoint(APIView):
+    """``POST|DELETE /api/workspaces/<slug>/prompt-labels/<label_id>/assignments``.
+
+    Attach (``POST``) or detach (``DELETE``) the label to/from one section or
+    receipt. Body: ``{"target_type": "section"|"receipt", "target_key": ...}``.
+    Admin-only, matching label management.
+    """
+
+    permission_classes = [IsAuthenticated]
+    throttle_classes = [UserRateThrottle]
+
+    def _get_label(self, workspace, label_id):
+        try:
+            return PromptLabel.objects.get(id=label_id, workspace=workspace)
+        except (PromptLabel.DoesNotExist, ValueError, DjangoValidationError):
+            return None
+
+    def post(self, request, slug: str, label_id):
+        workspace = _get_workspace_or_404(slug)
+        if workspace is None:
+            return Response({"error": "workspace not found"}, status=status.HTTP_404_NOT_FOUND)
+        if not _is_workspace_admin(request.user, workspace):
+            return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
+        label = self._get_label(workspace, label_id)
+        if label is None:
+            return Response({"error": "label not found"}, status=status.HTTP_404_NOT_FOUND)
+
+        target_type = request.data.get("target_type")
+        target_key = request.data.get("target_key")
+        err = _validate_target(target_type, target_key)
+        if err is not None:
+            return err
+
+        PromptLabelAssignment.objects.get_or_create(
+            label=label,
+            target_type=target_type,
+            target_key=target_key,
+            defaults={"created_by": request.user},
+        )
+        label = (
+            PromptLabel.objects.prefetch_related("assignments").get(id=label.id)
+        )
+        return Response(PromptLabelSerializer(label).data, status=status.HTTP_200_OK)
+
+    def delete(self, request, slug: str, label_id):
+        workspace = _get_workspace_or_404(slug)
+        if workspace is None:
+            return Response({"error": "workspace not found"}, status=status.HTTP_404_NOT_FOUND)
+        if not _is_workspace_admin(request.user, workspace):
+            return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
+        label = self._get_label(workspace, label_id)
+        if label is None:
+            return Response({"error": "label not found"}, status=status.HTTP_404_NOT_FOUND)
+
+        target_type = request.data.get("target_type") or request.query_params.get("target_type")
+        target_key = request.data.get("target_key") or request.query_params.get("target_key")
+        if target_type not in TARGET_TYPES or not target_key:
+            return Response(
+                {"error": "target_type and target_key are required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        deleted, _ = PromptLabelAssignment.objects.filter(
+            label=label, target_type=target_type, target_key=target_key
+        ).delete()
+        if not deleted:
+            return Response(
+                {"error": "no such assignment on this label"}, status=status.HTTP_404_NOT_FOUND
+            )
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/apps/api/pi_dash/tests/contract/prompting/test_labels_crud.py
+++ b/apps/api/pi_dash/tests/contract/prompting/test_labels_crud.py
@@ -1,0 +1,288 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Contract tests for the prompt-label CRUD + attach/detach endpoints
+(PDASHOSS01-71)."""
+
+from __future__ import annotations
+
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from pi_dash.db.models import User, WorkspaceMember
+from pi_dash.prompting.models import PromptLabel, PromptLabelAssignment
+
+
+@pytest.fixture
+def member_user(db):
+    return User.objects.create(
+        username="member", email="member@example.com", first_name="Mem", last_name="Ber"
+    )
+
+
+@pytest.fixture
+def member_client(db, workspace, member_user):
+    """A non-admin (role=15) workspace member."""
+    WorkspaceMember.objects.create(workspace=workspace, member=member_user, role=15)
+    client = APIClient()
+    client.force_authenticate(user=member_user)
+    return client
+
+
+@pytest.fixture
+def outsider_client(db):
+    outsider = User.objects.create(
+        username="outsider", email="out@example.com", first_name="Out", last_name="Sider"
+    )
+    client = APIClient()
+    client.force_authenticate(user=outsider)
+    return client
+
+
+def _list_url(workspace):
+    return reverse("prompting:prompt-label-list", kwargs={"slug": workspace.slug})
+
+
+def _detail_url(workspace, label_id):
+    return reverse(
+        "prompting:prompt-label-detail", kwargs={"slug": workspace.slug, "label_id": label_id}
+    )
+
+
+def _assign_url(workspace, label_id):
+    return reverse(
+        "prompting:prompt-label-assignments",
+        kwargs={"slug": workspace.slug, "label_id": label_id},
+    )
+
+
+def _make_label(session_client, workspace, name="Important", color="#ff0000"):
+    resp = session_client.post(
+        _list_url(workspace), {"name": name, "color": color}, format="json"
+    )
+    assert resp.status_code == 201, resp.data
+    return resp.data
+
+
+# ----------------------------------------------------------------------
+# Create / list
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.contract
+def test_admin_creates_label(session_client, workspace):
+    resp = session_client.post(
+        _list_url(workspace), {"name": "Tone", "color": "#00ff00"}, format="json"
+    )
+    assert resp.status_code == 201, resp.data
+    assert resp.data["name"] == "Tone"
+    assert resp.data["color"] == "#00ff00"
+    assert resp.data["targets"] == []
+    assert PromptLabel.objects.filter(workspace=workspace, name="Tone").exists()
+
+
+@pytest.mark.contract
+def test_create_defaults_color_when_missing(session_client, workspace):
+    resp = session_client.post(_list_url(workspace), {"name": "NoColor"}, format="json")
+    assert resp.status_code == 201, resp.data
+    assert resp.data["color"] == "#6b7280"
+
+
+@pytest.mark.contract
+def test_create_requires_name(session_client, workspace):
+    resp = session_client.post(_list_url(workspace), {"name": "   "}, format="json")
+    assert resp.status_code == 400
+
+
+@pytest.mark.contract
+def test_create_duplicate_name_conflicts(session_client, workspace):
+    _make_label(session_client, workspace, name="Dup")
+    resp = session_client.post(_list_url(workspace), {"name": "Dup"}, format="json")
+    assert resp.status_code == 409
+
+
+@pytest.mark.contract
+def test_member_cannot_create_label(member_client, workspace):
+    resp = member_client.post(_list_url(workspace), {"name": "Nope"}, format="json")
+    assert resp.status_code == 403
+
+
+@pytest.mark.contract
+def test_outsider_cannot_read_labels(outsider_client, workspace):
+    resp = outsider_client.get(_list_url(workspace))
+    assert resp.status_code == 403
+
+
+@pytest.mark.contract
+def test_member_can_read_labels(member_client, session_client, workspace):
+    _make_label(session_client, workspace, name="Visible")
+    resp = member_client.get(_list_url(workspace))
+    assert resp.status_code == 200
+    names = [label_row["name"] for label_row in resp.data["labels"]]
+    assert "Visible" in names
+
+
+# ----------------------------------------------------------------------
+# Update / delete
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.contract
+def test_admin_updates_label(session_client, workspace):
+    label = _make_label(session_client, workspace, name="Old", color="#111111")
+    resp = session_client.patch(
+        _detail_url(workspace, label["id"]), {"name": "New", "color": "#222222"}, format="json"
+    )
+    assert resp.status_code == 200, resp.data
+    assert resp.data["name"] == "New"
+    assert resp.data["color"] == "#222222"
+
+
+@pytest.mark.contract
+def test_member_cannot_update_label(session_client, member_client, workspace):
+    label = _make_label(session_client, workspace)
+    resp = member_client.patch(
+        _detail_url(workspace, label["id"]), {"name": "Hacked"}, format="json"
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.contract
+def test_admin_deletes_label_cascades_assignments(session_client, workspace):
+    label = _make_label(session_client, workspace)
+    session_client.post(
+        _assign_url(workspace, label["id"]),
+        {"target_type": "section", "target_key": "intro"},
+        format="json",
+    )
+    assert PromptLabelAssignment.objects.filter(label_id=label["id"]).exists()
+    resp = session_client.delete(_detail_url(workspace, label["id"]))
+    assert resp.status_code == 204
+    assert not PromptLabel.objects.filter(id=label["id"]).exists()
+    assert not PromptLabelAssignment.objects.filter(label_id=label["id"]).exists()
+
+
+# ----------------------------------------------------------------------
+# Attach / detach
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.contract
+def test_attach_to_section_and_receipt(session_client, workspace):
+    label = _make_label(session_client, workspace)
+    r1 = session_client.post(
+        _assign_url(workspace, label["id"]),
+        {"target_type": "section", "target_key": "intro"},
+        format="json",
+    )
+    assert r1.status_code == 200, r1.data
+    r2 = session_client.post(
+        _assign_url(workspace, label["id"]),
+        {"target_type": "receipt", "target_key": "coding-task"},
+        format="json",
+    )
+    assert r2.status_code == 200, r2.data
+    targets = {(t["target_type"], t["target_key"]) for t in r2.data["targets"]}
+    assert ("section", "intro") in targets
+    assert ("receipt", "coding-task") in targets
+
+
+@pytest.mark.contract
+def test_attach_is_idempotent(session_client, workspace):
+    label = _make_label(session_client, workspace)
+    payload = {"target_type": "section", "target_key": "intro"}
+    session_client.post(_assign_url(workspace, label["id"]), payload, format="json")
+    resp = session_client.post(_assign_url(workspace, label["id"]), payload, format="json")
+    assert resp.status_code == 200
+    assert (
+        PromptLabelAssignment.objects.filter(
+            label_id=label["id"], target_type="section", target_key="intro"
+        ).count()
+        == 1
+    )
+
+
+@pytest.mark.contract
+def test_attach_unknown_target_type_400(session_client, workspace):
+    label = _make_label(session_client, workspace)
+    resp = session_client.post(
+        _assign_url(workspace, label["id"]),
+        {"target_type": "bogus", "target_key": "intro"},
+        format="json",
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.contract
+def test_attach_unknown_section_404(session_client, workspace):
+    label = _make_label(session_client, workspace)
+    resp = session_client.post(
+        _assign_url(workspace, label["id"]),
+        {"target_type": "section", "target_key": "does-not-exist"},
+        format="json",
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.contract
+def test_attach_unknown_receipt_kind_404(session_client, workspace):
+    label = _make_label(session_client, workspace)
+    resp = session_client.post(
+        _assign_url(workspace, label["id"]),
+        {"target_type": "receipt", "target_key": "not-a-kind"},
+        format="json",
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.contract
+def test_member_cannot_attach(session_client, member_client, workspace):
+    label = _make_label(session_client, workspace)
+    resp = member_client.post(
+        _assign_url(workspace, label["id"]),
+        {"target_type": "section", "target_key": "intro"},
+        format="json",
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.contract
+def test_detach(session_client, workspace):
+    label = _make_label(session_client, workspace)
+    session_client.post(
+        _assign_url(workspace, label["id"]),
+        {"target_type": "section", "target_key": "intro"},
+        format="json",
+    )
+    resp = session_client.delete(
+        _assign_url(workspace, label["id"]) + "?target_type=section&target_key=intro"
+    )
+    assert resp.status_code == 204
+    assert not PromptLabelAssignment.objects.filter(label_id=label["id"]).exists()
+
+
+@pytest.mark.contract
+def test_detach_missing_assignment_404(session_client, workspace):
+    label = _make_label(session_client, workspace)
+    resp = session_client.delete(
+        _assign_url(workspace, label["id"]) + "?target_type=section&target_key=intro"
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.contract
+def test_labels_scoped_to_workspace(session_client, workspace, create_user):
+    """A label created in one workspace must not leak into another."""
+    from pi_dash.db.models import Workspace
+
+    other = Workspace.objects.create(
+        name="Other", slug="other-workspace", owner=create_user
+    )
+    WorkspaceMember.objects.create(workspace=other, member=create_user, role=20)
+    _make_label(session_client, workspace, name="OnlyHere")
+
+    resp = session_client.get(_list_url(other))
+    assert resp.status_code == 200
+    assert resp.data["labels"] == []

--- a/apps/web/app/(all)/[workspaceSlug]/prompts/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/prompts/page.tsx
@@ -13,9 +13,11 @@ import { useTranslation } from "@pi-dash/i18n";
 import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
 import type {
   IPromptCompiledResponse,
+  IPromptLabel,
   IPromptSectionListResponse,
   IResolvedSection,
   TPromptKind,
+  TPromptLabelTargetType,
   TPromptScope,
 } from "@pi-dash/types";
 import { AlertModalCore, Badge, Button } from "@pi-dash/ui";
@@ -23,6 +25,18 @@ import { PageHead } from "@/components/core/page-title";
 import { usePromptSection } from "@/hooks/store/use-prompt-section";
 import { useUserPermissions } from "@/hooks/store/user";
 import { useWorkspace } from "@/hooks/store/use-workspace";
+import { PromptCardLabels, PromptLabelBar, useWorkspaceLabels } from "./prompt-labels";
+
+/** Bundle of label state threaded from the page into the section/receipt libraries. */
+type TLabelBundle = {
+  slug: string;
+  allLabels: IPromptLabel[];
+  labelsFor: (targetType: TPromptLabelTargetType, targetKey: string) => IPromptLabel[];
+  activeLabelId: string | null;
+  isAdmin: boolean;
+  onSelectLabel: (labelId: string | null) => void;
+  onLabelsChanged: () => Promise<unknown>;
+};
 
 const KINDS: TPromptKind[] = ["coding-task", "review", "scheduler"];
 type TPromptPageTab = "sections" | "receipt";
@@ -102,6 +116,18 @@ const PromptsListPage = observer(function PromptsListPage() {
   const slug = workspaceSlug ?? "";
   const isAdmin = allowPermissions([EUserPermissions.ADMIN], EUserPermissionsLevel.WORKSPACE, slug);
   const [tab, setTab] = useState<TPromptPageTab>("sections");
+  const [activeLabelId, setActiveLabelId] = useState<string | null>(null);
+
+  const { labels, labelsFor, mutate: mutateLabels } = useWorkspaceLabels(slug);
+  const labelBundle: TLabelBundle = {
+    slug,
+    allLabels: labels,
+    labelsFor,
+    activeLabelId,
+    isAdmin,
+    onSelectLabel: setActiveLabelId,
+    onLabelsChanged: mutateLabels,
+  };
 
   const pageTitle = currentWorkspace?.name ? `${currentWorkspace.name} · ${t("Prompts")}` : t("Prompts");
 
@@ -131,16 +157,25 @@ const PromptsListPage = observer(function PromptsListPage() {
         ))}
       </div>
 
+      <PromptLabelBar
+        slug={slug}
+        labels={labels}
+        activeLabelId={activeLabelId}
+        isAdmin={isAdmin}
+        onSelect={setActiveLabelId}
+        onChanged={mutateLabels}
+      />
+
       {tab === "sections" ? (
-        <SectionsLibrary slug={slug} isAdmin={isAdmin} />
+        <SectionsLibrary slug={slug} isAdmin={isAdmin} labels={labelBundle} />
       ) : (
-        <ReceiptLibrary slug={slug} isAdmin={isAdmin} />
+        <ReceiptLibrary slug={slug} isAdmin={isAdmin} labels={labelBundle} />
       )}
     </div>
   );
 });
 
-function SectionsLibrary({ slug, isAdmin }: { slug: string; isAdmin: boolean }) {
+function SectionsLibrary({ slug, isAdmin, labels }: { slug: string; isAdmin: boolean; labels: TLabelBundle }) {
   const { t } = useTranslation();
   const { mutate } = useSWRConfig();
 
@@ -191,6 +226,14 @@ function SectionsLibrary({ slug, isAdmin }: { slug: string; isAdmin: boolean }) 
     return map;
   }, [wsLists]);
 
+  // When a label filter is active, show only the sections carrying it.
+  const visibleEntries = useMemo<TSectionEntry[]>(() => {
+    if (!labels.activeLabelId) return entries;
+    return entries.filter((entry) =>
+      labels.labelsFor("section", entry.section.key).some((label) => label.id === labels.activeLabelId)
+    );
+  }, [entries, labels]);
+
   const userError = codingUser.error || reviewUser.error || schedulerUser.error;
   const wsError = codingWs.error || reviewWs.error || schedulerWs.error;
   const userReady = codingUser.data !== undefined && reviewUser.data !== undefined && schedulerUser.data !== undefined;
@@ -221,7 +264,7 @@ function SectionsLibrary({ slug, isAdmin }: { slug: string; isAdmin: boolean }) 
 
   return (
     <section className="grid gap-4 lg:grid-cols-[16rem_minmax(0,1fr)]">
-      <SectionNavigation entries={entries} />
+      <SectionNavigation entries={visibleEntries} />
       <div className="flex min-w-0 flex-col gap-3">
         {isAdmin && wsError && (
           // The workspace-scope list is what gates the "Customize for
@@ -233,7 +276,12 @@ function SectionsLibrary({ slug, isAdmin }: { slug: string; isAdmin: boolean }) 
             )}
           </div>
         )}
-        {entries.map(({ section, kinds }) => (
+        {visibleEntries.length === 0 && labels.activeLabelId && (
+          <div className="rounded-md border border-subtle bg-layer-1 p-4 text-12 text-secondary">
+            {t("No sections carry this label.")}
+          </div>
+        )}
+        {visibleEntries.map(({ section, kinds }) => (
           <SectionCard
             key={section.key}
             sectionId={sectionAnchorId(section.key)}
@@ -244,6 +292,7 @@ function SectionsLibrary({ slug, isAdmin }: { slug: string; isAdmin: boolean }) 
             workspaceReady={workspaceReady}
             isAdmin={isAdmin}
             onChanged={refresh}
+            labels={labels}
           />
         ))}
       </div>
@@ -273,7 +322,7 @@ function SectionNavigation({ entries }: { entries: TSectionEntry[] }) {
   );
 }
 
-function ReceiptLibrary({ slug, isAdmin }: { slug: string; isAdmin: boolean }) {
+function ReceiptLibrary({ slug, isAdmin, labels }: { slug: string; isAdmin: boolean; labels: TLabelBundle }) {
   const { t } = useTranslation();
   const coding = useCompiledPrompt(slug, "coding-task");
   const review = useCompiledPrompt(slug, "review");
@@ -313,6 +362,12 @@ function ReceiptLibrary({ slug, isAdmin }: { slug: string; isAdmin: boolean }) {
     const sections = sectionsByKind[kind];
     if (compiled && sections) entries.push({ kind, compiled, sections });
   }
+  // When a label filter is active, show only the receipts carrying it.
+  const visibleEntries = labels.activeLabelId
+    ? entries.filter((entry) =>
+        labels.labelsFor("receipt", entry.kind).some((label) => label.id === labels.activeLabelId)
+      )
+    : entries;
 
   if (error) {
     return (
@@ -326,7 +381,7 @@ function ReceiptLibrary({ slug, isAdmin }: { slug: string; isAdmin: boolean }) {
 
   return (
     <section className="grid gap-4 lg:grid-cols-[16rem_minmax(0,1fr)]">
-      <ReceiptNavigation entries={entries} />
+      <ReceiptNavigation entries={visibleEntries} />
       <div className="flex min-w-0 flex-col gap-3">
         <div className="rounded-md border border-subtle bg-layer-1 px-4 py-3">
           <h2 className="text-13 font-medium text-primary">{t("Receipt")}</h2>
@@ -336,7 +391,12 @@ function ReceiptLibrary({ slug, isAdmin }: { slug: string; isAdmin: boolean }) {
             )}
           </p>
         </div>
-        {entries.map(({ kind, compiled, sections }) => (
+        {visibleEntries.length === 0 && labels.activeLabelId && (
+          <div className="rounded-md border border-subtle bg-layer-1 p-4 text-12 text-secondary">
+            {t("No receipts carry this label.")}
+          </div>
+        )}
+        {visibleEntries.map(({ kind, compiled, sections }) => (
           <ReceiptCard
             key={kind}
             receiptId={receiptAnchorId(kind)}
@@ -345,6 +405,7 @@ function ReceiptLibrary({ slug, isAdmin }: { slug: string; isAdmin: boolean }) {
             compiled={compiled}
             sections={sections}
             isAdmin={isAdmin}
+            labels={labels}
           />
         ))}
       </div>
@@ -393,6 +454,7 @@ type SectionCardProps = {
   workspaceReady: boolean;
   isAdmin: boolean;
   onChanged: () => Promise<void>;
+  labels: TLabelBundle;
 };
 
 function SectionCard({
@@ -404,6 +466,7 @@ function SectionCard({
   workspaceReady,
   isAdmin,
   onChanged,
+  labels,
 }: SectionCardProps) {
   const { t } = useTranslation();
   const kindLabel = useKindLabel();
@@ -452,6 +515,17 @@ function SectionCard({
               </Badge>
             ))}
           </div>
+          <PromptCardLabels
+            slug={labels.slug}
+            targetType="section"
+            targetKey={section.key}
+            labels={labels.labelsFor("section", section.key)}
+            allLabels={labels.allLabels}
+            activeLabelId={labels.activeLabelId}
+            isAdmin={labels.isAdmin}
+            onSelect={labels.onSelectLabel}
+            onChanged={labels.onLabelsChanged}
+          />
           {section.needs_attention && (
             <span className="text-11 text-warning-primary">
               {t("This override may no longer render after a recent change — review and re-save it.")}
@@ -711,6 +785,7 @@ function ReceiptCard({
   compiled,
   sections,
   isAdmin,
+  labels,
 }: {
   receiptId: string;
   slug: string;
@@ -718,6 +793,7 @@ function ReceiptCard({
   compiled: IPromptCompiledResponse;
   sections: IResolvedSection[];
   isAdmin: boolean;
+  labels: TLabelBundle;
 }) {
   const { t } = useTranslation();
   const kindLabel = useKindLabel();
@@ -738,6 +814,19 @@ function ReceiptCard({
         </span>
         <span className="text-11 text-secondary">{open ? t("Hide") : t("Show")}</span>
       </button>
+      <div className="flex flex-wrap items-center gap-1.5 px-4 pb-3">
+        <PromptCardLabels
+          slug={labels.slug}
+          targetType="receipt"
+          targetKey={kind}
+          labels={labels.labelsFor("receipt", kind)}
+          allLabels={labels.allLabels}
+          activeLabelId={labels.activeLabelId}
+          isAdmin={labels.isAdmin}
+          onSelect={labels.onSelectLabel}
+          onChanged={labels.onLabelsChanged}
+        />
+      </div>
       <div className="border-t border-subtle px-4 py-3">
         <h3 className="text-11 font-medium text-secondary">{t("Composed from")}</h3>
         <ol className="mt-2 grid gap-1.5 md:grid-cols-2">

--- a/apps/web/app/(all)/[workspaceSlug]/prompts/prompt-labels.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/prompts/prompt-labels.tsx
@@ -1,0 +1,480 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useMemo, useState } from "react";
+import useSWR from "swr";
+import { useTranslation } from "@pi-dash/i18n";
+import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
+import type { IPromptLabel, IPromptLabelListResponse, TPromptLabelTargetType } from "@pi-dash/types";
+import { Button, ColorPicker, EModalPosition, EModalWidth, ModalCore } from "@pi-dash/ui";
+import { usePromptLabel } from "@/hooks/store/use-prompt-label";
+
+const DEFAULT_NEW_LABEL_COLOR = "#6b7280";
+
+function targetMapKey(targetType: TPromptLabelTargetType, targetKey: string): string {
+  return `${targetType}:${targetKey}`;
+}
+
+/** Extract a friendly error message from the service's thrown `err.response.data`. */
+function labelError(e: unknown, fallback: string): string {
+  const err = e as { error?: string; detail?: string } | null;
+  return err?.detail ?? err?.error ?? fallback;
+}
+
+/**
+ * Fetch the workspace's prompt labels once and expose helpers to look them up
+ * per target (section/receipt). The prompts page holds the SWR cache so chips
+ * everywhere on the page stay in sync after an attach/detach/edit.
+ */
+export function useWorkspaceLabels(slug: string) {
+  const promptLabelStore = usePromptLabel();
+  const key = slug ? (["prompt-labels", slug] as const) : null;
+  const { data, error, isLoading, mutate } = useSWR<IPromptLabelListResponse>(key, () =>
+    promptLabelStore.fetchLabels(slug)
+  );
+  const labels = useMemo<IPromptLabel[]>(() => data?.labels ?? [], [data]);
+
+  const labelsByTarget = useMemo(() => {
+    const map = new Map<string, IPromptLabel[]>();
+    for (const label of labels) {
+      for (const target of label.targets) {
+        const mapKey = targetMapKey(target.target_type, target.target_key);
+        const bucket = map.get(mapKey);
+        if (bucket) bucket.push(label);
+        else map.set(mapKey, [label]);
+      }
+    }
+    return map;
+  }, [labels]);
+
+  const labelsFor = useMemo(
+    () =>
+      (targetType: TPromptLabelTargetType, targetKey: string): IPromptLabel[] =>
+        labelsByTarget.get(targetMapKey(targetType, targetKey)) ?? [],
+    [labelsByTarget]
+  );
+
+  return { labels, labelsFor, error, isLoading, mutate };
+}
+
+/** True when `label` is attached to the given target. */
+export function labelHasTarget(label: IPromptLabel, targetType: TPromptLabelTargetType, targetKey: string): boolean {
+  return label.targets.some((t) => t.target_type === targetType && t.target_key === targetKey);
+}
+
+/** Count of each target type a label carries, for the filter summary. */
+export function labelTargetCounts(label: IPromptLabel): { sections: number; receipts: number } {
+  let sections = 0;
+  let receipts = 0;
+  for (const t of label.targets) {
+    if (t.target_type === "section") sections += 1;
+    else if (t.target_type === "receipt") receipts += 1;
+  }
+  return { sections, receipts };
+}
+
+type ChipProps = {
+  label: IPromptLabel;
+  active?: boolean;
+  onClick?: () => void;
+  /** Optional detach affordance (admin, on a specific card). */
+  onRemove?: () => void;
+  title?: string;
+};
+
+/** A small colored, clickable label chip. */
+export function PromptLabelChip({ label, active = false, onClick, onRemove, title }: ChipProps) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full border py-0.5 pr-1 pl-1.5 text-11 transition-colors ${
+        active ? "border-accent-strong bg-layer-2 text-primary" : "border-subtle text-secondary hover:text-primary"
+      }`}
+      style={active ? undefined : { borderColor: `${label.color}66` }}
+    >
+      <button type="button" onClick={onClick} className="inline-flex items-center gap-1" title={title}>
+        <span className="size-2 shrink-0 rounded-full" style={{ backgroundColor: label.color }} />
+        <span className="max-w-[10rem] truncate">{label.name}</span>
+      </button>
+      {onRemove && (
+        <button
+          type="button"
+          onClick={onRemove}
+          aria-label="Remove label"
+          className="ml-0.5 rounded-full px-1 text-placeholder hover:text-danger-primary"
+        >
+          ×
+        </button>
+      )}
+    </span>
+  );
+}
+
+type CardLabelsProps = {
+  slug: string;
+  targetType: TPromptLabelTargetType;
+  targetKey: string;
+  labels: IPromptLabel[];
+  allLabels: IPromptLabel[];
+  activeLabelId: string | null;
+  isAdmin: boolean;
+  onSelect: (labelId: string) => void;
+  onChanged: () => Promise<unknown>;
+};
+
+/**
+ * The row of chips shown on a section/receipt card: the labels attached to this
+ * target (clickable to filter), plus an admin "＋ Label" attach/detach menu.
+ */
+export function PromptCardLabels({
+  slug,
+  targetType,
+  targetKey,
+  labels,
+  allLabels,
+  activeLabelId,
+  isAdmin,
+  onSelect,
+  onChanged,
+}: CardLabelsProps) {
+  const { t } = useTranslation();
+  const promptLabelStore = usePromptLabel();
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  async function toggle(label: IPromptLabel) {
+    if (busyId) return;
+    setBusyId(label.id);
+    const attached = labelHasTarget(label, targetType, targetKey);
+    try {
+      if (attached)
+        await promptLabelStore.detachLabel(slug, label.id, { target_type: targetType, target_key: targetKey });
+      else await promptLabelStore.attachLabel(slug, label.id, { target_type: targetType, target_key: targetKey });
+      await onChanged();
+    } catch (e: unknown) {
+      setToast({
+        type: TOAST_TYPE.ERROR,
+        title: t("Something went wrong"),
+        message: labelError(e, t("Could not update the label.")),
+      });
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function detach(label: IPromptLabel) {
+    if (busyId) return;
+    setBusyId(label.id);
+    try {
+      await promptLabelStore.detachLabel(slug, label.id, { target_type: targetType, target_key: targetKey });
+      await onChanged();
+    } catch (e: unknown) {
+      setToast({
+        type: TOAST_TYPE.ERROR,
+        title: t("Something went wrong"),
+        message: labelError(e, t("Could not remove the label.")),
+      });
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  if (labels.length === 0 && !isAdmin) return null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      {labels.map((label) => (
+        <PromptLabelChip
+          key={label.id}
+          label={label}
+          active={activeLabelId === label.id}
+          onClick={() => onSelect(label.id)}
+          onRemove={isAdmin ? () => detach(label) : undefined}
+          title={t("Filter by this label")}
+        />
+      ))}
+      {isAdmin && (
+        <details className="relative">
+          <summary className="flex cursor-pointer list-none items-center rounded-full border border-dashed border-subtle px-2 py-0.5 text-11 text-secondary hover:text-primary">
+            {t("＋ Label")}
+          </summary>
+          <div className="absolute left-0 z-20 mt-1 max-h-64 w-56 overflow-auto rounded-md border border-subtle bg-surface-1 p-1 shadow-raised-200">
+            {allLabels.length === 0 ? (
+              <p className="px-2 py-1.5 text-11 text-secondary">
+                {t("No labels yet. Create one from “Manage labels”.")}
+              </p>
+            ) : (
+              allLabels.map((label) => {
+                const attached = labelHasTarget(label, targetType, targetKey);
+                return (
+                  <button
+                    key={label.id}
+                    type="button"
+                    onClick={() => toggle(label)}
+                    disabled={busyId === label.id}
+                    className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-12 text-primary hover:bg-layer-2 disabled:opacity-60"
+                  >
+                    <span
+                      className="flex size-3.5 shrink-0 items-center justify-center rounded-sm border border-subtle text-10 text-on-color"
+                      style={{ backgroundColor: attached ? label.color : "transparent" }}
+                    >
+                      {attached ? "✓" : ""}
+                    </span>
+                    <span className="size-2 shrink-0 rounded-full" style={{ backgroundColor: label.color }} />
+                    <span className="flex-1 truncate">{label.name}</span>
+                  </button>
+                );
+              })
+            )}
+          </div>
+        </details>
+      )}
+    </div>
+  );
+}
+
+type BarProps = {
+  slug: string;
+  labels: IPromptLabel[];
+  activeLabelId: string | null;
+  isAdmin: boolean;
+  onSelect: (labelId: string | null) => void;
+  onChanged: () => Promise<unknown>;
+};
+
+/**
+ * Top-of-page label bar: every workspace label as a clickable filter chip, a
+ * "clear filter" control, and (for admins) a "Manage labels" button that opens
+ * the create/rename/recolor/delete modal.
+ */
+export function PromptLabelBar({ slug, labels, activeLabelId, isAdmin, onSelect, onChanged }: BarProps) {
+  const { t } = useTranslation();
+  const [managing, setManaging] = useState(false);
+  const activeLabel = labels.find((l) => l.id === activeLabelId) ?? null;
+  const activeCounts = activeLabel ? labelTargetCounts(activeLabel) : null;
+
+  return (
+    <div className="flex flex-col gap-2 rounded-md border border-subtle bg-layer-1 px-4 py-3">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-11 font-medium text-secondary">{t("Labels")}</span>
+        {isAdmin && (
+          <Button size="sm" variant="outline-primary" onClick={() => setManaging(true)}>
+            {t("Manage labels")}
+          </Button>
+        )}
+      </div>
+      {labels.length === 0 ? (
+        <p className="text-11 text-secondary">
+          {isAdmin
+            ? t("No labels yet. Create labels to tag sections and receipts, then click a label to filter.")
+            : t("No labels yet.")}
+        </p>
+      ) : (
+        <div className="flex flex-wrap items-center gap-1.5">
+          {labels.map((label) => (
+            <PromptLabelChip
+              key={label.id}
+              label={label}
+              active={activeLabelId === label.id}
+              onClick={() => onSelect(activeLabelId === label.id ? null : label.id)}
+              title={t("Filter by this label")}
+            />
+          ))}
+          {activeLabel && (
+            <button
+              type="button"
+              onClick={() => onSelect(null)}
+              className="ml-1 rounded-full border border-subtle px-2 py-0.5 text-11 text-secondary hover:text-primary"
+            >
+              {t("Clear filter")}
+            </button>
+          )}
+        </div>
+      )}
+      {activeLabel && activeCounts && (
+        <p className="text-11 text-secondary">
+          {t("Showing items labelled “{{name}}” — {{sections}} sections, {{receipts}} receipts.", {
+            name: activeLabel.name,
+            sections: activeCounts.sections,
+            receipts: activeCounts.receipts,
+          })}
+        </p>
+      )}
+      {isAdmin && (
+        <PromptLabelManagerModal
+          slug={slug}
+          labels={labels}
+          isOpen={managing}
+          onClose={() => setManaging(false)}
+          onChanged={onChanged}
+        />
+      )}
+    </div>
+  );
+}
+
+type ManagerProps = {
+  slug: string;
+  labels: IPromptLabel[];
+  isOpen: boolean;
+  onClose: () => void;
+  onChanged: () => Promise<unknown>;
+};
+
+function PromptLabelManagerModal({ slug, labels, isOpen, onClose, onChanged }: ManagerProps) {
+  const { t } = useTranslation();
+  const promptLabelStore = usePromptLabel();
+
+  const [newName, setNewName] = useState("");
+  const [newColor, setNewColor] = useState(DEFAULT_NEW_LABEL_COLOR);
+  const [creating, setCreating] = useState(false);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  async function handleCreate() {
+    const name = newName.trim();
+    if (!name || creating) return;
+    setCreating(true);
+    try {
+      await promptLabelStore.createLabel(slug, { name, color: newColor });
+      await onChanged();
+      setNewName("");
+      setNewColor(DEFAULT_NEW_LABEL_COLOR);
+      setToast({ type: TOAST_TYPE.SUCCESS, title: t("Label created") });
+    } catch (e: unknown) {
+      setToast({
+        type: TOAST_TYPE.ERROR,
+        title: t("Something went wrong"),
+        message: labelError(e, t("Could not create the label.")),
+      });
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function handleRename(label: IPromptLabel, name: string) {
+    const next = name.trim();
+    if (!next || next === label.name || busyId) return;
+    setBusyId(label.id);
+    try {
+      await promptLabelStore.updateLabel(slug, label.id, { name: next });
+      await onChanged();
+    } catch (e: unknown) {
+      setToast({
+        type: TOAST_TYPE.ERROR,
+        title: t("Something went wrong"),
+        message: labelError(e, t("Could not rename the label.")),
+      });
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function handleRecolor(label: IPromptLabel, color: string) {
+    if (busyId) return;
+    setBusyId(label.id);
+    try {
+      await promptLabelStore.updateLabel(slug, label.id, { color });
+      await onChanged();
+    } catch (e: unknown) {
+      setToast({
+        type: TOAST_TYPE.ERROR,
+        title: t("Something went wrong"),
+        message: labelError(e, t("Could not recolor the label.")),
+      });
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function handleDelete(label: IPromptLabel) {
+    if (busyId) return;
+    setBusyId(label.id);
+    try {
+      await promptLabelStore.deleteLabel(slug, label.id);
+      await onChanged();
+    } catch (e: unknown) {
+      setToast({
+        type: TOAST_TYPE.ERROR,
+        title: t("Something went wrong"),
+        message: labelError(e, t("Could not delete the label.")),
+      });
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  return (
+    <ModalCore isOpen={isOpen} handleClose={onClose} position={EModalPosition.CENTER} width={EModalWidth.XL}>
+      <div className="flex flex-col gap-4 p-5">
+        <div className="flex items-center justify-between">
+          <h2 className="text-14 font-semibold text-primary">{t("Manage labels")}</h2>
+          <button type="button" onClick={onClose} className="text-13 text-secondary hover:text-primary">
+            {t("Close")}
+          </button>
+        </div>
+
+        <div className="flex items-end gap-2 rounded-md border border-subtle bg-layer-1 p-3">
+          <div className="flex flex-1 flex-col gap-1">
+            <label className="text-11 font-medium text-secondary">{t("New label")}</label>
+            <input
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleCreate();
+              }}
+              placeholder={t("Label name")}
+              maxLength={64}
+              className="rounded-md border border-subtle bg-surface-1 px-3 py-1.5 text-12 text-primary focus:border-accent-strong focus:outline-none"
+            />
+          </div>
+          <div className="flex flex-col items-center gap-1">
+            <span className="text-11 text-secondary">{t("Color")}</span>
+            <ColorPicker value={newColor} onChange={setNewColor} />
+          </div>
+          <Button size="sm" onClick={handleCreate} loading={creating} disabled={!newName.trim() || creating}>
+            {t("Create")}
+          </Button>
+        </div>
+
+        <div className="flex max-h-[50vh] flex-col gap-1 overflow-auto">
+          {labels.length === 0 ? (
+            <p className="px-1 py-2 text-12 text-secondary">{t("No labels yet.")}</p>
+          ) : (
+            labels.map((label) => {
+              const counts = labelTargetCounts(label);
+              return (
+                <div
+                  key={label.id}
+                  className="flex items-center gap-2 rounded-md border border-subtle bg-layer-1 px-3 py-2"
+                >
+                  <ColorPicker value={label.color} onChange={(c) => handleRecolor(label, c)} />
+                  <input
+                    defaultValue={label.name}
+                    maxLength={64}
+                    onBlur={(e) => handleRename(label, e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") (e.target as HTMLInputElement).blur();
+                    }}
+                    className="flex-1 rounded-md border border-transparent bg-transparent px-2 py-1 text-12 text-primary hover:border-subtle focus:border-accent-strong focus:outline-none"
+                  />
+                  <span className="text-10 text-placeholder">
+                    {t("{{sections}} sec · {{receipts}} rec", { sections: counts.sections, receipts: counts.receipts })}
+                  </span>
+                  <Button
+                    size="sm"
+                    variant="tertiary-danger"
+                    onClick={() => handleDelete(label)}
+                    disabled={busyId === label.id}
+                  >
+                    {t("Delete")}
+                  </Button>
+                </div>
+              );
+            })
+          )}
+        </div>
+      </div>
+    </ModalCore>
+  );
+}

--- a/apps/web/core/hooks/store/use-prompt-label.ts
+++ b/apps/web/core/hooks/store/use-prompt-label.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useContext } from "react";
+// mobx store
+import { StoreContext } from "@/lib/store-context";
+// types
+import type { IPromptLabelStore } from "@/store/prompt-label.store";
+
+export const usePromptLabel = (): IPromptLabelStore => {
+  const context = useContext(StoreContext);
+  if (context === undefined) throw new Error("usePromptLabel must be used within StoreProvider");
+  return context.promptLabel;
+};

--- a/apps/web/core/store/prompt-label.store.ts
+++ b/apps/web/core/store/prompt-label.store.ts
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+// pi dash imports
+import type {
+  IPromptLabel,
+  IPromptLabelAssignmentPayload,
+  IPromptLabelCreatePayload,
+  IPromptLabelListResponse,
+  IPromptLabelUpdatePayload,
+} from "@pi-dash/types";
+import { PromptLabelService } from "@pi-dash/services";
+// store
+import type { CoreRootStore } from "./root.store";
+
+export interface IPromptLabelStore {
+  // actions
+  fetchLabels: (workspaceSlug: string) => Promise<IPromptLabelListResponse>;
+  createLabel: (workspaceSlug: string, payload: IPromptLabelCreatePayload) => Promise<IPromptLabel>;
+  updateLabel: (workspaceSlug: string, labelId: string, payload: IPromptLabelUpdatePayload) => Promise<IPromptLabel>;
+  deleteLabel: (workspaceSlug: string, labelId: string) => Promise<void>;
+  attachLabel: (
+    workspaceSlug: string,
+    labelId: string,
+    payload: IPromptLabelAssignmentPayload
+  ) => Promise<IPromptLabel>;
+  detachLabel: (workspaceSlug: string, labelId: string, payload: IPromptLabelAssignmentPayload) => Promise<void>;
+}
+
+/**
+ * Thin store over the prompt-label REST surface. Mirrors {@link
+ * PromptSectionStore}: the prompts page caches the label list with SWR and
+ * drives its own state, so this store holds no observable state; the mutating
+ * actions return the server row for optimistic UI / toast threading.
+ */
+export class PromptLabelStore implements IPromptLabelStore {
+  rootStore: CoreRootStore;
+  promptLabelService: PromptLabelService;
+
+  constructor(_rootStore: CoreRootStore) {
+    this.rootStore = _rootStore;
+    this.promptLabelService = new PromptLabelService();
+  }
+
+  fetchLabels = async (workspaceSlug: string): Promise<IPromptLabelListResponse> =>
+    this.promptLabelService.list(workspaceSlug);
+
+  createLabel = async (workspaceSlug: string, payload: IPromptLabelCreatePayload): Promise<IPromptLabel> =>
+    this.promptLabelService.create(workspaceSlug, payload);
+
+  updateLabel = async (
+    workspaceSlug: string,
+    labelId: string,
+    payload: IPromptLabelUpdatePayload
+  ): Promise<IPromptLabel> => this.promptLabelService.update(workspaceSlug, labelId, payload);
+
+  deleteLabel = async (workspaceSlug: string, labelId: string): Promise<void> =>
+    this.promptLabelService.remove(workspaceSlug, labelId);
+
+  attachLabel = async (
+    workspaceSlug: string,
+    labelId: string,
+    payload: IPromptLabelAssignmentPayload
+  ): Promise<IPromptLabel> => this.promptLabelService.attach(workspaceSlug, labelId, payload);
+
+  detachLabel = async (workspaceSlug: string, labelId: string, payload: IPromptLabelAssignmentPayload): Promise<void> =>
+    this.promptLabelService.detach(workspaceSlug, labelId, payload);
+}

--- a/apps/web/core/store/root.store.ts
+++ b/apps/web/core/store/root.store.ts
@@ -59,6 +59,8 @@ import type { IProjectRootStore } from "./project";
 import { ProjectRootStore } from "./project";
 import type { IProjectViewStore } from "./project-view.store";
 import { ProjectViewStore } from "./project-view.store";
+import type { IPromptLabelStore } from "./prompt-label.store";
+import { PromptLabelStore } from "./prompt-label.store";
 import type { IPromptSectionStore } from "./prompt-section.store";
 import { PromptSectionStore } from "./prompt-section.store";
 import type { IRouterStore } from "./router.store";
@@ -106,6 +108,7 @@ export class CoreRootStore {
   workItemFilters: IWorkItemFilterStore;
   powerK: IPowerKStore;
   promptSection: IPromptSectionStore;
+  promptLabel: IPromptLabelStore;
   scheduler: ISchedulerStore;
 
   constructor() {
@@ -139,6 +142,7 @@ export class CoreRootStore {
     this.workItemFilters = new WorkItemFilterStore();
     this.powerK = new PowerKStore();
     this.promptSection = new PromptSectionStore(this);
+    this.promptLabel = new PromptLabelStore(this);
     this.scheduler = new SchedulerStore(this);
   }
 
@@ -174,6 +178,7 @@ export class CoreRootStore {
     this.workItemFilters = new WorkItemFilterStore();
     this.powerK = new PowerKStore();
     this.promptSection = new PromptSectionStore(this);
+    this.promptLabel = new PromptLabelStore(this);
     this.scheduler = new SchedulerStore(this);
   }
 }

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -16,6 +16,7 @@ export * from "./intake";
 export * from "./module";
 export * from "./user";
 export * from "./project";
+export * from "./prompt-label";
 export * from "./prompt-section";
 export * from "./scheduler";
 export * from "./workspace";

--- a/packages/services/src/prompt-label/index.ts
+++ b/packages/services/src/prompt-label/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+export * from "./prompt-label.service";

--- a/packages/services/src/prompt-label/prompt-label.service.ts
+++ b/packages/services/src/prompt-label/prompt-label.service.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { API_BASE_URL } from "@pi-dash/constants";
+import type {
+  IPromptLabel,
+  IPromptLabelAssignmentPayload,
+  IPromptLabelCreatePayload,
+  IPromptLabelListResponse,
+  IPromptLabelUpdatePayload,
+} from "@pi-dash/types";
+import { APIService } from "../api.service";
+
+/**
+ * Workspace-scoped prompt **label** management (PDASHOSS01-71).
+ *
+ * Backed by the Django REST endpoints under ``/api/workspaces/<slug>/``:
+ * ``prompt-labels`` (list + create), ``prompt-labels/<id>`` (update/delete),
+ * and ``prompt-labels/<id>/assignments`` (attach/detach to a section/receipt).
+ * Reads are any active member; writes are admin-gated on the server.
+ */
+export class PromptLabelService extends APIService {
+  constructor(BASE_URL?: string) {
+    super(BASE_URL || API_BASE_URL);
+  }
+
+  async list(workspaceSlug: string): Promise<IPromptLabelListResponse> {
+    return this.get(`/api/workspaces/${workspaceSlug}/prompt-labels`)
+      .then((res) => res?.data)
+      .catch((err) => {
+        throw err?.response?.data;
+      });
+  }
+
+  async create(workspaceSlug: string, payload: IPromptLabelCreatePayload): Promise<IPromptLabel> {
+    return this.post(`/api/workspaces/${workspaceSlug}/prompt-labels`, payload)
+      .then((res) => res?.data)
+      .catch((err) => {
+        throw err?.response?.data;
+      });
+  }
+
+  async update(workspaceSlug: string, labelId: string, payload: IPromptLabelUpdatePayload): Promise<IPromptLabel> {
+    return this.patch(`/api/workspaces/${workspaceSlug}/prompt-labels/${labelId}`, payload)
+      .then((res) => res?.data)
+      .catch((err) => {
+        throw err?.response?.data;
+      });
+  }
+
+  async remove(workspaceSlug: string, labelId: string): Promise<void> {
+    return this.delete(`/api/workspaces/${workspaceSlug}/prompt-labels/${labelId}`)
+      .then((res) => res?.data)
+      .catch((err) => {
+        throw err?.response?.data;
+      });
+  }
+
+  async attach(workspaceSlug: string, labelId: string, payload: IPromptLabelAssignmentPayload): Promise<IPromptLabel> {
+    return this.post(`/api/workspaces/${workspaceSlug}/prompt-labels/${labelId}/assignments`, payload)
+      .then((res) => res?.data)
+      .catch((err) => {
+        throw err?.response?.data;
+      });
+  }
+
+  async detach(workspaceSlug: string, labelId: string, payload: IPromptLabelAssignmentPayload): Promise<void> {
+    return this.delete(
+      `/api/workspaces/${workspaceSlug}/prompt-labels/${labelId}/assignments` +
+        `?target_type=${encodeURIComponent(payload.target_type)}&target_key=${encodeURIComponent(payload.target_key)}`
+    )
+      .then((res) => res?.data)
+      .catch((err) => {
+        throw err?.response?.data;
+      });
+  }
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -39,6 +39,7 @@ export * from "./page";
 export * from "./payment";
 export * from "./pragmatic";
 export * from "./project";
+export * from "./prompt-label";
 export * from "./prompt-section";
 export * from "./publish";
 export * from "./reaction";

--- a/packages/types/src/prompt-label.ts
+++ b/packages/types/src/prompt-label.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+/** What a prompt label can be attached to: a section (by `section_key`) or a receipt (by prompt `kind`). */
+export type TPromptLabelTargetType = "section" | "receipt";
+
+/** One attachment of a label to a section/receipt target. */
+export interface IPromptLabelTarget {
+  id: string;
+  target_type: TPromptLabelTargetType;
+  target_key: string;
+  created_at: string;
+}
+
+/**
+ * A workspace-scoped, user-managed prompt label plus its section/receipt
+ * attachments. `targets` lets the client build both the per-target chip map
+ * (target → labels) and the click-to-filter map (label → targets).
+ */
+export interface IPromptLabel {
+  id: string;
+  workspace: string;
+  name: string;
+  color: string;
+  targets: IPromptLabelTarget[];
+  created_by: string | null;
+  updated_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface IPromptLabelListResponse {
+  labels: IPromptLabel[];
+}
+
+export interface IPromptLabelCreatePayload {
+  name: string;
+  color?: string;
+}
+
+export interface IPromptLabelUpdatePayload {
+  name?: string;
+  color?: string;
+}
+
+export interface IPromptLabelAssignmentPayload {
+  target_type: TPromptLabelTargetType;
+  target_key: string;
+}


### PR DESCRIPTION
## What

Adds workspace-scoped, user-managed **labels** for prompt **sections** and **receipts** (issue PDASHOSS01-71). A label can be attached to many sections/receipts and a section/receipt can carry many labels (n:n). Labels render as clickable chips; clicking one filters the prompts page down to everything carrying it.

## Design decisions (defaults — see issue thread)

The issue had no acceptance criteria and the design clarification went unanswered across several ticks (runner auth failures), so this proceeds with the documented, reversible defaults:

- **Workspace-scoped, shared** labels (mirrors `PromptSectionOverride` scoping).
- **Admin-managed** writes (create/edit/delete + attach/detach); reads for any member — mirrors how section overrides are admin-gated.
- A **dedicated `PromptLabel` model**, kept separate from the issue `Label` (which is project/issue-coupled and hierarchical).
- Assignments key off the **code-defined `section_key` / receipt `kind`** strings, because sections (`prompting/registry.py`) and receipts (`recipes.py`) are not DB rows.
- Clicking a chip **filters the current prompts tab in place**.

## Backend (`apps/api/pi_dash/prompting/`)

- `PromptLabel` + `PromptLabelAssignment` models + migration `0005_prompt_label.py`.
- REST under `/api/workspaces/<slug>/prompt-labels`: `GET` list (member-readable; each label includes its nested `targets`), `POST` create, `PATCH`/`DELETE` `<label_id>`, and `POST`/`DELETE` `<label_id>/assignments` (attach/detach). Writes admin-gated via the existing `_is_workspace_admin` helper; attach targets validated against the registry/recipes.
- Contract tests: CRUD, attach/detach, idempotency, invalid-target validation, admin/member/outsider permissions, workspace scoping.

## Frontend (`apps/web`)

- `prompt-label` types, service, thin MobX store (mirrors `prompt-section`), hook, root-store wiring.
- Label chips on section/receipt cards, an admin attach/detach menu, a manage-labels modal (create/rename/recolor/delete with `ColorPicker`), and a top-of-page label bar whose chips filter the current tab.

## Validation

- Frontend: `check:types` clean for my code (one pre-existing, unrelated failure in `apps/web/tests/runners/runner-runs-page.test.tsx` re `IAgentRunPage`, identical to `main`); oxlint 0/0; oxfmt clean.
- Backend: `ruff` clean; `py_compile` OK. **pytest was not runnable in the authoring environment** (the API dependency tree isn't installed there); the contract tests run under `--nomigrations` in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
