### PR TITLE
PDASHOSS01-98 Render tool_servers_skipped in the assistant chat UI

### DIFF
--- a/apps/web/core/components/assistant/assistant-message.tsx
+++ b/apps/web/core/components/assistant/assistant-message.tsx
@@ -4,10 +4,17 @@
  * See the LICENSE file for details.
  */
 
-import type { IAssistantLink, IAssistantMessage } from "@pi-dash/types";
+import type { IAssistantLink, IAssistantMessage, IAssistantSkippedServer } from "@pi-dash/types";
 import { ChatMessage, ChatToolActivity } from "@/components/chat/message";
+import { ToolServersSkippedNotice } from "@/components/assistant/tool-servers-skipped-notice";
 
 export function AssistantMessage({ message }: { message: IAssistantMessage }) {
+  // Client-synthesized notice (tool_servers_skipped) — render inline, not as a
+  // chat bubble.
+  if (message.role === "notice") {
+    const servers = (message.payload?.servers ?? []) as IAssistantSkippedServer[];
+    return <ToolServersSkippedNotice servers={servers} />;
+  }
   const isTool = message.role === "tool_call" || message.role === "tool_result";
   const links = (message.payload?.links ?? []) as IAssistantLink[];
   return (

--- a/apps/web/core/components/assistant/notices.ts
+++ b/apps/web/core/components/assistant/notices.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import type { IAssistantMessage, IAssistantSkippedServer } from "@pi-dash/types";
+
+/**
+ * Client-only `tool_servers_skipped` notices, and how they sit in a transcript.
+ *
+ * These are synthesized in the browser from an SSE event and never persisted,
+ * which makes their ordering the whole problem: events and messages are
+ * numbered by two independent per-thread counters (`_next_event_seq` /
+ * `_next_message_seq` in `assistant/runtime/events.py`), and every streamed
+ * delta consumes an event seq — so the event counter runs far ahead of the
+ * message counter and the two spaces are *not* comparable.
+ */
+
+export type ById = Record<string, IAssistantMessage>;
+
+export const isNotice = (m: IAssistantMessage): boolean => m.role === "notice";
+
+// The event seq a notice was synthesized from. Real messages have unique
+// integer seqs, so this only ever breaks ties between two notices anchored to
+// the same message.
+export const noticeEventSeq = (m: IAssistantMessage): number => {
+  const seq = (m.payload as { event_seq?: unknown } | undefined)?.event_seq;
+  return typeof seq === "number" ? seq : 0;
+};
+
+export const bySeq = (a: IAssistantMessage, b: IAssistantMessage): number =>
+  a.seq - b.seq || noticeEventSeq(a) - noticeEventSeq(b);
+
+/**
+ * Add the notice for one `tool_servers_skipped` event.
+ *
+ * Anchored just after the highest *message* seq present when it arrives — using
+ * the event seq directly would sort every notice below the newest turn — and
+ * never moved again, so an SSE replay from 0 is idempotent.
+ */
+export function withNotice(prev: ById, eventSeq: number, servers: IAssistantSkippedServer[], createdAt: string): ById {
+  const id = `notice:${eventSeq}`;
+  if (prev[id]) return prev; // already anchored — replay must not re-anchor it
+  let anchor = 0;
+  for (const m of Object.values(prev)) if (!isNotice(m) && m.seq > anchor) anchor = m.seq;
+  return {
+    ...prev,
+    [id]: {
+      id,
+      role: "notice",
+      content: "",
+      status: "completed",
+      // Between the anchor message and the next one; ties broken by event_seq.
+      seq: anchor + 0.5,
+      turn_id: null,
+      payload: { servers, event_seq: eventSeq },
+      created_at: createdAt,
+      completed_at: createdAt,
+    },
+  };
+}
+
+/**
+ * The highest-seq real message, used to detect turn completion from polled
+ * state when an SSE `turn_completed` is missed.
+ *
+ * Notices are excluded deliberately: they anchor *after* the message they
+ * follow, so a notice would otherwise always be the max-seq item, never carry a
+ * terminal role, and leave the composer disabled for the rest of the turn.
+ */
+export function latestRealMessage(list: IAssistantMessage[]): IAssistantMessage | undefined {
+  let last: IAssistantMessage | undefined;
+  for (const m of list) if (!isNotice(m) && (!last || m.seq > last.seq)) last = m;
+  return last;
+}

--- a/apps/web/core/components/assistant/tool-servers-skipped-notice.tsx
+++ b/apps/web/core/components/assistant/tool-servers-skipped-notice.tsx
@@ -17,7 +17,7 @@ const REASON_TEXT: Record<string, string> = {
   url_blocked: "its URL is not allowed",
   auth_header_unreadable: "its credential could not be read",
   toolset_unavailable: "it could not be reached",
-  toolsets_unavailable: "tools were unavailable",
+  toolsets_unavailable: "they could not be loaded",
   assistant_not_configured: "its credential could not be decrypted",
   openhub_unavailable: "OpenHub apps were unavailable",
 };
@@ -28,9 +28,13 @@ function reasonText(reason: string): string {
 
 function noticeLine(server: IAssistantSkippedServer): string {
   const detail = reasonText(server.reason);
-  // The resolver's total-failure sentinel isn't a real server name; phrase it
-  // as a whole-capability outage rather than "Tool server all tool servers…".
-  if (server.name === "all tool servers") {
+  // The resolver's total-failure sentinel carries a placeholder name, not a
+  // real server; phrase it as a whole-capability outage rather than "Tool
+  // server all tool servers…". Discriminate on the reason code, which is
+  // unique to that branch — the name is user-supplied for every other reason,
+  // so matching on it would let a server *named* "all tool servers" falsely
+  // report an outage of every server.
+  if (server.reason === "toolsets_unavailable") {
     return `Tool servers were unavailable for this reply (${detail}).`;
   }
   return `Tool server ${server.name} was unavailable for this reply (${detail}).`;

--- a/apps/web/core/components/assistant/tool-servers-skipped-notice.tsx
+++ b/apps/web/core/components/assistant/tool-servers-skipped-notice.tsx
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { PlugZap } from "lucide-react";
+import type { IAssistantSkippedServer } from "@pi-dash/types";
+
+// Machine-readable reason codes the backend emits for a dropped tool server,
+// mapped to short human text. The set covers OSS (mcp.py + the resolver
+// total-failure branch), the surfaced crypto AssistantError code, and the
+// cloud overlay's OpenHub reason. Runtime mid-run failures report a raw Python
+// exception class name rather than a fixed code, so anything unmapped falls
+// back to the raw reason below.
+const REASON_TEXT: Record<string, string> = {
+  url_blocked: "its URL is not allowed",
+  auth_header_unreadable: "its credential could not be read",
+  toolset_unavailable: "it could not be reached",
+  toolsets_unavailable: "tools were unavailable",
+  assistant_not_configured: "its credential could not be decrypted",
+  openhub_unavailable: "OpenHub apps were unavailable",
+};
+
+function reasonText(reason: string): string {
+  return REASON_TEXT[reason] ?? reason;
+}
+
+function noticeLine(server: IAssistantSkippedServer): string {
+  const detail = reasonText(server.reason);
+  // The resolver's total-failure sentinel isn't a real server name; phrase it
+  // as a whole-capability outage rather than "Tool server all tool servers…".
+  if (server.name === "all tool servers") {
+    return `Tool servers were unavailable for this reply (${detail}).`;
+  }
+  return `Tool server ${server.name} was unavailable for this reply (${detail}).`;
+}
+
+/**
+ * Unobtrusive inline notice for a `tool_servers_skipped` event. Rendered in the
+ * thread (not a toast) because the event can recur every turn while a server is
+ * down.
+ */
+export function ToolServersSkippedNotice({ servers }: { servers: IAssistantSkippedServer[] }) {
+  if (servers.length === 0) return null;
+  return (
+    <div className="flex items-start gap-2 rounded-md border border-subtle bg-surface-1 px-3 py-2 text-12 text-secondary">
+      <PlugZap className="mt-0.5 size-3.5 shrink-0" />
+      <div className="flex flex-col gap-0.5">
+        {servers.map((s) => (
+          <span key={`${s.name}:${s.reason}`}>{noticeLine(s)}</span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/core/components/assistant/use-assistant-chat.ts
+++ b/apps/web/core/components/assistant/use-assistant-chat.ts
@@ -7,7 +7,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import useSWR, { useSWRConfig } from "swr";
 import { AssistantService } from "@pi-dash/services";
-import type { IAssistantEvent, IAssistantMessage } from "@pi-dash/types";
+import type { IAssistantEvent, IAssistantMessage, IAssistantSkippedServer } from "@pi-dash/types";
 
 const service = new AssistantService();
 
@@ -151,6 +151,32 @@ export function useAssistantChat(slug: string | undefined, threadId: string | un
         case "tool_result": {
           const m = payload.message as IAssistantMessage | undefined;
           if (m) setById((prev) => ({ ...prev, [m.id]: { ...prev[m.id], ...m } }));
+          break;
+        }
+        case "tool_servers_skipped": {
+          // A run dropped one or more MCP tool servers (blocked URL, unreadable
+          // credential, unreachable, died mid-run, or the whole resolver
+          // failing). Surface it as an inline, non-fatal notice keyed by seq so
+          // it interleaves in the thread and an SSE replay from 0 is idempotent.
+          // It is client-only (never persisted); reload re-derives it from the
+          // replayed event.
+          const servers = (payload.servers as IAssistantSkippedServer[] | undefined) ?? [];
+          if (servers.length === 0) break;
+          const id = `notice:${event.seq}`;
+          setById((prev) => ({
+            ...prev,
+            [id]: {
+              id,
+              role: "notice",
+              content: "",
+              status: "completed",
+              seq: event.seq,
+              turn_id: null,
+              payload: { servers },
+              created_at: event.created_at,
+              completed_at: event.created_at,
+            },
+          }));
           break;
         }
         case "turn_failed":

--- a/apps/web/core/components/assistant/use-assistant-chat.ts
+++ b/apps/web/core/components/assistant/use-assistant-chat.ts
@@ -8,10 +8,9 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import useSWR, { useSWRConfig } from "swr";
 import { AssistantService } from "@pi-dash/services";
 import type { IAssistantEvent, IAssistantMessage, IAssistantSkippedServer } from "@pi-dash/types";
+import { bySeq, latestRealMessage, withNotice, type ById } from "@/components/assistant/notices";
 
 const service = new AssistantService();
-
-const bySeq = (a: IAssistantMessage, b: IAssistantMessage): number => a.seq - b.seq;
 
 // Server page size for transcript fetches. Threads are capped server-side
 // (MAX_THREAD_MESSAGES), so the pagination loop below is bounded to a few pages.
@@ -38,8 +37,6 @@ function deltaText(payload: Record<string, unknown>): string {
   }
   return "";
 }
-
-type ById = Record<string, IAssistantMessage>;
 
 export interface UseAssistantChat {
   messages: IAssistantMessage[];
@@ -70,6 +67,12 @@ export function useAssistantChat(slug: string | undefined, threadId: string | un
   // Track applied delta event seqs so an SSE reconnect (which replays from 0)
   // doesn't double-append in-flight streamed text.
   const appliedDeltas = useRef<Set<number>>(new Set());
+  // Notices anchor to the highest message seq present when they arrive, so on a
+  // cold load they must wait for the transcript — the SSE replay and the SWR
+  // fetch race, and anchoring against an empty map would pin every replayed
+  // notice to the top of the thread.
+  const transcriptLoaded = useRef(false);
+  const pendingNotices = useRef<{ seq: number; servers: IAssistantSkippedServer[]; at: string }[]>([]);
 
   const { data: base, mutate } = useSWR<IAssistantMessage[]>(
     slug && threadId ? ["assistant-messages", slug, threadId] : null,
@@ -84,6 +87,8 @@ export function useAssistantChat(slug: string | undefined, threadId: string | un
     setBusy(false);
     setError(null);
     appliedDeltas.current = new Set();
+    transcriptLoaded.current = false;
+    pendingNotices.current = [];
   }, [slug, threadId]);
 
   // Merge the durable transcript (SWR fetch/poll) into local state without
@@ -99,6 +104,22 @@ export function useAssistantChat(slug: string | undefined, threadId: string | un
       }
       return next;
     });
+    transcriptLoaded.current = true;
+    // The transcript is in — anchor any notices that replayed ahead of it,
+    // oldest event first so they keep their relative order. Drained out here
+    // rather than inside the updater above: an updater must stay pure, or
+    // StrictMode's double invocation drops the notices on the second pass.
+    if (pendingNotices.current.length > 0) {
+      const queued = pendingNotices.current;
+      pendingNotices.current = [];
+      // eslint-disable-next-line unicorn/no-array-sort -- local array, discarded; toSorted not in tsconfig lib target
+      queued.sort((a, b) => a.seq - b.seq);
+      setById((prev) => {
+        let next = prev;
+        for (const n of queued) next = withNotice(next, n.seq, n.servers, n.at);
+        return next;
+      });
+    }
   }, [base]);
 
   // Fallback turn-completion detection from polled state (covers a missed SSE
@@ -111,8 +132,10 @@ export function useAssistantChat(slug: string | undefined, threadId: string | un
     const list = Object.values(byId);
     if (list.length === 0) return;
     if (list.some((m) => m.status === "streaming")) return;
-    let last: IAssistantMessage | undefined;
-    for (const m of list) if (!last || m.seq > last.seq) last = m;
+    // Notices are excluded: anchored after the message they follow, one would
+    // otherwise always be the max-seq item, never carry a terminal role, and
+    // wedge the composer for the rest of the turn.
+    const last = latestRealMessage(list);
     if (last && (last.role === "assistant" || last.role === "error") && last.status !== "streaming") {
       setBusy(false);
     }
@@ -156,27 +179,19 @@ export function useAssistantChat(slug: string | undefined, threadId: string | un
         case "tool_servers_skipped": {
           // A run dropped one or more MCP tool servers (blocked URL, unreadable
           // credential, unreachable, died mid-run, or the whole resolver
-          // failing). Surface it as an inline, non-fatal notice keyed by seq so
-          // it interleaves in the thread and an SSE replay from 0 is idempotent.
-          // It is client-only (never persisted); reload re-derives it from the
-          // replayed event.
+          // failing). Surface it as an inline, non-fatal notice anchored to the
+          // turn it belongs to (see withNotice) so it interleaves in the thread
+          // and an SSE replay from 0 is idempotent. It is client-only (never
+          // persisted); reload re-derives it from the replayed event.
           const servers = (payload.servers as IAssistantSkippedServer[] | undefined) ?? [];
           if (servers.length === 0) break;
-          const id = `notice:${event.seq}`;
-          setById((prev) => ({
-            ...prev,
-            [id]: {
-              id,
-              role: "notice",
-              content: "",
-              status: "completed",
-              seq: event.seq,
-              turn_id: null,
-              payload: { servers },
-              created_at: event.created_at,
-              completed_at: event.created_at,
-            },
-          }));
+          if (!transcriptLoaded.current) {
+            // Replayed ahead of the transcript — hold it until there is
+            // something to anchor against (flushed by the merge effect).
+            pendingNotices.current.push({ seq: event.seq, servers, at: event.created_at });
+            break;
+          }
+          setById((prev) => withNotice(prev, event.seq, servers, event.created_at));
           break;
         }
         case "turn_failed":

--- a/apps/web/tests/assistant/notices.test.ts
+++ b/apps/web/tests/assistant/notices.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { IAssistantMessage } from "@pi-dash/types";
+
+import { bySeq, latestRealMessage, withNotice, type ById } from "@/components/assistant/notices";
+
+const AT = "2026-09-03T10:00:00Z";
+
+function msg(id: string, seq: number, role: IAssistantMessage["role"]): IAssistantMessage {
+  return {
+    id,
+    role,
+    content: "",
+    status: "completed",
+    seq,
+    turn_id: null,
+    payload: {},
+    created_at: AT,
+    completed_at: AT,
+  } as IAssistantMessage;
+}
+
+function transcript(...messages: IAssistantMessage[]): ById {
+  return Object.fromEntries(messages.map((m) => [m.id, m]));
+}
+
+const order = (m: ById): string[] =>
+  Object.values(m)
+    .slice()
+    // eslint-disable-next-line unicorn/no-array-sort -- fresh copy; toSorted not in tsconfig lib target
+    .sort(bySeq)
+    .map((x) => x.id);
+
+describe("notice anchoring", () => {
+  // Event seqs run far ahead of message seqs (every streamed delta burns one),
+  // so a notice numbered in the event space sorts below every later turn.
+  it("anchors a notice to the current turn, not to its event seq", () => {
+    let state = transcript(msg("u1", 1, "user"), msg("a1", 2, "assistant"));
+    // Event seq 900 is what the backend allocated; the turn only reached msg 2.
+    state = withNotice(state, 900, [{ name: "Jira", reason: "url_blocked" }], AT);
+    // A later turn arrives afterwards.
+    state = { ...state, u2: msg("u2", 3, "user"), a2: msg("a2", 4, "assistant") };
+
+    expect(order(state)).toEqual(["u1", "a1", "notice:900", "u2", "a2"]);
+  });
+
+  it("keeps two notices from one turn in event order", () => {
+    let state = transcript(msg("u1", 1, "user"));
+    state = withNotice(state, 900, [{ name: "Build-time", reason: "url_blocked" }], AT);
+    state = withNotice(state, 950, [{ name: "Run-time", reason: "toolset_unavailable" }], AT);
+
+    expect(order(state)).toEqual(["u1", "notice:900", "notice:950"]);
+  });
+
+  it("is idempotent across an SSE replay and never re-anchors", () => {
+    let state = transcript(msg("u1", 1, "user"), msg("a1", 2, "assistant"));
+    state = withNotice(state, 900, [{ name: "Jira", reason: "url_blocked" }], AT);
+    const anchored = state["notice:900"].seq;
+
+    // A later turn lands, then the stream reconnects and replays from 0.
+    state = { ...state, u2: msg("u2", 3, "user"), a2: msg("a2", 4, "assistant") };
+    state = withNotice(state, 900, [{ name: "Jira", reason: "url_blocked" }], AT);
+
+    expect(Object.keys(state).filter((k) => k.startsWith("notice:"))).toHaveLength(1);
+    expect(state["notice:900"].seq).toBe(anchored);
+    expect(order(state)).toEqual(["u1", "a1", "notice:900", "u2", "a2"]);
+  });
+});
+
+describe("latestRealMessage", () => {
+  // Regression: a notice is anchored *after* the reply it follows, so it is the
+  // max-seq item. If the turn-completion fallback picked it, it would see role
+  // "notice", never clear busy, and leave the composer disabled forever.
+  it("ignores a trailing notice so the terminal reply still wins", () => {
+    const state = withNotice(
+      transcript(msg("u1", 1, "user"), msg("a1", 2, "assistant")),
+      900,
+      [{ name: "Jira", reason: "url_blocked" }],
+      AT
+    );
+
+    const last = latestRealMessage(Object.values(state));
+    expect(last?.id).toBe("a1");
+    expect(last?.role).toBe("assistant");
+  });
+
+  it("returns undefined when a thread holds only notices", () => {
+    const state = withNotice({}, 900, [{ name: "Jira", reason: "url_blocked" }], AT);
+    expect(latestRealMessage(Object.values(state))).toBeUndefined();
+  });
+});

--- a/apps/web/tests/assistant/tool-servers-skipped-notice.test.tsx
+++ b/apps/web/tests/assistant/tool-servers-skipped-notice.test.tsx
@@ -28,7 +28,16 @@ describe("ToolServersSkippedNotice", () => {
 
   it("phrases the resolver total-failure sentinel as a whole-capability outage", () => {
     render(<ToolServersSkippedNotice servers={[{ name: "all tool servers", reason: "toolsets_unavailable" }]} />);
-    expect(screen.getByText("Tool servers were unavailable for this reply (tools were unavailable).")).toBeTruthy();
+    expect(screen.getByText("Tool servers were unavailable for this reply (they could not be loaded).")).toBeTruthy();
+  });
+
+  it("keys the whole-capability phrasing off the reason, not the server name", () => {
+    // A user may legitimately name a server "all tool servers"; that must not
+    // be reported as every server being down.
+    render(<ToolServersSkippedNotice servers={[{ name: "all tool servers", reason: "url_blocked" }]} />);
+    expect(
+      screen.getByText("Tool server all tool servers was unavailable for this reply (its URL is not allowed).")
+    ).toBeTruthy();
   });
 
   it("renders the cloud openhub reason", () => {

--- a/apps/web/tests/assistant/tool-servers-skipped-notice.test.tsx
+++ b/apps/web/tests/assistant/tool-servers-skipped-notice.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ToolServersSkippedNotice } from "@/components/assistant/tool-servers-skipped-notice";
+
+describe("ToolServersSkippedNotice", () => {
+  it("maps a known reason code to readable text", () => {
+    render(<ToolServersSkippedNotice servers={[{ name: "Jira Tools", reason: "url_blocked" }]} />);
+    expect(
+      screen.getByText("Tool server Jira Tools was unavailable for this reply (its URL is not allowed).")
+    ).toBeTruthy();
+  });
+
+  it("maps the surfaced crypto AssistantError code", () => {
+    render(<ToolServersSkippedNotice servers={[{ name: "Secure Tools", reason: "assistant_not_configured" }]} />);
+    expect(
+      screen.getByText(
+        "Tool server Secure Tools was unavailable for this reply (its credential could not be decrypted)."
+      )
+    ).toBeTruthy();
+  });
+
+  it("phrases the resolver total-failure sentinel as a whole-capability outage", () => {
+    render(<ToolServersSkippedNotice servers={[{ name: "all tool servers", reason: "toolsets_unavailable" }]} />);
+    expect(screen.getByText("Tool servers were unavailable for this reply (tools were unavailable).")).toBeTruthy();
+  });
+
+  it("renders the cloud openhub reason", () => {
+    render(<ToolServersSkippedNotice servers={[{ name: "OpenHub apps", reason: "openhub_unavailable" }]} />);
+    expect(
+      screen.getByText("Tool server OpenHub apps was unavailable for this reply (OpenHub apps were unavailable).")
+    ).toBeTruthy();
+  });
+
+  it("falls back to the raw reason for an unknown code (e.g. a runtime exception name)", () => {
+    render(<ToolServersSkippedNotice servers={[{ name: "Flaky Tools", reason: "ConnectionError" }]} />);
+    expect(screen.getByText("Tool server Flaky Tools was unavailable for this reply (ConnectionError).")).toBeTruthy();
+  });
+
+  it("renders one line per skipped server", () => {
+    render(
+      <ToolServersSkippedNotice
+        servers={[
+          { name: "Jira Tools", reason: "url_blocked" },
+          { name: "Confluence", reason: "toolset_unavailable" },
+        ]}
+      />
+    );
+    expect(
+      screen.getByText("Tool server Jira Tools was unavailable for this reply (its URL is not allowed).")
+    ).toBeTruthy();
+    expect(
+      screen.getByText("Tool server Confluence was unavailable for this reply (it could not be reached).")
+    ).toBeTruthy();
+  });
+
+  it("renders nothing when there are no servers", () => {
+    const { container } = render(<ToolServersSkippedNotice servers={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/packages/types/src/assistant.ts
+++ b/packages/types/src/assistant.ts
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // See the LICENSE file for details.
 
-export type TAssistantMessageRole = "user" | "assistant" | "tool_call" | "tool_result" | "error";
+// "notice" is a client-synthesized role (never persisted) used to render
+// inline, non-fatal notices in the thread — e.g. a tool_servers_skipped event.
+export type TAssistantMessageRole = "user" | "assistant" | "tool_call" | "tool_result" | "error" | "notice";
 export type TAssistantMessageStatus = "streaming" | "completed" | "failed" | "cancelled";
 export type TAssistantProviderKind = "openai_compatible" | "anthropic";
 
@@ -33,6 +35,21 @@ export interface IAssistantMessage {
   payload: { links?: IAssistantLink[] } & Record<string, unknown>;
   created_at: string;
   completed_at: string | null;
+}
+
+/** One MCP tool server that was dropped from a run, with a machine-readable reason. */
+export interface IAssistantSkippedServer {
+  name: string;
+  reason: string;
+}
+
+/**
+ * Payload of the `tool_servers_skipped` SSE event: the servers a run could not
+ * use, so the UI can tell the user a capability was unavailable instead of
+ * silently losing it.
+ */
+export interface IToolServersSkippedPayload {
+  servers: IAssistantSkippedServer[];
 }
 
 export interface IAssistantEvent {


### PR DESCRIPTION
## What

Render the `tool_servers_skipped` SSE event in the assistant chat UI.

The event switch in `apps/web/core/components/assistant/use-assistant-chat.ts`
ended in `default: break`, so when a run silently dropped a user-configured MCP
tool server (blocked URL, unreadable credential, unreachable at connect, died
mid-run, or the whole resolver failing) the event was discarded and the user
was never told a capability had gone missing. The backend fail-open shipped in
PR #327; this closes the reporting gap.

## Changes

- `packages/types/src/assistant.ts` — add `IAssistantSkippedServer` and
  `IToolServersSkippedPayload`; add a client-only `"notice"` UI message role.
- `use-assistant-chat.ts` — handle `tool_servers_skipped` by synthesizing a
  notice message keyed by `notice:<seq>` into the transcript so it interleaves
  in the thread by seq and an SSE replay from 0 is idempotent (the notice is
  never persisted; reload re-derives it from the replayed event).
- `tool-servers-skipped-notice.tsx` — new unobtrusive inline notice (not a
  toast, since the event can recur every turn while a server is down). Maps
  known reason codes (`url_blocked`, `auth_header_unreadable`,
  `toolset_unavailable`, `toolsets_unavailable`, the surfaced crypto
  `assistant_not_configured`, and the cloud `openhub_unavailable`) to readable
  text, falling back to the raw code for runtime exception-name reasons. The
  resolver total-failure sentinel (`"all tool servers"`) is phrased as a
  whole-capability outage.
- `assistant-message.tsx` — render the notice role.

Covers both OSS and the cloud overlay's `("OpenHub apps", "openhub_unavailable")`
through the same renderer.

## Testing

- New `tests/assistant/tool-servers-skipped-notice.test.tsx` (7 cases: reason
  mapping, crypto code, total-failure sentinel, cloud openhub, unknown-code
  fallback, multiple servers, empty).
- `pnpm --filter web test` — 59/59 pass.
- `pnpm turbo run check:types --filter=web --filter=@pi-dash/types` — pass.
- `pnpm check:lint` — 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
