### PR TITLE
PDASHOSS01-101 Research Meta Muse Code as Pi Dash runner

### DIFF
--- a/apps/web/core/components/runners/add-runner-modal.tsx
+++ b/apps/web/core/components/runners/add-runner-modal.tsx
@@ -35,7 +35,7 @@ type Props = {
 
 // Mirrors the runner CLI's ``--agent`` value-enum (kebab-case). Keep in
 // sync with runner/src/config/schema.rs:AgentKind.
-const AGENT_OPTIONS = ["claude-code", "codex", "cursor-agent", "open-claw", "grok"] as const;
+const AGENT_OPTIONS = ["claude-code", "codex", "cursor-agent", "open-claw", "grok", "muse-code"] as const;
 type TAgent = (typeof AGENT_OPTIONS)[number];
 const DEFAULT_AGENT: TAgent = "claude-code";
 const RUNNER_NAME_WHITESPACE_RE = /\s/;
@@ -227,6 +227,7 @@ export const AddRunnerModal = observer(function AddRunnerModal(props: Props) {
     if (value === "cursor-agent") return t("Cursor");
     if (value === "open-claw") return t("OpenClaw");
     if (value === "grok") return t("Grok");
+    if (value === "muse-code") return t("Muse Code");
     return t("Codex");
   };
 

--- a/apps/web/core/components/runners/runner-models.ts
+++ b/apps/web/core/components/runners/runner-models.ts
@@ -18,7 +18,7 @@
  */
 
 // Mirrors the runner CLI's ``--agent`` value-enum (kebab-case).
-export type TRunnerAgent = "claude-code" | "codex" | "cursor-agent" | "open-claw" | "grok";
+export type TRunnerAgent = "claude-code" | "codex" | "cursor-agent" | "open-claw" | "grok" | "muse-code";
 
 export interface IRunnerModelOption {
   /** Unique select value within an agent's list. */
@@ -116,6 +116,9 @@ export const RUNNER_MODEL_OPTIONS: Record<TRunnerAgent, IRunnerModelOption[]> = 
   "cursor-agent": [DEFAULT_OPTION, ...CURSOR_OPTIONS],
   "open-claw": [DEFAULT_OPTION],
   grok: [DEFAULT_OPTION, ...GROK_OPTIONS],
+  // Muse Code's model slug space is provider-specific (Meta Model API); the
+  // runner accepts any non-empty slug, so offer just the agent default here.
+  "muse-code": [DEFAULT_OPTION],
 };
 
 /**
@@ -130,6 +133,7 @@ export const DEFAULT_MODEL_BY_AGENT: Record<TRunnerAgent, string> = {
   "cursor-agent": DEFAULT_MODEL_ID,
   "open-claw": DEFAULT_MODEL_ID,
   grok: DEFAULT_MODEL_ID,
+  "muse-code": DEFAULT_MODEL_ID,
 };
 
 /** Look up a selected option's label; falls back to the default label. */

--- a/apps/web/tests/runners/muse-code-runner.test.tsx
+++ b/apps/web/tests/runners/muse-code-runner.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { apiBaseUrl, listPods, listProjects, setToast, listDevMachines } = vi.hoisted(() => ({
+  apiBaseUrl: { value: "http://localhost:8000" },
+  listPods: vi.fn(),
+  listProjects: vi.fn(),
+  setToast: vi.fn(),
+  listDevMachines: vi.fn(),
+}));
+
+vi.mock("@pi-dash/constants", () => ({
+  get API_BASE_URL() {
+    return apiBaseUrl.value;
+  },
+}));
+
+vi.mock("@pi-dash/services", () => ({
+  PodService: class {
+    list = listPods;
+  },
+  RunnerService: class {
+    listDevMachines = listDevMachines;
+    createRunnerOnMachine = vi.fn();
+    getCreateRunnerOnMachineStatus = vi.fn();
+  },
+}));
+
+vi.mock("@/services/project", () => ({
+  ProjectService: class {
+    getProjectsLite = listProjects;
+  },
+}));
+
+vi.mock("@pi-dash/i18n", () => ({
+  useTranslation: () => ({
+    t: (key: string, vars?: Record<string, unknown>) => (vars ? `${key}:${JSON.stringify(vars)}` : key),
+  }),
+}));
+
+vi.mock("@pi-dash/propel/toast", () => ({
+  TOAST_TYPE: { ERROR: "ERROR", SUCCESS: "SUCCESS" },
+  setToast,
+}));
+
+vi.mock("@pi-dash/propel/button", () => ({
+  Button: ({
+    children,
+    loading: _loading,
+    variant: _variant,
+    size: _size,
+    ...props
+  }: {
+    children: React.ReactNode;
+    loading?: boolean;
+    variant?: string;
+    size?: string;
+  } & React.ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+}));
+
+vi.mock("@pi-dash/ui", async () => {
+  const { forwardRef: fwd } = await import("react");
+  type SelectProps = {
+    value: string;
+    onChange: (v: string) => void;
+    children: React.ReactNode;
+    disabled?: boolean;
+  };
+  // eslint-disable-next-line unicorn/consistent-function-scoping -- inside vi.mock factory; cannot hoist out
+  const Sel = ({ value, onChange, children, disabled }: SelectProps) => (
+    <select data-testid="select" value={value} disabled={disabled} onChange={(e) => onChange(e.target.value)}>
+      <option value="" disabled>
+        placeholder
+      </option>
+      {children}
+    </select>
+  );
+  Sel.Option = ({ value, children }: { value: string; children: React.ReactNode }) => (
+    <option value={value}>{children}</option>
+  );
+  return {
+    ModalCore: ({ isOpen, children }: { isOpen: boolean; children: React.ReactNode }) =>
+      isOpen ? <div role="dialog">{children}</div> : null,
+    EModalPosition: { CENTER: "CENTER" },
+    EModalWidth: { XXL: "XXL" },
+    Input: fwd<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(function Input(props, ref) {
+      return <input ref={ref} {...props} />;
+    }),
+    CustomSelect: Sel,
+  };
+});
+
+import { AddRunnerModal } from "@/components/runners/add-runner-modal";
+
+const PROJECTS = [{ id: "project-1", identifier: "BROWSERX", name: "BrowserX" }];
+const PODS = [
+  {
+    id: "pod-1",
+    name: "pod-a",
+    description: "",
+    is_default: false,
+    workspace: "workspace-1",
+    project: "project-1",
+    project_identifier: "BROWSERX",
+    created_by: null,
+    runner_count: 0,
+    created_at: "2026-05-23T00:00:00Z",
+    updated_at: "2026-05-23T00:00:00Z",
+  },
+];
+
+describe("AddRunnerModal — Muse Code agent", () => {
+  beforeEach(() => {
+    apiBaseUrl.value = "http://localhost:8000";
+    listPods.mockReset().mockResolvedValue(PODS);
+    listProjects.mockReset().mockResolvedValue(PROJECTS);
+    listDevMachines.mockReset().mockResolvedValue([]);
+    setToast.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function renderModal(workspaceId = "workspace-muse") {
+    const onClose = vi.fn();
+    const utils = render(<AddRunnerModal isOpen onClose={onClose} workspaceId={workspaceId} workspaceSlug="acme" />);
+    return { ...utils, onClose };
+  }
+
+  it("lists 'Muse Code' as a selectable agent in the dropdown", async () => {
+    renderModal();
+    await screen.findByRole("option", { name: "BrowserX" });
+
+    // selects: [0]=dev machine, [1]=project, [2]=pod, [3]=agent, [4]=model
+    const agentSelect = screen.getAllByTestId("select")[3];
+    expect(within(agentSelect).getByRole("option", { name: "Muse Code" })).toBeInTheDocument();
+  });
+
+  it("generates a `--agent muse-code` runner-add command", async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await screen.findByRole("option", { name: "BrowserX" });
+
+    const selects = screen.getAllByTestId("select");
+    await user.selectOptions(selects[1], "BROWSERX");
+    await user.selectOptions(selects[2], "pod-a");
+    await user.type(screen.getByPlaceholderText("my-laptop-runner"), "muse-local");
+    await user.type(screen.getByPlaceholderText("local dev machine project working dir"), "/home/rich/dev/browserx");
+    await user.selectOptions(selects[3], "muse-code");
+    await user.click(screen.getByRole("button", { name: "Generate Runner" }));
+
+    const command = await screen.findByText(
+      (_content: string, node: Element | null) => node?.tagName.toLowerCase() === "pre"
+    );
+    expect(command.textContent).toContain("pidash runner add");
+    expect(command.textContent).toContain("--agent muse-code");
+    expect(command.textContent).toContain("--name muse-local");
+  });
+});

--- a/packages/i18n/src/locales/en/translations.ts
+++ b/packages/i18n/src/locales/en/translations.ts
@@ -1121,6 +1121,7 @@ export default {
   "Open work item in full screen": "Open work item in full screen",
   "Open workspace switcher": "Open workspace switcher",
   OpenClaw: "OpenClaw",
+  "Muse Code": "Muse Code",
   Optional: "Optional",
   Options: "Options",
   "Order by": "Order by",

--- a/runner/src/agent/mod.rs
+++ b/runner/src/agent/mod.rs
@@ -271,6 +271,7 @@ pub enum AgentBridge {
     CursorAgent(crate::cursor_agent::bridge::Bridge),
     OpenClaw(crate::openclaw::bridge::Bridge),
     Grok(crate::grok::bridge::Bridge),
+    MuseCode(crate::muse_code::bridge::Bridge),
 }
 
 /// Per-run cursor, paired with an `AgentBridge`. Holds agent-specific frame
@@ -281,6 +282,7 @@ pub enum AgentCursor {
     CursorAgent(crate::cursor_agent::bridge::BridgeCursor),
     OpenClaw(crate::openclaw::bridge::BridgeCursor),
     Grok(crate::grok::bridge::BridgeCursor),
+    MuseCode(crate::muse_code::bridge::BridgeCursor),
 }
 
 impl AgentCursor {
@@ -291,6 +293,7 @@ impl AgentCursor {
             AgentCursor::CursorAgent(c) => c.run_id,
             AgentCursor::OpenClaw(c) => c.run_id,
             AgentCursor::Grok(c) => c.run_id,
+            AgentCursor::MuseCode(c) => c.run_id,
         }
     }
 
@@ -301,6 +304,7 @@ impl AgentCursor {
             AgentCursor::CursorAgent(c) => &c.thread_id,
             AgentCursor::OpenClaw(c) => &c.thread_id,
             AgentCursor::Grok(c) => &c.thread_id,
+            AgentCursor::MuseCode(c) => &c.thread_id,
         }
     }
 
@@ -311,6 +315,7 @@ impl AgentCursor {
             AgentCursor::CursorAgent(c) => c.model.as_deref(),
             AgentCursor::OpenClaw(c) => c.model.as_deref(),
             AgentCursor::Grok(c) => c.model.as_deref(),
+            AgentCursor::MuseCode(c) => c.model.as_deref(),
         }
     }
 }
@@ -384,6 +389,16 @@ impl AgentBridge {
                 .await?;
                 Ok(AgentBridge::Grok(b))
             }
+            AgentKind::MuseCode => {
+                let b = crate::muse_code::bridge::Bridge::spawn_with_resume(
+                    &runner.muse_code.binary,
+                    cwd,
+                    selected_model(model_override, runner.muse_code.model_default.clone()),
+                    resume_session_id,
+                )
+                .await?;
+                Ok(AgentBridge::MuseCode(b))
+            }
         }
     }
 
@@ -394,6 +409,7 @@ impl AgentBridge {
             AgentBridge::CursorAgent(b) => Ok(AgentCursor::CursorAgent(b.run(payload, cwd).await?)),
             AgentBridge::OpenClaw(b) => Ok(AgentCursor::OpenClaw(b.run(payload, cwd).await?)),
             AgentBridge::Grok(b) => Ok(AgentCursor::Grok(b.run(payload, cwd).await?)),
+            AgentBridge::MuseCode(b) => Ok(AgentCursor::MuseCode(b.run(payload, cwd).await?)),
         }
     }
 
@@ -410,6 +426,9 @@ impl AgentBridge {
                 Ok(AgentCursor::OpenClaw(b.run_one_shot(payload, cwd).await?))
             }
             AgentBridge::Grok(b) => Ok(AgentCursor::Grok(b.run_one_shot(payload, cwd).await?)),
+            AgentBridge::MuseCode(b) => {
+                Ok(AgentCursor::MuseCode(b.run_one_shot(payload, cwd).await?))
+            }
         }
     }
 
@@ -425,6 +444,7 @@ impl AgentBridge {
             AgentBridge::CursorAgent(b) => b.warm(cwd).await,
             AgentBridge::OpenClaw(b) => b.warm(cwd).await,
             AgentBridge::Grok(b) => b.warm(cwd).await,
+            AgentBridge::MuseCode(b) => b.warm(cwd).await,
         }
     }
 
@@ -441,6 +461,7 @@ impl AgentBridge {
             (AgentBridge::CursorAgent(b), AgentCursor::CursorAgent(c)) => b.next_events(c).await,
             (AgentBridge::OpenClaw(b), AgentCursor::OpenClaw(c)) => b.next_events(c).await,
             (AgentBridge::Grok(b), AgentCursor::Grok(c)) => b.next_events(c).await,
+            (AgentBridge::MuseCode(b), AgentCursor::MuseCode(c)) => b.next_events(c).await,
             // These pairings are constructed together by `run`, so a mismatch
             // is a programmer error — fail loudly.
             _ => panic!("agent bridge and cursor variants mismatched"),
@@ -458,6 +479,7 @@ impl AgentBridge {
             AgentBridge::CursorAgent(b) => b.send_approval(approval_id, decision).await,
             AgentBridge::OpenClaw(b) => b.send_approval(approval_id, decision).await,
             AgentBridge::Grok(b) => b.send_approval(approval_id, decision).await,
+            AgentBridge::MuseCode(b) => b.send_approval(approval_id, decision).await,
         }
     }
 
@@ -468,6 +490,7 @@ impl AgentBridge {
             AgentBridge::CursorAgent(b) => b.interrupt().await,
             AgentBridge::OpenClaw(b) => b.interrupt().await,
             AgentBridge::Grok(b) => b.interrupt().await,
+            AgentBridge::MuseCode(b) => b.interrupt().await,
         }
     }
 
@@ -478,6 +501,7 @@ impl AgentBridge {
             AgentBridge::CursorAgent(b) => b.shutdown(grace).await,
             AgentBridge::OpenClaw(b) => b.shutdown(grace).await,
             AgentBridge::Grok(b) => b.shutdown(grace).await,
+            AgentBridge::MuseCode(b) => b.shutdown(grace).await,
         }
     }
 
@@ -492,6 +516,7 @@ impl AgentBridge {
             AgentBridge::CursorAgent(b) => b.process_handle(),
             AgentBridge::OpenClaw(b) => b.process_handle(),
             AgentBridge::Grok(b) => b.process_handle(),
+            AgentBridge::MuseCode(b) => b.process_handle(),
         }
     }
 
@@ -507,6 +532,7 @@ impl AgentBridge {
             AgentBridge::CursorAgent(b) => b.recent_stderr().await,
             AgentBridge::OpenClaw(b) => b.recent_stderr().await,
             AgentBridge::Grok(b) => b.recent_stderr().await,
+            AgentBridge::MuseCode(b) => b.recent_stderr().await,
         }
     }
 }

--- a/runner/src/api_client.rs
+++ b/runner/src/api_client.rs
@@ -331,6 +331,7 @@ mod resolve_tests {
                 cursor_agent: CursorAgentSection::default(),
                 openclaw: Default::default(),
                 grok: Default::default(),
+                muse_code: Default::default(),
                 approval_policy: ApprovalPolicySection::default(),
             }],
             workdirs: vec![],

--- a/runner/src/cli/connect.rs
+++ b/runner/src/cli/connect.rs
@@ -190,7 +190,7 @@ pub async fn run(args: Args, paths: &Paths) -> Result<()> {
         .unwrap_or_else(|| paths.runner_dir(resp.runner_id).join("workspace"));
 
     let agent_kind = args.agent.unwrap_or_default();
-    let (codex, claude_code, cursor_agent, openclaw, grok) =
+    let (codex, claude_code, cursor_agent, openclaw, grok, muse_code) =
         crate::cli::runner_ops::agent_sections_for(
             agent_kind,
             args.model.as_deref(),
@@ -210,6 +210,7 @@ pub async fn run(args: Args, paths: &Paths) -> Result<()> {
         cursor_agent,
         openclaw,
         grok,
+        muse_code,
         approval_policy: Default::default(),
     };
 
@@ -528,6 +529,7 @@ pub async fn enroll_additional_runner(
         cursor_agent: Default::default(),
         openclaw: Default::default(),
         grok: Default::default(),
+        muse_code: Default::default(),
         approval_policy: Default::default(),
     };
     cfg.runners.push(new_runner.clone());
@@ -671,6 +673,7 @@ mod tests {
             cursor_agent: CursorAgentSection::default(),
             openclaw: crate::config::schema::OpenClawSection::default(),
             grok: crate::config::schema::GrokSection::default(),
+            muse_code: crate::config::schema::MuseCodeSection::default(),
             approval_policy: ApprovalPolicySection::default(),
         }
     }

--- a/runner/src/cli/doctor.rs
+++ b/runner/src/cli/doctor.rs
@@ -108,6 +108,7 @@ pub async fn execute(paths: &Paths, runner_filter: Option<&str>) -> Result<Repor
             "cursor-agent",
             "acpx",
             "grok",
+            "muse",
         )
         .await;
     } else {
@@ -122,6 +123,7 @@ pub async fn execute(paths: &Paths, runner_filter: Option<&str>) -> Result<Repor
                 &r.cursor_agent.binary,
                 &r.openclaw.binary,
                 &r.grok.binary,
+                &r.muse_code.binary,
             )
             .await;
         }
@@ -181,6 +183,7 @@ async fn run_agent_checks(
     cursor_binary: &str,
     openclaw_binary: &str,
     grok_binary: &str,
+    muse_binary: &str,
 ) {
     let tag = |base: &str| match prefix {
         Some(p) => format!("{base}@{p}"),
@@ -339,6 +342,30 @@ async fn run_agent_checks(
                 blocker: false,
             });
         }
+        crate::config::schema::AgentKind::MuseCode => {
+            match check_version(muse_binary).await {
+                Ok(detail) => checks.push(Check {
+                    name: tag("muse"),
+                    ok: true,
+                    detail,
+                    blocker: true,
+                }),
+                Err(e) => checks.push(Check {
+                    name: tag("muse"),
+                    ok: false,
+                    detail: e.to_string(),
+                    blocker: true,
+                }),
+            }
+            // Muse Code auth is via the `META_API_KEY` env var; there's no cheap
+            // non-interactive probe, so surface a hint rather than block.
+            checks.push(Check {
+                name: tag("muse-auth"),
+                ok: true,
+                detail: "assumed ok (set META_API_KEY if runs fail with auth errors)".to_string(),
+                blocker: false,
+            });
+        }
     }
 }
 
@@ -410,8 +437,8 @@ mod tests {
     //! per-runner tags are correct.
     use super::*;
     use crate::config::schema::{
-        AgentKind, ClaudeCodeSection, CursorAgentSection, CodexSection, Config, DaemonConfig,
-        GrokSection, OpenClawSection, RunnerConfig, WorkspaceSection,
+        AgentKind, ClaudeCodeSection, CodexSection, Config, CursorAgentSection, DaemonConfig,
+        GrokSection, MuseCodeSection, OpenClawSection, RunnerConfig, WorkspaceSection,
     };
     use std::path::PathBuf;
     use uuid::Uuid;
@@ -447,6 +474,7 @@ mod tests {
             cursor_agent: CursorAgentSection::default(),
             openclaw: OpenClawSection::default(),
             grok: GrokSection::default(),
+            muse_code: MuseCodeSection::default(),
             approval_policy: Default::default(),
         }
     }
@@ -574,6 +602,7 @@ mod tests {
             "cursor-missing",
             "acpx-missing",
             "grok-missing",
+            "muse-missing",
         )
         .await;
         run_agent_checks(
@@ -585,6 +614,7 @@ mod tests {
             "cursor-missing",
             "acpx-missing",
             "grok-missing",
+            "muse-missing",
         )
         .await;
         run_agent_checks(
@@ -596,6 +626,7 @@ mod tests {
             "cursor-missing",
             "acpx-missing",
             "grok-missing",
+            "muse-missing",
         )
         .await;
         run_agent_checks(
@@ -607,6 +638,7 @@ mod tests {
             "cursor-missing",
             "acpx-missing",
             "grok-missing",
+            "muse-missing",
         )
         .await;
         run_agent_checks(
@@ -618,6 +650,20 @@ mod tests {
             "cursor-missing",
             "acpx-missing",
             "grok-missing",
+            "muse-missing",
+        )
+        .await;
+        let mut muse_checks: Vec<Check> = Vec::new();
+        run_agent_checks(
+            &mut muse_checks,
+            None,
+            AgentKind::MuseCode,
+            "codex-missing",
+            "claude-missing",
+            "cursor-missing",
+            "acpx-missing",
+            "grok-missing",
+            "muse-missing",
         )
         .await;
         assert!(codex_checks.iter().any(|c| c.name == "codex"));
@@ -630,5 +676,7 @@ mod tests {
         assert!(openclaw_checks.iter().any(|c| c.name == "openclaw"));
         assert!(grok_checks.iter().any(|c| c.name == "grok"));
         assert!(grok_checks.iter().any(|c| c.name == "grok-auth"));
+        assert!(muse_checks.iter().any(|c| c.name == "muse"));
+        assert!(muse_checks.iter().any(|c| c.name == "muse-auth"));
     }
 }

--- a/runner/src/cli/runner_ops.rs
+++ b/runner/src/cli/runner_ops.rs
@@ -15,7 +15,8 @@ use crate::config::file;
 use crate::config::schema::{
     AgentKind, AgentSection, ApprovalPolicySection, ClaudeCodeSection, CleanMode, CliSection,
     CodexSection, Config, CursorAgentSection, DEFAULT_POOL_SIZE, DaemonConfig, GrokSection,
-    OpenClawSection, RunnerConfig, WorkdirConfig, WorkspaceSection, canonical_for_compare,
+    MuseCodeSection, OpenClawSection, RunnerConfig, WorkdirConfig, WorkspaceSection,
+    canonical_for_compare,
 };
 use crate::util::paths::Paths;
 use std::io::IsTerminal;
@@ -70,10 +71,12 @@ fn model_applies_to_agent(kind: AgentKind, model: &str) -> bool {
         AgentKind::Codex => {
             has("gpt-") || m == "o3" || m == "o4" || has("o3-") || has("o4-") || has("codex")
         }
-        // Cursor, OpenClaw, and Grok pull their model slug from their own
-        // provider's catalog; accept any non-empty value and let the agent
-        // reject unknown slugs.
-        AgentKind::CursorAgent | AgentKind::OpenClaw | AgentKind::Grok => !m.is_empty(),
+        // Cursor, OpenClaw, Grok, and Muse Code pull their model slug from
+        // their own provider's catalog; accept any non-empty value and let the
+        // agent reject unknown slugs.
+        AgentKind::CursorAgent | AgentKind::OpenClaw | AgentKind::Grok | AgentKind::MuseCode => {
+            !m.is_empty()
+        }
     }
 }
 
@@ -93,6 +96,7 @@ pub fn agent_sections_for(
     CursorAgentSection,
     OpenClawSection,
     GrokSection,
+    MuseCodeSection,
 ) {
     let model = model.map(str::trim).filter(|s| !s.is_empty());
     let effort = reasoning_effort.map(str::trim).filter(|s| !s.is_empty());
@@ -150,6 +154,7 @@ pub fn agent_sections_for(
     let mut cursor_agent = CursorAgentSection::default();
     let mut openclaw = OpenClawSection::default();
     let mut grok = GrokSection::default();
+    let mut muse_code = MuseCodeSection::default();
     match agent_kind {
         AgentKind::Codex => {
             codex.model_default = model;
@@ -159,8 +164,9 @@ pub fn agent_sections_for(
         AgentKind::CursorAgent => cursor_agent.model_default = model,
         AgentKind::OpenClaw => openclaw.model_default = model,
         AgentKind::Grok => grok.model_default = model,
+        AgentKind::MuseCode => muse_code.model_default = model,
     }
-    (codex, claude_code, cursor_agent, openclaw, grok)
+    (codex, claude_code, cursor_agent, openclaw, grok, muse_code)
 }
 
 /// Read the user's CLI token from `[cli].token` in `config.toml`.
@@ -381,7 +387,7 @@ pub async fn apply_enroll_response(
         .working_dir
         .unwrap_or_else(|| paths.runner_dir(resp.runner_id).join("workspace"));
 
-    let (codex, claude_code, cursor_agent, openclaw, grok) =
+    let (codex, claude_code, cursor_agent, openclaw, grok, muse_code) =
         agent_sections_for(options.agent_kind, options.model, options.reasoning_effort);
     let new_runner = RunnerConfig {
         name: resp.runner_name.clone(),
@@ -399,6 +405,7 @@ pub async fn apply_enroll_response(
         cursor_agent,
         openclaw,
         grok,
+        muse_code,
         approval_policy: ApprovalPolicySection::default(),
     };
 
@@ -634,7 +641,7 @@ mod tests {
 
     #[test]
     fn model_routes_to_selected_agent_section() {
-        let (codex, claude, cursor, openclaw, _) =
+        let (codex, claude, cursor, openclaw, _, _) =
             agent_sections_for(AgentKind::ClaudeCode, Some("claude-opus-4-8"), None);
         assert_eq!(claude.model_default.as_deref(), Some("claude-opus-4-8"));
         assert_eq!(codex.model_default, None);
@@ -644,7 +651,8 @@ mod tests {
 
     #[test]
     fn codex_model_and_effort_are_applied_together() {
-        let (codex, _, _, _, _) = agent_sections_for(AgentKind::Codex, Some("gpt-5.5"), Some("High"));
+        let (codex, _, _, _, _, _) =
+            agent_sections_for(AgentKind::Codex, Some("gpt-5.5"), Some("High"));
         assert_eq!(codex.model_default.as_deref(), Some("gpt-5.5"));
         // Effort is normalized to lowercase.
         assert_eq!(codex.effort_default.as_deref(), Some("high"));
@@ -655,14 +663,14 @@ mod tests {
         // The user's example: a Codex model handed to the Claude agent.
         // Non-fatal — the model is dropped (warning printed) and the
         // section is left at its default (None).
-        let (_, claude, _, _, _) =
- agent_sections_for(AgentKind::ClaudeCode, Some("gpt-5.5"), None);
+        let (_, claude, _, _, _, _) =
+            agent_sections_for(AgentKind::ClaudeCode, Some("gpt-5.5"), None);
         assert_eq!(claude.model_default, None);
     }
 
     #[test]
     fn effort_ignored_for_non_codex_agents() {
-        let (_, claude, _, _, _) =
+        let (_, claude, _, _, _, _) =
             agent_sections_for(AgentKind::ClaudeCode, Some("claude-opus-4-8"), Some("high"));
         // Model still applies; effort has no home on the claude section.
         assert_eq!(claude.model_default.as_deref(), Some("claude-opus-4-8"));
@@ -670,14 +678,15 @@ mod tests {
 
     #[test]
     fn unknown_codex_effort_is_dropped() {
-        let (codex, _, _, _, _) = agent_sections_for(AgentKind::Codex, Some("gpt-5.5"), Some("turbo"));
+        let (codex, _, _, _, _, _) =
+            agent_sections_for(AgentKind::Codex, Some("gpt-5.5"), Some("turbo"));
         assert_eq!(codex.model_default.as_deref(), Some("gpt-5.5"));
         assert_eq!(codex.effort_default, None);
     }
 
     #[test]
     fn cursor_accepts_any_nonempty_slug() {
-        let (_, _, cursor, _, _) = agent_sections_for(
+        let (_, _, cursor, _, _, _) = agent_sections_for(
             AgentKind::CursorAgent,
             Some("claude-opus-4-8-thinking-high"),
             None,
@@ -692,7 +701,7 @@ mod tests {
     fn openclaw_accepts_any_nonempty_slug() {
         // OpenClaw's model space is provider-agnostic (resolved by the
         // Gateway), so any non-empty slug routes to its section.
-        let (codex, claude, cursor, openclaw, _) =
+        let (codex, claude, cursor, openclaw, _, _) =
             agent_sections_for(AgentKind::OpenClaw, Some("anthropic/claude-opus-4-8"), None);
         assert_eq!(
             openclaw.model_default.as_deref(),
@@ -705,7 +714,7 @@ mod tests {
 
     #[test]
     fn blank_model_is_treated_as_unset() {
-        let (codex, _, _, _, _) = agent_sections_for(AgentKind::Codex, Some("   "), None);
+        let (codex, _, _, _, _, _) = agent_sections_for(AgentKind::Codex, Some("   "), None);
         assert_eq!(codex.model_default, None);
     }
 
@@ -713,7 +722,7 @@ mod tests {
     fn codex_effort_dropped_when_model_inapplicable() {
         // A Claude model handed to codex: the model is dropped, and the
         // effort meant for it must not survive onto codex's default model.
-        let (codex, _, _, _, _) =
+        let (codex, _, _, _, _, _) =
             agent_sections_for(AgentKind::Codex, Some("claude-opus-4-8"), Some("high"));
         assert_eq!(codex.model_default, None);
         assert_eq!(codex.effort_default, None);
@@ -723,7 +732,7 @@ mod tests {
     fn codex_effort_dropped_without_a_model() {
         // Effort is meaningless without an explicit model (see the
         // CodexSection::effort_default contract).
-        let (codex, _, _, _, _) = agent_sections_for(AgentKind::Codex, None, Some("high"));
+        let (codex, _, _, _, _, _) = agent_sections_for(AgentKind::Codex, None, Some("high"));
         assert_eq!(codex.model_default, None);
         assert_eq!(codex.effort_default, None);
     }
@@ -732,10 +741,10 @@ mod tests {
     fn bare_prefix_models_are_rejected() {
         // A dash-terminated prefix with nothing after it is an incomplete
         // slug, not a model — it must not become a bogus model_default.
-        let (_, claude, _, _, _) =
- agent_sections_for(AgentKind::ClaudeCode, Some("claude-"), None);
+        let (_, claude, _, _, _, _) =
+            agent_sections_for(AgentKind::ClaudeCode, Some("claude-"), None);
         assert_eq!(claude.model_default, None);
-        let (codex, _, _, _, _) = agent_sections_for(AgentKind::Codex, Some("gpt-"), None);
+        let (codex, _, _, _, _, _) = agent_sections_for(AgentKind::Codex, Some("gpt-"), None);
         assert_eq!(codex.model_default, None);
     }
 
@@ -743,7 +752,7 @@ mod tests {
     fn bare_openai_reasoning_models_are_accepted() {
         // `o3` / `o4` are valid bare model names; the bare-prefix guard
         // must not reject them.
-        let (codex, _, _, _, _) = agent_sections_for(AgentKind::Codex, Some("o3"), None);
+        let (codex, _, _, _, _, _) = agent_sections_for(AgentKind::Codex, Some("o3"), None);
         assert_eq!(codex.model_default.as_deref(), Some("o3"));
     }
 
@@ -1087,6 +1096,7 @@ mod tests {
             cursor_agent: CursorAgentSection::default(),
             openclaw: OpenClawSection::default(),
             grok: GrokSection::default(),
+            muse_code: MuseCodeSection::default(),
             approval_policy: ApprovalPolicySection::default(),
         });
         file::write_config(&paths, &cfg).unwrap();

--- a/runner/src/config/file.rs
+++ b/runner/src/config/file.rs
@@ -244,6 +244,7 @@ mod tests {
             cursor_agent: Default::default(),
             openclaw: Default::default(),
             grok: Default::default(),
+            muse_code: Default::default(),
             approval_policy: Default::default(),
         }
     }

--- a/runner/src/config/schema.rs
+++ b/runner/src/config/schema.rs
@@ -179,6 +179,12 @@ pub struct RunnerConfig {
     /// parse. Only consulted when `agent.kind == grok`.
     #[serde(default)]
     pub grok: GrokSection,
+    /// Muse Code settings. Missing section falls back to
+    /// `MuseCodeSection::default()` so existing `config.toml` files (written
+    /// before Muse Code support) still parse. Only consulted when
+    /// `agent.kind == muse_code`.
+    #[serde(default)]
+    pub muse_code: MuseCodeSection,
     /// Missing section falls back to `ApprovalPolicySection::default()` so
     /// a minimal `config.toml` doesn't have to spell out every knob.
     #[serde(default)]
@@ -321,6 +327,10 @@ pub enum AgentKind {
     /// xAI Grok via its native ACP server (`grok agent stdio`), which the
     /// runner drives directly over the Agent Client Protocol.
     Grok,
+    /// Meta Muse Code via its headless one-shot mode
+    /// (`muse exec --json --prompt-file <PATH>`), whose JSONL event stream the
+    /// runner drives one turn per subprocess.
+    MuseCode,
 }
 
 impl AgentKind {
@@ -350,10 +360,14 @@ impl AgentKind {
             // for the full duration of a single tool call with no intra-tool
             // progress on the ACP stream. Use the same 15-minute envelope.
             // Grok, also driven over ACP, has the same quiet-tool-call profile.
+            // Muse Code (`muse exec`), like Cursor, is one-shot per turn and can
+            // be silent for the full duration of a single tool call; use the
+            // same 15-minute envelope.
             AgentKind::ClaudeCode
             | AgentKind::CursorAgent
             | AgentKind::OpenClaw
-            | AgentKind::Grok => Duration::from_secs(15 * 60),
+            | AgentKind::Grok
+            | AgentKind::MuseCode => Duration::from_secs(15 * 60),
         }
     }
 
@@ -366,6 +380,7 @@ impl AgentKind {
             AgentKind::CursorAgent => "Cursor",
             AgentKind::OpenClaw => "OpenClaw",
             AgentKind::Grok => "Grok",
+            AgentKind::MuseCode => "Muse Code",
         }
     }
 
@@ -384,6 +399,8 @@ impl AgentKind {
             // Grok is its own ACP server (`grok agent stdio`), so the runner
             // invokes `grok` directly.
             AgentKind::Grok => "grok",
+            // Muse Code ships as the `muse` CLI; the runner drives `muse exec`.
+            AgentKind::MuseCode => "muse",
         }
     }
 
@@ -397,6 +414,7 @@ impl AgentKind {
             AgentKind::CursorAgent => "https://cursor.com/download",
             AgentKind::OpenClaw => "https://github.com/openclaw/acpx",
             AgentKind::Grok => "https://x.ai/cli",
+            AgentKind::MuseCode => "https://developer.meta.com/ai/products/muse-code/",
         }
     }
 }
@@ -492,6 +510,30 @@ impl Default for GrokSection {
     fn default() -> Self {
         Self {
             binary: default_grok_binary(),
+            model_default: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MuseCodeSection {
+    /// The `muse` CLI binary the runner drives as `muse exec --json`. Per-field
+    /// default so a partial `[muse_code]` block (e.g. only `model_default`)
+    /// still parses without spelling out `binary = "muse"`.
+    #[serde(default = "default_muse_binary")]
+    pub binary: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_default: Option<String>,
+}
+
+fn default_muse_binary() -> String {
+    "muse".to_string()
+}
+
+impl Default for MuseCodeSection {
+    fn default() -> Self {
+        Self {
+            binary: default_muse_binary(),
             model_default: None,
         }
     }
@@ -966,6 +1008,7 @@ mod tests {
             cursor_agent: Default::default(),
             openclaw: Default::default(),
             grok: Default::default(),
+            muse_code: Default::default(),
             approval_policy: Default::default(),
         }
     }
@@ -1169,6 +1212,10 @@ mod tests {
             OpenClawSection::default().binary
         );
         assert_eq!(AgentKind::Grok.default_binary(), GrokSection::default().binary);
+        assert_eq!(
+            AgentKind::MuseCode.default_binary(),
+            MuseCodeSection::default().binary
+        );
     }
 
     #[test]
@@ -1181,6 +1228,7 @@ mod tests {
             AgentKind::CursorAgent,
             AgentKind::OpenClaw,
             AgentKind::Grok,
+            AgentKind::MuseCode,
         ] {
             let url = kind.install_page_url();
             assert!(url.starts_with("https://"), "{kind:?} url not https: {url}");

--- a/runner/src/daemon/runner_instance.rs
+++ b/runner/src/daemon/runner_instance.rs
@@ -170,6 +170,7 @@ mod tests {
             cursor_agent: CursorAgentSection::default(),
             openclaw: Default::default(),
             grok: Default::default(),
+            muse_code: Default::default(),
             approval_policy: ApprovalPolicySection::default(),
         }
     }

--- a/runner/src/daemon/supervisor.rs
+++ b/runner/src/daemon/supervisor.rs
@@ -2707,7 +2707,8 @@ impl AssignWorker {
             AgentKind::ClaudeCode
             | AgentKind::CursorAgent
             | AgentKind::OpenClaw
-            | AgentKind::Grok => FailureReason::AgentCrash,
+            | AgentKind::Grok
+            | AgentKind::MuseCode => FailureReason::AgentCrash,
         }
     }
 
@@ -3588,7 +3589,7 @@ mod tests {
     use crate::cloud::protocol::Envelope;
     use crate::config::schema::{
         AgentSection, ApprovalPolicySection, ClaudeCodeSection, CodexSection, CursorAgentSection,
-        GrokSection, OpenClawSection, RunnerConfig, WorkspaceSection,
+        GrokSection, MuseCodeSection, OpenClawSection, RunnerConfig, WorkspaceSection,
     };
     use crate::daemon::state::ExecCommandSnapshot;
     use chrono::TimeZone;
@@ -3618,6 +3619,7 @@ mod tests {
             cursor_agent: CursorAgentSection::default(),
             openclaw: OpenClawSection::default(),
             grok: GrokSection::default(),
+            muse_code: MuseCodeSection::default(),
             approval_policy: ApprovalPolicySection::default(),
         }
     }

--- a/runner/src/lib.rs
+++ b/runner/src/lib.rs
@@ -14,6 +14,7 @@ pub mod daemon;
 pub mod grok;
 pub mod history;
 pub mod ipc;
+pub mod muse_code;
 pub mod openclaw;
 pub mod service;
 pub mod tui;

--- a/runner/src/muse_code/bridge.rs
+++ b/runner/src/muse_code/bridge.rs
@@ -1,0 +1,513 @@
+//! Muse Code bridge. Drives the `muse exec --json --prompt-file <PATH>`
+//! subprocess (Meta Muse Code's headless one-shot mode) and translates its
+//! JSONL events into agent-agnostic [`crate::agent::BridgeEvent`]s.
+//!
+//! The public surface mirrors `cursor_agent::bridge::Bridge` so the agent
+//! dispatch layer can treat every backend uniformly:
+//!
+//! - [`Bridge::spawn`] / [`Bridge::spawn_with_resume`] — prepare the bridge
+//!   (does **not** launch a subprocess)
+//! - [`Bridge::warm`] — return the known resume session id, if any
+//! - [`Bridge::run`] — spawn `muse exec` for one turn, return a per-run cursor
+//! - [`Bridge::next_events`] — pump translated events until the run ends
+//! - [`Bridge::send_approval`] — stub for MVP (`--yolo` is on)
+//! - [`Bridge::interrupt`] — cancel the run (SIGINT the child)
+//! - [`Bridge::shutdown`] — drain and exit
+//!
+//! Structural notes (vs. Cursor):
+//! - Muse's `exec` mode is one-shot: it runs one prompt to completion and
+//!   exits, so — like Cursor — the subprocess is spawned lazily inside `run`,
+//!   reusing the prior `--session-id` for continuity across turns.
+//! - The prompt is delivered via a temp file (`--prompt-file`), not argv. See
+//!   [`crate::muse_code::process::PromptFile`].
+//! - Muse Code is closed-source and its JSONL schema is not fully documented,
+//!   so the schema layer (and this translator) are deliberately tolerant: a
+//!   `system/init` frame is used when present, but its absence does not break
+//!   the run (the first frame of any kind starts it).
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use std::collections::VecDeque;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::process::Command;
+use tokio::sync::{Mutex, watch};
+use uuid::Uuid;
+
+use crate::agent::{
+    AgentProcessHandle, BridgeEvent, ExitSnapshot, RunPayload, STDERR_RING_LINES, StderrBuffer,
+    StderrRing, StderrSnapshot,
+};
+use crate::cloud::protocol::{ApprovalDecision, FailureReason};
+use crate::muse_code::process::{MuseProcess, PromptFile};
+use crate::muse_code::schema::StreamEvent;
+use crate::util::shell::login_shell_command;
+
+/// How long to wait for `muse exec`'s first JSONL frame before giving up on
+/// the run setup. Generous: the CLI can take several seconds to authenticate
+/// against the Meta Model API and emit its first event when starting cold.
+const INIT_TIMEOUT: Duration = Duration::from_secs(30);
+
+pub struct Bridge {
+    binary: String,
+    model: Option<String>,
+    /// `--yolo` (disable approval prompts and sandbox). Always on for MVP,
+    /// mirroring the Cursor bridge's `--force` posture — a real approval loop
+    /// is a follow-up.
+    yolo: bool,
+    /// Muse session id captured from the first frame, or seeded from a prior
+    /// turn's `--session-id`. Reused as the `--session-id` argument on
+    /// follow-up turns for conversational continuity.
+    session_id: Option<String>,
+    /// Single exit-watch channel owned by the bridge. Reset to `None` at the
+    /// start of each `run` and republished by the spawned process's wait task,
+    /// so both `process_handle()` and `shutdown()` read a consistent liveness
+    /// signal. See the Cursor bridge for the full rationale.
+    exit_tx: watch::Sender<Option<ExitSnapshot>>,
+    exit_rx: watch::Receiver<Option<ExitSnapshot>>,
+    stderr_ring: StderrRing,
+    /// The currently-spawned one-shot subprocess, if a `run` is in flight (or
+    /// just finished). `None` before the first `run`.
+    proc: Option<MuseProcess>,
+    /// Events pulled off stdout while waiting synchronously for the first
+    /// frame. Drained by `next_events` before touching the mpsc so no frame is
+    /// lost.
+    pending: VecDeque<StreamEvent>,
+}
+
+impl Bridge {
+    pub async fn spawn(binary: &str, cwd: &Path, model_default: Option<String>) -> Result<Self> {
+        Self::spawn_with_resume(binary, cwd, model_default, None).await
+    }
+
+    pub async fn spawn_with_resume(
+        binary: &str,
+        _cwd: &Path,
+        model_default: Option<String>,
+        resume_session_id: Option<&str>,
+    ) -> Result<Self> {
+        let (exit_tx, exit_rx) = watch::channel::<Option<ExitSnapshot>>(None);
+        let stderr_ring: StderrRing = Arc::new(Mutex::new(StderrBuffer::new(STDERR_RING_LINES)));
+        Ok(Self {
+            binary: binary.to_string(),
+            model: model_default.filter(|s| !s.is_empty()),
+            yolo: true,
+            session_id: resume_session_id
+                .filter(|s| !s.is_empty())
+                .map(ToOwned::to_owned),
+            exit_tx,
+            exit_rx,
+            stderr_ring,
+            proc: None,
+            pending: VecDeque::new(),
+        })
+    }
+
+    /// `muse exec` only starts emitting once it has a prompt, so warm cannot
+    /// pre-spawn a useful process. Return the known resume session id (if any)
+    /// so the cloud can keep its local-session pointer stable until the first
+    /// turn lands.
+    pub async fn warm(&mut self, _cwd: &Path) -> Result<Option<String>> {
+        Ok(self.session_id.clone())
+    }
+
+    /// Build the production `muse exec` command for a turn. The prompt lives in
+    /// `prompt_path` (a temp file the caller owns for the process lifetime).
+    fn build_command(&self, prompt_path: &Path, cwd: &Path) -> Command {
+        let prompt_arg = prompt_path.to_string_lossy();
+        let mut argv: Vec<&str> = vec!["exec", "--json", "--prompt-file", &prompt_arg];
+        if self.yolo {
+            argv.push("--yolo");
+        }
+        if let Some(model) = self.model.as_deref() {
+            argv.extend(["--model", model]);
+        }
+        if let Some(session_id) = self.session_id.as_deref().filter(|s| !s.is_empty()) {
+            argv.extend(["--session-id", session_id]);
+        }
+        login_shell_command(&self.binary, &argv, Some(cwd))
+    }
+
+    /// Spawn the turn's subprocess and wait for its first frame. Production
+    /// `run` builds the command from config and supplies the prompt file;
+    /// tests inject a fake command directly with `prompt_file: None`.
+    pub async fn run_with_command(
+        &mut self,
+        cmd: Command,
+        prompt_file: Option<PromptFile>,
+        run_id: Uuid,
+    ) -> Result<BridgeCursor> {
+        // Reset the exit signal before the new process can publish into it, so a
+        // prior turn's exit snapshot doesn't make this turn look already-dead.
+        // Use `send_if_modified` so a no-op reset (a fresh bridge whose value is
+        // already `None`) does NOT fire a watch notification that a subscriber
+        // captured before `run` would misread as "already exited". Only a
+        // genuine `Some -> None` clear (a reused bridge) publishes a change.
+        self.exit_tx.send_if_modified(|v| {
+            if v.is_some() {
+                *v = None;
+                true
+            } else {
+                false
+            }
+        });
+        self.pending.clear();
+        let proc = MuseProcess::spawn_command(
+            cmd,
+            prompt_file,
+            self.exit_tx.clone(),
+            self.stderr_ring.clone(),
+        )
+        .await?;
+        self.proc = Some(proc);
+        let thread_id = self.wait_for_init(run_id).await?;
+        Ok(BridgeCursor {
+            run_id,
+            thread_id,
+            model: self.model.clone(),
+            terminal: false,
+            seq: 0,
+        })
+    }
+
+    pub async fn run(&mut self, payload: &RunPayload, cwd: &Path) -> Result<BridgeCursor> {
+        // Prefer a per-run model override if the supervisor supplied one.
+        if let Some(m) = payload.model.as_deref().filter(|s| !s.is_empty()) {
+            self.model = Some(m.to_string());
+        }
+        let prompt_file =
+            PromptFile::create(&payload.prompt).context("preparing muse prompt file")?;
+        let cmd = self.build_command(prompt_file.path(), cwd);
+        self.run_with_command(cmd, Some(prompt_file), payload.run_id)
+            .await
+    }
+
+    /// `muse exec` is inherently one-shot: it reads the prompt file, runs to
+    /// completion, emits `result`, then exits — there is no stdin to close. So
+    /// one-shot and chat `run` are identical at the process level.
+    pub async fn run_one_shot(&mut self, payload: &RunPayload, cwd: &Path) -> Result<BridgeCursor> {
+        self.run(payload, cwd).await
+    }
+
+    /// Wait for the first JSONL frame so the returned cursor carries a
+    /// populated `thread_id` (matching the Codex / Claude / Cursor contract).
+    /// A `system/init` frame is preferred (it carries `session_id` + `model`),
+    /// but Muse's schema is not guaranteed to emit one, so any first frame
+    /// starts the run: we capture its `session_id` when present and otherwise
+    /// synthesize a stable id.
+    async fn wait_for_init(&mut self, run_id: Uuid) -> Result<String> {
+        let proc = self
+            .proc
+            .as_mut()
+            .context("muse exec process not spawned")?;
+        let deadline = tokio::time::Instant::now() + INIT_TIMEOUT;
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        let recv = tokio::time::timeout(remaining, proc.inbound.recv())
+            .await
+            .context("timed out waiting for muse exec's first frame")?;
+        match recv {
+            Some(StreamEvent::System(ref sys)) if sys.subtype == "init" => {
+                let thread_id = sys
+                    .session_id
+                    .clone()
+                    .unwrap_or_else(|| format!("muse-{run_id}"));
+                self.model = sys
+                    .rest
+                    .get("model")
+                    .and_then(|v| v.as_str())
+                    .filter(|s| !s.is_empty())
+                    .map(ToOwned::to_owned)
+                    .or_else(|| self.model.clone());
+                self.session_id = Some(thread_id.clone());
+                Ok(thread_id)
+            }
+            Some(ev) => {
+                // No init frame (or Muse skipped straight to output / a terminal
+                // `result` on an auth or quota error). Adopt any session id the
+                // frame carries, else synthesize one, then buffer the frame so
+                // the normal pump translates it — keeping the real error /
+                // content instead of dropping it.
+                let sid = session_id_of(&ev);
+                let thread_id = sid.unwrap_or_else(|| format!("muse-{run_id}"));
+                self.session_id = Some(thread_id.clone());
+                self.pending.push_back(ev);
+                Ok(thread_id)
+            }
+            None => anyhow::bail!("muse exec stdout closed before emitting any frame"),
+        }
+    }
+
+    /// Pull the next event off the subprocess (or the pre-init buffer) and
+    /// translate it. Returns `None` once the stdout stream closes for good;
+    /// callers treat that as EOF and exit their pump loop.
+    pub async fn next_events(&mut self, cursor: &mut BridgeCursor) -> Option<Vec<BridgeEvent>> {
+        loop {
+            let ev = if let Some(buffered) = self.pending.pop_front() {
+                buffered
+            } else {
+                self.proc.as_mut()?.inbound.recv().await?
+            };
+            let translated = cursor.translate(ev);
+            if !translated.is_empty() {
+                return Some(translated);
+            }
+        }
+    }
+
+    /// Approvals aren't wired for muse exec in the MVP (`--yolo` is set, so the
+    /// subprocess never asks). Reaching this is a programmer error; fail fast so
+    /// the supervisor surfaces the bug instead of silently dropping the
+    /// operator's decision.
+    pub async fn send_approval(
+        &mut self,
+        approval_id: &str,
+        _decision: ApprovalDecision,
+    ) -> Result<()> {
+        tracing::error!(
+            approval_id,
+            "muse_code bridge received an approval decision but approvals are \
+             not wired (--yolo is on); refusing to silently drop it"
+        );
+        anyhow::bail!(
+            "muse_code bridge received approval {approval_id} but approvals are \
+             not wired in MVP"
+        );
+    }
+
+    pub async fn interrupt(&mut self) -> Result<()> {
+        match self.proc.as_mut() {
+            Some(proc) => proc.interrupt().await,
+            None => Ok(()),
+        }
+    }
+
+    pub async fn shutdown(self, grace: Duration) -> Result<()> {
+        if let Some(proc) = self.proc {
+            proc.shutdown(grace, self.exit_rx.clone()).await
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn process_handle(&self) -> AgentProcessHandle {
+        AgentProcessHandle {
+            pid: self.proc.as_ref().and_then(|p| p.pid()),
+            exit_rx: self.exit_rx.clone(),
+        }
+    }
+
+    pub async fn recent_stderr(&self) -> StderrSnapshot {
+        self.stderr_ring.lock().await.snapshot()
+    }
+}
+
+/// The `session_id` carried by a frame, if any. Used to adopt a thread id when
+/// Muse doesn't lead with a `system/init` frame.
+fn session_id_of(ev: &StreamEvent) -> Option<String> {
+    match ev {
+        StreamEvent::System(s) => s.session_id.clone(),
+        StreamEvent::Assistant(m) | StreamEvent::User(m) => m.session_id.clone(),
+        StreamEvent::ToolCall(t) => t.session_id.clone(),
+        StreamEvent::Result(r) => r.session_id.clone(),
+        StreamEvent::Unknown(v) => v
+            .get("session_id")
+            .and_then(|x| x.as_str())
+            .map(ToOwned::to_owned),
+    }
+}
+
+/// Per-run translation state. Mirrors the Cursor bridge cursor: a populated
+/// `thread_id` established during run setup, plus a terminal latch.
+pub struct BridgeCursor {
+    pub run_id: Uuid,
+    pub thread_id: String,
+    pub model: Option<String>,
+    /// Flipped once we see a terminal `result` frame. Suppresses any trailing
+    /// frames a stubborn subprocess might emit after completion.
+    terminal: bool,
+    pub seq: u64,
+}
+
+impl BridgeCursor {
+    pub fn translate(&mut self, ev: StreamEvent) -> Vec<BridgeEvent> {
+        if self.terminal {
+            return Vec::new();
+        }
+        self.seq = self.seq.saturating_add(1);
+
+        match ev {
+            StreamEvent::System(sys) => {
+                // `init` was already consumed during run setup; drop any repeat.
+                if sys.subtype == "init" {
+                    return Vec::new();
+                }
+                let params = serde_json::to_value(&sys.rest).unwrap_or(serde_json::Value::Null);
+                vec![BridgeEvent::Raw {
+                    run_id: self.run_id,
+                    method: format!("system/{}", sys.subtype),
+                    params,
+                }]
+            }
+            StreamEvent::Assistant(a) => vec![BridgeEvent::Raw {
+                run_id: self.run_id,
+                method: "assistant/message".into(),
+                params: a.message,
+            }],
+            StreamEvent::User(u) => vec![BridgeEvent::Raw {
+                run_id: self.run_id,
+                method: "user/message".into(),
+                params: u.message,
+            }],
+            StreamEvent::ToolCall(t) => {
+                let params = serde_json::to_value(&t.rest).unwrap_or(serde_json::Value::Null);
+                vec![BridgeEvent::Raw {
+                    run_id: self.run_id,
+                    method: format!("tool_call/{}", t.subtype),
+                    params,
+                }]
+            }
+            StreamEvent::Result(r) => {
+                self.terminal = true;
+                let is_err = r.is_error.unwrap_or(false) || r.subtype.starts_with("error");
+                if is_err {
+                    let detail = r
+                        .result
+                        .clone()
+                        .or_else(|| Some(format!("muse exec result subtype: {}", r.subtype)));
+                    vec![BridgeEvent::Failed {
+                        run_id: self.run_id,
+                        reason: classify_failure(&r.subtype),
+                        detail,
+                    }]
+                } else {
+                    let done_payload = serde_json::json!({
+                        "conclusion": r.subtype,
+                        "result": r.result,
+                        "duration_ms": r.duration_ms,
+                        "ended_at": Utc::now().to_rfc3339(),
+                    });
+                    vec![BridgeEvent::Completed {
+                        run_id: self.run_id,
+                        done_payload,
+                    }]
+                }
+            }
+            StreamEvent::Unknown(v) => vec![BridgeEvent::Raw {
+                run_id: self.run_id,
+                method: "unknown".into(),
+                params: v,
+            }],
+        }
+    }
+}
+
+/// Best-effort mapping from muse exec's `result.subtype` to our
+/// `FailureReason`. Muse has no documented turn-budget subtype, so all error
+/// results map to the generic `AgentCrash` (shared with the other headless
+/// bridges; kept distinct from `CodexCrash`).
+fn classify_failure(_subtype: &str) -> FailureReason {
+    FailureReason::AgentCrash
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn argv_of(cmd: &Command) -> Vec<String> {
+        cmd.as_std()
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn build_command_uses_exec_json_and_prompt_file() {
+        let bridge = Bridge::spawn("muse", Path::new("/tmp"), None)
+            .await
+            .expect("bridge setup");
+        let cmd = bridge.build_command(Path::new("/tmp/prompt.md"), Path::new("/tmp"));
+        let argv = argv_of(&cmd);
+        // The subcommand and headless flags must be present and ordered so the
+        // prompt file is read and JSONL is emitted.
+        let exec = argv
+            .iter()
+            .position(|a| a == "exec")
+            .expect("exec subcommand");
+        assert!(argv.iter().any(|a| a == "--json"), "argv: {argv:?}");
+        let pf = argv
+            .iter()
+            .position(|a| a == "--prompt-file")
+            .expect("--prompt-file flag");
+        assert!(pf > exec, "--prompt-file must follow exec: {argv:?}");
+        assert_eq!(
+            argv.get(pf + 1).map(String::as_str),
+            Some("/tmp/prompt.md"),
+            "prompt path must directly follow --prompt-file: {argv:?}"
+        );
+        // MVP approval posture.
+        assert!(argv.iter().any(|a| a == "--yolo"), "argv: {argv:?}");
+    }
+
+    #[tokio::test]
+    async fn build_command_includes_model_and_session_id_when_set() {
+        let mut bridge = Bridge::spawn("muse", Path::new("/tmp"), Some("muse-spark".into()))
+            .await
+            .expect("bridge setup");
+        bridge.session_id = Some("sess-123".into());
+        let cmd = bridge.build_command(Path::new("/tmp/p.md"), Path::new("/tmp"));
+        let argv = argv_of(&cmd);
+        let m = argv.iter().position(|a| a == "--model").expect("--model");
+        assert_eq!(argv.get(m + 1).map(String::as_str), Some("muse-spark"));
+        let s = argv
+            .iter()
+            .position(|a| a == "--session-id")
+            .expect("--session-id");
+        assert_eq!(argv.get(s + 1).map(String::as_str), Some("sess-123"));
+    }
+
+    #[test]
+    fn translate_result_success_emits_completed() {
+        let mut cursor = BridgeCursor {
+            run_id: Uuid::new_v4(),
+            thread_id: "muse-x".into(),
+            model: None,
+            terminal: false,
+            seq: 0,
+        };
+        let ev = serde_json::from_str::<StreamEvent>(
+            r#"{"type":"result","subtype":"success","is_error":false,"result":"ok"}"#,
+        )
+        .unwrap();
+        let out = cursor.translate(ev);
+        assert!(matches!(out.as_slice(), [BridgeEvent::Completed { .. }]));
+        // Terminal latch: any trailing frame is suppressed.
+        let trailing = serde_json::from_str::<StreamEvent>(
+            r#"{"type":"assistant","message":{"role":"assistant","content":[]}}"#,
+        )
+        .unwrap();
+        assert!(cursor.translate(trailing).is_empty());
+    }
+
+    #[test]
+    fn translate_result_error_emits_failed() {
+        let mut cursor = BridgeCursor {
+            run_id: Uuid::new_v4(),
+            thread_id: "muse-x".into(),
+            model: None,
+            terminal: false,
+            seq: 0,
+        };
+        let ev = serde_json::from_str::<StreamEvent>(
+            r#"{"type":"result","subtype":"error_auth","is_error":true,"result":"unauthorized"}"#,
+        )
+        .unwrap();
+        let out = cursor.translate(ev);
+        match out.as_slice() {
+            [BridgeEvent::Failed { detail, .. }] => {
+                assert_eq!(detail.as_deref(), Some("unauthorized"));
+            }
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+}

--- a/runner/src/muse_code/mod.rs
+++ b/runner/src/muse_code/mod.rs
@@ -1,0 +1,19 @@
+//! Muse Code integration. Drives Meta's `muse exec --json --prompt-file
+//! <PATH>` headless one-shot mode and translates the emitted JSONL events into
+//! the agent-agnostic [`crate::agent::BridgeEvent`] shape used by the daemon.
+//!
+//! MVP limitations (tracked as follow-ups):
+//! - Approvals bypass: runs with `--yolo` (disable approval prompts and
+//!   sandbox). Wiring a real approval prompt is out of scope for the first
+//!   pass, mirroring the Cursor bridge's `--force` posture.
+//! - One-shot per turn: `muse exec` reads the prompt from a file and runs the
+//!   turn to completion, so each turn spawns a fresh subprocess (reusing the
+//!   prior `--session-id` for continuity) rather than feeding turns over stdin.
+//! - Closed-source schema: Muse Code's JSONL event schema is not fully
+//!   documented publicly; the schema layer is tolerant (envelope + retained
+//!   raw body + an `Unknown` catch-all), so upstream drift degrades to
+//!   "preserved but unmapped" rather than a bridge crash.
+
+pub mod bridge;
+pub mod process;
+pub mod schema;

--- a/runner/src/muse_code/process.rs
+++ b/runner/src/muse_code/process.rs
@@ -1,0 +1,304 @@
+//! `muse exec` CLI subprocess wrapper. Mirrors the shape of
+//! `cursor_agent::process::CursorProcess`: Muse Code's headless mode
+//! (`muse exec --json`) runs one prompt to completion and exits, so the
+//! process is one-shot per run, spawned by the bridge only once the prompt is
+//! known.
+//!
+//! One structural difference from Cursor: Muse takes its prompt from a file
+//! (`--prompt-file <PATH>`) rather than a positional argv element. The bridge
+//! writes the turn's prompt to a temp file and hands the resulting
+//! [`PromptFile`] guard here; the guard deletes the file when the process
+//! wrapper drops, so the prompt (which can contain private repo context) never
+//! outlives the run on disk.
+//!
+//! Because the bridge spawns lazily (at `run`, not at construction), the
+//! exit-watch channel and stderr ring are created up front by the bridge and
+//! handed in here, so the supervisor's `process_handle()` — captured before
+//! the first run — observes the real subprocess once it starts.
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use std::path::PathBuf;
+use std::process::Stdio;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::sync::{mpsc, watch};
+use uuid::Uuid;
+
+use crate::agent::{ExitSnapshot, StderrRing};
+use crate::muse_code::schema::StreamEvent;
+use crate::util::shell::is_benign_login_shell_warning;
+
+/// A temp file holding one turn's prompt, deleted on drop. `muse exec` reads
+/// its prompt from `--prompt-file <PATH>`; we materialize that file in the OS
+/// temp dir (never inside the repo worktree, so it can't pollute git status)
+/// and remove it once the run's process wrapper is torn down.
+pub struct PromptFile {
+    path: PathBuf,
+}
+
+impl PromptFile {
+    /// Write `prompt` to a uniquely-named temp file and return a guard that
+    /// owns its path. The file is created with the current process's default
+    /// permissions; on Unix the OS temp dir is world-readable, so this is no
+    /// weaker than the argv/stdin the other bridges use (both visible via
+    /// `/proc`), and the guard bounds its lifetime to the run.
+    pub fn create(prompt: &str) -> Result<Self> {
+        let mut path = std::env::temp_dir();
+        path.push(format!("pidash-muse-prompt-{}.md", Uuid::new_v4()));
+        std::fs::write(&path, prompt)
+            .with_context(|| format!("writing muse prompt file to {}", path.display()))?;
+        Ok(Self { path })
+    }
+
+    pub fn path(&self) -> &std::path::Path {
+        &self.path
+    }
+}
+
+impl Drop for PromptFile {
+    fn drop(&mut self) {
+        // Best-effort cleanup: the run is over (or the bridge was dropped), so
+        // a leftover temp file is the only cost of a failed unlink.
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+/// Handles the `muse exec --json --prompt-file <PATH>` subprocess lifecycle.
+/// Owns no stdin (the prompt rides in a file); it exposes an mpsc receiver of
+/// parsed events coming off stdout and a kill channel for interrupt/shutdown.
+/// It also holds the [`PromptFile`] guard so the prompt file lives at least as
+/// long as the process that reads it.
+pub struct MuseProcess {
+    pid: Option<u32>,
+    pub inbound: mpsc::Receiver<StreamEvent>,
+    kill_tx: mpsc::Sender<KillRequest>,
+    /// Kept alive for the process lifetime; dropping it deletes the prompt
+    /// file. `None` in tests that inject a fake command with no prompt file.
+    _prompt_file: Option<PromptFile>,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum KillRequest {
+    Graceful,
+    Force,
+}
+
+impl MuseProcess {
+    /// Spawn the subprocess from a fully-built `Command`. The command's argv
+    /// (`exec --json --prompt-file <PATH> [--model ..] [--session-id ..]`) is
+    /// assembled by `muse_code::bridge::Bridge`; tests inject a shell-script
+    /// fake here (and pass `prompt_file: None`). Forces the stdio disposition
+    /// the reader task expects.
+    pub async fn spawn_command(
+        mut cmd: Command,
+        prompt_file: Option<PromptFile>,
+        exit_tx: watch::Sender<Option<ExitSnapshot>>,
+        stderr_ring: StderrRing,
+    ) -> Result<Self> {
+        // No stdin: muse exec takes the prompt from a file.
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        let mut child = cmd.spawn().context("spawning muse exec subprocess")?;
+        let stdout = child.stdout.take().context("muse exec stdout missing")?;
+        let stderr = child.stderr.take().context("muse exec stderr missing")?;
+        let pid = child.id();
+
+        let (tx, rx) = mpsc::channel(128);
+        tokio::spawn(read_events(stdout, tx));
+        tokio::spawn(drain_stderr(stderr, stderr_ring));
+
+        let (kill_tx, kill_rx) = mpsc::channel::<KillRequest>(2);
+        tokio::spawn(wait_task(child, kill_rx, exit_tx));
+
+        Ok(Self {
+            pid,
+            inbound: rx,
+            kill_tx,
+            _prompt_file: prompt_file,
+        })
+    }
+
+    pub fn pid(&self) -> Option<u32> {
+        self.pid
+    }
+
+    /// Best-effort interrupt: send SIGINT if we can, otherwise fall back to
+    /// SIGKILL via the kill channel. muse exec has no in-protocol cancel, so
+    /// the OS signal is the only lever.
+    pub async fn interrupt(&mut self) -> Result<()> {
+        #[cfg(unix)]
+        {
+            use nix::sys::signal::{Signal, kill};
+            use nix::unistd::Pid;
+            if let Some(pid) = self.pid {
+                let pid_t = Pid::from_raw(pid as i32);
+                match kill(pid_t, Signal::SIGINT) {
+                    Ok(()) => return Ok(()),
+                    Err(e) => {
+                        tracing::warn!("muse exec SIGINT failed ({e}); falling back to SIGKILL");
+                    }
+                }
+            }
+        }
+        self.kill_tx
+            .send(KillRequest::Force)
+            .await
+            .context("failed to send kill request to muse exec wait task")?;
+        Ok(())
+    }
+
+    pub async fn shutdown(
+        self,
+        grace: std::time::Duration,
+        mut exit_rx: watch::Receiver<Option<ExitSnapshot>>,
+    ) -> Result<()> {
+        // Already exited (the one-shot turn finished, or a prior kill landed):
+        // there is nothing to wait on, and the wait task has already published
+        // its final snapshot and ended — so a `changed()` here would never fire.
+        // Return immediately instead of blocking the full `grace`.
+        if exit_rx.borrow().is_some() {
+            return Ok(());
+        }
+        let _ = self.kill_tx.send(KillRequest::Graceful).await;
+        match tokio::time::timeout(grace, exit_rx.changed()).await {
+            Ok(Ok(())) => {
+                let snap = exit_rx.borrow().clone();
+                tracing::debug!(?snap, "muse exec exited gracefully");
+            }
+            _ => {
+                tracing::warn!("muse exec did not exit within grace; sending SIGKILL");
+                let _ = self.kill_tx.send(KillRequest::Force).await;
+                // Bounded wait: the wait task may have already ended (so the
+                // snapshot is never republished); never let shutdown hang
+                // indefinitely on a `changed()` that will not come.
+                let _ = tokio::time::timeout(grace, exit_rx.changed()).await;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Owns the `Child` exclusively. Awaits either a kill request (force-kill the
+/// subprocess) or the child's natural exit, then publishes an `ExitSnapshot`
+/// and terminates.
+async fn wait_task(
+    mut child: Child,
+    mut kill_rx: mpsc::Receiver<KillRequest>,
+    exit_tx: watch::Sender<Option<ExitSnapshot>>,
+) {
+    let snapshot = loop {
+        tokio::select! {
+            biased;
+            req = kill_rx.recv() => {
+                match req {
+                    Some(KillRequest::Force) => {
+                        let _ = child.start_kill();
+                    }
+                    Some(KillRequest::Graceful) => {
+                        // No-op: wait for natural exit.
+                    }
+                    None => {
+                        // All senders dropped — the owning `MuseProcess` (and
+                        // its kill channel) is gone, i.e. the bridge was dropped
+                        // without a graceful shutdown. Kill the child rather than
+                        // leaving an orphaned `muse` running to completion.
+                        // `start_kill` is a no-op if it already exited; we then
+                        // `wait` to reap it (no zombie). Breaking out here also
+                        // stops the biased select! from spinning on the
+                        // now-closed recv channel.
+                        let _ = child.start_kill();
+                        let res = child.wait().await;
+                        break exit_snapshot_from(res.ok());
+                    }
+                }
+            }
+            res = child.wait() => {
+                break exit_snapshot_from(res.ok());
+            }
+        }
+    };
+    let _ = exit_tx.send(Some(snapshot));
+}
+
+fn exit_snapshot_from(status: Option<std::process::ExitStatus>) -> ExitSnapshot {
+    #[cfg(unix)]
+    let signal = {
+        use std::os::unix::process::ExitStatusExt;
+        status.as_ref().and_then(|s| s.signal())
+    };
+    #[cfg(not(unix))]
+    let signal: Option<i32> = None;
+    let status_code = status.as_ref().and_then(|s| s.code());
+    ExitSnapshot {
+        status_code,
+        signal,
+        observed_at: Utc::now(),
+    }
+}
+
+async fn read_events(stdout: tokio::process::ChildStdout, tx: mpsc::Sender<StreamEvent>) {
+    let mut reader = BufReader::new(stdout);
+    let mut line = String::new();
+    loop {
+        line.clear();
+        match reader.read_line(&mut line).await {
+            Ok(0) => break,
+            Ok(_) => {
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                // Try structured parse first; fall back to stashing the raw
+                // value as `Unknown` so upstream changes don't crash the daemon.
+                let ev = match serde_json::from_str::<StreamEvent>(trimmed) {
+                    Ok(e) => e,
+                    Err(e) => {
+                        tracing::warn!("muse exec emitted unparsable json ({e}): {trimmed}");
+                        match serde_json::from_str::<serde_json::Value>(trimmed) {
+                            Ok(v) => StreamEvent::Unknown(v),
+                            Err(_) => continue,
+                        }
+                    }
+                };
+                if tx.send(ev).await.is_err() {
+                    break;
+                }
+            }
+            Err(e) => {
+                tracing::warn!("muse exec stdout read error: {e}");
+                break;
+            }
+        }
+    }
+}
+
+async fn drain_stderr(stderr: tokio::process::ChildStderr, ring: StderrRing) {
+    // muse exec surfaces auth, model, and runtime errors here. At the default
+    // `info` level these would be invisible, so every non-empty line is logged
+    // at `warn!` AND buffered into the per-process ring for RunFailed-detail
+    // enrichment. The login-shell wrapper emits two TTY-less diagnostics before
+    // exec; suppress those so logs aren't noisy on spawn.
+    let mut reader = BufReader::new(stderr);
+    let mut line = String::new();
+    loop {
+        line.clear();
+        match reader.read_line(&mut line).await {
+            Ok(0) => break,
+            Ok(_) => {
+                let trimmed = line.trim_end();
+                if trimmed.is_empty() || is_benign_login_shell_warning(trimmed) {
+                    continue;
+                }
+                tracing::warn!(target: "muse_code.stderr", "{trimmed}");
+                ring.lock().await.push(trimmed);
+            }
+            Err(e) => {
+                tracing::warn!("muse exec stderr read error: {e}");
+                break;
+            }
+        }
+    }
+}

--- a/runner/src/muse_code/schema.rs
+++ b/runner/src/muse_code/schema.rs
@@ -1,0 +1,179 @@
+//! JSONL event shapes emitted by `muse exec --json`. Muse Code (Meta) is
+//! closed-source and its event schema is not publicly documented in full, so —
+//! exactly like the Cursor bridge — we capture only the envelope (`type` +
+//! `subtype`) plus the handful of fields we actually read, and retain the full
+//! body as a `serde_json::Value` so the daemon can ship it to local history
+//! verbatim without tracking every upstream schema revision.
+//!
+//! The frame families modeled here (`system`/`user`/`assistant`/`tool_call`/
+//! `result`) mirror the shape Meta's harness documents for its headless
+//! (`exec`) mode; anything unrecognized collapses to [`StreamEvent::Unknown`]
+//! so a schema drift on Meta's side degrades to "preserved but unmapped"
+//! rather than crashing the bridge.
+
+use serde::de::Error as _;
+use serde::{Deserialize, Deserializer};
+
+/// Top-level JSONL event. Dispatch is on the top-level `type` tag; unknown
+/// tags collapse to [`StreamEvent::Unknown`] so forward-compatible upstream
+/// changes don't crash the bridge.
+#[derive(Debug, Clone)]
+pub enum StreamEvent {
+    /// The first frame of a run: `{"type":"system","subtype":"init",
+    /// "session_id":"...","model":"..."}`. We capture `session_id` as the
+    /// thread id so history/IPC can link follow-up work to the same session.
+    System(SystemEvent),
+    /// `{"type":"assistant","message":{...}}` — one message segment from the
+    /// model (emitted between tool calls).
+    Assistant(MessageEvent),
+    /// `{"type":"user","message":{...}}` — the prompt echo and/or tool-result
+    /// echoes. Useful for transcripts.
+    User(MessageEvent),
+    /// `{"type":"tool_call","subtype":"started|completed",...}` — tool
+    /// execution lifecycle.
+    ToolCall(ToolCallEvent),
+    /// `{"type":"result","subtype":"success","is_error":false,...}` — the
+    /// terminal frame `muse exec` emits before exiting.
+    Result(ResultEvent),
+    /// Anything else: new event types Muse may emit that we don't map yet.
+    /// Preserved verbatim in history.
+    Unknown(serde_json::Value),
+}
+
+impl<'de> Deserialize<'de> for StreamEvent {
+    // Dispatch manually on `type` rather than `#[serde(untagged)]`: several
+    // variants share field sets (`system` and `result` both carry `subtype` +
+    // `session_id`), so an untagged enum would greedily misroute frames.
+    // Tagging on `type` is unambiguous and keeps a catch-all for forward-compat.
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let v = serde_json::Value::deserialize(d)?;
+        let ty = v.get("type").and_then(|x| x.as_str()).unwrap_or("");
+        match ty {
+            "system" => serde_json::from_value(v)
+                .map(StreamEvent::System)
+                .map_err(D::Error::custom),
+            "assistant" => serde_json::from_value(v)
+                .map(StreamEvent::Assistant)
+                .map_err(D::Error::custom),
+            "user" => serde_json::from_value(v)
+                .map(StreamEvent::User)
+                .map_err(D::Error::custom),
+            "tool_call" => serde_json::from_value(v)
+                .map(StreamEvent::ToolCall)
+                .map_err(D::Error::custom),
+            "result" => serde_json::from_value(v)
+                .map(StreamEvent::Result)
+                .map_err(D::Error::custom),
+            _ => Ok(StreamEvent::Unknown(v)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SystemEvent {
+    pub subtype: String,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(flatten)]
+    pub rest: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Shared shape for `assistant` and `user` events: both wrap a `message`
+/// object (`{role, content}`) and may carry the session id.
+#[derive(Debug, Clone, Deserialize)]
+pub struct MessageEvent {
+    pub message: serde_json::Value,
+    #[serde(default)]
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ToolCallEvent {
+    pub subtype: String,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(flatten)]
+    pub rest: serde_json::Map<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ResultEvent {
+    pub subtype: String,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub result: Option<String>,
+    #[serde(default)]
+    pub is_error: Option<bool>,
+    #[serde(default)]
+    pub duration_ms: Option<u64>,
+    #[serde(flatten)]
+    pub rest: serde_json::Map<String, serde_json::Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dispatches_system_init() {
+        let line = r#"{"type":"system","subtype":"init","session_id":"s1","model":"muse-spark","permissionMode":"yolo"}"#;
+        match serde_json::from_str::<StreamEvent>(line).unwrap() {
+            StreamEvent::System(s) => {
+                assert_eq!(s.subtype, "init");
+                assert_eq!(s.session_id.as_deref(), Some("s1"));
+                assert_eq!(
+                    s.rest.get("model").and_then(|m| m.as_str()),
+                    Some("muse-spark")
+                );
+            }
+            other => panic!("expected System, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dispatches_assistant_and_user() {
+        let a = r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hi"}]},"session_id":"s1"}"#;
+        assert!(matches!(
+            serde_json::from_str::<StreamEvent>(a).unwrap(),
+            StreamEvent::Assistant(_)
+        ));
+        let u = r#"{"type":"user","message":{"role":"user","content":[]},"session_id":"s1"}"#;
+        assert!(matches!(
+            serde_json::from_str::<StreamEvent>(u).unwrap(),
+            StreamEvent::User(_)
+        ));
+    }
+
+    #[test]
+    fn dispatches_tool_call_subtypes() {
+        let started = r#"{"type":"tool_call","subtype":"started","call_id":"c1","tool_call":{"shell":{}},"session_id":"s1"}"#;
+        match serde_json::from_str::<StreamEvent>(started).unwrap() {
+            StreamEvent::ToolCall(t) => assert_eq!(t.subtype, "started"),
+            other => panic!("expected ToolCall, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dispatches_result_terminal() {
+        let line = r#"{"type":"result","subtype":"success","is_error":false,"duration_ms":1200,"result":"done","session_id":"s1"}"#;
+        match serde_json::from_str::<StreamEvent>(line).unwrap() {
+            StreamEvent::Result(r) => {
+                assert_eq!(r.subtype, "success");
+                assert_eq!(r.is_error, Some(false));
+                assert_eq!(r.duration_ms, Some(1200));
+                assert_eq!(r.result.as_deref(), Some("done"));
+            }
+            other => panic!("expected Result, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_type_is_preserved() {
+        let line = r#"{"type":"telemetry","foo":1}"#;
+        assert!(matches!(
+            serde_json::from_str::<StreamEvent>(line).unwrap(),
+            StreamEvent::Unknown(_)
+        ));
+    }
+}

--- a/runner/src/tui/views/config.rs
+++ b/runner/src/tui/views/config.rs
@@ -21,7 +21,14 @@ use crate::service::reload::ReloadOutcome;
 
 use super::super::app::AppData;
 
-pub const AGENT_KINDS: &[&str] = &["codex", "claude-code", "cursor-agent", "open-claw", "grok"];
+pub const AGENT_KINDS: &[&str] = &[
+    "codex",
+    "claude-code",
+    "cursor-agent",
+    "open-claw",
+    "grok",
+    "muse-code",
+];
 pub const LOG_LEVELS: &[&str] = &["trace", "debug", "info", "warn", "error"];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -39,6 +46,8 @@ pub enum FieldId {
     OpenClawModelDefault,
     GrokBinary,
     GrokModelDefault,
+    MuseCodeBinary,
+    MuseCodeModelDefault,
     ApprovalAutoReadonly,
     ApprovalAutoWrites,
     ApprovalAutoNetwork,
@@ -63,6 +72,8 @@ impl FieldId {
             FieldId::OpenClawModelDefault => "field:openclaw_model_default",
             FieldId::GrokBinary => "field:grok_binary",
             FieldId::GrokModelDefault => "field:grok_model_default",
+            FieldId::MuseCodeBinary => "field:muse_code_binary",
+            FieldId::MuseCodeModelDefault => "field:muse_code_model_default",
             FieldId::ApprovalAutoReadonly => "field:approval_auto_readonly",
             FieldId::ApprovalAutoWrites => "field:approval_auto_writes",
             FieldId::ApprovalAutoNetwork => "field:approval_auto_network",
@@ -86,6 +97,8 @@ impl FieldId {
             "field:openclaw_model_default" => FieldId::OpenClawModelDefault,
             "field:grok_binary" => FieldId::GrokBinary,
             "field:grok_model_default" => FieldId::GrokModelDefault,
+            "field:muse_code_binary" => FieldId::MuseCodeBinary,
+            "field:muse_code_model_default" => FieldId::MuseCodeModelDefault,
             "field:approval_auto_readonly" => FieldId::ApprovalAutoReadonly,
             "field:approval_auto_writes" => FieldId::ApprovalAutoWrites,
             "field:approval_auto_network" => FieldId::ApprovalAutoNetwork,
@@ -191,6 +204,18 @@ pub const FIELDS: &[FieldSpec] = &[
         kind: FieldKind::Text,
     },
     FieldSpec {
+        id: FieldId::MuseCodeBinary,
+        label: "binary",
+        section: "Muse Code",
+        kind: FieldKind::Text,
+    },
+    FieldSpec {
+        id: FieldId::MuseCodeModelDefault,
+        label: "model_default",
+        section: "Muse Code",
+        kind: FieldKind::Text,
+    },
+    FieldSpec {
         id: FieldId::ApprovalAutoReadonly,
         label: "auto_approve_readonly_shell",
         section: "Approval policy",
@@ -228,6 +253,7 @@ pub fn field_agent_kind(id: FieldId) -> Option<AgentKind> {
         FieldId::CursorBinary | FieldId::CursorModelDefault => Some(AgentKind::CursorAgent),
         FieldId::OpenClawBinary | FieldId::OpenClawModelDefault => Some(AgentKind::OpenClaw),
         FieldId::GrokBinary | FieldId::GrokModelDefault => Some(AgentKind::Grok),
+        FieldId::MuseCodeBinary | FieldId::MuseCodeModelDefault => Some(AgentKind::MuseCode),
         _ => None,
     }
 }
@@ -289,6 +315,7 @@ pub fn display_value(cfg: &Config, id: FieldId, runner_idx: usize) -> String {
             AgentKind::CursorAgent => "cursor-agent".into(),
             AgentKind::OpenClaw => "open-claw".into(),
             AgentKind::Grok => "grok".into(),
+            AgentKind::MuseCode => "muse-code".into(),
         },
         FieldId::CodexBinary => runner.codex.binary.clone(),
         FieldId::CodexModelDefault => runner.codex.model_default.clone().unwrap_or_default(),
@@ -310,6 +337,10 @@ pub fn display_value(cfg: &Config, id: FieldId, runner_idx: usize) -> String {
         }
         FieldId::GrokBinary => runner.grok.binary.clone(),
         FieldId::GrokModelDefault => runner.grok.model_default.clone().unwrap_or_default(),
+        FieldId::MuseCodeBinary => runner.muse_code.binary.clone(),
+        FieldId::MuseCodeModelDefault => {
+            runner.muse_code.model_default.clone().unwrap_or_default()
+        }
         FieldId::ApprovalAutoReadonly => runner
             .approval_policy
             .auto_approve_readonly_shell
@@ -415,6 +446,19 @@ pub fn set_text_value(
                 Some(s.to_string())
             };
         }
+        FieldId::MuseCodeBinary => {
+            if s.trim().is_empty() {
+                return Err("binary cannot be empty".into());
+            }
+            runner.muse_code.binary = s.to_string();
+        }
+        FieldId::MuseCodeModelDefault => {
+            runner.muse_code.model_default = if s.is_empty() {
+                None
+            } else {
+                Some(s.to_string())
+            };
+        }
         FieldId::AgentKind
         | FieldId::ApprovalAutoReadonly
         | FieldId::ApprovalAutoWrites
@@ -459,7 +503,8 @@ pub fn cycle_enum(cfg: &mut Config, id: FieldId, runner_idx: usize) {
                 AgentKind::ClaudeCode => AgentKind::CursorAgent,
                 AgentKind::CursorAgent => AgentKind::OpenClaw,
                 AgentKind::OpenClaw => AgentKind::Grok,
-                AgentKind::Grok => AgentKind::Codex,
+                AgentKind::Grok => AgentKind::MuseCode,
+                AgentKind::MuseCode => AgentKind::Codex,
             };
         }
         FieldId::LogLevel => {
@@ -879,6 +924,7 @@ mod tests {
             cursor_agent: Default::default(),
             openclaw: Default::default(),
             grok: Default::default(),
+            muse_code: Default::default(),
             approval_policy: Default::default(),
         };
         runner.agent.kind = kind;

--- a/runner/src/tui/views/general.rs
+++ b/runner/src/tui/views/general.rs
@@ -922,6 +922,7 @@ pub async fn submit_register(
         cursor_agent: Default::default(),
         openclaw: Default::default(),
         grok: Default::default(),
+        muse_code: Default::default(),
         approval_policy: Default::default(),
     };
     let cfg = crate::config::schema::Config {

--- a/runner/src/tui/views/runner_status.rs
+++ b/runner/src/tui/views/runner_status.rs
@@ -694,6 +694,7 @@ mod tests {
             cursor_agent: Default::default(),
             openclaw: Default::default(),
             grok: Default::default(),
+            muse_code: Default::default(),
             approval_policy: Default::default(),
         }
     }

--- a/runner/tests/muse_code_bridge_fake.rs
+++ b/runner/tests/muse_code_bridge_fake.rs
@@ -1,0 +1,376 @@
+//! End-to-end Muse Code bridge test. A shell subprocess plays the role of
+//! `muse exec --json --prompt-file <PATH>` and emits canned JSONL events; the
+//! Bridge drives it through `system/init → assistant message → tool_call →
+//! result`.
+//!
+//! Like the Cursor bridge, `muse exec` is spawned lazily by `run` (the prompt
+//! isn't known at construction), so these tests inject the fake command through
+//! `Bridge::run_with_command`. Muse takes its prompt from a file rather than
+//! argv, so the injected command carries no real prompt file (`None`).
+
+use pidash::agent::BridgeEvent;
+use pidash::muse_code::bridge::{Bridge, BridgeCursor};
+use std::path::PathBuf;
+use std::time::Duration;
+use tokio::process::Command;
+use uuid::Uuid;
+
+/// Emits a deterministic sequence of muse exec JSONL events: an init frame with
+/// a session id, one assistant message, a tool_call started/completed pair, and
+/// a terminal `result.success` frame.
+fn fake_muse_script() -> &'static str {
+    r#"
+        set -e
+        printf '%s\n' '{"type":"system","subtype":"init","session_id":"muse_fake_001","model":"muse-spark","permissionMode":"yolo","cwd":"/tmp"}'
+        printf '%s\n' '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hello"}]},"session_id":"muse_fake_001"}'
+        printf '%s\n' '{"type":"tool_call","subtype":"started","call_id":"c1","tool_call":{"read":{"path":"README.md"}},"session_id":"muse_fake_001"}'
+        printf '%s\n' '{"type":"tool_call","subtype":"completed","call_id":"c1","tool_call":{"read":{"result":{"success":{}}}},"session_id":"muse_fake_001"}'
+        printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"duration_ms":1234,"result":"all done","session_id":"muse_fake_001"}'
+        sleep 0.2
+    "#
+}
+
+fn fake_cmd(script: &str) -> Command {
+    let mut cmd = Command::new("sh");
+    cmd.arg("-c").arg(script);
+    cmd
+}
+
+async fn drain_until_completed(
+    bridge: &mut Bridge,
+    cursor: &mut BridgeCursor,
+) -> serde_json::Value {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+    while tokio::time::Instant::now() < deadline {
+        let Some(events) =
+            tokio::time::timeout(Duration::from_millis(500), bridge.next_events(cursor))
+                .await
+                .ok()
+                .flatten()
+        else {
+            break;
+        };
+        for ev in events {
+            match ev {
+                BridgeEvent::Completed { done_payload, .. } => return done_payload,
+                BridgeEvent::Failed { detail, .. } => panic!("unexpected Failed event: {detail:?}"),
+                _ => {}
+            }
+        }
+    }
+    panic!("expected to observe a Completed event");
+}
+
+#[tokio::test]
+async fn bridge_happy_path_drives_fake_muse_to_completion() {
+    let cwd = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut bridge = Bridge::spawn("muse", &cwd, None)
+        .await
+        .expect("bridge setup");
+
+    // run_with_command spawns the fake, consumes the first frame, and surfaces
+    // its session id as the cursor's thread_id (matching the Codex/Cursor
+    // contract). No real prompt file is injected in the test.
+    let mut cursor = bridge
+        .run_with_command(fake_cmd(fake_muse_script()), None, Uuid::new_v4())
+        .await
+        .expect("bridge run setup");
+    assert_eq!(cursor.thread_id, "muse_fake_001");
+
+    let mut saw_assistant = false;
+    let mut saw_tool_call = false;
+    let mut saw_completed = false;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+    while tokio::time::Instant::now() < deadline {
+        let Some(events) =
+            tokio::time::timeout(Duration::from_millis(500), bridge.next_events(&mut cursor))
+                .await
+                .ok()
+                .flatten()
+        else {
+            break;
+        };
+        for ev in events {
+            match ev {
+                BridgeEvent::Raw { method, .. } if method == "assistant/message" => {
+                    saw_assistant = true;
+                }
+                BridgeEvent::Raw { method, .. } if method.starts_with("tool_call/") => {
+                    saw_tool_call = true;
+                }
+                BridgeEvent::Completed { done_payload, .. } => {
+                    saw_completed = true;
+                    assert_eq!(
+                        done_payload.get("conclusion").and_then(|v| v.as_str()),
+                        Some("success"),
+                    );
+                    assert_eq!(
+                        done_payload.get("duration_ms").and_then(|v| v.as_u64()),
+                        Some(1234),
+                    );
+                    break;
+                }
+                BridgeEvent::Failed { detail, .. } => panic!("unexpected Failed event: {detail:?}"),
+                _ => {}
+            }
+        }
+        if saw_completed {
+            break;
+        }
+    }
+
+    assert!(saw_assistant, "expected to observe an assistant/message");
+    assert!(saw_tool_call, "expected to observe a tool_call event");
+    assert!(saw_completed, "expected to observe a Completed event");
+}
+
+#[tokio::test]
+async fn one_shot_run_drives_fake_muse_to_completion() {
+    // muse exec is inherently one-shot; run_one_shot must reach a terminal
+    // result just like run. We exercise the same path via the test seam, which
+    // is what run_one_shot funnels through in production.
+    let cwd = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut bridge = Bridge::spawn("muse", &cwd, None)
+        .await
+        .expect("bridge setup");
+    let mut cursor = bridge
+        .run_with_command(fake_cmd(fake_muse_script()), None, Uuid::new_v4())
+        .await
+        .expect("one-shot run setup");
+    assert_eq!(cursor.thread_id, "muse_fake_001");
+    let done = drain_until_completed(&mut bridge, &mut cursor).await;
+    assert_eq!(
+        done.get("result").and_then(|v| v.as_str()),
+        Some("all done")
+    );
+}
+
+#[tokio::test]
+async fn bridge_translates_result_error_to_failed() {
+    let script = r#"
+        set -e
+        printf '%s\n' '{"type":"system","subtype":"init","session_id":"muse_err_001"}'
+        printf '%s\n' '{"type":"result","subtype":"error","is_error":true,"result":"model refused"}'
+        sleep 0.2
+    "#;
+    let cwd = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut bridge = Bridge::spawn("muse", &cwd, None)
+        .await
+        .expect("bridge setup");
+    let mut cursor = bridge
+        .run_with_command(fake_cmd(script), None, Uuid::new_v4())
+        .await
+        .expect("bridge run setup");
+
+    let events = tokio::time::timeout(Duration::from_secs(2), bridge.next_events(&mut cursor))
+        .await
+        .expect("pump should not time out")
+        .expect("expected a Failed event, got None");
+
+    let mut saw_failed = false;
+    for ev in events {
+        if let BridgeEvent::Failed { detail, .. } = ev {
+            saw_failed = true;
+            assert!(
+                detail.as_deref().unwrap_or("").contains("model refused"),
+                "expected detail to include error message, got {detail:?}"
+            );
+        }
+    }
+    assert!(saw_failed, "expected a Failed event from result.error");
+}
+
+#[tokio::test]
+async fn result_before_init_is_surfaced_as_failed() {
+    // muse exec can fail (auth/quota) before ever emitting a `system/init`
+    // frame, going straight to a terminal `result`. The bridge must still
+    // complete run setup and surface that result as a Failed event carrying the
+    // real detail, not bail with a generic "stdout closed" crash that drops it.
+    let script = r#"
+        set -e
+        printf '%s\n' '{"type":"result","subtype":"error","is_error":true,"result":"unauthorized: set META_API_KEY"}'
+        sleep 0.2
+    "#;
+    let cwd = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut bridge = Bridge::spawn("muse", &cwd, None)
+        .await
+        .expect("bridge setup");
+    // Run setup must succeed even though no init frame arrives; the thread id is
+    // synthesized from the run id.
+    let mut cursor = bridge
+        .run_with_command(fake_cmd(script), None, Uuid::new_v4())
+        .await
+        .expect("run setup should not bail when result precedes init");
+
+    let events = tokio::time::timeout(Duration::from_secs(2), bridge.next_events(&mut cursor))
+        .await
+        .expect("pump should not time out")
+        .expect("expected a Failed event, got None");
+
+    let mut saw_failed = false;
+    for ev in events {
+        if let BridgeEvent::Failed { detail, .. } = ev {
+            saw_failed = true;
+            assert!(
+                detail.as_deref().unwrap_or("").contains("unauthorized"),
+                "expected detail to include the pre-init error, got {detail:?}"
+            );
+        }
+    }
+    assert!(
+        saw_failed,
+        "expected a Failed event from a result-before-init"
+    );
+}
+
+#[tokio::test]
+async fn no_init_frame_still_streams_content_and_completes() {
+    // Muse's schema is not guaranteed to lead with `system/init`. When the first
+    // frame is ordinary content, the bridge must adopt the frame's session id as
+    // the thread id, surface the content, and still reach completion.
+    let script = r#"
+        set -e
+        printf '%s\n' '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"working"}]},"session_id":"muse_noinit_001"}'
+        printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"result":"done"}'
+        sleep 0.2
+    "#;
+    let cwd = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut bridge = Bridge::spawn("muse", &cwd, None)
+        .await
+        .expect("bridge setup");
+    let mut cursor = bridge
+        .run_with_command(fake_cmd(script), None, Uuid::new_v4())
+        .await
+        .expect("run setup should not require an init frame");
+    // The thread id is adopted from the first content frame's session id.
+    assert_eq!(cursor.thread_id, "muse_noinit_001");
+
+    let mut saw_assistant = false;
+    let mut saw_completed = false;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+    while tokio::time::Instant::now() < deadline && !saw_completed {
+        let Some(events) =
+            tokio::time::timeout(Duration::from_millis(500), bridge.next_events(&mut cursor))
+                .await
+                .ok()
+                .flatten()
+        else {
+            break;
+        };
+        for ev in events {
+            match ev {
+                BridgeEvent::Raw { method, .. } if method == "assistant/message" => {
+                    saw_assistant = true;
+                }
+                BridgeEvent::Completed { .. } => saw_completed = true,
+                BridgeEvent::Failed { detail, .. } => panic!("unexpected Failed: {detail:?}"),
+                _ => {}
+            }
+        }
+    }
+    assert!(saw_assistant, "expected the pre-buffered assistant frame");
+    assert!(
+        saw_completed,
+        "expected to reach completion without an init frame"
+    );
+}
+
+#[tokio::test]
+async fn warm_returns_resume_session_id_without_spawning() {
+    // warm must not spawn a process; it only echoes a known resume id so the
+    // cloud can keep its session pointer stable until the first turn.
+    let cwd = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut bridge = Bridge::spawn_with_resume("muse", &cwd, None, Some("prev_sess_42"))
+        .await
+        .expect("bridge setup");
+    let warmed = bridge.warm(&cwd).await.expect("warm");
+    assert_eq!(warmed.as_deref(), Some("prev_sess_42"));
+    // No process spawned yet, so the observability handle reports no PID.
+    assert!(bridge.process_handle().pid.is_none());
+}
+
+/// Liveness check via `kill -0` (portable across Linux/macOS). Returns false
+/// once the process is gone (reaped) — `wait_task` reaps right after killing, so
+/// the brief zombie window closes immediately.
+fn proc_alive(pid: u32) -> bool {
+    std::process::Command::new("kill")
+        .args(["-0", &pid.to_string()])
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+async fn wait_until(mut cond: impl FnMut() -> bool, timeout: Duration) -> bool {
+    let deadline = tokio::time::Instant::now() + timeout;
+    while tokio::time::Instant::now() < deadline {
+        if cond() {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    cond()
+}
+
+#[tokio::test]
+async fn dropping_bridge_kills_a_running_muse() {
+    // A fake that emits init then blocks on a long sleep, so the subprocess
+    // stays alive after run setup. Dropping the bridge (without a graceful
+    // shutdown) must kill it rather than leave it orphaned to completion.
+    let script = r#"
+        printf '%s\n' '{"type":"system","subtype":"init","session_id":"muse_long_001"}'
+        sleep 30
+    "#;
+    let cwd = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut bridge = Bridge::spawn("muse", &cwd, None)
+        .await
+        .expect("bridge setup");
+    let _cursor = bridge
+        .run_with_command(fake_cmd(script), None, Uuid::new_v4())
+        .await
+        .expect("run setup");
+    let pid = bridge
+        .process_handle()
+        .pid
+        .expect("a spawned process should report a pid");
+    assert!(
+        proc_alive(pid),
+        "child should be alive right after run setup"
+    );
+
+    // Drop the bridge — its kill channel closes; the wait task should kill +
+    // reap the still-running child.
+    drop(bridge);
+
+    let gone = wait_until(|| !proc_alive(pid), Duration::from_secs(5)).await;
+    assert!(
+        gone,
+        "dropping the bridge should kill the running muse (pid {pid})"
+    );
+}
+
+#[tokio::test]
+async fn shutdown_returns_promptly_after_the_process_exits() {
+    // Drive a fake to completion (process exits), then `shutdown` must not block
+    // on a `changed()` that will never fire — it should observe the prior exit
+    // and return well under the (deliberately large) grace.
+    let cwd = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut bridge = Bridge::spawn("muse", &cwd, None)
+        .await
+        .expect("bridge setup");
+    let mut cursor = bridge
+        .run_with_command(fake_cmd(fake_muse_script()), None, Uuid::new_v4())
+        .await
+        .expect("run setup");
+    let _ = drain_until_completed(&mut bridge, &mut cursor).await;
+
+    let started = tokio::time::Instant::now();
+    bridge
+        .shutdown(Duration::from_secs(30))
+        .await
+        .expect("shutdown");
+    assert!(
+        started.elapsed() < Duration::from_secs(5),
+        "shutdown should return promptly after the process already exited"
+    );
+}


### PR DESCRIPTION
## What

Implements Meta **Muse Code** as a first-class Pi Dash runner backend (`AgentKind::MuseCode`), driven in its headless one-shot mode `muse exec --json --prompt-file <PATH>`. Per the issue discussion, the research concluded Muse Code has no Codex-style app-server daemon but does expose a headless one-shot mode; the human confirmed "headless CLI mode is enough to start, let's implement the integration in this task directly."

Modeled on the existing **Cursor** adapter (one-shot per turn, JSONL on stdout). Two differences:
- The prompt is delivered via a temp `--prompt-file` (RAII-cleaned in the OS temp dir, no new dependency) instead of argv.
- MVP approval posture uses `--yolo` (mirrors Cursor's `--force`).

Muse Code is closed-source and its JSONL schema isn't fully documented, so the schema layer is deliberately tolerant: `type`/`subtype` dispatch with an `Unknown` catch-all, and run setup does **not** hard-depend on a `system/init` frame (any first frame starts the run; its `session_id` is adopted or synthesized).

## Runner changes

- New `runner/src/muse_code/` module (`schema` / `process` / `bridge` / `mod`) + `lib.rs` registration.
- `MuseCode` wired through every dispatch point: config schema (enum, `stall_timeout`, `display_name`, `default_binary` = `muse`, `install_page_url`, `MuseCodeSection`, `RunnerConfig.muse_code`), the `AgentBridge`/`AgentCursor` enums and all methods, CLI `runner add` (`agent_sections_for`, model applicability), `pidash doctor` (binary probe + `META_API_KEY` auth hint), supervisor crash classification, and the TUI config editor.

## Web changes

- `muse-code` added to `TRunnerAgent`, the model-option Records, the add-runner modal options + label, and an i18n label — selectable in the UI. The CLI path `pidash runner add --agent muse-code` also works.

## Testing

- New `runner/tests/muse_code_bridge_fake.rs`: **8 end-to-end tests** drive a fake `muse` CLI through init → assistant → tool_call → result, plus error results, no-init streaming, `warm`, drop-kills-child, and prompt shutdown. All pass.
- Unit tests for schema dispatch + command construction; all touched-module tests pass (`cargo test --lib` = 463 passed; the 2 failures are pre-existing, environment-specific, in files this PR does not touch).
- `cargo clippy --lib --tests` clean; web + i18n `check:types` clean.

## Notes / assumptions

- Cannot run the real `muse` binary in CI, so `muse exec`'s exact flag spellings (`--json`, `--prompt-file`, `--yolo`, `--session-id`, `--model`) and JSONL field names are taken from public Muse Code docs and treated as assumptions; the tolerant schema + fake-CLI harness bound the risk.
- Non-technical caveats flagged during research (Muse Code is closed-source; near-free access is contingent on Meta training on prompts/completions) are product decisions for the maintainers, not blockers to this adapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)