### PR TITLE
OPENHUB-69 Inline folded comment metadata with timestamp

### DIFF
--- a/apps/space/components/issues/peek-overview/comment/comment-detail-card.tsx
+++ b/apps/space/components/issues/peek-overview/comment/comment-detail-card.tsx
@@ -101,8 +101,18 @@ export const CommentCard = observer(function CommentCard(props: Props) {
           <div className="text-11">
             {comment.actor_detail.is_bot ? comment.actor_detail.first_name + " Bot" : comment.actor_detail.display_name}
           </div>
-          <p className="mt-0.5 text-11 text-secondary">
+          <p className="mt-0.5 flex flex-wrap items-center gap-1 text-11 text-secondary">
             <>commented {timeAgo(comment.created_at)}</>
+            {isFolded && !isEditing ? (
+              <button
+                type="button"
+                className="whitespace-nowrap hover:text-primary"
+                aria-expanded={isFoldExpanded}
+                onClick={() => setIsFoldExpanded((expanded) => !expanded)}
+              >
+                Folded comment · Click to {isFoldExpanded ? "collapse" : "expand"}
+              </button>
+            ) : null}
           </p>
         </div>
         <div className="issue-comments-section p-0">
@@ -156,16 +166,6 @@ export const CommentCard = observer(function CommentCard(props: Props) {
             </div>
           </form>
           <div className={`${isEditing ? "hidden" : ""}`}>
-            {isFolded ? (
-              <button
-                type="button"
-                className="w-full rounded-md border border-subtle bg-layer-1 px-3 py-2 text-left text-11 text-secondary hover:bg-layer-2"
-                aria-expanded={isFoldExpanded}
-                onClick={() => setIsFoldExpanded((expanded) => !expanded)}
-              >
-                Folded comment · Click to {isFoldExpanded ? "collapse" : "expand"}
-              </button>
-            ) : null}
             {showCommentContent ? (
               <>
                 {agentSpeakerLabel ? (

--- a/apps/web/core/components/comments/card/display.tsx
+++ b/apps/web/core/components/comments/card/display.tsx
@@ -120,7 +120,7 @@ export const CommentCardDisplay = observer(function CommentCardDisplay(props: TC
           )}
         </div>
       )}
-      <div className="relative mb-3 flex w-full items-center gap-2">
+      <div className={cn("relative flex w-full items-center gap-2", showCommentContent && "mb-3")}>
         <Avatar size="sm" name={displayName} src={getFileURL(avatarUrl)} className="shrink-0" />
         <div className="flex flex-1 flex-wrap items-center gap-1">
           <div className="text-caption-sm-medium">{displayName}</div>
@@ -136,6 +136,16 @@ export const CommentCardDisplay = observer(function CommentCardDisplay(props: TC
               </span>
             </Tooltip>
           </div>
+          {isFolded && !(isEditing && setIsEditing) ? (
+            <button
+              type="button"
+              className="text-caption-sm-regular whitespace-nowrap text-secondary hover:text-primary"
+              aria-expanded={isFoldExpanded}
+              onClick={() => setIsFoldExpanded((expanded) => !expanded)}
+            >
+              Folded comment · Click to {isFoldExpanded ? "collapse" : "expand"}
+            </button>
+          ) : null}
         </div>
         {!disabled && (
           <div className="flex shrink-0 items-center gap-1">
@@ -164,16 +174,6 @@ export const CommentCardDisplay = observer(function CommentCardDisplay(props: TC
         />
       ) : (
         <>
-          {isFolded ? (
-            <button
-              type="button"
-              className="w-full rounded-md border border-subtle bg-layer-1 px-3 py-2 text-left text-caption-sm-regular text-secondary hover:bg-layer-2"
-              aria-expanded={isFoldExpanded}
-              onClick={() => setIsFoldExpanded((expanded) => !expanded)}
-            >
-              Folded comment · Click to {isFoldExpanded ? "collapse" : "expand"}
-            </button>
-          ) : null}
           {showCommentContent ? (
             <>
               {agentSpeakerLabel ? (

--- a/apps/web/tests/comments/folded-comment-metadata.test.ts
+++ b/apps/web/tests/comments/folded-comment-metadata.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const foldLabel = "Folded comment · Click to";
+
+function readSource(relativePath: string): string {
+  return readFileSync(new URL(relativePath, import.meta.url), "utf8");
+}
+
+function occurrences(source: string, value: string): number {
+  return source.split(value).length - 1;
+}
+
+describe("folded comment metadata layout", () => {
+  it("keeps the Web fold toggle inside the author and timestamp metadata row", () => {
+    const source = readSource("../../core/components/comments/card/display.tsx");
+    const metadataStart = source.indexOf('<div className="flex flex-1 flex-wrap items-center gap-1">');
+    const metadataEnd = source.indexOf("{!disabled &&", metadataStart);
+    const metadata = source.slice(metadataStart, metadataEnd);
+
+    expect(metadataStart).toBeGreaterThan(-1);
+    expect(metadataEnd).toBeGreaterThan(metadataStart);
+    expect(metadata).toContain("calculateTimeAgo(comment.created_at)");
+    expect(metadata).toContain(foldLabel);
+    expect(metadata).toContain("aria-expanded={isFoldExpanded}");
+    expect(metadata).toContain("setIsFoldExpanded");
+    expect(occurrences(source, foldLabel)).toBe(1);
+  });
+
+  it("keeps the Space fold toggle inside the timestamp metadata row", () => {
+    const source = readSource("../../../space/components/issues/peek-overview/comment/comment-detail-card.tsx");
+    const metadataStart = source.indexOf('<p className="mt-0.5 flex flex-wrap items-center gap-1');
+    const metadataEnd = source.indexOf("</p>", metadataStart);
+    const metadata = source.slice(metadataStart, metadataEnd);
+
+    expect(metadataStart).toBeGreaterThan(-1);
+    expect(metadataEnd).toBeGreaterThan(metadataStart);
+    expect(metadata).toContain("timeAgo(comment.created_at)");
+    expect(metadata).toContain(foldLabel);
+    expect(metadata).toContain("aria-expanded={isFoldExpanded}");
+    expect(metadata).toContain("setIsFoldExpanded");
+    expect(occurrences(source, foldLabel)).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- render folded-comment expand/collapse metadata inline with the existing timestamp
- remove the redundant full-width fold row from authenticated Web and public Space comment cards
- preserve fold state, editing visibility, accessibility state, and normal-comment behavior
- add focused regression coverage for both metadata layouts

## Validation

- `pnpm --filter=web exec vitest run` (54 tests passed)
- `pnpm --filter=space check:types`
- `pnpm --filter=web build`
- `pnpm --filter=space build`
- changed-file Oxfmt and OxLint checks

The full Web type check has one unrelated existing fixture error in `tests/runners/runner-runs-page.test.tsx:94`, where `IAgentRunPage.page` and `per_page` are absent.

Pi Dash issue: OPENHUB-69
