### PR TITLE
PDASHOSS01-81 Pod edit and delete support in pidash

### DIFF
--- a/apps/web/app/(all)/[workspaceSlug]/runners/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/page.tsx
@@ -6,17 +6,19 @@
 
 import { useState } from "react";
 import { observer } from "mobx-react";
-import { HelpCircle, Plus } from "lucide-react";
+import { HelpCircle, MoreHorizontal, Pencil, Plus, Trash2 } from "lucide-react";
 import { useNavigate } from "react-router";
 import useSWR from "swr";
 import { useTranslation } from "@pi-dash/i18n";
+import { IconButton } from "@pi-dash/propel/icon-button";
 import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
 import { PodService, RunnerService } from "@pi-dash/services";
 import type { IPod, IRunner } from "@pi-dash/types";
-import { AlertModalCore, Badge, Button, Tooltip } from "@pi-dash/ui";
+import { AlertModalCore, Badge, Button, CustomMenu, Tooltip } from "@pi-dash/ui";
 import { PageHead } from "@/components/core/page-title";
 import { AddRunnerModal } from "@/components/runners/add-runner-modal";
 import { CreatePodModal } from "@/components/runners/create-pod-modal";
+import { EditPodModal } from "@/components/runners/edit-pod-modal";
 import { RUNNER_STATUS_I18N_LABELS, STATUS_BADGE_VARIANT } from "@/components/runners/runner-status";
 import { RunnersTabs } from "@/components/runners/runners-tabs";
 import { useSelectedPodFilter } from "@/hooks/use-selected-pod-filter";
@@ -55,11 +57,43 @@ const RunnersListPage = observer(function RunnersListPage() {
 
   const [addOpen, setAddOpen] = useState(false);
   const [createPodOpen, setCreatePodOpen] = useState(false);
+  const [editPod, setEditPod] = useState<IPod | null>(null);
+  const [deletePod, setDeletePod] = useState<IPod | null>(null);
+  const [deletingPod, setDeletingPod] = useState(false);
   const { selectedPodId, setSelectedPodId, filteredRunners, selectedPod } = useSelectedPodFilter(runners, pods);
   const [deleteRunner, setDeleteRunner] = useState<IRunner | null>(null);
   const [deleting, setDeleting] = useState(false);
   const [revokeRunner, setRevokeRunner] = useState<IRunner | null>(null);
   const [revoking, setRevoking] = useState(false);
+
+  async function confirmDeletePod() {
+    if (!deletePod) return;
+    setDeletingPod(true);
+    try {
+      await podService.remove(deletePod.id);
+      // Clearing the filter avoids stranding the list on a pod that no
+      // longer exists.
+      if (selectedPodId === deletePod.id) setSelectedPodId(null);
+      setDeletePod(null);
+      mutatePods();
+    } catch (e: unknown) {
+      const err = e as { error?: string; code?: string } | null;
+      // Surface the server's §7.2 delete guards in plain language; fall back
+      // to the raw message for anything unrecognized.
+      const byCode: Record<string, string> = {
+        pod_has_runners: t("Move or revoke this pod's runners before deleting it."),
+        pod_has_active_runs: t("This pod has active runs. Cancel them or wait before deleting it."),
+        default_pod_undeletable: t("You can't delete the project's default pod. Promote another pod first."),
+      };
+      setToast({
+        type: TOAST_TYPE.ERROR,
+        title: t("Error!"),
+        message: (err?.code && byCode[err.code]) || err?.error || t("Failed to delete pod"),
+      });
+    } finally {
+      setDeletingPod(false);
+    }
+  }
 
   async function confirmDeleteRunner() {
     if (!deleteRunner) return;
@@ -160,28 +194,59 @@ const RunnersListPage = observer(function RunnersListPage() {
             {(pods ?? []).map((p) => {
               const isSelected = p.id === selectedPodId;
               return (
-                <button
+                <div
                   key={p.id}
-                  type="button"
-                  aria-pressed={isSelected}
-                  aria-label={t("Filter runners by pod {name}", { name: p.name })}
-                  onClick={() => setSelectedPodId(isSelected ? null : p.id)}
-                  className={`rounded-md border px-3 py-2 text-left text-12 transition-colors ${
+                  className={`relative rounded-md border text-12 transition-colors ${
                     isSelected
                       ? "border-accent-strong bg-accent-primary/10 ring-1 ring-accent-strong"
                       : "border-subtle bg-layer-1 hover:border-strong"
                   }`}
                 >
-                  <div className="flex items-center gap-2">
-                    <span className="font-medium text-primary">{p.name}</span>
-                    {p.is_default && (
-                      <Badge variant="accent-neutral" size="sm">
-                        {t("default")}
-                      </Badge>
-                    )}
+                  <button
+                    type="button"
+                    aria-pressed={isSelected}
+                    aria-label={t("Filter runners by pod {name}", { name: p.name })}
+                    onClick={() => setSelectedPodId(isSelected ? null : p.id)}
+                    className="w-full rounded-md px-3 py-2 pr-9 text-left"
+                  >
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium text-primary">{p.name}</span>
+                      {p.is_default && (
+                        <Badge variant="accent-neutral" size="sm">
+                          {t("default")}
+                        </Badge>
+                      )}
+                    </div>
+                    <div className="text-secondary">{t("{count} runner(s)", { count: p.runner_count })}</div>
+                  </button>
+                  <div className="absolute top-1 right-1">
+                    <CustomMenu
+                      customButton={
+                        <IconButton
+                          icon={MoreHorizontal}
+                          variant="ghost"
+                          size="sm"
+                          aria-label={t("Pod actions for {name}", { name: p.name })}
+                        />
+                      }
+                      placement="bottom-end"
+                      closeOnSelect
+                    >
+                      <CustomMenu.MenuItem key="edit" onClick={() => setEditPod(p)} className="flex items-center gap-2">
+                        <Pencil className="size-3 shrink-0" />
+                        {t("Edit")}
+                      </CustomMenu.MenuItem>
+                      <CustomMenu.MenuItem
+                        key="delete"
+                        onClick={() => setDeletePod(p)}
+                        className="flex items-center gap-2 text-danger-primary"
+                      >
+                        <Trash2 className="size-3 shrink-0" />
+                        {t("Delete")}
+                      </CustomMenu.MenuItem>
+                    </CustomMenu>
                   </div>
-                  <div className="text-secondary">{t("{count} runner(s)", { count: p.runner_count })}</div>
-                </button>
+                </div>
               );
             })}
             <button
@@ -293,6 +358,18 @@ const RunnersListPage = observer(function RunnersListPage() {
           onCreated={() => mutatePods()}
         />
       )}
+      <EditPodModal isOpen={!!editPod} pod={editPod} onClose={() => setEditPod(null)} onUpdated={() => mutatePods()} />
+      <AlertModalCore
+        isOpen={!!deletePod}
+        handleClose={() => (deletingPod ? null : setDeletePod(null))}
+        handleSubmit={confirmDeletePod}
+        isSubmitting={deletingPod}
+        title={t("Delete pod?")}
+        content={t(
+          "The pod is removed and any issues assigned to it are unassigned. Runners and past runs are preserved. A pod with active runners or runs, or a project's default pod, can't be deleted."
+        )}
+        primaryButtonText={{ default: t("Delete"), loading: t("Delete") }}
+      />
       <AlertModalCore
         isOpen={!!deleteRunner}
         handleClose={() => (deleting ? null : setDeleteRunner(null))}

--- a/apps/web/core/components/runners/edit-pod-modal.tsx
+++ b/apps/web/core/components/runners/edit-pod-modal.tsx
@@ -1,0 +1,178 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useEffect } from "react";
+import { observer } from "mobx-react";
+import type { SubmitHandler } from "react-hook-form";
+import { Controller, useForm } from "react-hook-form";
+import { useTranslation } from "@pi-dash/i18n";
+import { Button } from "@pi-dash/propel/button";
+import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
+import { PodService } from "@pi-dash/services";
+import type { IPod } from "@pi-dash/types";
+import { EModalPosition, EModalWidth, Input, ModalCore, ToggleSwitch } from "@pi-dash/ui";
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+  /** The pod being edited. ``null`` renders nothing (modal closed). */
+  pod: IPod | null;
+  onUpdated: (pod: IPod) => void;
+};
+
+interface FormValues {
+  name: string;
+  description: string;
+  isDefault: boolean;
+}
+
+const podService = new PodService();
+
+/** Strip the ``{PROJECT}_`` prefix so the user edits only the suffix, the
+ * same shape the create modal collects. The server re-prefixes on save. */
+function suffixOf(pod: IPod): string {
+  const prefix = `${pod.project_identifier}_`;
+  return pod.name.startsWith(prefix) ? pod.name.slice(prefix.length) : pod.name;
+}
+
+export const EditPodModal = observer(function EditPodModal(props: Props) {
+  const { isOpen, onClose, pod, onUpdated } = props;
+  const { t } = useTranslation();
+
+  const {
+    control,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<FormValues>({
+    defaultValues: { name: "", description: "", isDefault: false },
+  });
+
+  // Re-seed the form each time a pod is opened so stale values from a prior
+  // edit never leak into the next one.
+  useEffect(() => {
+    if (!isOpen || !pod) return;
+    reset({
+      name: suffixOf(pod),
+      description: pod.description ?? "",
+      isDefault: pod.is_default,
+    });
+  }, [isOpen, pod, reset]);
+
+  const onSubmit: SubmitHandler<FormValues> = async (values) => {
+    if (!pod) return;
+    // Send only what actually changed; an unchanged is_default toggle stays
+    // out of the payload so we never re-issue a promote/demote no-op.
+    const payload: { name?: string; description?: string; is_default?: boolean } = {};
+    const nextName = values.name.trim();
+    if (nextName !== suffixOf(pod)) payload.name = nextName;
+    if (values.description.trim() !== (pod.description ?? "").trim()) {
+      payload.description = values.description.trim();
+    }
+    if (values.isDefault !== pod.is_default) payload.is_default = values.isDefault;
+
+    if (Object.keys(payload).length === 0) {
+      onClose();
+      return;
+    }
+
+    try {
+      const updated = await podService.update(pod.id, payload);
+      onUpdated(updated);
+      onClose();
+    } catch (e: unknown) {
+      const err = e as { error?: string } | null;
+      setToast({
+        type: TOAST_TYPE.ERROR,
+        title: t("Error!"),
+        message: err?.error ?? t("Could not update the pod."),
+      });
+    }
+  };
+
+  return (
+    <ModalCore isOpen={isOpen && !!pod} handleClose={onClose} position={EModalPosition.CENTER} width={EModalWidth.XXL}>
+      <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-5 p-5">
+        <div>
+          <div className="text-18 font-medium text-primary">{t("Edit pod")}</div>
+          <p className="mt-1 text-13 text-secondary">
+            {t("Rename the pod, update its description, or make it the project's default.")}
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor="edit-pod-name" className="text-13 font-medium text-primary">
+            {t("Name")}
+          </label>
+          <Controller
+            control={control}
+            name="name"
+            rules={{
+              validate: (v) => v.trim().length > 0 || t("Name is required."),
+            }}
+            render={({ field }) => <Input {...field} id="edit-pod-name" placeholder={t("beefy")} />}
+          />
+          <p className="text-12 text-secondary">
+            {t("Letters, digits, dashes, and underscores. The project prefix is added automatically.")}
+          </p>
+          {errors.name && <span className="text-12 text-danger-primary">{errors.name.message}</span>}
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor="edit-pod-description" className="text-13 font-medium text-primary">
+            {t("Description (optional)")}
+          </label>
+          <Controller
+            control={control}
+            name="description"
+            render={({ field }) => (
+              <Input {...field} id="edit-pod-description" placeholder={t("Where this pod runs, what it's for, etc.")} />
+            )}
+          />
+        </div>
+
+        <Controller
+          control={control}
+          name="isDefault"
+          render={({ field }) => {
+            // A pod that is already the default cannot be un-defaulted here —
+            // the project must always have a default, and the server only
+            // transfers the flag by promoting another pod. Offer the toggle
+            // only to promote a non-default pod.
+            const alreadyDefault = pod?.is_default ?? false;
+            return (
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <div className="text-13 font-medium text-primary">{t("Project default")}</div>
+                  <p className="text-12 text-secondary">
+                    {alreadyDefault
+                      ? t("This is the project's default pod. Promote another pod to change the default.")
+                      : t("New issues without an explicit pod delegate to the project's default.")}
+                  </p>
+                </div>
+                <ToggleSwitch
+                  value={field.value}
+                  onChange={field.onChange}
+                  disabled={alreadyDefault}
+                  label={t("Project default")}
+                />
+              </div>
+            );
+          }}
+        />
+
+        <div className="flex justify-end gap-2">
+          <Button variant="secondary" onClick={onClose} disabled={isSubmitting}>
+            {t("Cancel")}
+          </Button>
+          <Button type="submit" loading={isSubmitting} disabled={isSubmitting}>
+            {isSubmitting ? t("Saving…") : t("Save changes")}
+          </Button>
+        </div>
+      </form>
+    </ModalCore>
+  );
+});

--- a/apps/web/tests/runners/edit-pod-modal.test.tsx
+++ b/apps/web/tests/runners/edit-pod-modal.test.tsx
@@ -1,0 +1,221 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// vi.mock is hoisted above all imports; use vi.hoisted so the spy
+// references survive that hoist and stay shared with the test body.
+const { podUpdate, setToast } = vi.hoisted(() => ({
+  podUpdate: vi.fn(),
+  setToast: vi.fn(),
+}));
+
+vi.mock("@pi-dash/services", () => ({
+  PodService: class {
+    update = podUpdate;
+  },
+}));
+
+vi.mock("@pi-dash/i18n", () => ({
+  useTranslation: () => ({
+    t: (key: string, vars?: Record<string, unknown>) => (vars ? `${key}:${JSON.stringify(vars)}` : key),
+  }),
+}));
+
+vi.mock("@pi-dash/propel/toast", () => ({
+  TOAST_TYPE: { ERROR: "ERROR", SUCCESS: "SUCCESS" },
+  setToast,
+}));
+
+vi.mock("@pi-dash/propel/button", () => ({
+  Button: ({
+    children,
+    loading: _loading,
+    variant: _variant,
+    ...props
+  }: {
+    children: React.ReactNode;
+    loading?: boolean;
+    variant?: string;
+  } & React.ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+}));
+
+// Replace the heavy UI lib with plain DOM equivalents so the modal can be
+// driven with userEvent without dragging in headlessui machinery. The
+// ToggleSwitch stands in as a checkbox.
+vi.mock("@pi-dash/ui", async () => {
+  const { forwardRef: fwd } = await import("react");
+  return {
+    ModalCore: ({ isOpen, children }: { isOpen: boolean; children: React.ReactNode }) =>
+      isOpen ? <div role="dialog">{children}</div> : null,
+    EModalPosition: { CENTER: "CENTER" },
+    EModalWidth: { XXL: "XXL" },
+    Input: fwd<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(function Input(props, ref) {
+      return <input ref={ref} {...props} />;
+    }),
+    ToggleSwitch: ({
+      value,
+      onChange,
+      disabled,
+      label,
+    }: {
+      value: boolean;
+      onChange: (v: boolean) => void;
+      disabled?: boolean;
+      label?: string;
+    }) => (
+      <input
+        type="checkbox"
+        aria-label={label}
+        checked={value}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.checked)}
+      />
+    ),
+  };
+});
+
+import { EditPodModal } from "@/components/runners/edit-pod-modal";
+
+const POD = {
+  id: "pod-1",
+  name: "WEB_beefy",
+  description: "the spare laptop",
+  is_default: false,
+  workspace: "ws-1",
+  project: "proj-1",
+  project_identifier: "WEB",
+  created_by: "user-1",
+  runner_count: 0,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+describe("EditPodModal", () => {
+  beforeEach(() => {
+    podUpdate.mockReset();
+    setToast.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function renderModal(overrides: Partial<React.ComponentProps<typeof EditPodModal>> = {}) {
+    const onClose = vi.fn();
+    const onUpdated = vi.fn();
+    const utils = render(<EditPodModal isOpen pod={POD} onClose={onClose} onUpdated={onUpdated} {...overrides} />);
+    return { ...utils, onClose, onUpdated };
+  }
+
+  it("renders nothing when isOpen=false", () => {
+    render(<EditPodModal isOpen={false} pod={POD} onClose={vi.fn()} onUpdated={vi.fn()} />);
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("renders nothing when pod is null", () => {
+    render(<EditPodModal isOpen pod={null} onClose={vi.fn()} onUpdated={vi.fn()} />);
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("prefills the name suffix (project prefix stripped) and description", () => {
+    renderModal();
+    expect((screen.getByPlaceholderText("beefy") as HTMLInputElement).value).toBe("beefy");
+    expect((screen.getByPlaceholderText("Where this pod runs, what it's for, etc.") as HTMLInputElement).value).toBe(
+      "the spare laptop"
+    );
+  });
+
+  it("blocks submit when name is whitespace and shows name_required", async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await user.clear(screen.getByPlaceholderText("beefy"));
+    await user.type(screen.getByPlaceholderText("beefy"), "   ");
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    expect(podUpdate).not.toHaveBeenCalled();
+    expect(await screen.findByText("Name is required.")).toBeInTheDocument();
+  });
+
+  it("closes without calling update when nothing changed", async () => {
+    const user = userEvent.setup();
+    const { onClose, onUpdated } = renderModal();
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    expect(podUpdate).not.toHaveBeenCalled();
+    expect(onUpdated).not.toHaveBeenCalled();
+  });
+
+  it("sends only the changed name (trimmed) and closes on success", async () => {
+    const user = userEvent.setup();
+    podUpdate.mockResolvedValue({ ...POD, name: "WEB_chonky" });
+    const { onClose, onUpdated } = renderModal();
+
+    await user.clear(screen.getByPlaceholderText("beefy"));
+    await user.type(screen.getByPlaceholderText("beefy"), "  chonky  ");
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => {
+      expect(podUpdate).toHaveBeenCalledWith("pod-1", { name: "chonky" });
+    });
+    expect(onUpdated).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+    expect(setToast).not.toHaveBeenCalled();
+  });
+
+  it("sends is_default when the pod is promoted to default", async () => {
+    const user = userEvent.setup();
+    podUpdate.mockResolvedValue({ ...POD, is_default: true });
+    renderModal();
+
+    await user.click(screen.getByRole("checkbox", { name: "Project default" }));
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => {
+      expect(podUpdate).toHaveBeenCalledWith("pod-1", { is_default: true });
+    });
+  });
+
+  it("disables the default toggle for a pod that is already the default", () => {
+    render(<EditPodModal isOpen pod={{ ...POD, is_default: true }} onClose={vi.fn()} onUpdated={vi.fn()} />);
+    expect(screen.getByRole("checkbox", { name: "Project default" })).toBeDisabled();
+  });
+
+  it("shows a toast with the backend error and keeps the modal open on failure", async () => {
+    const user = userEvent.setup();
+    podUpdate.mockRejectedValue({ error: "name already exists" });
+    const { onClose, onUpdated } = renderModal();
+
+    await user.clear(screen.getByPlaceholderText("beefy"));
+    await user.type(screen.getByPlaceholderText("beefy"), "chonky");
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => {
+      expect(setToast).toHaveBeenCalledWith(expect.objectContaining({ type: "ERROR", message: "name already exists" }));
+    });
+    expect(onUpdated).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the generic update_failed message when the error has no .error field", async () => {
+    const user = userEvent.setup();
+    podUpdate.mockRejectedValue(null);
+    renderModal();
+
+    await user.clear(screen.getByPlaceholderText("beefy"));
+    await user.type(screen.getByPlaceholderText("beefy"), "chonky");
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => {
+      expect(setToast).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "ERROR", message: "Could not update the pod." })
+      );
+    });
+  });
+});


### PR DESCRIPTION
## What

Wires the missing **pod edit & delete UI** into the Runners page. The backend `PATCH`/`DELETE` endpoints (`PodDetailEndpoint`) and the `PodService.update`/`.remove` client already existed; the web UI only exposed create + list. Issue PDASHOSS01-81.

## Changes

- **`EditPodModal`** (`apps/web/core/components/runners/edit-pod-modal.tsx`) — rename, edit description, and promote a pod to the project default. Mirrors `CreatePodModal`. Sends only changed fields; strips/re-adds the `{PROJECT}_` name prefix like create does; disables un-defaulting the current default pod (the server only transfers the flag by promoting another pod).
- **Per-pod overflow menu** on each pod tile (`runners/page.tsx`) — an Edit / Delete `CustomMenu`. The filter tile was restructured from a bare `<button>` into a container so the menu button isn't nested inside it.
- **Delete confirm** via `AlertModalCore`, mapping the server's 409 guards (`pod_has_runners`, `pod_has_active_runs`, `default_pod_undeletable`) to plain-language toasts, and clearing the pod filter when the selected pod is deleted.
- **Tests** (`tests/runners/edit-pod-modal.test.tsx`) — prefill, no-op close, changed-field payloads, default promotion, disabled toggle, and error handling.

## Testing

- `vitest run tests/runners/edit-pod-modal.test.tsx tests/runners/create-pod-modal.test.tsx` → 18 passed.
- `tsc --noEmit` → no new errors in touched files.
- `oxlint` + `oxfmt --check` → clean on touched files.

Permission gating stays server-side (workspace admin or pod creator): the menu is shown to all members and the server's 403/409 responses surface as toasts, matching the existing runner Delete/Revoke pattern on this page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
