### PR TITLE
PDASHOSS01-99 Add GPT-6 Astra to runner model selection for Codex

### DIFF
--- a/apps/web/core/components/runners/runner-models.ts
+++ b/apps/web/core/components/runners/runner-models.ts
@@ -42,6 +42,8 @@ const DEFAULT_OPTION: IRunnerModelOption = {
 // Codex: model × reasoning effort. The effort tier is sent on `turn/start`;
 // `xhigh` is Codex's "extra high" tier.
 const CODEX_MODELS: Array<{ label: string; model: string }> = [
+  // GPT-6 Astra is the current flagship; a single snapshot with no tier slugs.
+  { label: "GPT-6 Astra", model: "gpt-6-astra" },
   // GPT-5.6 is a three-tier family: Sol (flagship), Terra (balanced), Luna
   // (fastest/cheapest). `gpt-5.6` aliases Sol; we pin explicit tier slugs.
   { label: "GPT-5.6 Sol", model: "gpt-5.6-sol" },


### PR DESCRIPTION
## Summary

Adds **GPT-6 Astra** (`gpt-6-astra`) to the Codex agent's model catalog in the "Add runner" form, so operators can pin a Codex runner to OpenAI's current flagship. Mirrors PDASHOSS01-84 (Opus 5), but for the Codex catalog.

- One entry added to `CODEX_MODELS` in `apps/web/core/components/runners/runner-models.ts`, placed at the top as the flagship (ahead of the GPT-5.6 family).
- `CODEX_OPTIONS` expands each model across the existing reasoning-effort tiers, so this yields **Low / Medium / High / Extra High** dropdown options for GPT-6 Astra, each emitting `--model gpt-6-astra --reasoning-effort <tier>`.

Model slug confirmed against the [OpenAI GPT-6 Astra docs](https://developers.openai.com/api/docs/models/gpt-6-astra).

## Note / out of scope

The docs indicate GPT-6 Astra also supports a `max` reasoning-effort tier. The shared `CODEX_EFFORTS` list currently tops out at `xhigh`; adding `max` would affect all Codex models, so it's intentionally left out of this change for separate triage.

## Validation

- `pnpm turbo run check:types --filter=web` — passes
- `oxlint` on the changed file — 0 warnings, 0 errors

Resolves PDASHOSS01-99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
