### PR TITLE
PDASHOSS01-76 Show assigned pod in issue detail metadata

### DIFF
--- a/apps/web/core/components/issues/issue-detail/sidebar.tsx
+++ b/apps/web/core/components/issues/issue-detail/sidebar.tsx
@@ -22,11 +22,13 @@ import {
   ParentPropertyIcon,
 } from "@pi-dash/propel/icons";
 import { cn, getDate, renderFormattedPayloadDate, shouldHighlightIssueDueDate } from "@pi-dash/utils";
+import { Container } from "lucide-react";
 // components
 import { DateDropdown } from "@/components/dropdowns/date";
 import { EstimateDropdown } from "@/components/dropdowns/estimate";
 import { ButtonAvatars } from "@/components/dropdowns/member/avatar";
 import { MemberDropdown } from "@/components/dropdowns/member/dropdown";
+import { PodDropdown } from "@/components/dropdowns/pod/dropdown";
 import { PriorityDropdown } from "@/components/dropdowns/priority";
 import { StateDropdown } from "@/components/dropdowns/state/dropdown";
 // hooks
@@ -129,6 +131,21 @@ export const IssueDetailsSidebar = observer(function IssueDetailsSidebar(props: 
                 buttonContainerClassName="w-full text-left h-7.5"
                 buttonClassName={`text-body-xs-regular justify-between ${issue?.assignee_ids?.length > 0 ? "" : "text-placeholder"}`}
                 hideIcon={issue.assignee_ids?.length === 0}
+                dropdownArrow
+                dropdownArrowClassName="h-3.5 w-3.5 hidden group-hover:inline"
+              />
+            </SidebarPropertyListItem>
+
+            <SidebarPropertyListItem icon={Container} label={t("Pod")}>
+              <PodDropdown
+                value={issue?.assigned_pod_id}
+                onChange={(val) => issueOperations.update(workspaceSlug, projectId, issueId, { assigned_pod_id: val })}
+                disabled={!isEditable}
+                projectId={projectId?.toString() ?? ""}
+                buttonVariant="transparent-with-text"
+                className="group w-full grow"
+                buttonContainerClassName="w-full text-left h-7.5"
+                buttonClassName={`text-body-xs-regular ${issue?.assigned_pod_id ? "" : "text-placeholder"}`}
                 dropdownArrow
                 dropdownArrowClassName="h-3.5 w-3.5 hidden group-hover:inline"
               />

--- a/apps/web/core/components/issues/peek-overview/properties.tsx
+++ b/apps/web/core/components/issues/peek-overview/properties.tsx
@@ -22,11 +22,13 @@ import {
   ParentPropertyIcon,
 } from "@pi-dash/propel/icons";
 import { cn, getDate, renderFormattedPayloadDate, shouldHighlightIssueDueDate } from "@pi-dash/utils";
+import { Container } from "lucide-react";
 // components
 import { DateDropdown } from "@/components/dropdowns/date";
 import { EstimateDropdown } from "@/components/dropdowns/estimate";
 import { ButtonAvatars } from "@/components/dropdowns/member/avatar";
 import { MemberDropdown } from "@/components/dropdowns/member/dropdown";
+import { PodDropdown } from "@/components/dropdowns/pod/dropdown";
 import { PriorityDropdown } from "@/components/dropdowns/priority";
 import { StateDropdown } from "@/components/dropdowns/state/dropdown";
 import { SidebarPropertyListItem } from "@/components/common/layout/sidebar/property-list-item";
@@ -116,6 +118,21 @@ export const PeekOverviewProperties = observer(function PeekOverviewProperties(p
             />
           </SidebarPropertyListItem>
 
+          <SidebarPropertyListItem icon={Container} label={t("Pod")}>
+            <PodDropdown
+              value={issue?.assigned_pod_id}
+              onChange={(val) => issueOperations.update(workspaceSlug, projectId, issueId, { assigned_pod_id: val })}
+              disabled={disabled}
+              projectId={projectId}
+              buttonVariant="transparent-with-text"
+              className="group w-full grow"
+              buttonContainerClassName="w-full text-left h-7.5"
+              buttonClassName={`text-body-xs-medium ${issue?.assigned_pod_id ? "" : "text-placeholder"}`}
+              dropdownArrow
+              dropdownArrowClassName="h-3.5 w-3.5 hidden group-hover:inline"
+            />
+          </SidebarPropertyListItem>
+
           <SidebarPropertyListItem icon={PriorityPropertyIcon} label={t("Priority")}>
             <PriorityDropdown
               value={issue?.priority}
@@ -129,11 +146,7 @@ export const PeekOverviewProperties = observer(function PeekOverviewProperties(p
           </SidebarPropertyListItem>
 
           {createdByDetails && (
-            <SidebarPropertyListItem
-              icon={UserCirclePropertyIcon}
-              label={t("Created by")}
-              childrenClassName="px-2"
-            >
+            <SidebarPropertyListItem icon={UserCirclePropertyIcon} label={t("Created by")} childrenClassName="px-2">
               <ButtonAvatars
                 showTooltip
                 userIds={createdByDetails?.display_name.includes("-intake") ? null : createdByDetails?.id}


### PR DESCRIPTION
## What

Adds the issue's assigned **Pod** to the issue detail metadata, alongside State, Assignees, and Priority.

## Where

- `apps/web/core/components/issues/issue-detail/sidebar.tsx` — full detail page sidebar
- `apps/web/core/components/issues/peek-overview/properties.tsx` — peek slide-over properties

Both surfaces get a new `SidebarPropertyListItem` ("Pod") placed between Assignees and Priority — mirroring the create-modal ordering (State → Pod → Priority). It reuses the existing editable `PodDropdown` (which self-fetches the project's pods) bound to `issue.assigned_pod_id`, and the lucide `Container` icon already used by the pod dropdown.

## Validation

- `pnpm --filter=web check:types` — no new errors from these files. (The only failure is a pre-existing, unrelated error in `tests/runners/runner-runs-page.test.tsx`, confirmed present on a clean base.)
- `oxlint` + `oxfmt --check` clean on both changed files.

Resolves PDASHOSS01-76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
