### PR TITLE
PDASHOSS01-87 Adding AI reasoning complexity score to the pi dash issue

### DIFF
--- a/apps/api/pi_dash/app/serializers/issue.py
+++ b/apps/api/pi_dash/app/serializers/issue.py
@@ -98,6 +98,7 @@ class IssueFlatSerializer(BaseSerializer):
             "description_json",
             "description_html",
             "priority",
+            "complexity_score",
             "start_date",
             "target_date",
             "sequence_id",
@@ -173,6 +174,19 @@ class IssueCreateSerializer(BaseSerializer):
         label_ids = self.initial_data.get("label_ids")
         data["label_ids"] = label_ids if label_ids else []
         return data
+
+    def validate_complexity_score(self, value):
+        # AI-reasoning complexity rule check: only 0..10 is allowed. 0 means
+        # "no score" (unrated); a rated issue is 1..10. The model already carries
+        # Min/Max validators, but re-checking here gives a precise, field-scoped
+        # error instead of DRF's generic min/max wording.
+        if value is None:
+            return value
+        if not 0 <= value <= 10:
+            raise serializers.ValidationError(
+                "complexity_score must be an integer from 0 to 10 (0 means unrated)."
+            )
+        return value
 
     def validate(self, attrs):
         allow_triage = self.context.get("allow_triage_state", False)
@@ -991,6 +1005,7 @@ class IssueSerializer(DynamicBaseSerializer):
             "completed_at",
             "estimate_point",
             "priority",
+            "complexity_score",
             "start_date",
             "target_date",
             "sequence_id",

--- a/apps/api/pi_dash/db/migrations/0159_issue_complexity_score.py
+++ b/apps/api/pi_dash/db/migrations/0159_issue_complexity_score.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Add ``Issue.complexity_score``.
+
+An integer AI-reasoning-complexity rating for the task, used to route the
+issue to an LLM of matching capability. ``0`` means "no score" (unrated) and
+is the default; a rated issue takes an integer ``1..10``. The ``0..10`` bound
+is enforced by model validators (surfaced by DRF on the write serializer).
+
+No data migration: every existing issue takes the ``0`` default (unrated),
+which is the intended starting state. How the score is derived is out of scope.
+"""
+
+from __future__ import annotations
+
+import django.core.validators
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("db", "0158_test_cadence_fields"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="issue",
+            name="complexity_score",
+            field=models.IntegerField(
+                default=0,
+                validators=[
+                    django.core.validators.MinValueValidator(0),
+                    django.core.validators.MaxValueValidator(10),
+                ],
+                verbose_name="AI Reasoning Complexity Score",
+            ),
+        ),
+    ]

--- a/apps/api/pi_dash/db/models/issue.py
+++ b/apps/api/pi_dash/db/models/issue.py
@@ -144,6 +144,17 @@ class Issue(ProjectBaseModel):
         verbose_name="Issue Priority",
         default="none",
     )
+    # AI-reasoning complexity of the task, used to route the issue to an LLM of
+    # matching capability. 0 = "no score" (the default, i.e. unrated); a rated
+    # issue takes an integer 1..10. The 0..10 bound is enforced here by model
+    # validators (which DRF surfaces on the write serializer) and, for a clearer
+    # message, by ``validate_complexity_score`` on IssueCreateSerializer. How the
+    # score is *derived* is intentionally out of scope for this field.
+    complexity_score = models.IntegerField(
+        default=0,
+        validators=[MinValueValidator(0), MaxValueValidator(10)],
+        verbose_name="AI Reasoning Complexity Score",
+    )
     start_date = models.DateField(null=True, blank=True)
     target_date = models.DateField(null=True, blank=True)
     assignees = models.ManyToManyField(

--- a/apps/api/pi_dash/tests/unit/serializers/test_issue_complexity_score.py
+++ b/apps/api/pi_dash/tests/unit/serializers/test_issue_complexity_score.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""``Issue.complexity_score`` — the AI-reasoning-complexity rating field.
+
+Rule: only integers 0..10 are accepted. ``0`` means "no score" (unrated) and
+is the default; a rated issue takes 1..10. Anything outside that range is
+rejected by the write serializer. How the score is derived is out of scope.
+"""
+
+import pytest
+from rest_framework.exceptions import ValidationError
+
+from pi_dash.app.serializers.issue import IssueCreateSerializer
+from pi_dash.db.models import Issue, Project, State
+
+
+@pytest.fixture
+def project(db, workspace):
+    return Project.objects.create(name="Complexity Test", identifier="CX", workspace=workspace)
+
+
+@pytest.fixture
+def state(db, project, workspace):
+    return State.objects.create(name="Backlog", project=project, workspace=workspace, group="backlog", default=True)
+
+
+@pytest.fixture
+def issue(db, project, workspace, state):
+    return Issue.objects.create(project=project, workspace=workspace, name="Rate me", state=state)
+
+
+def _serializer(issue, value):
+    return IssueCreateSerializer(
+        instance=issue,
+        data={"complexity_score": value},
+        partial=True,
+        context={"project_id": str(issue.project_id), "workspace_id": str(issue.workspace_id)},
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+class TestComplexityScore:
+    def test_default_is_zero(self, issue):
+        # A freshly created issue is unrated.
+        assert issue.complexity_score == 0
+
+    @pytest.mark.parametrize("value", [0, 1, 5, 10])
+    def test_accepts_in_range(self, issue, value):
+        serializer = _serializer(issue, value)
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["complexity_score"] == value
+
+    @pytest.mark.parametrize("value", [-1, 11, 100])
+    def test_rejects_out_of_range(self, issue, value):
+        serializer = _serializer(issue, value)
+        with pytest.raises(ValidationError):
+            serializer.is_valid(raise_exception=True)
+
+    def test_saved_value_round_trips(self, issue):
+        serializer = _serializer(issue, 7)
+        assert serializer.is_valid(), serializer.errors
+        serializer.save()
+        issue.refresh_from_db()
+        assert issue.complexity_score == 7

--- a/apps/api/pi_dash/utils/porters/serializers/issue.py
+++ b/apps/api/pi_dash/utils/porters/serializers/issue.py
@@ -43,6 +43,7 @@ class IssueExportSerializer(IssueSerializer):
             "name",
             "state_name",
             "priority",
+            "complexity_score",
             "assignees",
             "subscribers",
             "created_by_name",


### PR DESCRIPTION
## Summary

Adds an integer `complexity_score` metadata field to the Issue — an AI-reasoning-complexity rating used to route an issue to an LLM of matching capability.

- `0` means **"no score"** (unrated) and is the **default**.
- A rated issue takes an integer **1..10**.
- Values outside `0..10` are rejected (rule check).

Deriving/rating the score is intentionally **out of scope** for this change (per the issue) — this only adds the field, its bounds, and API exposure.

## Changes

- **Model** (`db/models/issue.py`): `complexity_score = IntegerField(default=0, validators=[MinValueValidator(0), MaxValueValidator(10)])`.
- **Migration** `0159_issue_complexity_score` — additive; existing issues take the `0` default.
- **Serializers** (`app/serializers/issue.py`): exposed on `IssueSerializer` and `IssueFlatSerializer`; auto-included on the write path (`IssueCreateSerializer` uses `exclude`). Added `validate_complexity_score` for a clear, field-scoped rule-check error message.
- **Porter serializer** (`utils/porters/serializers/issue.py`): added to the export field list.
- **Tests** (`tests/unit/serializers/test_issue_complexity_score.py`): default is 0; accepts 0/1/5/10; rejects -1/11/100; save round-trips.

## Validation

- Targeted test: 9/9 pass (incl. DB round-trip proving the column).
- Regression: `tests/unit/serializers/` + `test_issue_assigned_pod.py` = 58/58 pass.
- `makemigrations db --check`: `0159` captures the field; no missing migration for `complexity_score`.

## Follow-ups (not in this PR)

`IssueVersion` snapshot, activity-history tracking, frontend TS types / UI control, and CSV exporter column are left for separate triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
