### PR TITLE
Warn before project ID changes disconnect runners

### DIFF
--- a/apps/web/core/components/project/form.tsx
+++ b/apps/web/core/components/project/form.tsx
@@ -33,6 +33,7 @@ import { GIT_PROJECT_BINDING } from "@/constants/fetch-keys";
 // services
 import { ProjectService } from "@/services/project";
 // local imports
+import { ProjectIdentifierChangeAlert } from "./project-identifier-change-alert";
 import { ProjectNetworkIcon } from "./project-network-icon";
 
 export interface IProjectDetailsForm {
@@ -49,6 +50,7 @@ export function ProjectDetailsForm(props: IProjectDetailsForm) {
   // states
   const [isOpen, setIsOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const [pendingIdentifierChange, setPendingIdentifierChange] = useState<IProject | null>(null);
   // store hooks
   const { updateProject } = useProject();
   const { isMobile } = usePlatformOS();
@@ -198,7 +200,7 @@ export function ProjectDetailsForm(props: IProjectDetailsForm) {
     }
   };
 
-  const onSubmit = async (formData: IProject) => {
+  const updateProjectDetails = async (formData: IProject) => {
     if (!workspaceSlug) return;
     setIsLoading(true);
     // `repo_url` is intentionally NOT included in the regular save payload.
@@ -254,8 +256,31 @@ export function ProjectDetailsForm(props: IProjectDetailsForm) {
     }, 300);
   };
 
+  const onSubmit = async (formData: IProject) => {
+    if (project.identifier !== formData.identifier) {
+      setPendingIdentifierChange(formData);
+      return;
+    }
+
+    await updateProjectDetails(formData);
+  };
+
+  const confirmIdentifierChange = async () => {
+    if (!pendingIdentifierChange) return;
+    await updateProjectDetails(pendingIdentifierChange);
+    setPendingIdentifierChange(null);
+  };
+
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
+      <ProjectIdentifierChangeAlert
+        isOpen={Boolean(pendingIdentifierChange)}
+        oldIdentifier={project.identifier}
+        newIdentifier={pendingIdentifierChange?.identifier ?? ""}
+        onClose={() => (isLoading ? null : setPendingIdentifierChange(null))}
+        onConfirm={confirmIdentifierChange}
+        isSubmitting={isLoading}
+      />
       <div className="relative h-44 w-full">
         <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent" />
         <CoverImage src={coverImage} alt="Project cover image" className="h-44 w-full rounded-md" />

--- a/apps/web/core/components/project/project-identifier-change-alert.tsx
+++ b/apps/web/core/components/project/project-identifier-change-alert.tsx
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useTranslation } from "@pi-dash/i18n";
+import { AlertModalCore } from "@pi-dash/ui";
+
+type Props = {
+  isOpen: boolean;
+  isSubmitting: boolean;
+  oldIdentifier: string;
+  newIdentifier: string;
+  onClose: () => void;
+  onConfirm: () => void;
+};
+
+export function ProjectIdentifierChangeAlert(props: Props) {
+  const { isOpen, isSubmitting, oldIdentifier, newIdentifier, onClose, onConfirm } = props;
+  const { t } = useTranslation();
+
+  return (
+    <AlertModalCore
+      isOpen={isOpen}
+      handleClose={onClose}
+      handleSubmit={onConfirm}
+      isSubmitting={isSubmitting}
+      title={t("Change project ID?")}
+      content={
+        <div className="space-y-2">
+          <p>
+            {t(
+              "Changing the project ID from {oldIdentifier} to {newIdentifier} can disconnect local runners configured with the current ID.",
+              { oldIdentifier, newIdentifier }
+            )}
+          </p>
+          <p>
+            {t(
+              "After this change, update each affected runner's project_slug to {newIdentifier} and restart the Pi Dash runner daemon. Agent runs may remain queued until the runners reconnect.",
+              { newIdentifier }
+            )}
+          </p>
+        </div>
+      }
+      primaryButtonText={{
+        default: t("Change project ID"),
+        loading: t("Changing project ID"),
+      }}
+    />
+  );
+}

--- a/apps/web/tests/projects/project-identifier-change-alert.test.tsx
+++ b/apps/web/tests/projects/project-identifier-change-alert.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@pi-dash/i18n", () => ({
+  useTranslation: () => ({
+    t: (key: string, values?: Record<string, string>) =>
+      values
+        ? Object.entries(values).reduce((message, [name, value]) => message.replace(`{${name}}`, value), key)
+        : key,
+  }),
+}));
+
+vi.mock("@pi-dash/ui", () => ({
+  AlertModalCore: ({
+    isOpen,
+    title,
+    content,
+    handleSubmit,
+    primaryButtonText,
+  }: {
+    isOpen: boolean;
+    title: string;
+    content: React.ReactNode;
+    handleSubmit: () => void;
+    primaryButtonText: { default: string };
+  }) =>
+    isOpen ? (
+      <div role="dialog" aria-label={title}>
+        {content}
+        <button type="button" onClick={handleSubmit}>
+          {primaryButtonText.default}
+        </button>
+      </div>
+    ) : null,
+}));
+
+import { ProjectIdentifierChangeAlert } from "@/components/project/project-identifier-change-alert";
+
+describe("ProjectIdentifierChangeAlert", () => {
+  it("warns about disconnected runners and queued runs before confirming a project ID change", async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+
+    render(
+      <ProjectIdentifierChangeAlert
+        isOpen
+        isSubmitting={false}
+        oldIdentifier="AIREPUBLIC"
+        newIdentifier="OPENHUB"
+        onClose={vi.fn()}
+        onConfirm={onConfirm}
+      />
+    );
+
+    const alert = screen.getByRole("dialog", { name: "Change project ID?" });
+    expect(alert).toHaveTextContent(
+      "Changing the project ID from AIREPUBLIC to OPENHUB can disconnect local runners configured with the current ID."
+    );
+    expect(alert).toHaveTextContent(
+      "update each affected runner's project_slug to OPENHUB and restart the Pi Dash runner daemon"
+    );
+    expect(alert).toHaveTextContent("Agent runs may remain queued until the runners reconnect.");
+
+    await user.click(screen.getByRole("button", { name: "Change project ID" }));
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

- require explicit confirmation before saving a changed project ID
- explain that local runners configured with the old ID can disconnect and leave agent runs queued
- tell users to update project_slug and restart the Pi Dash runner daemon
- cover the warning content and confirmation action with a regression test

## Verification

- pnpm --filter web test — 53 tests passed
- targeted Oxlint and Oxfmt checks passed
- pnpm --filter web check:types reaches an existing unrelated fixture error in tests/runners/runner-runs-page.test.tsx: IAgentRunPage is missing page and per_page; changed files report no type errors

## Context

Observed while recovering OPENHUB-59 after the project ID changed from AIREPUBLIC to OPENHUB.