### PR TITLE
PDASHOSS01-75 Prevent duplicate runner working directories

### DIFF
--- a/runner/src/daemon/machine_control.rs
+++ b/runner/src/daemon/machine_control.rs
@@ -220,18 +220,23 @@ impl MachineControl {
         .await
         .map_err(|e| anyhow::anyhow!("cloud registration failed: {e}"))?;
 
-        // 2. Persist the `[[runner]]` block. `Legacy` workdir plan —
-        //    worktree pools are built once at daemon startup, so a
-        //    hot-added runner can't join one until the next restart;
-        //    running the agent directly in working_dir keeps config and
-        //    runtime consistent. Operators can migrate via the CLI.
+        // 2. Persist the `[[runner]]` block. `AutoPoolIfGit` — the same
+        //    plan `pidash runner add` defaults to: if `working_dir` is a
+        //    git repo, create or reuse a `[[workdir]]` pool and bind this
+        //    runner to it (migrating any existing legacy runner on the
+        //    exact same path). Legacy single-dir runners are deprecated and
+        //    no longer created by our own code; the pool exemption is what
+        //    lets two runners share one repo without a `DuplicateWorkingDir`
+        //    collision. Worktree pools are otherwise built once at daemon
+        //    startup, so `add_runner` below builds and registers this
+        //    runner's pool on hot-add — no restart required.
         let options = ApplyEnrollOptions {
             working_dir: (!cmd.working_dir.is_empty()).then(|| PathBuf::from(&cmd.working_dir)),
             agent_kind,
             model: (!cmd.model.is_empty()).then_some(cmd.model.as_str()),
             reasoning_effort: (!cmd.reasoning_effort.is_empty())
                 .then_some(cmd.reasoning_effort.as_str()),
-            workdir_plan: RunnerWorkdirPlan::Legacy,
+            workdir_plan: RunnerWorkdirPlan::AutoPoolIfGit,
         };
         let cloud_url = self.spawn_ctx.cloud_url();
         let applied = match apply_enroll_response(&self.spawn_ctx.paths, &resp, &cloud_url, options)

--- a/runner/src/daemon/supervisor.rs
+++ b/runner/src/daemon/supervisor.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -109,11 +109,17 @@ impl Supervisor {
             instances.push(inst);
         }
 
-        // Worktree pools — one per `[[workdir]]`. Built once at startup; each
+        // Worktree pools — one per `[[workdir]]`. Seeded at startup; each
         // runner that references a work dir leases desks from the matching
         // pool instead of running the agent directly in its `working_dir`.
         // Runners with no `workdir` reference (legacy) get no pool and keep
         // the single-dir behavior. See `.ai_design/worktree_pooling/`.
+        //
+        // The map is wrapped in an `RwLock` so the cloud-driven hot-add path
+        // (`RunnerSpawnCtx::add_runner`) can build and register a new pool at
+        // runtime — auto-pooled runners created from the UI would otherwise
+        // fail every run ("work dir has no worktree pool") until the next
+        // daemon restart.
         let worktrees_base = paths.data_dir.join("worktrees");
         let mut pools: HashMap<String, PoolHandle> = HashMap::new();
         for wd in &config.workdirs {
@@ -129,7 +135,7 @@ impl Supervisor {
                 }
             }
         }
-        let pools = Arc::new(pools);
+        let pools = Arc::new(RwLock::new(pools));
 
         let mailboxes = Arc::new(RwLock::new(
             instances
@@ -320,7 +326,7 @@ pub(crate) struct RunnerSpawnCtx {
     shared_machine_token: Option<String>,
     pub(crate) paths: Paths,
     daemon: DaemonConfig,
-    pools: Arc<HashMap<String, PoolHandle>>,
+    pools: Arc<RwLock<HashMap<String, PoolHandle>>>,
     mailboxes: Arc<RwLock<HashMap<uuid::Uuid, mpsc::Sender<InboundEnvelope>>>>,
     hello_runners: Arc<RwLock<HelloRunnerMap>>,
     daemon_state: StateHandle,
@@ -341,6 +347,19 @@ impl RunnerSpawnCtx {
     /// snapshot is built at startup, so the TUI won't list this runner
     /// until the next daemon restart.
     pub(crate) async fn add_runner(&self, runner_cfg: RunnerConfig) -> Result<()> {
+        // Auto-pooled runners created from the cloud/UI reference a
+        // `[[workdir]]` pool, but pools are otherwise seeded once at startup.
+        // Build and register this runner's pool now if it isn't live yet —
+        // otherwise every run would fail with "work dir has no worktree
+        // pool" until the next daemon restart.
+        if let Some(name) = runner_cfg.workdir.clone() {
+            let already_live = self.pools.read().await.contains_key(&name);
+            if !already_live {
+                self.ensure_pool(&name).await.with_context(|| {
+                    format!("building worktree pool for hot-added work dir {name:?}")
+                })?;
+            }
+        }
         let inst = build_runner_instance(
             runner_cfg,
             self.transport.as_ref(),
@@ -366,6 +385,30 @@ impl RunnerSpawnCtx {
         }
         let _tasks = spawn_instance_tasks(&inst, self).await;
         tracing::info!(runner_id = %inst.runner_id, name = %inst.name, "hot-added runner from machine control session");
+        Ok(())
+    }
+
+    /// Build a worktree pool for the `[[workdir]]` named `name` and register
+    /// it in the shared pool map. Used by the hot-add path when a runner
+    /// created after daemon startup references a pool that isn't live yet.
+    /// The `WorkdirConfig` is read back from `config.toml` (the enroll path
+    /// just wrote it) so the pool is built from the authoritative on-disk
+    /// definition. `pool::spawn` runs outside the write lock so a slow pool
+    /// init never blocks concurrent readers.
+    async fn ensure_pool(&self, name: &str) -> Result<()> {
+        let cfg = crate::config::file::load_config(&self.paths)
+            .context("loading config to build hot-added runner's worktree pool")?;
+        let wd = cfg
+            .workdirs
+            .iter()
+            .find(|w| w.name == name)
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("work dir {name:?} not found in config after enroll"))?;
+        let worktrees_base = self.paths.data_dir.join("worktrees");
+        let handle = crate::workspace::pool::spawn(wd, &worktrees_base).await?;
+        // Re-check under the write lock: a concurrent hot-add may have raced
+        // us. Last writer wins; a redundant pool's owner task idles harmlessly.
+        self.pools.write().await.insert(name.to_string(), handle);
         Ok(())
     }
 }
@@ -408,12 +451,19 @@ async fn spawn_instance_tasks(inst: &RunnerInstance, ctx: &RunnerSpawnCtx) -> Sp
     let live_mailboxes = ctx.mailboxes.clone();
     let live_hello_runners = ctx.hello_runners.clone();
     let daemon_paths = ctx.paths.clone();
-    // Resolve this runner's pool (if it references a work dir). Cloned
-    // handle is cheap (wraps an mpsc sender).
-    let inst_pool = runner_config
-        .workdir
-        .as_deref()
-        .and_then(|name| ctx.pools.get(name).cloned());
+    // Resolve this runner's pool and reported working dir up front, under a
+    // single read of the shared pool map, so the lock isn't held across the
+    // spawns/awaits below. Cloned handles are cheap (each wraps an mpsc
+    // sender).
+    let (inst_pool, attach_working_dir) = {
+        let pools = ctx.pools.read().await;
+        let pool = runner_config
+            .workdir
+            .as_deref()
+            .and_then(|name| pools.get(name).cloned());
+        (pool, resolve_working_dir(inst, &pools))
+    };
+    let http_pool = inst_pool.clone();
     let h = tokio::spawn(async move {
         let run = RunnerLoop {
             runner_paths,
@@ -455,15 +505,10 @@ async fn spawn_instance_tasks(inst: &RunnerInstance, ctx: &RunnerSpawnCtx) -> Sp
             inst.state.rx_status.clone(),
             inst.state.rx_in_flight.clone(),
             inst.state.shutdown_notified(),
-            attach_body_for_instance(inst, resolve_working_dir(inst, &ctx.pools)),
+            attach_body_for_instance(inst, attach_working_dir),
         )
         .with_state(inst.state.clone())
-        .with_pool(
-            inst.config
-                .workdir
-                .as_deref()
-                .and_then(|name| ctx.pools.get(name).cloned()),
-        )
+        .with_pool(http_pool)
         .with_teardown_rx(inst.remove_tx.subscribe());
         let close_client = client.clone();
         let local_state = inst.state.clone();

--- a/runner/src/ipc/server.rs
+++ b/runner/src/ipc/server.rs
@@ -9,6 +9,7 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufStream};
 use tokio::net::windows::named_pipe::{NamedPipeServer as IpcStream, ServerOptions};
 #[cfg(unix)]
 use tokio::net::{UnixListener, UnixStream as IpcStream};
+use tokio::sync::RwLock;
 use uuid::Uuid;
 
 use super::protocol::{Request, Response, RpcError, StatusSnapshot};
@@ -34,8 +35,9 @@ pub struct IpcServer {
     pub instances: Arc<HashMap<Uuid, RunnerInstance>>,
     /// Worktree pools keyed by work-dir name. Snapshotted into `pidash status`
     /// so operators can see desk occupancy and queue depth. Empty for daemons
-    /// with no `[[workdir]]` blocks.
-    pub pools: Arc<HashMap<String, crate::workspace::pool::PoolHandle>>,
+    /// with no `[[workdir]]` blocks. Wrapped in an `RwLock` because the hot-add
+    /// path registers new pools at runtime (see `RunnerSpawnCtx::add_runner`).
+    pub pools: Arc<RwLock<HashMap<String, crate::workspace::pool::PoolHandle>>>,
 }
 
 impl IpcServer {
@@ -352,8 +354,9 @@ impl IpcServer {
         }
         // Stable order so successive snapshots don't churn rendering.
         runners.sort_by(|a, b| a.name.cmp(&b.name));
-        let mut pools = Vec::with_capacity(self.pools.len());
-        for handle in self.pools.values() {
+        let pool_handles: Vec<_> = self.pools.read().await.values().cloned().collect();
+        let mut pools = Vec::with_capacity(pool_handles.len());
+        for handle in &pool_handles {
             if let Some(snap) = handle.snapshot().await {
                 pools.push(snap);
             }


### PR DESCRIPTION
## What

Runners created from the cloud/UI go through the daemon's `create_runner_inner`, which hardcoded `RunnerWorkdirPlan::Legacy`. A legacy runner runs directly in `workspace.working_dir` and is **not** exempt from `Config::validate()`'s `DuplicateWorkingDir` check, so creating a second UI runner on a repo already used by another runner failed with:

> Each runner must have its own working directory; concurrent git operations on the same tree corrupt state silently.

Per the issue decision, legacy single-dir runner creation is deprecated — our own code should no longer create legacy runners (the legacy code stays only for backward compatibility with un-upgraded CLI installs).

## Changes

- **`machine_control.rs`** — `create_runner_inner` now uses `RunnerWorkdirPlan::AutoPoolIfGit` (the same plan `pidash runner add` defaults to). On a git repo it creates/reuses a `[[workdir]]` pool and migrates any existing exact-path legacy runner into it, so two runners can share one repo via leased worktrees and both are exempt from the duplicate-dir check.
- **`supervisor.rs`** — worktree pools were built once at daemon startup, so a runner hot-added afterward would reference a pool that isn't live and fail every run with *"work dir has no worktree pool"* until the next restart. The shared pool map is now `Arc<RwLock<HashMap<..>>>`, and `RunnerSpawnCtx::add_runner` builds and registers the runner's pool on hot-add when it isn't already live — so UI-created runners work immediately, no restart required.
- **`ipc/server.rs`** — pool map field/reader updated for the new `RwLock` type; `pidash status` still snapshots live pools.

`RunnerWorkdirPlan::Legacy` and its code paths are retained for backward compatibility.

## Testing

- `cargo build -p pidash` ✅
- `cargo test -p pidash --lib` ✅ (455 passed; the one failure `workspace::git::tests::checked_out_branches_...` is a pre-existing macOS `$TMPDIR` `/private/var` vs `/var` symlink mismatch — reproduces identically on `main` with this change stashed, unrelated)
- All integration test targets compile (`cargo test -p pidash --no-run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
