### PR TITLE
PDASHOSS01-84 Add Claude Opus 5 to agent model selection

### DIFF
--- a/apps/web/core/components/runners/runner-models.ts
+++ b/apps/web/core/components/runners/runner-models.ts
@@ -70,6 +70,7 @@ const CODEX_OPTIONS: IRunnerModelOption[] = CODEX_MODELS.flatMap((m) =>
 // variant.
 const CLAUDE_OPTIONS: IRunnerModelOption[] = [
   { id: "claude-fable-5", label: "Fable 5", model: "claude-fable-5" },
+  { id: "claude-opus-5", label: "Opus 5", model: "claude-opus-5" },
   { id: "claude-opus-4-8", label: "Opus 4.8", model: "claude-opus-4-8" },
   { id: "claude-sonnet-4-6", label: "Sonnet 4.6", model: "claude-sonnet-4-6" },
   { id: "claude-sonnet-4-6-1m", label: "Sonnet 4.6 (1M context)", model: "claude-sonnet-4-6[1m]" },


### PR DESCRIPTION
## What

Adds **Claude Opus 5** (`claude-opus-5`) as a selectable option in the "Add runner" agent-model selection, so operators can pin a Claude Code runner to Opus 5.

## Change

Single entry added to `CLAUDE_OPTIONS` in `apps/web/core/components/runners/runner-models.ts`, positioned as the flagship (right after Fable 5):

```ts
{ id: "claude-opus-5", label: "Opus 5", model: "claude-opus-5" },
```

Selecting it appends `--model claude-opus-5` to the generated `pidash runner add` command via the existing generic `resolveRunnerModel` path — no other code changes needed.

## Scope notes

- The pre-selected default (`DEFAULT_MODEL_BY_AGENT["claude-code"]`) is left at Opus 4.8 — changing the default pin is a product decision, out of scope here.
- The Cursor catalog is untouched (separate provider with its own slug format).

## Validation

- `pnpm --filter=web check:lint` → 0 errors.
- No test asserts on the model list; the pre-existing `add-runner-modal` suite load failure (stale `packages/constants/dist` → `lucide-react`) reproduces identically without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
