### PR TITLE
PDASHOSS01-100 Add AgentRun.agent_metadata JSON field to durably record the local agent session id

### DIFF
--- a/apps/api/pi_dash/runner/migrations/0024_agentrun_agent_metadata.py
+++ b/apps/api/pi_dash/runner/migrations/0024_agentrun_agent_metadata.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Add ``AgentRun.agent_metadata`` — a general-purpose, write-once-per-attempt
+JSON column for run metadata that has no owned single-producer/consumer
+contract. Used to durably record the runner-reported local agent session id /
+thread id / agent kind at run start; unlike ``thread_id`` it is never cleared
+on retry, so a failed attempt's session id survives for audit."""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("runner", "0023_one_active_includes_cancel_requested"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="agentrun",
+            name="agent_metadata",
+            field=models.JSONField(blank=True, default=dict),
+        ),
+    ]

--- a/apps/api/pi_dash/runner/models.py
+++ b/apps/api/pi_dash/runner/models.py
@@ -938,6 +938,16 @@ class AgentRun(models.Model):
     run_config = models.JSONField(default=dict, blank=True)
     required_capabilities = models.JSONField(default=list, blank=True)
     thread_id = models.CharField(max_length=128, blank=True, default="")
+    # General-purpose per-attempt run metadata. Unlike the four owned JSON
+    # contracts above (``run_config`` / ``done_payload`` / ``prompt_manifest``
+    # / ``required_capabilities``), this column has no single downstream
+    # consumer and is not fed back into any prompt or capability match. It is
+    # written once at run start with the runner-reported
+    # ``{local_session_id, local_thread_id, agent_kind}`` and — unlike
+    # ``thread_id``, which is a resume handle cleared on retry
+    # (run_lifecycle.apply_run_resume_unavailable) — is never cleared, so a
+    # failed attempt's session id survives for audit / local session lookup.
+    agent_metadata = models.JSONField(default=dict, blank=True)
     lease_expires_at = models.DateTimeField(null=True, blank=True)
     done_payload = models.JSONField(null=True, blank=True)
     error = models.TextField(blank=True, default="")

--- a/apps/api/pi_dash/runner/serializers.py
+++ b/apps/api/pi_dash/runner/serializers.py
@@ -274,6 +274,7 @@ class AgentRunSerializer(serializers.ModelSerializer):
             "cancel_reason",
             "prompt",
             "thread_id",
+            "agent_metadata",
             "runner",
             "work_item",
             "pod",

--- a/apps/api/pi_dash/runner/views/run_endpoints.py
+++ b/apps/api/pi_dash/runner/views/run_endpoints.py
@@ -212,10 +212,25 @@ class RunStartedEndpoint(_RunEndpointBase):
             if pending := self._cancellation_pending(locked):
                 return pending
             thread_id = (request.data.get("thread_id") or "")[:128]
+            # ``local_thread_id`` defaults to ``thread_id`` for older runners
+            # that report only the resume handle; ``local_session_id`` and
+            # ``agent_kind`` are new keys the run bridge reports at start.
+            # agent_metadata is write-once here and never cleared on retry (so
+            # a failed attempt's session id survives), in contrast to the
+            # ``thread_id`` write, which run_lifecycle nulls on the parent when
+            # a resume is unavailable.
+            local_thread_id = (request.data.get("local_thread_id") or thread_id or "")[:128]
+            local_session_id = (request.data.get("local_session_id") or "")[:128]
+            agent_kind = (request.data.get("agent_kind") or "")[:24]
             updates = {
                 "status": AgentRunStatus.RUNNING,
                 "thread_id": thread_id,
                 "started_at": timezone.now(),
+                "agent_metadata": {
+                    "local_session_id": local_session_id,
+                    "local_thread_id": local_thread_id,
+                    "agent_kind": agent_kind,
+                },
             }
             model = str(request.data.get("model") or "").strip()
             if model:

--- a/apps/api/pi_dash/tests/unit/runner/test_https_transport_run_endpoints.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_https_transport_run_endpoints.py
@@ -201,6 +201,100 @@ def test_idempotency_key_dedupes_duplicate(db, api_client, runner_token, assigne
 
 
 @pytest.mark.unit
+def test_started_endpoint_persists_agent_metadata(db, api_client, runner_token, assigned_run):
+    """The run-started call records the runner-reported session id / thread id
+    / agent kind into ``agent_metadata`` while keeping the ``thread_id`` write
+    for backward-compatible resume."""
+    resp = api_client.post(
+        f"/api/v1/runner/runs/{assigned_run.id}/started/",
+        {
+            "thread_id": "sess_xyz",
+            "local_session_id": "sess_xyz",
+            "agent_kind": "claude_code",
+        },
+        format="json",
+        HTTP_AUTHORIZATION=f"Bearer {runner_token}",
+    )
+    assert resp.status_code == 200, resp.data
+    assigned_run.refresh_from_db()
+    assert assigned_run.status == AgentRunStatus.RUNNING
+    assert assigned_run.thread_id == "sess_xyz"
+    assert assigned_run.agent_metadata == {
+        "local_session_id": "sess_xyz",
+        # local_thread_id defaults to thread_id when not sent explicitly.
+        "local_thread_id": "sess_xyz",
+        "agent_kind": "claude_code",
+    }
+
+
+@pytest.mark.unit
+def test_started_endpoint_agent_metadata_backward_compatible(db, api_client, runner_token, assigned_run):
+    """An older runner that reports only ``thread_id`` still populates
+    ``agent_metadata`` (local_thread_id mirrors thread_id; the unreported keys
+    are empty rather than absent)."""
+    resp = api_client.post(
+        f"/api/v1/runner/runs/{assigned_run.id}/started/",
+        {"thread_id": "sess_legacy"},
+        format="json",
+        HTTP_AUTHORIZATION=f"Bearer {runner_token}",
+    )
+    assert resp.status_code == 200, resp.data
+    assigned_run.refresh_from_db()
+    assert assigned_run.agent_metadata == {
+        "local_session_id": "",
+        "local_thread_id": "sess_legacy",
+        "agent_kind": "",
+    }
+
+
+@pytest.mark.unit
+def test_resume_unavailable_clears_thread_id_but_keeps_agent_metadata(
+    db, api_client, runner_token, assigned_run, create_user, workspace, pod, enrolled_runner
+):
+    """A retry that nulls the parent's ``thread_id`` (fresh-session Assign)
+    must leave the parent's ``agent_metadata`` intact — the failed attempt's
+    session id survives for audit."""
+    parent = AgentRun.objects.create(
+        owner=create_user,
+        created_by=create_user,
+        workspace=workspace,
+        pod=pod,
+        runner=enrolled_runner,
+        prompt="parent",
+        status=AgentRunStatus.RUNNING,
+        thread_id="sess_parent",
+        agent_metadata={
+            "local_session_id": "sess_parent",
+            "local_thread_id": "sess_parent",
+            "agent_kind": "codex",
+        },
+        started_at=timezone.now(),
+    )
+    assigned_run.parent_run = parent
+    assigned_run.save(update_fields=["parent_run"])
+
+    resp = api_client.post(
+        f"/api/v1/runner/runs/{assigned_run.id}/fail/",
+        {"reason": "resume_unavailable", "detail": "session gone"},
+        format="json",
+        HTTP_AUTHORIZATION=f"Bearer {runner_token}",
+    )
+    assert resp.status_code == 200, resp.data
+    assert resp.data.get("rescheduled") is True
+
+    parent.refresh_from_db()
+    # thread_id is a resume handle and is cleared so the next dispatch builds a
+    # fresh-session Assign...
+    assert parent.thread_id == ""
+    # ...but agent_metadata is never cleared.
+    assert parent.agent_metadata == {
+        "local_session_id": "sess_parent",
+        "local_thread_id": "sess_parent",
+        "agent_kind": "codex",
+    }
+
+
+@pytest.mark.unit
 def test_complete_endpoint_marks_terminal_and_drains(db, api_client, runner_token, assigned_run):
     resp = api_client.post(
         f"/api/v1/runner/runs/{assigned_run.id}/complete/",

--- a/runner/src/agent/mod.rs
+++ b/runner/src/agent/mod.rs
@@ -304,6 +304,23 @@ impl AgentCursor {
         }
     }
 
+    /// Which agent CLI produced this run, as the stable wire string the cloud
+    /// stores in ``AgentRun.agent_metadata["agent_kind"]`` (mirrors
+    /// ``AgentChatSession.agent_kind``). Reported on the run-started call so a
+    /// consumer can interpret ``local_session_id`` / ``thread_id``, whose
+    /// meaning is agent-kind dependent (for Claude Code the runner aliases the
+    /// session id as the thread id; for Codex the thread id is a distinct
+    /// concept).
+    pub fn agent_kind(&self) -> &'static str {
+        match self {
+            AgentCursor::Codex(_) => "codex",
+            AgentCursor::ClaudeCode(_) => "claude_code",
+            AgentCursor::CursorAgent(_) => "cursor_agent",
+            AgentCursor::OpenClaw(_) => "openclaw",
+            AgentCursor::Grok(_) => "grok",
+        }
+    }
+
     pub fn model(&self) -> Option<&str> {
         match self {
             AgentCursor::Codex(c) => c.model.as_deref(),

--- a/runner/src/cloud/protocol.rs
+++ b/runner/src/cloud/protocol.rs
@@ -129,6 +129,16 @@ pub enum ClientMsg {
     RunStarted {
         run_id: Uuid,
         thread_id: String,
+        // Durably recorded into ``AgentRun.agent_metadata`` at run start
+        // (unlike ``thread_id``, which is a resume handle cleared on retry).
+        // ``local_session_id`` mirrors the chat bridge's warm-path alias of
+        // the thread id; ``agent_kind`` labels which CLI produced the run so a
+        // consumer can interpret the session/thread ids. Older cloud builds
+        // simply ignore the extra keys.
+        #[serde(default)]
+        local_session_id: String,
+        #[serde(default)]
+        agent_kind: String,
         started_at: DateTime<Utc>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         model: Option<String>,

--- a/runner/src/daemon/supervisor.rs
+++ b/runner/src/daemon/supervisor.rs
@@ -3038,6 +3038,13 @@ impl AssignWorker {
         self.send(ClientMsg::RunStarted {
             run_id,
             thread_id: cursor.thread_id().to_string(),
+            // Alias the session id to the thread id, mirroring the chat
+            // bridge's warm path (`local_session_id: Some(thread_id)`): the
+            // run path's only session handle today is the thread id. `agent_kind`
+            // lets the cloud interpret it per-CLI. Both are recorded durably in
+            // `agent_metadata`, which — unlike `thread_id` — survives a retry.
+            local_session_id: cursor.thread_id().to_string(),
+            agent_kind: cursor.agent_kind().to_string(),
             started_at: Utc::now(),
             model: run_model,
         })


### PR DESCRIPTION
## Summary

Adds a general-purpose `AgentRun.agent_metadata = models.JSONField(default=dict, blank=True)` column and uses it to durably record the local AI agent session id reported by the runner at run start.

AgentRun's four existing JSON columns are each an owned single-producer/consumer contract (`run_config`, `done_payload`, `prompt_manifest`, `required_capabilities`), so none is a safe home for general run metadata. `thread_id` holds the session id today but is a **resume handle**: it is cleared on retry (`run_lifecycle.apply_run_resume_unavailable`) and its meaning is agent-kind dependent. `agent_metadata` is **write-once-per-attempt and never cleared**, so a failed attempt's session id survives for audit / local-session lookup.

## Cloud (`apps/api`)

- `AgentRun.agent_metadata` field + migration `0024`.
- `RunStartedEndpoint` accepts `local_session_id` / `agent_kind` alongside the existing `thread_id` (write unchanged) and populates `agent_metadata` with `{local_session_id, local_thread_id, agent_kind}`. `local_thread_id` defaults to `thread_id` for older runners.
- Exposes `agent_metadata` on `AgentRunSerializer`.

## Runner (Rust)

- `AgentCursor::agent_kind()` maps each CLI to its wire string (`codex | claude_code | cursor_agent | openclaw | grok`).
- `ClientMsg::RunStarted` carries `local_session_id` + `agent_kind`; the supervisor aliases `local_session_id` to the thread id, mirroring the chat bridge's warm path. The genuinely per-kind distinct session id noted in the issue is left for a future design pass.

## Tests

- run-started persists the new keys, and stays backward compatible for a `thread_id`-only runner.
- a resume-unavailable retry that clears the parent's `thread_id` leaves its `agent_metadata` intact.

Validated: 21/21 in `test_https_transport_run_endpoints.py` pass; `cargo check` clean; `makemigrations --check` shows no missing migration for the new field.

## Open questions (from the issue)

- `agent_kind` kept in JSON rather than a typed column (keeps the migration to one field).
- No backfill (existing rows' `thread_id` only maps to a session id for Claude Code, and only where not already cleared — not worth it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)