### PR TITLE
PDASHOSS01-103 Add delete option for personal dev machine connections

### DIFF
--- a/apps/api/pi_dash/runner/services/runner_delete.py
+++ b/apps/api/pi_dash/runner/services/runner_delete.py
@@ -34,8 +34,9 @@ from __future__ import annotations
 from uuid import UUID
 
 from django.db import transaction
+from django.utils import timezone
 
-from pi_dash.runner.models import Runner
+from pi_dash.runner.models import DevMachine, MachineToken, Runner
 from pi_dash.runner.services.pubsub import (
     close_runner_session,
     send_runner_remove,
@@ -91,6 +92,55 @@ def delete_runner(runner: Runner, *, purge_local: bool) -> None:
         runner.revoke(reason=revoke_reason)
         close_runner_session(runner_pk)
         Runner.objects.filter(pk=runner_pk).delete()
+
+
+def delete_dev_machine(machine: DevMachine, *, purge_local: bool) -> None:
+    """Hard-delete a dev-machine *connection* cloud-side.
+
+    This is the destructive counterpart to ``DevMachineRevokeEndpoint``:
+    revoke leaves the machine (and its runner history) in the list marked
+    revoked; delete removes the connection entirely. Because the
+    ``DevMachine`` FKs are ``MachineSession=CASCADE``,
+    ``MachineToken=SET_NULL`` and ``Runner=SET_NULL``, a bare
+    ``machine.delete()`` would strand still-connecting runners and active
+    tokens. So we tear them down first, then drop the row.
+
+    Caller is responsible for authentication + authorization.
+
+    Order mirrors ``delete_runner``: the daemon control frame for each
+    runner is enqueued *before* ``runner.revoke()`` revokes the session —
+    once the session is revoked ``enqueue_for_runner`` would divert the
+    frame into the offline buffer that never drains for a row we are about
+    to delete. So we enqueue for every active runner first, then revoke +
+    close, then hard-delete the runner rows and the machine row (the
+    latter cascades ``MachineSession``).
+
+    ``purge_local`` matches ``delete_runner``: ``True`` sends
+    ``remove_runner`` + the canonical ``runner_removed`` reason so the
+    daemon also wipes the local ``[[runner]]`` block + data dir; ``False``
+    sends a plain ``revoke`` with a non-canonical reason so the local
+    install is left untouched.
+    """
+    machine_pk: UUID = machine.pk
+    with transaction.atomic():
+        now = timezone.now()
+        MachineToken.objects.filter(dev_machine_id=machine_pk, revoked_at__isnull=True).update(revoked_at=now)
+        runners = list(Runner.objects.select_for_update().filter(dev_machine_id=machine_pk))
+        active = [r for r in runners if r.revoked_at is None]
+        reason = "runner_removed" if purge_local else "user_revoke"
+        for runner in active:
+            if purge_local:
+                send_runner_remove(runner.pk, reason="dev machine deleted")
+            else:
+                send_runner_revoke(runner.pk, reason="dev machine deleted")
+        for runner in active:
+            runner.revoke(reason=reason)
+            close_runner_session(runner.pk)
+        # Drop the runner rows explicitly (FK is SET_NULL, so a machine
+        # delete alone would leave them orphaned) and then the machine row,
+        # which cascades any MachineSession rows.
+        Runner.objects.filter(dev_machine_id=machine_pk).delete()
+        DevMachine.objects.filter(pk=machine_pk).delete()
 
 
 def parse_purge_local(query_params, *, default: bool = True) -> bool:

--- a/apps/api/pi_dash/runner/views/__init__.py
+++ b/apps/api/pi_dash/runner/views/__init__.py
@@ -50,6 +50,7 @@ from .run_endpoints import (
     RunStreamUpgradeEndpoint,
 )
 from .runners import (
+    DevMachineDeleteEndpoint,
     DevMachineListEndpoint,
     DevMachineRevokeEndpoint,
     DevMachineRotateEndpoint,
@@ -113,6 +114,7 @@ __all__ = [
     "PodDetailEndpoint",
     "PodListEndpoint",
     "ProjectListEndpoint",
+    "DevMachineDeleteEndpoint",
     "DevMachineListEndpoint",
     "DevMachineRevokeEndpoint",
     "DevMachineRotateEndpoint",

--- a/apps/api/pi_dash/runner/views/runners.py
+++ b/apps/api/pi_dash/runner/views/runners.py
@@ -37,6 +37,7 @@ from pi_dash.runner.services.pubsub import (
     send_runner_revoke,
 )
 from pi_dash.runner.services.runner_delete import (
+    delete_dev_machine as delete_dev_machine_svc,
     delete_runner as delete_runner_svc,
     parse_purge_local,
 )
@@ -243,6 +244,46 @@ class DevMachineRotateEndpoint(APIView):
                 close_runner_session(runner_id)
 
         return Response(_serialize_dev_machine(machine, request.user, workspace_id), status=status.HTTP_200_OK)
+
+
+class DevMachineDeleteEndpoint(APIView):
+    """``DELETE /api/runners/dev-machines/<machine_id>/`` — hard-delete a
+    dev-machine connection.
+
+    The destructive counterpart to revoke: revoke leaves the machine in
+    the list marked revoked (history preserved); delete removes the
+    connection entirely — its tokens are invalidated, its runners are torn
+    down, and the machine row is dropped so it disappears from the page.
+
+    Owner-scoped like every other dev-machine action (the machine must be
+    in the caller's workspace scope). Accepts a ``?purge_local=true|false``
+    query flag (default ``true``) with the same semantics as the
+    runner-delete endpoint.
+    """
+
+    authentication_classes = [BaseSessionAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def delete(self, request, machine_id):
+        workspace_id = _request_workspace_id(request)
+        if not workspace_id:
+            return Response(
+                {"error": "workspace is required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if not is_workspace_member(request.user, workspace_id):
+            return Response({"error": "forbidden"}, status=status.HTTP_403_FORBIDDEN)
+        try:
+            purge_local = parse_purge_local(request.query_params)
+        except ValueError as exc:
+            return Response({"error": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+
+        machine = DevMachine.objects.filter(pk=machine_id).first()
+        if machine is None or not _machine_is_in_workspace_scope(request.user, machine, workspace_id):
+            return Response({"error": "not found"}, status=status.HTTP_404_NOT_FOUND)
+
+        delete_dev_machine_svc(machine, purge_local=purge_local)
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 class RunnerListEndpoint(APIView):

--- a/apps/api/pi_dash/runner/web_urls.py
+++ b/apps/api/pi_dash/runner/web_urls.py
@@ -22,6 +22,7 @@ from pi_dash.runner.views import (
     AgentRunReleasePinEndpoint,
     ApprovalDecideEndpoint,
     ApprovalListEndpoint,
+    DevMachineDeleteEndpoint,
     DevMachineListEndpoint,
     DevMachineRevokeEndpoint,
     DevMachineRotateEndpoint,
@@ -62,6 +63,14 @@ urlpatterns = [
         "dev-machines/<uuid:machine_id>/create-runner/<uuid:request_id>/",
         MachineCreateRunnerStatusEndpoint.as_view(),
         name="dev-machine-create-runner-status",
+    ),
+    # Hard-delete a dev-machine connection (destructive counterpart to
+    # revoke). Bare ``<machine_id>/`` — the action routes above carry an
+    # extra path segment, so they still match first.
+    path(
+        "dev-machines/<uuid:machine_id>/",
+        DevMachineDeleteEndpoint.as_view(),
+        name="dev-machine-delete",
     ),
     # Deprecated token-mint route retained only to return a clear 410.
     # New runners are created by `pidash runner add` through the

--- a/apps/api/pi_dash/tests/unit/runner/test_runner_delete_views.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_runner_delete_views.py
@@ -476,3 +476,93 @@ def test_dev_machine_actions_hide_other_users_private_machines(
     assert machine.revoked_at is None
     assert token.revoked_at is None
     assert runner.revoked_at is None
+
+
+@pytest.mark.unit
+def test_dev_machine_delete_drops_machine_and_tears_down_runners(
+    db, session_client, create_user, workspace, pod, _stub_outbox_send
+):
+    """Default (no ``purge_local``) → the connection is removed entirely:
+    the machine row and its runner rows are gone, the token is revoked,
+    and a ``remove_runner`` cascade frame is enqueued."""
+    machine = DevMachine.objects.create(owner=create_user, host_label="host-del")
+    token = _make_machine_token(create_user, workspace, machine, raw="mt_delete")
+    runner = _make_runner(create_user, workspace, pod, "delete-runner", dev_machine=machine)
+
+    url = reverse("dev-machine-delete", kwargs={"machine_id": machine.id}) + f"?workspace={workspace.id}"
+    resp = session_client.delete(url)
+
+    assert resp.status_code == 204, getattr(resp, "data", resp.content)
+    assert not DevMachine.objects.filter(pk=machine.id).exists()
+    assert not Runner.objects.filter(pk=runner.id).exists()
+    token.refresh_from_db()
+    assert token.revoked_at is not None
+    types_enqueued = [
+        c.kwargs.get("message", c.args[1] if len(c.args) > 1 else {}).get("type")
+        for c in _stub_outbox_send["enqueue"].call_args_list
+    ]
+    assert "remove_runner" in types_enqueued
+    assert "revoke" not in types_enqueued
+
+
+@pytest.mark.unit
+def test_dev_machine_delete_purge_false_emits_revoke_only(
+    db, session_client, create_user, workspace, pod, _stub_outbox_send
+):
+    machine = DevMachine.objects.create(owner=create_user, host_label="host-del-norepurge")
+    _make_machine_token(create_user, workspace, machine, raw="mt_delete_np")
+    runner = _make_runner(create_user, workspace, pod, "delete-runner-np", dev_machine=machine)
+
+    base = reverse("dev-machine-delete", kwargs={"machine_id": machine.id})
+    resp = session_client.delete(f"{base}?workspace={workspace.id}&purge_local=false")
+
+    assert resp.status_code == 204, getattr(resp, "data", resp.content)
+    assert not DevMachine.objects.filter(pk=machine.id).exists()
+    assert not Runner.objects.filter(pk=runner.id).exists()
+    types_enqueued = [
+        c.kwargs.get("message", c.args[1] if len(c.args) > 1 else {}).get("type")
+        for c in _stub_outbox_send["enqueue"].call_args_list
+    ]
+    assert "revoke" in types_enqueued
+    assert "remove_runner" not in types_enqueued
+
+
+@pytest.mark.unit
+def test_dev_machine_delete_404_for_other_users_private_machine(db, session_client, workspace, pod):
+    from pi_dash.db.models import User, WorkspaceMember
+
+    other = User.objects.create_user(
+        email="other-dev-machine-delete@example.com",
+        username="other-dev-machine-delete",
+    )
+    WorkspaceMember.objects.create(workspace=workspace, member=other, role=15)
+    machine = DevMachine.objects.create(owner=other, host_label="host-other-del")
+    _make_machine_token(other, workspace, machine, raw="mt_other_del")
+    runner = _make_runner(other, workspace, pod, "other-runner-del", dev_machine=machine)
+
+    url = reverse("dev-machine-delete", kwargs={"machine_id": machine.id}) + f"?workspace={workspace.id}"
+    resp = session_client.delete(url)
+
+    assert resp.status_code == 404
+    assert DevMachine.objects.filter(pk=machine.id).exists()
+    assert Runner.objects.filter(pk=runner.id).exists()
+
+
+@pytest.mark.unit
+def test_dev_machine_delete_requires_workspace(db, session_client, create_user):
+    machine = DevMachine.objects.create(owner=create_user, host_label="host-no-ws")
+    url = reverse("dev-machine-delete", kwargs={"machine_id": machine.id})
+    resp = session_client.delete(url)
+    assert resp.status_code == 400
+    assert DevMachine.objects.filter(pk=machine.id).exists()
+
+
+@pytest.mark.unit
+def test_dev_machine_delete_invalid_purge_returns_400(db, session_client, create_user, workspace, pod):
+    machine = DevMachine.objects.create(owner=create_user, host_label="host-bad-flag")
+    _make_machine_token(create_user, workspace, machine, raw="mt_bad_flag")
+    base = reverse("dev-machine-delete", kwargs={"machine_id": machine.id})
+    resp = session_client.delete(f"{base}?workspace={workspace.id}&purge_local=maybe")
+    assert resp.status_code == 400
+    # Validation runs before any destructive work.
+    assert DevMachine.objects.filter(pk=machine.id).exists()

--- a/apps/web/app/(all)/[workspaceSlug]/ai-dev-machines/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/ai-dev-machines/page.tsx
@@ -6,7 +6,7 @@
 
 import { useState } from "react";
 import { observer } from "mobx-react";
-import { Ban, Check, Copy, Cpu, Download, Laptop, RotateCw, Terminal } from "lucide-react";
+import { Ban, Check, Copy, Cpu, Download, Laptop, RotateCw, Terminal, Trash2 } from "lucide-react";
 import useSWR from "swr";
 import { useTranslation } from "@pi-dash/i18n";
 import { Button, getButtonStyling } from "@pi-dash/propel/button";
@@ -83,8 +83,10 @@ const AiDevMachinesPage = observer(function AiDevMachinesPage() {
   const [addOpen, setAddOpen] = useState(false);
   const [rotateMachine, setRotateMachine] = useState<IDevMachine | null>(null);
   const [revokeMachine, setRevokeMachine] = useState<IDevMachine | null>(null);
+  const [deleteMachine, setDeleteMachine] = useState<IDevMachine | null>(null);
   const [rotating, setRotating] = useState(false);
   const [revoking, setRevoking] = useState(false);
+  const [deleting, setDeleting] = useState(false);
   const {
     data: devMachines,
     error: devMachinesError,
@@ -133,6 +135,25 @@ const AiDevMachinesPage = observer(function AiDevMachinesPage() {
     }
   }
 
+  async function confirmDeleteMachine() {
+    if (!deleteMachine || !workspaceId) return;
+    setDeleting(true);
+    try {
+      await service.deleteDevMachine(deleteMachine.id, workspaceId);
+      setDeleteMachine(null);
+      mutateDevMachines();
+    } catch (e: unknown) {
+      const err = e as { error?: string } | null;
+      setToast({
+        type: TOAST_TYPE.ERROR,
+        title: t("Error!"),
+        message: err?.error ?? t("Could not delete the dev machine."),
+      });
+    } finally {
+      setDeleting(false);
+    }
+  }
+
   return (
     <div className="flex flex-col gap-8 p-6">
       <PageHead title={pageTitle} />
@@ -144,22 +165,32 @@ const AiDevMachinesPage = observer(function AiDevMachinesPage() {
       {/* Intro — what the CLI / daemon / runner each are */}
       <section className="flex flex-col gap-4">
         <h2 className="text-14 font-semibold text-primary">{t("What is the pidash CLI, daemon, and runner?")}</h2>
-        <p className="text-13 text-secondary">{t("Pi Dash hands AI agents (Claude Code, Codex, …) the keys to a real dev machine so they can pick up work items, write code, and open changes. Three pieces work together to make that possible:")}</p>
+        <p className="text-13 text-secondary">
+          {t(
+            "Pi Dash hands AI agents (Claude Code, Codex, …) the keys to a real dev machine so they can pick up work items, write code, and open changes. Three pieces work together to make that possible:"
+          )}
+        </p>
         <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
           <ConceptCard
             icon={<Terminal className="size-4" />}
             title={t("pidash CLI")}
-            body={t("The command-line tool installed on each dev machine. Handles authentication with the cloud, manages local config (`~/.pidash/config.toml`), and exposes commands for issues, comments, and runner management (`pidash auth login`, `pidash runner add`, `pidash doctor`, …).")}
+            body={t(
+              "The command-line tool installed on each dev machine. Handles authentication with the cloud, manages local config (`~/.pidash/config.toml`), and exposes commands for issues, comments, and runner management (`pidash auth login`, `pidash runner add`, `pidash doctor`, …)."
+            )}
           />
           <ConceptCard
             icon={<Cpu className="size-4" />}
             title={t("pidash daemon")}
-            body={t("A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.")}
+            body={t(
+              "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine."
+            )}
           />
           <ConceptCard
             icon={<Laptop className="size-4" />}
             title={t("AI Agent runner")}
-            body={t("A cloud-side row that represents one agent instance bound to a project (and optionally a pod). Running `pidash runner add` on a logged-in machine creates the row and binds that machine as the host. A machine can host many runners.")}
+            body={t(
+              "A cloud-side row that represents one agent instance bound to a project (and optionally a pod). Running `pidash runner add` on a logged-in machine creates the row and binds that machine as the host. A machine can host many runners."
+            )}
           />
         </div>
       </section>
@@ -168,7 +199,9 @@ const AiDevMachinesPage = observer(function AiDevMachinesPage() {
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div>
             <h2 className="text-14 font-semibold text-primary">{t("Dev machines")}</h2>
-            <p className="mt-1 text-13 text-secondary">{t("Machines that have authenticated with Pi Dash or host runners for this workspace.")}</p>
+            <p className="mt-1 text-13 text-secondary">
+              {t("Machines that have authenticated with Pi Dash or host runners for this workspace.")}
+            </p>
           </div>
           <Button onClick={() => setAddOpen(true)} disabled={!workspaceId}>
             {t("Add runner")}
@@ -225,12 +258,8 @@ const AiDevMachinesPage = observer(function AiDevMachinesPage() {
                           total: machine.runner_count,
                         })}
                       </td>
-                      <td className="px-3 py-2">
-                        {formatDateTime(machine.last_seen_at, t("Never"))}
-                      </td>
-                      <td className="px-3 py-2">
-                        {formatDateTime(machine.last_heartbeat_at, t("Never"))}
-                      </td>
+                      <td className="px-3 py-2">{formatDateTime(machine.last_seen_at, t("Never"))}</td>
+                      <td className="px-3 py-2">{formatDateTime(machine.last_heartbeat_at, t("Never"))}</td>
                       <td className="px-3 py-2 text-right">
                         <div className="flex justify-end gap-2">
                           {!machine.revoked_at && (
@@ -253,6 +282,14 @@ const AiDevMachinesPage = observer(function AiDevMachinesPage() {
                               </Button>
                             </>
                           )}
+                          <Button
+                            size="sm"
+                            variant="error-outline"
+                            prependIcon={<Trash2 />}
+                            onClick={() => setDeleteMachine(machine)}
+                          >
+                            {t("Delete")}
+                          </Button>
                         </div>
                       </td>
                     </tr>
@@ -273,7 +310,11 @@ const AiDevMachinesPage = observer(function AiDevMachinesPage() {
       {/* Install command — copy / paste */}
       <section className="flex flex-col gap-3">
         <h2 className="text-14 font-semibold text-primary">{t("Install the pidash CLI")}</h2>
-        <p className="text-13 text-secondary">{t("Run an installer on the machine that will host your AI agent. The wrapper commands download the latest signed binary, drop `pidash` on your PATH, and walk you through the device-code login.")}</p>
+        <p className="text-13 text-secondary">
+          {t(
+            "Run an installer on the machine that will host your AI agent. The wrapper commands download the latest signed binary, drop `pidash` on your PATH, and walk you through the device-code login."
+          )}
+        </p>
 
         <InstallCommand label={t("macOS / Linux")} command={INSTALL_CMD_UNIX} />
         <InstallCommand label={t("Windows (PowerShell)")} command={INSTALL_CMD_WINDOWS} />
@@ -284,7 +325,11 @@ const AiDevMachinesPage = observer(function AiDevMachinesPage() {
           hrefLabel={t("Download MSI")}
         />
 
-        <p className="text-12 text-secondary">{t("Prerequisite: the agent CLI you plan to use (`codex` or `claude`) must already be installed and on PATH. Run `pidash doctor` after install to verify.")}</p>
+        <p className="text-12 text-secondary">
+          {t(
+            "Prerequisite: the agent CLI you plan to use (`codex` or `claude`) must already be installed and on PATH. Run `pidash doctor` after install to verify."
+          )}
+        </p>
       </section>
 
       {workspaceId && workspaceSlug && (
@@ -301,7 +346,9 @@ const AiDevMachinesPage = observer(function AiDevMachinesPage() {
         handleSubmit={confirmRotateMachine}
         isSubmitting={rotating}
         title={t("Rotate dev machine token?")}
-        content={t("The active auth token for this dev machine will be invalidated. Runners on that machine will stop connecting until `pidash auth login` is run there again.")}
+        content={t(
+          "The active auth token for this dev machine will be invalidated. Runners on that machine will stop connecting until `pidash auth login` is run there again."
+        )}
         variant="primary"
         primaryButtonText={{ default: t("Rotate"), loading: t("Rotate") }}
       />
@@ -311,8 +358,21 @@ const AiDevMachinesPage = observer(function AiDevMachinesPage() {
         handleSubmit={confirmRevokeMachine}
         isSubmitting={revoking}
         title={t("Revoke dev machine?")}
-        content={t("This permanently revokes the dev machine, invalidates its auth token, and revokes runners hosted on it. Use this when the machine should no longer be trusted.")}
+        content={t(
+          "This permanently revokes the dev machine, invalidates its auth token, and revokes runners hosted on it. Use this when the machine should no longer be trusted."
+        )}
         primaryButtonText={{ default: t("Revoke"), loading: t("Revoke") }}
+      />
+      <AlertModalCore
+        isOpen={!!deleteMachine}
+        handleClose={() => (deleting ? null : setDeleteMachine(null))}
+        handleSubmit={confirmDeleteMachine}
+        isSubmitting={deleting}
+        title={t("Delete dev machine?")}
+        content={t(
+          "This removes the dev machine connection entirely: its auth token is invalidated, the runners hosted on it are torn down, and the machine disappears from this list. Deleting a dev machine does not uninstall the AI agent (such as Codex or Claude) on the machine itself."
+        )}
+        primaryButtonText={{ default: t("Delete"), loading: t("Delete") }}
       />
     </div>
   );

--- a/packages/i18n/src/locales/en/translations.ts
+++ b/packages/i18n/src/locales/en/translations.ts
@@ -370,6 +370,7 @@ export default {
   "Could not load pods.": "Could not load pods.",
   "Could not load projects.": "Could not load projects.",
   "Could not revert the prompt.": "Could not revert the prompt.",
+  "Could not delete the dev machine.": "Could not delete the dev machine.",
   "Could not revoke the dev machine.": "Could not revoke the dev machine.",
   "Could not rotate the dev machine token.": "Could not rotate the dev machine token.",
   "Could not save the prompt.": "Could not save the prompt.",
@@ -485,6 +486,7 @@ export default {
   Delete: "Delete",
   "Delete {entity}": "Delete {entity}",
   "Delete attachment": "Delete attachment",
+  "Delete dev machine?": "Delete dev machine?",
   "Delete draft": "Delete draft",
   "Delete personal access token": "Delete personal access token",
   "Delete runner?": "Delete runner?",
@@ -1575,6 +1577,8 @@ export default {
   "This module isn't active yet.": "This module isn't active yet.",
   "This permanently revokes the dev machine, invalidates its auth token, and revokes runners hosted on it. Use this when the machine should no longer be trusted.":
     "This permanently revokes the dev machine, invalidates its auth token, and revokes runners hosted on it. Use this when the machine should no longer be trusted.",
+  "This removes the dev machine connection entirely: its auth token is invalidated, the runners hosted on it are torn down, and the machine disappears from this list. Deleting a dev machine does not uninstall the AI agent (such as Codex or Claude) on the machine itself.":
+    "This removes the dev machine connection entirely: its auth token is invalidated, the runners hosted on it are torn down, and the machine disappears from this list. Deleting a dev machine does not uninstall the AI agent (such as Codex or Claude) on the machine itself.",
   "This run is not available. It may have been deleted or belong to a different workspace.":
     "This run is not available. It may have been deleted or belong to a different workspace.",
   "This soft-deletes the scheduler. Any active project bindings will stop firing. The slug becomes available for re-creation.":

--- a/packages/services/src/runner/runner.service.ts
+++ b/packages/services/src/runner/runner.service.ts
@@ -63,6 +63,24 @@ export class RunnerService extends APIService {
   }
 
   /**
+   * Hard-delete a dev-machine connection. The destructive counterpart to
+   * ``revokeDevMachine``: revoke leaves the machine in the list marked
+   * revoked, delete removes it entirely (tokens invalidated, runners torn
+   * down, row dropped). Pass ``purgeLocal: false`` to leave the local
+   * install untouched; the default (``true``) cascades the teardown to the
+   * daemon, matching ``deleteRunner``.
+   */
+  async deleteDevMachine(machineId: string, workspaceId: string, options?: { purgeLocal?: boolean }): Promise<void> {
+    const purge = options?.purgeLocal ?? true;
+    const url = `/api/runners/dev-machines/${machineId}/?workspace=${workspaceId}&purge_local=${purge ? "true" : "false"}`;
+    return this.delete(url)
+      .then(() => undefined)
+      .catch((e) => {
+        throw e?.response?.data;
+      });
+  }
+
+  /**
    * Cloud-driven runner creation: push a ``create_runner`` command down
    * the machine control session of a connected dev machine. Returns the
    * ``request_id`` to poll via ``getCreateRunnerOnMachineStatus``.


### PR DESCRIPTION
## Summary

The **AI Dev Machines** page (`/:workspaceSlug/ai-dev-machines`) listed each connected dev machine with **Rotate** and **Revoke** actions but no way to remove the connection entirely. This adds a **Delete** action — the destructive counterpart to Revoke (which soft-marks the machine revoked and keeps its history in the list).

## Changes

**Backend**
- `delete_dev_machine` service (`runner/services/runner_delete.py`): invalidates the machine's tokens, tears down its runners (enqueue daemon frame → revoke → close → delete row, mirroring `delete_runner`'s ordering so the offline buffer doesn't strand a frame), then hard-deletes the machine row (cascading its `MachineSession` rows).
- `DevMachineDeleteEndpoint` — `DELETE /api/runners/dev-machines/<id>/`, owner-scoped like the existing revoke/rotate actions, honoring `?purge_local=true|false` (default `true`).

**Frontend**
- `RunnerService.deleteDevMachine` + a Delete button and confirm modal on the page (available for revoked machines too).
- i18n keys.

## Personal, not admin-only

Dev-machine add/list/revoke/rotate — and now delete — are all owner-scoped (`Visibility.PRIVATE`, `owner=request.user`) and the page gates ADMIN **and** MEMBER, so these actions are already personal, not admin-only. Delete follows the same rule.

## Testing

- 5 new API tests in `test_runner_delete_views.py` (default teardown, purge_local=false, non-owner 404, missing workspace 400, invalid flag 400). Full `pi_dash/tests/unit/runner/` suite: 408 passed.
- `pnpm check:types` and `check:lint` pass for web / services / i18n.

🤖 Generated with [Claude Code](https://claude.com/claude-code)