### PR TITLE
OPENHUB-45 Add folded comments concept to PiDash

### DIFF
--- a/apps/api/pi_dash/api/serializers/issue.py
+++ b/apps/api/pi_dash/api/serializers/issue.py
@@ -817,6 +817,7 @@ class IssueCommentCreateSerializer(BaseSerializer):
             "access",
             "external_source",
             "external_id",
+            "labels",
             "speaker_type",
             "speaker_label",
             "speaker_agent_run_id",

--- a/apps/api/pi_dash/assistant/tools/comments.py
+++ b/apps/api/pi_dash/assistant/tools/comments.py
@@ -19,8 +19,17 @@ from pi_dash.db.models import IssueComment
 
 
 @assistant.tool
-def create_comment(ctx: RunContext[AssistantDeps], issue_id: str, body_md: str) -> dict:
-    """Add a comment to an issue, attributed to you and marked 'via assistant'."""
+def create_comment(
+    ctx: RunContext[AssistantDeps],
+    issue_id: str,
+    body_md: str,
+    fold: bool = False,
+) -> dict:
+    """Add a comment to an issue.
+
+    Set ``fold`` for low-value status/noop updates that should stay available
+    to humans but remain collapsed and be omitted from future agent prompts.
+    """
     deps = ctx.deps
     issue = _scoping.get_issue(deps, issue_id)
 
@@ -50,6 +59,7 @@ def create_comment(ctx: RunContext[AssistantDeps], issue_id: str, body_md: str) 
             comment_html=html,
             comment_json={},
             comment_stripped=strip_tags(html),
+            labels=["fold"] if fold else [],
             speaker_type="agent",
             speaker_label="Pi Dash AI",
         )
@@ -63,4 +73,5 @@ def create_comment(ctx: RunContext[AssistantDeps], issue_id: str, body_md: str) 
         "created": True,
         "comment_id": str(comment.id),
         "issue_id": str(issue.id),
+        "folded": fold,
     }

--- a/apps/api/pi_dash/db/migrations/0156_issuecomment_labels.py
+++ b/apps/api/pi_dash/db/migrations/0156_issuecomment_labels.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+import django.contrib.postgres.fields
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("db", "0155_reduce_review_max_ticks"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="issuecomment",
+            name="labels",
+            field=django.contrib.postgres.fields.ArrayField(
+                base_field=models.CharField(max_length=32),
+                blank=True,
+                default=list,
+                size=8,
+            ),
+        ),
+    ]

--- a/apps/api/pi_dash/db/migrations/0157_merge_intervals_and_comment_labels.py
+++ b/apps/api/pi_dash/db/migrations/0157_merge_intervals_and_comment_labels.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Merge the three leaf migrations off 0155_reduce_review_max_ticks:
+In Progress interval 12 h (PDASHOSS01-78), In Review interval 8 h
+(PDASHOSS01-70), and issuecomment labels (OPENHUB-45).
+
+The three touch disjoint fields — two Project interval defaults and one
+IssueComment field — so no ordering matters between them; this migration
+only rejoins the graph into a single leaf so `migrate` runs."""
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("db", "0156_increase_in_progress_interval"),
+        ("db", "0156_review_interval_8h"),
+        ("db", "0156_issuecomment_labels"),
+    ]
+
+    operations = []

--- a/apps/api/pi_dash/db/models/issue.py
+++ b/apps/api/pi_dash/db/models/issue.py
@@ -534,6 +534,9 @@ class IssueComment(ChangeTrackerMixin, ProjectBaseModel):
         "db.Description", on_delete=models.CASCADE, related_name="issue_comment_description", null=True
     )
     attachments = ArrayField(models.URLField(), size=10, blank=True, default=list)
+    # Lightweight behavior markers for comments. ``fold`` is intentionally
+    # opt-in: Pi Dash never infers it from the comment body or speaker.
+    labels = ArrayField(models.CharField(max_length=32), size=8, blank=True, default=list)
     issue = models.ForeignKey(Issue, on_delete=models.CASCADE, related_name="issue_comments")
     # System can also create comment
     actor = models.ForeignKey(

--- a/apps/api/pi_dash/prompting/context.py
+++ b/apps/api/pi_dash/prompting/context.py
@@ -118,9 +118,10 @@ def _comment_author_label(comment) -> str:
 
 
 def _comments_section(issue: Issue) -> str:
-    """Render the issue's full comment thread as a numbered chronological log.
+    """Render the issue's unfolded comments as a numbered chronological log.
 
-    Includes both human-authored and agent-authored (bot) comments —
+    Includes both human-authored and agent-authored (bot) comments, except
+    comments explicitly labeled ``fold`` —
     a continuation run needs to see its own prior question alongside the
     human's reply so it can pick up the conversation. Each entry is
     formatted as ``### Comment N — <author> at <ISO timestamp>`` followed
@@ -130,6 +131,7 @@ def _comments_section(issue: Issue) -> str:
 
     comments = (
         IssueComment.objects.filter(issue=issue)
+        .exclude(labels__contains=["fold"])
         .select_related("actor")
         .order_by("created_at")
     )

--- a/apps/api/pi_dash/prompting/fragments/03_pidash_cli.md
+++ b/apps/api/pi_dash/prompting/fragments/03_pidash_cli.md
@@ -30,9 +30,11 @@ On success every command prints a single JSON document to stdout and exits `0`. 
 
 Comments are the human ↔ agent conversation channel. Use them to ask clarifying questions, post blocker notices, share PR links, and announce completion. **Comments are not for tracking your own progress — that's what the workpad is for.**
 
-- `pidash comment list <identifier>` — list comments on the issue. Each entry has `id` (UUID), `comment_html`, `comment_stripped`, `actor_detail`, `speaker_type`, `speaker_label`, `speaker_agent_run_id`, and timestamps. Read these in chronological order to pick up any human replies since your last run.
-- `pidash comment add <identifier> --body-file <path> --as-agent "<agent name>" --agent-run-id "{{ run.id }}"` — post a new comment from a file and mark it as spoken by this AI agent run. `--body <markdown>` works for one-liners. Prefer `--body-file` for anything multi-line — shell quoting of markdown is error-prone. When you post any issue comment during this run, always include `--as-agent` and `--agent-run-id`; use your actual runtime name if you know it (`Codex`, `Claude Code`, etc.), otherwise use `AI Agent`.
+- `pidash comment list <identifier>` — list comments on the issue. Each entry has `id` (UUID), `comment_html`, `comment_stripped`, `labels`, `actor_detail`, `speaker_type`, `speaker_label`, `speaker_agent_run_id`, and timestamps. Read these in chronological order to pick up any human replies since your last run.
+- `pidash comment add <identifier> --body-file <path> --as-agent "<agent name>" --agent-run-id "{{ run.id }}" [--fold]` — post a new comment from a file and mark it as spoken by this AI agent run. `--body <markdown>` works for one-liners. Prefer `--body-file` for anything multi-line — shell quoting of markdown is error-prone. When you post any issue comment during this run, always include `--as-agent` and `--agent-run-id`; use your actual runtime name if you know it (`Codex`, `Claude Code`, etc.), otherwise use `AI Agent`.
 - `pidash comment update <identifier> <comment-id> --body-file <path>` — edit a comment you own. Both the issue identifier and the comment UUID are required. Rarely needed — prefer posting a fresh comment for new information.
+
+Use `--fold` only for low-value status/noop updates that should remain available to humans without cluttering the thread. Folded comments are collapsed by default in the UI and omitted from future agent-run task prompts, though `pidash comment list` still returns them. Pi Dash never folds comments automatically. Do not fold questions, blockers, decisions, results, or other context a future run needs.
 
 #### Workpad
 

--- a/apps/api/pi_dash/prompting/sections/pidash-cli.md
+++ b/apps/api/pi_dash/prompting/sections/pidash-cli.md
@@ -36,9 +36,11 @@ On success every command prints a single JSON document to stdout and exits `0`. 
 
 Comments are the human ↔ agent conversation channel. Use them to ask clarifying questions, post blocker notices, share PR links, and announce completion. **Comments are not for tracking your own progress — that's what the workpad is for.**
 
-- `pidash comment list <identifier>` — list comments on the issue. Each entry has `id` (UUID), `comment_html`, `comment_stripped`, `actor_detail`, `speaker_type`, `speaker_label`, `speaker_agent_run_id`, and timestamps. Read these in chronological order to pick up any human replies since your last run.
-- `pidash comment add <identifier> --body-file <path> --as-agent "<agent name>" --agent-run-id "{{ run.id }}"` — post a new comment from a file and mark it as spoken by this AI agent run. `--body <markdown>` works for one-liners. Prefer `--body-file` for anything multi-line — shell quoting of markdown is error-prone. When you post any issue comment during this run, always include `--as-agent` and `--agent-run-id`; use your actual runtime name if you know it (`Codex`, `Claude Code`, etc.), otherwise use `AI Agent`.
+- `pidash comment list <identifier>` — list comments on the issue. Each entry has `id` (UUID), `comment_html`, `comment_stripped`, `labels`, `actor_detail`, `speaker_type`, `speaker_label`, `speaker_agent_run_id`, and timestamps. Read these in chronological order to pick up any human replies since your last run.
+- `pidash comment add <identifier> --body-file <path> --as-agent "<agent name>" --agent-run-id "{{ run.id }}" [--fold]` — post a new comment from a file and mark it as spoken by this AI agent run. `--body <markdown>` works for one-liners. Prefer `--body-file` for anything multi-line — shell quoting of markdown is error-prone. When you post any issue comment during this run, always include `--as-agent` and `--agent-run-id`; use your actual runtime name if you know it (`Codex`, `Claude Code`, etc.), otherwise use `AI Agent`.
 - `pidash comment update <identifier> <comment-id> --body-file <path>` — edit a comment you own. Both the issue identifier and the comment UUID are required. Rarely needed — prefer posting a fresh comment for new information.
+
+Use `--fold` only for low-value status/noop updates that should remain available to humans without cluttering the thread. Folded comments are collapsed by default in the UI and omitted from future agent-run task prompts, though `pidash comment list` still returns them. Pi Dash never folds comments automatically. Do not fold questions, blockers, decisions, results, or other context a future run needs.
 
 {% if run.kind != "scheduler" %}#### Workpad
 

--- a/apps/api/pi_dash/tests/contract/assistant/test_tools.py
+++ b/apps/api/pi_dash/tests/contract/assistant/test_tools.py
@@ -89,6 +89,21 @@ def test_create_comment_attribution(world, member_ctx):
     assert comment.speaker_type == "agent"
     assert comment.speaker_label == "Pi Dash AI"
     assert comment.actor_id == world.member.id
+    assert comment.labels == []
+
+
+def test_create_comment_can_be_folded(world, member_ctx):
+    ctx, *_ = member_ctx
+    res = comments.create_comment(
+        ctx,
+        issue_id=str(world.issue_a.id),
+        body_md="No change from the last tick.",
+        fold=True,
+    )
+
+    assert res["folded"] is True
+    comment = IssueComment.objects.get(id=res["comment_id"])
+    assert comment.labels == ["fold"]
 
 
 def test_guest_comment_only_on_own_issue(world, guest_ctx):

--- a/apps/api/pi_dash/tests/unit/prompting/test_context.py
+++ b/apps/api/pi_dash/tests/unit/prompting/test_context.py
@@ -9,6 +9,7 @@ from pi_dash.db.models import (
     GitRepository,
     GitRepositoryBinding,
     Issue,
+    IssueComment,
     Project,
     State,
 )
@@ -75,6 +76,29 @@ def test_context_shape(issue, run):
     assert ctx["repo"]["work_branch"] is None
     assert ctx["run"]["attempt"] == 1
     assert ctx["run"]["turn_number"] == 1
+
+
+@pytest.mark.unit
+def test_context_excludes_folded_comments(issue, run, workspace, project, create_user):
+    IssueComment.objects.create(
+        issue=issue,
+        workspace=workspace,
+        project=project,
+        actor=create_user,
+        comment_html="<p>Substantive update</p>",
+    )
+    IssueComment.objects.create(
+        issue=issue,
+        workspace=workspace,
+        project=project,
+        actor=create_user,
+        comment_html="<p>No change from the last tick</p>",
+        labels=["fold"],
+    )
+
+    comments_section = build_context(issue, run)["comments_section"]
+    assert "Substantive update" in comments_section
+    assert "No change from the last tick" not in comments_section
 
 
 @pytest.mark.unit

--- a/apps/api/pi_dash/tests/unit/prompting/test_registry.py
+++ b/apps/api/pi_dash/tests/unit/prompting/test_registry.py
@@ -39,6 +39,14 @@ def test_locked_and_overridable_classification():
 
 
 @pytest.mark.unit
+def test_pidash_cli_documents_folded_comments():
+    body = registry.get_section("pidash-cli").default_body
+    assert "--fold" in body
+    assert "omitted from future agent-run task prompts" in body
+    assert "never folds comments automatically" in body
+
+
+@pytest.mark.unit
 def test_customizable_tier_capabilities():
     """The three tiers map to (workspace-override, personal-override) capability."""
     locked = registry.PromptSection("k", "T", registry.CUSTOMIZABLE_LOCKED, "b\n")

--- a/apps/api/pi_dash/tests/unit/serializers/test_issue_comment_labels.py
+++ b/apps/api/pi_dash/tests/unit/serializers/test_issue_comment_labels.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+import pytest
+
+from pi_dash.api.serializers.issue import IssueCommentCreateSerializer
+
+
+@pytest.mark.unit
+def test_comment_create_serializer_accepts_fold_label():
+    serializer = IssueCommentCreateSerializer(
+        data={"comment_html": "<p>No change</p>", "labels": ["fold"]}
+    )
+
+    assert serializer.is_valid(), serializer.errors
+    assert serializer.validated_data["labels"] == ["fold"]

--- a/apps/api/pi_dash/utils/openapi/examples.py
+++ b/apps/api/pi_dash/utils/openapi/examples.py
@@ -188,6 +188,7 @@ ISSUE_COMMENT_CREATE_EXAMPLE = OpenApiExample(
     "IssueCommentCreateSerializer",
     value={
         "comment_html": "<p>New comment content</p>",
+        "labels": [],
         "external_id": "1234567890",
         "external_source": "github",
     },
@@ -198,6 +199,7 @@ ISSUE_COMMENT_UPDATE_EXAMPLE = OpenApiExample(
     "IssueCommentCreateSerializer",
     value={
         "comment_html": "<p>Updated comment content</p>",
+        "labels": ["fold"],
         "external_id": "1234567890",
         "external_source": "github",
     },
@@ -504,6 +506,7 @@ ISSUE_COMMENT_EXAMPLE = OpenApiExample(
     value={
         "id": "550e8400-e29b-41d4-a716-446655440000",
         "comment_html": "<p>This issue has been resolved by implementing OAuth 2.0 flow.</p>",  # noqa: E501
+        "labels": [],
         "comment_json": {
             "type": "doc",
             "content": [

--- a/apps/space/components/issues/peek-overview/comment/comment-detail-card.tsx
+++ b/apps/space/components/issues/peek-overview/comment/comment-detail-card.tsx
@@ -40,6 +40,7 @@ export const CommentCard = observer(function CommentCard(props: Props) {
 
   // states
   const [isEditing, setIsEditing] = useState(false);
+  const [isFoldExpanded, setIsFoldExpanded] = useState(false);
   // refs
   const editorRef = useRef<EditorRefApi>(null);
   const showEditorRef = useRef<EditorRefApi>(null);
@@ -65,6 +66,8 @@ export const CommentCard = observer(function CommentCard(props: Props) {
     showEditorRef.current?.setEditorValue(formData.comment_html);
   };
   const agentSpeakerLabel = comment.speaker_type === "agent" ? comment.speaker_label?.trim() || "AI Agent" : undefined;
+  const isFolded = comment.labels?.includes("fold") ?? false;
+  const showCommentContent = !isFolded || isFoldExpanded;
 
   return (
     <div className="relative flex items-start space-x-3">
@@ -153,23 +156,37 @@ export const CommentCard = observer(function CommentCard(props: Props) {
             </div>
           </form>
           <div className={`${isEditing ? "hidden" : ""}`}>
-            {agentSpeakerLabel ? (
-              <div className="px-3 pt-1 text-12 text-primary">
-                <span className="font-medium">{agentSpeakerLabel}:</span>
-              </div>
+            {isFolded ? (
+              <button
+                type="button"
+                className="w-full rounded-md border border-subtle bg-layer-1 px-3 py-2 text-left text-11 text-secondary hover:bg-layer-2"
+                aria-expanded={isFoldExpanded}
+                onClick={() => setIsFoldExpanded((expanded) => !expanded)}
+              >
+                Folded comment · Click to {isFoldExpanded ? "collapse" : "expand"}
+              </button>
             ) : null}
-            <LiteTextEditor
-              editable={false}
-              anchor={anchor}
-              workspaceId={workspaceID?.toString() ?? ""}
-              ref={showEditorRef}
-              id={comment.id}
-              initialValue={comment.comment_html}
-              displayConfig={{
-                fontSize: "small-font",
-              }}
-            />
-            <CommentReactions anchor={anchor} commentId={comment.id} />
+            {showCommentContent ? (
+              <>
+                {agentSpeakerLabel ? (
+                  <div className="px-3 pt-1 text-12 text-primary">
+                    <span className="font-medium">{agentSpeakerLabel}:</span>
+                  </div>
+                ) : null}
+                <LiteTextEditor
+                  editable={false}
+                  anchor={anchor}
+                  workspaceId={workspaceID?.toString() ?? ""}
+                  ref={showEditorRef}
+                  id={comment.id}
+                  initialValue={comment.comment_html}
+                  displayConfig={{
+                    fontSize: "small-font",
+                  }}
+                />
+                <CommentReactions anchor={anchor} commentId={comment.id} />
+              </>
+            ) : null}
           </div>
         </div>
       </div>

--- a/apps/web/core/components/comments/card/display.tsx
+++ b/apps/web/core/components/comments/card/display.tsx
@@ -59,6 +59,7 @@ export const CommentCardDisplay = observer(function CommentCardDisplay(props: TC
   const [highlightClassName, setHighlightClassName] = useState("");
   // state
   const [isPickerOpen, setIsPickerOpen] = useState(false);
+  const [isFoldExpanded, setIsFoldExpanded] = useState(false);
   // store hooks
   const { getUserDetails } = useMember();
   // derived values
@@ -68,6 +69,8 @@ export const CommentCardDisplay = observer(function CommentCardDisplay(props: TC
     : (userDetails?.display_name ?? comment?.actor_detail?.display_name);
   const avatarUrl = userDetails?.avatar_url ?? comment?.actor_detail?.avatar_url;
   const agentSpeakerLabel = comment.speaker_type === "agent" ? comment.speaker_label?.trim() || "AI Agent" : undefined;
+  const isFolded = comment.labels?.includes("fold") ?? false;
+  const showCommentContent = !isFolded || isFoldExpanded;
 
   const userReactions = activityOperations.userReactions(comment.id);
 
@@ -161,26 +164,41 @@ export const CommentCardDisplay = observer(function CommentCardDisplay(props: TC
         />
       ) : (
         <>
-          {agentSpeakerLabel ? (
-            <div className="px-3 pt-1 text-body-sm-regular text-primary">
-              <span className="font-medium">{agentSpeakerLabel}:</span>
-            </div>
+          {isFolded ? (
+            <button
+              type="button"
+              className="w-full rounded-md border border-subtle bg-layer-1 px-3 py-2 text-left text-caption-sm-regular text-secondary hover:bg-layer-2"
+              aria-expanded={isFoldExpanded}
+              onClick={() => setIsFoldExpanded((expanded) => !expanded)}
+            >
+              Folded comment · Click to {isFoldExpanded ? "collapse" : "expand"}
+            </button>
           ) : null}
-          <LiteTextEditor
-            editable={false}
-            ref={readOnlyEditorRef}
-            id={comment.id}
-            initialValue={comment.comment_html ?? ""}
-            workspaceId={workspaceId}
-            workspaceSlug={workspaceSlug}
-            containerClassName={cn("!py-1 transition-[border-color] duration-500", highlightClassName)}
-            projectId={projectId?.toString()}
-            displayConfig={{
-              fontSize: "small-font",
-            }}
-            parentClassName="border-none"
-          />
-          {shouldRenderReactions &&
+          {showCommentContent ? (
+            <>
+              {agentSpeakerLabel ? (
+                <div className="px-3 pt-1 text-body-sm-regular text-primary">
+                  <span className="font-medium">{agentSpeakerLabel}:</span>
+                </div>
+              ) : null}
+              <LiteTextEditor
+                editable={false}
+                ref={readOnlyEditorRef}
+                id={comment.id}
+                initialValue={comment.comment_html ?? ""}
+                workspaceId={workspaceId}
+                workspaceSlug={workspaceSlug}
+                containerClassName={cn("!py-1 transition-[border-color] duration-500", highlightClassName)}
+                projectId={projectId?.toString()}
+                displayConfig={{
+                  fontSize: "small-font",
+                }}
+                parentClassName="border-none"
+              />
+            </>
+          ) : null}
+          {showCommentContent &&
+            shouldRenderReactions &&
             (renderFooter ? (
               renderFooter(
                 <CommentReactions comment={comment} disabled={disabled} activityOperations={activityOperations} />

--- a/packages/types/src/issues/activity/issue_comment.ts
+++ b/packages/types/src/issues/activity/issue_comment.ts
@@ -38,6 +38,7 @@ export type TIssueComment = {
   created_by: string | undefined;
   updated_by: string | undefined;
   attachments: any[];
+  labels?: string[];
   comment_reactions: any[];
   comment_stripped: string;
   comment_html: string;
@@ -133,6 +134,7 @@ export type TIssuePublicComment = {
   access: string;
   actor: string;
   attachments: any[];
+  labels?: string[];
   comment_html: string;
   comment_reactions: {
     actor_detail: ActorDetail;

--- a/runner/src/cli/comment.rs
+++ b/runner/src/cli/comment.rs
@@ -55,6 +55,9 @@ pub enum CommentCommand {
         comment_body: CommentBodyArgs,
         #[command(flatten)]
         speaker: CommentSpeakerArgs,
+        /// Fold this low-value status comment in the UI and omit it from future agent prompts.
+        #[arg(long)]
+        fold: bool,
     },
     /// Edit an existing comment owned by this user. Requires the issue
     /// identifier because the REST URL is project-scoped.
@@ -84,7 +87,8 @@ pub async fn run(args: CommentArgs, paths: &crate::util::paths::Paths) -> i32 {
             identifier,
             comment_body,
             speaker,
-        } => cmd_add(&client, &identifier, comment_body, speaker).await,
+            fold,
+        } => cmd_add(&client, &identifier, comment_body, speaker, fold).await,
         CommentCommand::Update {
             identifier,
             comment_id,
@@ -116,6 +120,7 @@ async fn cmd_add(
     identifier: &str,
     comment_body: CommentBodyArgs,
     speaker: CommentSpeakerArgs,
+    fold: bool,
 ) -> Result<(), CliError> {
     let body = load_comment_body(comment_body)?;
     let issue = resolve_issue(client, identifier).await?;
@@ -125,6 +130,7 @@ async fn cmd_add(
     );
     let mut payload: Map<String, Value> = Map::new();
     payload.insert("comment_html".into(), Value::String(body));
+    add_fold_label(&mut payload, fold);
     add_speaker_metadata(&mut payload, speaker)?;
     let resp = client.post(&path, &Value::Object(payload)).await?;
     println!(
@@ -132,6 +138,15 @@ async fn cmd_add(
         serde_json::to_string(&resp).expect("serialize JSON value")
     );
     Ok(())
+}
+
+fn add_fold_label(payload: &mut Map<String, Value>, fold: bool) {
+    if fold {
+        payload.insert(
+            "labels".into(),
+            Value::Array(vec![Value::String("fold".into())]),
+        );
+    }
 }
 
 fn add_speaker_metadata(
@@ -214,7 +229,18 @@ fn display_path(path: &Path) -> String {
 mod tests {
     use serde_json::{Map, Value};
 
-    use super::{CommentBodyArgs, CommentSpeakerArgs, add_speaker_metadata, load_comment_body};
+    use clap::Parser;
+
+    use super::{
+        CommentBodyArgs, CommentSpeakerArgs, add_fold_label, add_speaker_metadata,
+        load_comment_body,
+    };
+
+    #[derive(Debug, Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        comments: super::CommentArgs,
+    }
 
     #[test]
     fn load_comment_body_prefers_inline_body() {
@@ -283,5 +309,28 @@ mod tests {
         assert_eq!(err.exit_code, crate::api_client::EXIT_INVALID);
         assert!(err.message.contains("--agent-run-id requires --as-agent"));
         assert!(payload.is_empty());
+    }
+
+    #[test]
+    fn add_accepts_fold_flag() {
+        let parsed =
+            TestCli::try_parse_from(["pidash", "add", "ENG-42", "--body", "No change", "--fold"])
+                .expect("parse folded comment");
+
+        match parsed.comments.command {
+            super::CommentCommand::Add { fold, .. } => assert!(fold),
+            _ => panic!("expected comment add"),
+        }
+    }
+
+    #[test]
+    fn fold_flag_adds_reserved_label_to_payload() {
+        let mut payload = Map::new();
+        add_fold_label(&mut payload, true);
+
+        assert_eq!(
+            payload.get("labels"),
+            Some(&Value::Array(vec![Value::String("fold".into())]))
+        );
     }
 }


### PR DESCRIPTION
## Summary

- add opt-in `fold` labels to issue comments and expose them through the API/types
- add `--fold` to `pidash comment add` and `fold` to the assistant comment tool
- exclude folded comments from agent-run prompt context and document the behavior for agents
- render folded comments collapsed by default with click-to-expand in Web and Space

## Validation

- `cargo test --manifest-path runner/Cargo.toml cli::comment` (6 passed)
- feature-specific Django prompt/assistant/serializer tests (5 passed)
- `manage.py sqlmigrate db 0156`
- `pnpm turbo run check:types --filter=space` and dependency builds
- changed-file OxLint and formatting checks

## Existing baseline issues observed

- Web type checking reaches an unrelated existing fixture error in `apps/web/tests/runners/runner-runs-page.test.tsx:94` (`IAgentRunPage` fixture lacks `page`/`per_page`); no changed file reports a type error.
- An expanded prompting test run passes 41/42; the remaining existing soft-delete test tries to connect to RabbitMQ on an unexposed host port.
- `makemigrations --check` reports unrelated pre-existing model drift after migration `0156`; it proposes no further change for `IssueComment.labels`.
