### PR TITLE
fix(runner): trust native certificate authorities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,10 +811,10 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -1682,6 +1682,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -1696,7 +1697,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2356,11 +2356,11 @@ dependencies = [
  "futures-util",
  "log",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tungstenite",
- "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -2834,24 +2834,6 @@ name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.7",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -36,12 +36,12 @@ tokio = { version = "1", features = [
     "time",
     "fs",
 ] }
-tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }
+tokio-tungstenite = { version = "0.24", features = ["rustls-tls-native-roots"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 futures-util = "0.3"
 reqwest = { version = "0.12", default-features = false, features = [
     "json",
-    "rustls-tls",
+    "rustls-tls-native-roots",
 ] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }


### PR DESCRIPTION
Summary:
- use the operating system CA store for runner HTTP requests
- use the same native roots for runner WebSocket connections
- support trusted development and corporate CAs without disabling TLS verification

Testing:
- cargo test --manifest-path runner/Cargo.toml --locked --offline --lib
- 461 tests passed
- verified CLI authentication and daemon sessions against a trusted local mkcert endpoint