### PR TITLE
Make folded comments visible as a count in the agent prompt

### DIFF
--- a/apps/api/pi_dash/prompting/context.py
+++ b/apps/api/pi_dash/prompting/context.py
@@ -52,6 +52,19 @@ def _issue_comment_count(issue: Issue) -> int:
     return IssueComment.objects.filter(issue=issue).count()
 
 
+def _folded_comment_count(issue: Issue) -> int:
+    """How many of ``issue``'s comments carry the ``fold`` label.
+
+    Folded comments are omitted from the rendered thread (see
+    ``_comments_section``), so the count is surfaced alongside it to keep the
+    omission visible — an agent that cannot see *that* something was hidden
+    has no way to decide whether it needs to go read it.
+    """
+    from pi_dash.db.models.issue import IssueComment
+
+    return IssueComment.objects.filter(issue=issue, labels__contains=["fold"]).count()
+
+
 def _ancestor_chain(issue: Issue) -> list[Issue]:
     """Return ``[issue, parent, grandparent, ... root]``.
 
@@ -126,6 +139,10 @@ def _comments_section(issue: Issue) -> str:
     human's reply so it can pick up the conversation. Each entry is
     formatted as ``### Comment N — <author> at <ISO timestamp>`` followed
     by the comment body, separated by blank lines.
+
+    When any comment is folded, a trailing note records how many were left
+    out and how to read them. The omission is never silent: an all-folded
+    thread must not read as an empty one.
     """
     from pi_dash.db.models.issue import IssueComment
 
@@ -151,9 +168,26 @@ def _comments_section(issue: Issue) -> str:
         parts.append(
             f"### Comment {index} — {author} at {timestamp}{run_line}\n\n{body}"
         )
+    folded = _folded_comment_count(issue)
     if not parts:
+        if folded:
+            return (
+                f"(no visible comments; {_plural_comments(folded)} folded and omitted "
+                f"here — run `pidash comment list {_issue_identifier(issue)}` to read them)"
+            )
         return "(no comments on this issue yet)"
+    if folded:
+        parts.append(
+            f"({_plural_comments(folded)} on this issue folded and omitted here "
+            f"— low-value status/noop updates. Run "
+            f"`pidash comment list {_issue_identifier(issue)}` to read them.)"
+        )
     return "\n\n".join(parts)
+
+
+def _plural_comments(count: int) -> str:
+    """``"1 comment"`` / ``"3 comments"`` — used in the folded-count notes."""
+    return f"{count} comment" if count == 1 else f"{count} comments"
 
 
 def _humanize_interval(seconds: int) -> str:
@@ -375,6 +409,10 @@ def build_context(issue: Issue, run: AgentRun) -> Dict[str, Any]:
                 "work_branch": (getattr(parent, "git_work_branch", "") or None),
                 "description": _issue_description_markdown(parent),
                 "comments_count": _issue_comment_count(parent),
+                # Subset of ``comments_count`` that is folded. The parent's
+                # bodies are never inlined here, so this is purely a hint
+                # about what ``pidash comment list`` will return.
+                "folded_comments_count": _folded_comment_count(parent),
             }
             if parent is not None
             else None

--- a/apps/api/pi_dash/prompting/fragments/01_intro.md
+++ b/apps/api/pi_dash/prompting/fragments/01_intro.md
@@ -33,7 +33,7 @@ Parent issue context (this issue is a sub-issue of {{ parent.identifier }}):
 {% else %}
 (no description on the parent issue)
 {% endif %}
-- The parent has {{ parent.comments_count }} comment(s); their contents are not included here. Run `pidash comment list {{ parent.identifier }}` to read them.
+- The parent has {{ parent.comments_count }} comment(s){% if parent.folded_comments_count %}, {{ parent.folded_comments_count }} of them folded{% endif %}; their contents are not included here. Run `pidash comment list {{ parent.identifier }}` to read them.
 {% if lineage %}
 - This issue has a multi-level parent lineage. Full chain, current issue first up to the root:
 {% for node in lineage %}{{ node.identifier }}: {{ node.title }}{% if loop.first %} (current){% endif %}{% if not loop.last %} → {% endif %}{% endfor %}

--- a/apps/api/pi_dash/prompting/sections/intro.md
+++ b/apps/api/pi_dash/prompting/sections/intro.md
@@ -38,7 +38,7 @@ Parent issue context (this issue is a sub-issue of {{ parent.identifier }}):
 {% else %}
 (no description on the parent issue)
 {% endif %}
-- The parent has {{ parent.comments_count }} comment(s); their contents are not included here. Run `pidash comment list {{ parent.identifier }}` to read them.
+- The parent has {{ parent.comments_count }} comment(s){% if parent.folded_comments_count %}, {{ parent.folded_comments_count }} of them folded{% endif %}; their contents are not included here. Run `pidash comment list {{ parent.identifier }}` to read them.
 {% if lineage %}
 - This issue has a multi-level parent lineage. Full chain, current issue first up to the root:
 {% for node in lineage %}{{ node.identifier }}: {{ node.title }}{% if loop.first %} (current){% endif %}{% if not loop.last %} → {% endif %}{% endfor %}

--- a/apps/api/pi_dash/prompting/validation.py
+++ b/apps/api/pi_dash/prompting/validation.py
@@ -95,6 +95,7 @@ def _issue_sample(kind: str, *, populated: bool) -> Dict[str, Any]:
                 "work_branch": "pi-dash/sample-0",
                 "description": "Parent description.",
                 "comments_count": 3,
+                "folded_comments_count": 1,
             },
             "lineage": [
                 {"identifier": "SAMPLE-1", "title": "Sample issue title"},

--- a/apps/api/pi_dash/tests/unit/prompting/test_context.py
+++ b/apps/api/pi_dash/tests/unit/prompting/test_context.py
@@ -99,6 +99,43 @@ def test_context_excludes_folded_comments(issue, run, workspace, project, create
     comments_section = build_context(issue, run)["comments_section"]
     assert "Substantive update" in comments_section
     assert "No change from the last tick" not in comments_section
+    # The omission must be visible: an agent that cannot tell something was
+    # hidden has no way to decide whether to go read it.
+    assert "1 comment on this issue folded and omitted here" in comments_section
+
+
+@pytest.mark.unit
+def test_context_all_folded_thread_does_not_read_as_empty(
+    issue, run, workspace, project, create_user
+):
+    for body in ("<p>tick noop</p>", "<p>still nothing</p>"):
+        IssueComment.objects.create(
+            issue=issue,
+            workspace=workspace,
+            project=project,
+            actor=create_user,
+            comment_html=body,
+            labels=["fold"],
+        )
+
+    comments_section = build_context(issue, run)["comments_section"]
+    assert "no comments on this issue yet" not in comments_section
+    assert "2 comments folded and omitted here" in comments_section
+
+
+@pytest.mark.unit
+def test_context_unfolded_thread_has_no_folded_note(
+    issue, run, workspace, project, create_user
+):
+    IssueComment.objects.create(
+        issue=issue,
+        workspace=workspace,
+        project=project,
+        actor=create_user,
+        comment_html="<p>Substantive update</p>",
+    )
+
+    assert "folded" not in build_context(issue, run)["comments_section"]
 
 
 @pytest.mark.unit
@@ -313,6 +350,7 @@ def test_context_parent_includes_description_and_comment_count(
     assert ctx["parent"]["description"] == "Parent framing and acceptance criteria."
     # Comment count surfaces the discussion volume without inlining bodies.
     assert ctx["parent"]["comments_count"] == 2
+    assert ctx["parent"]["folded_comments_count"] == 0
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Follow-up to #326. Folded comments were removed from the run prompt *silently* — the agent could not tell anything had been hidden, so it had no basis for deciding whether to go read it.

Worse, an issue whose comments were all folded rendered as `(no comments on this issue yet)`, which is false and could lead an agent to conclude a thread had never been discussed.

- `_comments_section` appends a note with the folded count and the command to read them
- the all-folded case now says so explicitly instead of claiming the thread is empty
- the parent-issue line gains the same subset count: `The parent has 7 comment(s), 1 of them folded; ...`
- `validation.py`'s sample context gains `folded_comments_count` so the strict renderer keeps passing for every kind

Folded comments remain excluded from the prompt body — only their existence is surfaced. `pidash comment list` is unchanged.

## Validation

- `pytest pi_dash/tests/unit/prompting` — 95 passed, 1 pre-existing failure (`test_context_code_reviews_excludes_soft_deleted` needs RabbitMQ, unexposed locally; same baseline noted in #326)
- Three new tests: folded note present, all-folded thread does not read as empty, unfolded thread carries no note
- Rendered the parent line at folded counts 0/1/3 to confirm the clause only appears when non-zero

## Note

`fragments/01_intro.md` is updated alongside `sections/intro.md` per the sync convention established in #264 / #272. Only `sections/` reaches a real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)