### PR TITLE
refactor(settings): compose downstream schemas with OSS

### DIFF
--- a/apps/api/pi_dash/core/user_settings.py
+++ b/apps/api/pi_dash/core/user_settings.py
@@ -5,9 +5,10 @@
 """Validation, merge and read semantics for ``Profile.settings``.
 
 Deliberately separate from the ``ee.settings.user_settings`` seam: a build
-overlays that module to declare its own namespaces, and a whole-file
-replacement cannot import from the file it replaces. Keeping the logic here
-means an overlay declares a schema and inherits all of this unchanged.
+overlays that module to declare its own namespaces. Keeping the OSS-owned
+schema and the composition logic here means an overlay can extend the public
+declaration instead of replacing it, while inheriting all validation, merge,
+and read behavior unchanged.
 """
 
 from __future__ import annotations
@@ -21,6 +22,41 @@ from typing import Any
 #: (declared keys x this) — capping the patch caps the bag. Generous for a
 #: settings field, far too small to be worth using as storage.
 MAX_SETTINGS_PATCH_BYTES = 4096
+
+
+def base_settings_schema() -> dict[str, dict[str, Any]]:
+    """Settings namespaces owned by OSS Pi Dash.
+
+    The public build currently declares none. This function nevertheless lives
+    outside the overlayable ``ee`` seam so downstream builds can always import
+    the OSS declaration, merge their own namespaces into it, and automatically
+    inherit public settings added later.
+    """
+    return {}
+
+
+def extend_settings_schema(
+    base: dict[str, dict[str, Any]], extension: dict[str, dict[str, Any]]
+) -> dict[str, dict[str, Any]]:
+    """Return ``base`` plus an independently owned schema ``extension``.
+
+    Namespaces may be shared, but a key may have only one owner. Silently
+    overriding a public key from a private build would make its validation and
+    default depend on packaging order, so collisions fail when the schema is
+    assembled rather than changing user-facing behavior implicitly.
+
+    Neither input is mutated.
+    """
+    merged = {namespace: dict(values) for namespace, values in base.items()}
+    for namespace, values in extension.items():
+        existing = merged.setdefault(namespace, {})
+        collisions = sorted(set(existing) & set(values))
+        if collisions:
+            raise ValueError(
+                f"settings schema collision(s) in {namespace}: {', '.join(collisions)}"
+            )
+        existing.update(values)
+    return merged
 
 
 def _schema() -> dict[str, dict[str, Any]]:

--- a/apps/api/pi_dash/ee/settings/user_settings.py
+++ b/apps/api/pi_dash/ee/settings/user_settings.py
@@ -10,11 +10,11 @@ per such preference would put deployment-specific concepts into the shared
 schema, so ``Profile.settings`` is a generic ``{namespace: {key: value}}`` bag
 and *this module* is the only thing that says what may live in it.
 
-Open source declares no namespaces, so the bag stays empty and the API rejects
-every write to it. A downstream build replaces this file to declare its own,
-and inherits validation, defaults and the API surface without changing any
-model. The semantics live in ``pi_dash.core.user_settings`` precisely so a
-replacement of this file does not have to reimplement them.
+Open source currently declares no namespaces, so the bag stays empty and the
+API rejects every write to it. A downstream build replaces this file to add
+its own declaration, but composes it with
+``pi_dash.core.user_settings.base_settings_schema`` so public settings are
+retained. Validation, defaults and the API surface remain shared.
 
 The declaration is values-with-defaults rather than a schema language: it
 answers "which keys exist and what do they mean when unset", which is all the
@@ -24,6 +24,8 @@ endpoint and the readers need.
 from __future__ import annotations
 
 from typing import Any
+
+from pi_dash.core import user_settings as core_user_settings
 
 # Re-exported so callers import one module regardless of which build declared
 # the schema.
@@ -43,4 +45,4 @@ def known_settings_schema() -> dict[str, dict[str, Any]]:
     read, so an overlay that stops declaring a namespace does not start serving
     values it no longer understands.
     """
-    return {}
+    return core_user_settings.base_settings_schema()

--- a/apps/api/pi_dash/tests/unit/settings/test_user_settings.py
+++ b/apps/api/pi_dash/tests/unit/settings/test_user_settings.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import pytest
 
+from pi_dash.core import user_settings as core_user_settings
 from pi_dash.ee.settings import user_settings
 
 pytestmark = pytest.mark.unit
@@ -36,6 +37,14 @@ class _Profile:
 def test_ce_declares_no_namespaces():
     # The bag exists but nothing may go in it until a build says otherwise.
     assert user_settings.known_settings_schema() == {}
+
+
+def test_ce_schema_comes_from_the_non_overlayed_oss_declaration(monkeypatch):
+    """Downstream builds need a stable public declaration they can extend."""
+    public = {"notifications": {"daily_digest": False}}
+    monkeypatch.setattr(core_user_settings, "base_settings_schema", lambda: public)
+
+    assert user_settings.known_settings_schema() == public
 
 
 def test_every_write_is_refused_when_nothing_is_declared():
@@ -135,6 +144,41 @@ def test_an_oversized_payload_is_refused(monkeypatch):
 # --------------------------------------------------------------------------- #
 # Merge semantics
 # --------------------------------------------------------------------------- #
+
+
+def test_extending_a_schema_preserves_public_namespaces_and_merges_shared_ones():
+    public = {
+        "notifications": {"daily_digest": False},
+        "assistant": {"public_tools": True},
+    }
+    private = {
+        "openhub": {"apps_enabled": False},
+        "assistant": {"private_models": True},
+    }
+
+    assert core_user_settings.extend_settings_schema(public, private) == {
+        "notifications": {"daily_digest": False},
+        "assistant": {"public_tools": True, "private_models": True},
+        "openhub": {"apps_enabled": False},
+    }
+
+
+def test_extending_a_schema_does_not_mutate_either_input():
+    public = {"assistant": {"public_tools": True}}
+    private = {"assistant": {"private_models": True}}
+
+    core_user_settings.extend_settings_schema(public, private)
+
+    assert public == {"assistant": {"public_tools": True}}
+    assert private == {"assistant": {"private_models": True}}
+
+
+def test_extending_a_schema_rejects_a_key_owned_by_both_builds():
+    with pytest.raises(ValueError, match="settings schema collision.*apps_enabled"):
+        core_user_settings.extend_settings_schema(
+            {"openhub": {"apps_enabled": True}},
+            {"openhub": {"apps_enabled": False}},
+        )
 
 
 def test_patching_one_namespace_leaves_the_others_intact():


### PR DESCRIPTION
## Summary
- define the OSS-owned settings schema outside the overlayable `ee` seam
- add a non-mutating schema composition helper
- let the OSS seam delegate to the stable base declaration
- reject duplicate key ownership instead of silently overriding defaults

## Why
Private builds overlay `pi_dash.ee.settings.user_settings`. If that replacement returns only private namespaces, any namespaced setting later added by OSS disappears from the private build. This gives downstream builds a stable base to extend while keeping the existing closed allow-list.

## Verification
- settings unit suite: `30 passed`
- regression coverage proves public namespaces survive, shared namespaces gain independent keys, inputs are not mutated, and duplicate keys fail fast
- profile contract suite was collected locally but could not initialize because no local PostgreSQL test database is configured; no contract test body ran