### PR TITLE
PDASHOSS01-82 MCP connector: include the issue web URL in issue payloads

### DIFF
--- a/apps/api/pi_dash/api/serializers/issue.py
+++ b/apps/api/pi_dash/api/serializers/issue.py
@@ -36,6 +36,7 @@ from pi_dash.utils.content_validator import (
     validate_html_content,
     validate_binary_data,
 )
+from pi_dash.utils.host import issue_web_url
 
 from .base import BaseSerializer
 from .cycle import CycleLiteSerializer, CycleSerializer
@@ -85,6 +86,12 @@ class IssueSerializer(BaseSerializer):
     type_id = serializers.PrimaryKeyRelatedField(
         source="type", queryset=IssueType.objects.all(), required=False, allow_null=True
     )
+
+    # Absolute, human-clickable web URL for the issue. Built from deployment
+    # config (see ``issue_web_url``); omitted from the payload when no web base
+    # URL is configured (a missing url is easy for a client to handle, a broken
+    # one is not).
+    url = serializers.SerializerMethodField()
 
     class Meta:
         model = Issue
@@ -337,8 +344,19 @@ class IssueSerializer(BaseSerializer):
         instance.updated_at = timezone.now()
         return super().update(instance, validated_data)
 
+    def get_url(self, obj):
+        return issue_web_url(
+            obj.workspace.slug if obj.workspace_id else None,
+            obj.project.identifier if obj.project_id else None,
+            obj.sequence_id,
+        )
+
     def to_representation(self, instance):
         data = super().to_representation(instance)
+        # Omit ``url`` entirely when no web base URL is configured, rather than
+        # emitting ``null`` — keeps the contract "present and absolute, or absent".
+        if data.get("url") is None:
+            data.pop("url", None)
         if "assignees" in self.fields:
             if "assignees" in self.expand:
                 from .user import UserLiteSerializer
@@ -848,6 +866,11 @@ class IssueCommentSerializer(BaseSerializer):
 
     is_member = serializers.BooleanField(read_only=True)
 
+    # Absolute web URL of the issue this comment belongs to (there is no
+    # per-comment anchor route in the UI). Omitted when no web base URL is
+    # configured. See ``issue_web_url``.
+    url = serializers.SerializerMethodField()
+
     class Meta:
         model = IssueComment
         read_only_fields = [
@@ -861,6 +884,20 @@ class IssueCommentSerializer(BaseSerializer):
             "updated_at",
         ]
         exclude = ["comment_stripped", "comment_json"]
+
+    def get_url(self, obj):
+        return issue_web_url(
+            obj.workspace.slug if obj.workspace_id else None,
+            obj.project.identifier if obj.project_id else None,
+            obj.issue.sequence_id if obj.issue_id else None,
+        )
+
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        # Omit ``url`` entirely when unconfigured (see IssueSerializer note).
+        if data.get("url") is None:
+            data.pop("url", None)
+        return data
 
     def validate(self, data):
         try:
@@ -1044,7 +1081,14 @@ class IssueAdvancedSearchResultSerializer(serializers.Serializer):
     updated_at = serializers.DateTimeField()
     completed_at = serializers.DateTimeField(allow_null=True)
     rank = serializers.FloatField(help_text="ts_rank score (higher = more relevant)")
-    url = serializers.CharField(help_text="Canonical API URL for the issue")
+    url = serializers.CharField(
+        required=False,
+        allow_null=True,
+        help_text=(
+            "Absolute, human-clickable web URL for the issue. Omitted when no "
+            "deployment web base URL (WEB_URL / APP_BASE_URL) is configured."
+        ),
+    )
 
 
 class IssueAdvancedSearchResponseSerializer(serializers.Serializer):

--- a/apps/api/pi_dash/api/views/issue.py
+++ b/apps/api/pi_dash/api/views/issue.py
@@ -9,7 +9,6 @@ import uuid
 # Django imports
 from django.core.serializers.json import DjangoJSONEncoder
 from django.http import HttpResponseRedirect
-from django.urls import reverse
 from django.utils.dateparse import parse_datetime
 from django.db import IntegrityError, transaction
 from django.db.models import (
@@ -87,7 +86,7 @@ from pi_dash.db.models import (
 from pi_dash.settings.storage import S3Storage
 from pi_dash.bgtasks.storage_metadata_task import get_asset_object_metadata
 from .base import BaseAPIView
-from pi_dash.utils.host import base_host
+from pi_dash.utils.host import base_host, issue_web_url
 from pi_dash.utils.constants import CLOSED_STATE_GROUPS, OPEN_STATE_GROUPS, STATE_GROUP_ORDER
 from pi_dash.utils.issue_relation_mapper import get_actual_relation
 from pi_dash.search.issue import extract_snippet, issue_search_queryset
@@ -2482,8 +2481,9 @@ class IssueAdvancedSearchEndpoint(BaseAPIView):
             )[:limit]
         )
 
-        results = [
-            {
+        results = []
+        for row in rows:
+            result = {
                 "id": str(row["id"]),
                 "sequence_id": row["sequence_id"],
                 "identifier": f"{row['project__identifier']}-{row['sequence_id']}",
@@ -2503,17 +2503,17 @@ class IssueAdvancedSearchEndpoint(BaseAPIView):
                 "updated_at": row["updated_at"],
                 "completed_at": row["completed_at"],
                 "rank": float(row["_rank"] or 0.0),
-                "url": reverse(
-                    "work-item-by-identifier",
-                    kwargs={
-                        "slug": row["workspace__slug"],
-                        "project_identifier": row["project__identifier"],
-                        "issue_identifier": str(row["sequence_id"]),
-                    },
-                ),
             }
-            for row in rows
-        ]
+            # Absolute, human-clickable web URL. Omitted (rather than emitted as
+            # a relative/broken link) when no web base URL is configured.
+            web_url = issue_web_url(
+                row["workspace__slug"],
+                row["project__identifier"],
+                row["sequence_id"],
+            )
+            if web_url is not None:
+                result["url"] = web_url
+            results.append(result)
 
         return Response(
             {"query": query, "count": len(results), "results": results},

--- a/apps/api/pi_dash/tests/contract/api/test_issue_search.py
+++ b/apps/api/pi_dash/tests/contract/api/test_issue_search.py
@@ -19,6 +19,7 @@ and the standard ``django_db_setup`` fixture (same surface as
 """
 
 import pytest
+from django.test import override_settings
 from rest_framework import status as http_status
 
 from pi_dash.db.models import (
@@ -354,3 +355,34 @@ class TestIssueAdvancedSearchProjectScoping:
         )
         assert response.status_code == http_status.HTTP_200_OK
         assert response.data["count"] == 1
+
+
+@pytest.mark.contract
+class TestIssueAdvancedSearchWebUrl:
+    """Each result row carries an absolute, human-clickable web URL built
+    from deployment config, and omits it entirely when no base is set.
+    """
+
+    @pytest.mark.django_db
+    @override_settings(WEB_URL="https://pi-dash.example.com", APP_BASE_URL=None)
+    def test_result_has_absolute_web_url(
+        self, api_key_client, workspace, search_project, create_user
+    ):
+        issue = _make_issue(search_project, create_user, name="linkable", description="alpha")
+        response = api_key_client.get(_url(workspace.slug) + "?q=alpha")
+        assert response.status_code == http_status.HTTP_200_OK
+        row = next(r for r in response.data["results"] if r["id"] == str(issue.id))
+        assert (
+            row["url"]
+            == f"https://pi-dash.example.com/{workspace.slug}/browse/ST-{issue.sequence_id}"
+        )
+
+    @pytest.mark.django_db
+    @override_settings(WEB_URL=None, APP_BASE_URL=None)
+    def test_url_omitted_when_base_unset(
+        self, api_key_client, workspace, search_project, create_user
+    ):
+        _make_issue(search_project, create_user, name="linkable", description="alpha")
+        response = api_key_client.get(_url(workspace.slug) + "?q=alpha")
+        assert response.status_code == http_status.HTTP_200_OK
+        assert all("url" not in r for r in response.data["results"])

--- a/apps/api/pi_dash/tests/unit/serializers/test_issue_url.py
+++ b/apps/api/pi_dash/tests/unit/serializers/test_issue_url.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+import pytest
+from django.test import override_settings
+
+from pi_dash.api.serializers.issue import IssueCommentSerializer, IssueSerializer
+from pi_dash.db.models import (
+    Issue,
+    IssueComment,
+    Project,
+    User,
+    Workspace,
+)
+
+
+@pytest.fixture
+def issue(db):
+    user = User.objects.create(email="url_test@example.com", first_name="URL", last_name="Test")
+    workspace = Workspace.objects.create(name="Eng", slug="eng", owner=user)
+    project = Project.objects.create(name="Engine", identifier="eng", workspace=workspace)
+    return Issue.objects.create(name="Add a url field", workspace=workspace, project=project)
+
+
+@pytest.mark.unit
+class TestIssueSerializerUrl:
+    @override_settings(WEB_URL="https://pi-dash.example.com", APP_BASE_URL=None)
+    def test_url_present_and_absolute(self, issue):
+        data = IssueSerializer(issue).data
+        assert data["url"] == f"https://pi-dash.example.com/eng/browse/ENG-{issue.sequence_id}"
+
+    @override_settings(WEB_URL=None, APP_BASE_URL=None)
+    def test_url_omitted_when_base_unset(self, issue):
+        data = IssueSerializer(issue).data
+        assert "url" not in data
+
+
+@pytest.mark.unit
+class TestIssueCommentSerializerUrl:
+    @override_settings(WEB_URL="https://pi-dash.example.com", APP_BASE_URL=None)
+    def test_url_links_to_issue(self, issue):
+        comment = IssueComment.objects.create(
+            issue=issue,
+            project=issue.project,
+            workspace=issue.workspace,
+            comment_html="<p>hi</p>",
+        )
+        data = IssueCommentSerializer(comment).data
+        assert data["url"] == f"https://pi-dash.example.com/eng/browse/ENG-{issue.sequence_id}"
+
+    @override_settings(WEB_URL=None, APP_BASE_URL=None)
+    def test_url_omitted_when_base_unset(self, issue):
+        comment = IssueComment.objects.create(
+            issue=issue,
+            project=issue.project,
+            workspace=issue.workspace,
+            comment_html="<p>hi</p>",
+        )
+        data = IssueCommentSerializer(comment).data
+        assert "url" not in data

--- a/apps/api/pi_dash/tests/unit/utils/test_web_url.py
+++ b/apps/api/pi_dash/tests/unit/utils/test_web_url.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+import pytest
+from django.test import override_settings
+
+from pi_dash.utils.host import issue_web_url, web_base_url
+
+
+@pytest.mark.unit
+class TestWebBaseUrl:
+    @override_settings(WEB_URL="https://pi-dash.example.com", APP_BASE_URL=None)
+    def test_uses_web_url(self):
+        assert web_base_url() == "https://pi-dash.example.com"
+
+    @override_settings(WEB_URL="https://pi-dash.example.com/", APP_BASE_URL=None)
+    def test_strips_trailing_slash(self):
+        assert web_base_url() == "https://pi-dash.example.com"
+
+    @override_settings(WEB_URL=None, APP_BASE_URL="https://app.example.com")
+    def test_falls_back_to_app_base_url(self):
+        assert web_base_url() == "https://app.example.com"
+
+    @override_settings(WEB_URL=None, APP_BASE_URL=None)
+    def test_returns_none_when_unset(self):
+        assert web_base_url() is None
+
+    @override_settings(WEB_URL="", APP_BASE_URL="")
+    def test_returns_none_when_blank(self):
+        assert web_base_url() is None
+
+
+@pytest.mark.unit
+class TestIssueWebUrl:
+    @override_settings(WEB_URL="https://pi-dash.example.com", APP_BASE_URL=None)
+    def test_builds_browse_url(self):
+        assert issue_web_url("eng", "ENG", 42) == "https://pi-dash.example.com/eng/browse/ENG-42"
+
+    @override_settings(WEB_URL=None, APP_BASE_URL=None)
+    def test_omitted_when_base_unset(self):
+        assert issue_web_url("eng", "ENG", 42) is None
+
+    @override_settings(WEB_URL="https://pi-dash.example.com", APP_BASE_URL=None)
+    def test_none_when_parts_missing(self):
+        assert issue_web_url(None, "ENG", 42) is None
+        assert issue_web_url("eng", None, 42) is None
+        assert issue_web_url("eng", "ENG", None) is None

--- a/apps/api/pi_dash/utils/host.py
+++ b/apps/api/pi_dash/utils/host.py
@@ -67,5 +67,35 @@ def base_host(
     return base_origin
 
 
+def web_base_url() -> str | None:
+    """Return the configured public web (frontend) origin, or ``None``.
+
+    The value comes from deployment configuration (``WEB_URL``, falling back to
+    ``APP_BASE_URL``) — never from the inbound request host, which may be a
+    proxy or a non-public hostname and would produce links that do not work for
+    the user. Returns ``None`` when neither is configured so callers can *omit*
+    a url field rather than emit a wrong or relative one. The trailing slash is
+    stripped so callers can join paths with a leading ``/``.
+    """
+    base_origin = settings.WEB_URL or settings.APP_BASE_URL
+    if not base_origin:
+        return None
+    return base_origin.rstrip("/")
+
+
+def issue_web_url(workspace_slug, project_identifier, sequence_id) -> str | None:
+    """Build the absolute, human-clickable web URL for an issue, or ``None``.
+
+    Uses the canonical browse route (``/<slug>/browse/<PROJ>-<seq>``), which the
+    web UI resolves directly (the UUID route redirects to it). Returns ``None``
+    when the web base URL is unconfigured or any identifier part is missing, so
+    the caller can omit the field entirely.
+    """
+    base = web_base_url()
+    if not base or not workspace_slug or not project_identifier or sequence_id is None:
+        return None
+    return f"{base}/{workspace_slug}/browse/{project_identifier}-{sequence_id}"
+
+
 def user_ip(request: Request | HttpRequest) -> str:
     return get_client_ip(request=request)

--- a/docs/mcp-connector.md
+++ b/docs/mcp-connector.md
@@ -1,0 +1,53 @@
+# Pi Dash MCP connector
+
+The Pi Dash MCP connector exposes work items, projects, comments and workpads to
+MCP-capable AI clients (e.g. Claude) as tools. It is a thin wrapper over the same
+public REST surface (`/api/v1/`) that the `pidash` CLI uses, so tool responses
+mirror the REST serializers documented below.
+
+## Issue web URL (`url`)
+
+Every issue-returning tool includes an absolute, human-clickable `url` pointing
+at the issue in the web UI, so an agent that has just filed or fetched work can
+hand the user a link straight from the response.
+
+Tools that carry the field:
+
+| Tool                   | `url` points to                   |
+| ---------------------- | --------------------------------- |
+| `pidash_get_issue`     | the issue                         |
+| `pidash_create_issue`  | the newly created issue           |
+| `pidash_update_issue`  | the issue                         |
+| `pidash_list_issues`   | each result row's issue           |
+| `pidash_search_issues` | each result row's issue           |
+| `pidash_comment_issue` | the issue the comment belongs to  |
+| `pidash_list_comments` | the issue each comment belongs to |
+
+The same field flows through the `pidash` CLI: `pidash issue get <PROJ-123>`
+prints the REST payload verbatim, so its JSON includes `url` as well.
+
+### Shape
+
+The value uses the canonical browse route, which the web UI resolves directly:
+
+```
+<web-base-url>/<workspace-slug>/browse/<PROJ>-<sequence_id>
+```
+
+for example `https://pi-dash.example.com/eng/browse/ENG-42`.
+
+### Where the base URL comes from
+
+The base URL is taken from **deployment configuration** — the `WEB_URL` setting
+(falling back to `APP_BASE_URL`) — never from the inbound request host. An MCP
+server can sit behind a proxy or be reached over a non-public hostname, and
+either would produce a link that does not work for the user.
+
+### When it is omitted
+
+If no web base URL is configured, the `url` field is **omitted entirely** rather
+than emitted as a relative or otherwise broken link. A missing `url` is easy for
+a client to handle; a broken one is not. Clients should treat `url` as optional.
+
+There is no per-comment anchor in the UI, so comment tools link to the parent
+issue rather than to the individual comment.

--- a/docs/wiki/17-cli-reference.md
+++ b/docs/wiki/17-cli-reference.md
@@ -261,7 +261,9 @@ pidash context init --project <PROJECT> [--workspace <PATH>]
 
 ### `pidash issue get <IDENTIFIER>`
 
-Fetch one work item. Prints full JSON.
+Fetch one work item. Prints full JSON. The payload includes an absolute `url`
+pointing at the issue in the web UI, built from the deployment's `WEB_URL` (or
+`APP_BASE_URL`); the field is omitted when neither is configured.
 
 ```
 pidash issue get ENG-42


### PR DESCRIPTION
## What & why

No MCP tool response (or `pidash` CLI issue payload) carried a clickable link to the issue in the web UI — only UUIDs and sequence ids. An agent that had just filed work for a human couldn't hand them a link. This adds an absolute, human-clickable `url` to every issue-returning payload.

## Approach

There is **no standalone MCP server in this repo** — the hosted claude.ai "Pi Dash" connector and the `pidash` CLI both wrap this repo's REST `/api/v1/` surface, and the CLI prints the REST payload verbatim. So adding `url` to the REST serializers propagates to **both** the MCP tools and the CLI.

- **`utils/host.py`** — `web_base_url()` + `issue_web_url(slug, project_identifier, sequence_id)`. Built from deployment config (`WEB_URL`, falling back to `APP_BASE_URL`), **never** the inbound request host (which may be a proxy / non-public hostname). Returns `None` when unconfigured.
- **`IssueSerializer` / `IssueCommentSerializer`** — add a `url` field using the canonical browse route `…/<slug>/browse/<PROJ>-<seq>` (the UI resolves this directly; the UUID route redirects to it). **Omitted** from the payload when no base URL is configured — a missing `url` is easy for a client to handle, a broken one is not. Covers `get` / `create` / `update` / `list` / `move` / `comment` tools + CLI `issue get`.
- **Advanced search endpoint** — each result row's `url` is now the absolute web URL (previously a relative API path), omitted when unconfigured.
- **Docs** — new `docs/mcp-connector.md` documents the field; CLI reference updated.

## Testing

- New unit tests: `tests/unit/utils/test_web_url.py`, `tests/unit/serializers/test_issue_url.py`.
- Extended `tests/contract/api/test_issue_search.py` with web-URL present/omitted cases.
- Full `tests/contract/api/` (133) + `tests/unit/serializers/` + `tests/contract/assistant/` (78) pass; `ruff check` clean.

## Acceptance criteria

- [x] Every issue-returning MCP tool includes an absolute `url`
- [x] Value built from configured deployment config, omitted when unset
- [x] A link from a `create_issue` response opens the issue in the web UI (canonical browse route)
- [x] `docs/mcp-connector.md` documents the field
- [x] CLI `pidash issue get` includes the `url` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)
