### PR TITLE
PDASHOSS01-78 Update "in progress" ticking cadence to 12 hours

### DIFF
--- a/apps/api/pi_dash/db/migrations/0156_increase_in_progress_interval.py
+++ b/apps/api/pi_dash/db/migrations/0156_increase_in_progress_interval.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Increase the default In Progress ticking cadence from 3 h to 12 h.
+
+Per PDASHOSS01-78 the In Progress phase re-invokes the agent too often at
+the 3 h interval; the cadence is lengthened to 12 h (43200 s) so periodic
+runs are spaced further apart. Only the In Progress phase changes — the
+In Review cadence (``agent_review_default_interval_seconds``) is untouched.
+
+Only the project-level default changes; per-issue
+``IssueAgentTicker.interval_seconds`` overrides are untouched. Following
+the same rationale as ``0155_reduce_review_max_ticks`` a data migration is
+intentionally *not* run: projects created before this change already
+materialized ``10800`` into their row, and silently rewriting an
+operator's stored value is more surprising than leaving it. New projects
+created after this migration get ``43200``.
+"""
+
+from __future__ import annotations
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("db", "0155_reduce_review_max_ticks"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="project",
+            name="agent_default_interval_seconds",
+            field=models.IntegerField(default=43200),
+        ),
+    ]

--- a/apps/api/pi_dash/db/models/project.py
+++ b/apps/api/pi_dash/db/models/project.py
@@ -147,7 +147,7 @@ class Project(BaseModel):
     # (review iterations are bounded shorter — see design §3.2).
     # ``agent_ticking_enabled`` gates the project globally; both
     # phases respect it.
-    agent_default_interval_seconds = models.IntegerField(default=10800)  # 3 h
+    agent_default_interval_seconds = models.IntegerField(default=43200)  # 12 h
     agent_default_max_ticks = models.IntegerField(default=24)            # 3 days
     agent_review_default_interval_seconds = models.IntegerField(default=10800)  # 3 h
     agent_review_default_max_ticks = models.IntegerField(default=4)             # 12 h window


### PR DESCRIPTION
## What

Lengthen the default periodic re-invocation ("ticking") cadence for the **In Progress** (started) phase from **3 hours to 12 hours**.

## How

- `Project.agent_default_interval_seconds` default raised `10800 → 43200` (the documented In Progress phase default; resolved through `IssueAgentTicker.effective_interval_seconds()`).
- New migration `0156_increase_in_progress_interval` performs an `AlterField` only — **no data migration**, mirroring the precedent in `0155_reduce_review_max_ticks`. Existing operator-customized project rows keep their stored value; only new projects pick up 12h.
- The **In Review** cadence (`agent_review_default_interval_seconds`) is intentionally unchanged.
- Prompt prose updates automatically: `_humanize_interval(43200)` → `"12 hours"`.

## Validation

- Verified `_humanize_interval(43200)` renders `"12 hours"`.
- Confirmed migration `0156` is the sole child of the current head `0155`, with the `AlterField` default matching the model default 1:1.
- Note: the full Django test suite could not be executed in the runner environment (no usable virtualenv present in the checkout). Existing ticker/context tests set the interval explicitly in fixtures, so a default change does not alter their assertions.

Resolves PDASHOSS01-78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
