### PR TITLE
PDASHOSS01-125 Windows MSI: launch pidash auth login from the installer ExitDialog instead of asking the user to run it manually

### DIFF
--- a/runner/README.md
+++ b/runner/README.md
@@ -71,14 +71,18 @@ Or on Windows, download and run the MSI installer:
 
 <https://github.com/The-AI-Republic/pi-dash/releases/latest/download/pidash-x86_64-pc-windows-msvc.msi>
 
-The MSI is a standard double-click Windows Installer — it drops `pidash.exe` and exits. It does **not** automatically launch the auth flow (MSI typically runs elevated as the Windows Installer service, and many MSI invocations are silent for IT/Group Policy deploys, so spawning a terminal from it would be wrong). To finish setup after the MSI closes:
+The MSI is a standard double-click Windows Installer — it drops `pidash.exe`, adds a **Sign in to Pi Dash** Start Menu shortcut, and (on an interactive install) offers to finish setup for you. The final installer screen shows a **Sign in to Pi Dash now** checkbox, ticked by default; leaving it ticked and clicking **Finish** opens a console and runs `pidash auth login`, walking you through the same device-code flow as the `install.ps1` one-liner.
+
+The auto-launch is deliberately scoped to interactive installs. Silent invocations (`msiexec /qn`, and the basic-UI `/qb`) — the IT/Group Policy/Intune/SCCM deploy paths — skip the installer UI entirely, so no terminal is ever spawned under the Windows Installer service. For those deploys, the admin ships the MSI and the user completes sign-in later from the **Sign in to Pi Dash** Start Menu shortcut (or by opening PowerShell and running `pidash`). Repairs and upgrades don't re-launch it either.
+
+If you skipped the checkbox, you can finish setup any time from the Start Menu shortcut, or:
 
 ```powershell
 # Open PowerShell and run:
 pidash
 ```
 
-With no config yet, bare `pidash` drops into `auth login` and walks you through the same device-code flow as the `install.ps1` one-liner. (A discoverable Start Menu shortcut for this step is tracked as a follow-up.)
+With no config yet, bare `pidash` drops into `auth login` and walks you through the device-code flow.
 
 Windows release assets also include a `pidash-x86_64-pc-windows-msvc.zip` archive with `pidash.exe` for advanced/manual installs.
 

--- a/runner/wix/main.wxs
+++ b/runner/wix/main.wxs
@@ -128,7 +128,46 @@
                                 Source='$(var.CargoTargetBinDir)\pidash.exe'
                                 KeyPath='yes'/>
                         </Component>
+
+                        <!--
+                          Post-install setup shim. Launched (a) from the ExitDialog
+                          checkbox on interactive installs and (b) from the Start Menu
+                          shortcut. Runs `pidash auth login` and pauses so the console
+                          survives the login flow. See wix\setup.cmd for the rationale.
+                        -->
+                        <Component Id='SetupCmd' Guid='*'>
+                            <File
+                                Id='setupCmd'
+                                Name='setup.cmd'
+                                DiskId='1'
+                                Source='wix\setup.cmd'
+                                KeyPath='yes'/>
+                        </Component>
                     </Directory>
+                </Directory>
+            </Directory>
+
+            <!--
+              Start Menu shortcut ("Sign in to Pi Dash"). This is the fallback for
+              silent/Group-Policy installs where the ExitDialog never runs: the admin
+              deploys the MSI, the user finds the shortcut and completes sign-in.
+            -->
+            <Directory Id='ProgramMenuFolder'>
+                <Directory Id='ApplicationProgramsFolder' Name='Pi Dash'>
+                    <Component Id='StartMenuShortcut' Guid='*'>
+                        <Shortcut Id='SetupShortcut'
+                                  Name='Sign in to Pi Dash'
+                                  Description='Complete Pi Dash setup: sign in via the device-code flow.'
+                                  Target='[#setupCmd]'
+                                  WorkingDirectory='Bin'/>
+                        <RemoveFolder Id='CleanupProgramsFolder' Directory='ApplicationProgramsFolder' On='uninstall'/>
+                        <!--
+                          perMachine package: the execute sequence is elevated, so an
+                          HKLM keypath is writable and avoids the ICE57 per-user/
+                          per-machine mixing warning that an HKCU keypath would trigger.
+                        -->
+                        <RegistryValue Root='HKLM' Key='Software\AI Republic\pidash' Name='StartMenuShortcut' Type='integer' Value='1' KeyPath='yes'/>
+                    </Component>
                 </Directory>
             </Directory>
         </Directory>
@@ -150,6 +189,8 @@
             <!--<ComponentRef Id='License'/>-->
 
             <ComponentRef Id='binary0'/>
+            <ComponentRef Id='SetupCmd'/>
+            <ComponentRef Id='StartMenuShortcut'/>
 
             <Feature
                 Id='Environment'
@@ -174,7 +215,29 @@
         <!--<Property Id='ARPPRODUCTICON' Value='ProductICO' />-->
 
         <Property Id='ARPHELPLINK' Value='https://github.com/The-AI-Republic/pi-dash'/>
-        
+
+        <!--
+          ExitDialog "Sign in to Pi Dash now" checkbox. WixUI_FeatureTree's
+          ExitDialog renders this optional checkbox automatically when the text
+          property is set; it defaults to ticked (value 1).
+        -->
+        <Property Id='WIXUI_EXITDIALOGOPTIONALCHECKBOX' Value='1'/>
+        <Property Id='WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT' Value='Sign in to Pi Dash now'/>
+
+        <!--
+          Launches the setup shim when the ExitDialog checkbox is ticked.
+          Type-18 custom action (FileKey + ExeCommand) so no WixUtilExtension /
+          extra light.exe -ext flag is needed through the cargo-dist build.
+          Impersonate='yes' runs it unelevated as the installing user so the
+          device-code token lands under that user's profile (see login.rs);
+          asyncNoWait lets the paused console outlive msiexec.
+        -->
+        <CustomAction Id='LaunchPidashSetup'
+                      FileKey='setupCmd'
+                      ExeCommand=''
+                      Return='asyncNoWait'
+                      Impersonate='yes'/>
+
         <UI>
             <UIRef Id='WixUI_FeatureTree'/>
             
@@ -190,6 +253,17 @@
             -->
             <Publish Dialog='WelcomeDlg' Control='Next' Event='NewDialog' Value='CustomizeDlg' Order='99'>1</Publish>
             <Publish Dialog='CustomizeDlg' Control='Back' Event='NewDialog' Value='WelcomeDlg' Order='99'>1</Publish>
+
+            <!--
+              On the ExitDialog "Finish" click, run the setup shim when the
+              checkbox is ticked and this is a fresh install (not a repair or
+              major upgrade). Silent installs (msiexec /qn, /qb) skip the UI
+              sequence entirely, so nothing spawns there. Order='999' runs the
+              DoAction before WixUI's own EndDialog on Finish.
+            -->
+            <Publish Dialog='ExitDialog' Control='Finish' Event='DoAction'
+                     Value='LaunchPidashSetup'
+                     Order='999'>WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1 and NOT Installed</Publish>
 
         </UI>
 

--- a/runner/wix/main.wxs
+++ b/runner/wix/main.wxs
@@ -170,6 +170,14 @@
                     </Component>
                 </Directory>
             </Directory>
+
+            <!--
+              Standard system directory, declared so [System64Folder] resolves
+              to a real path when referenced from the LaunchPidashSetup command
+              line below. Without this declaration the formatted [System64Folder]
+              can expand to empty and cmd.exe would only be found via PATH.
+            -->
+            <Directory Id='System64Folder'/>
         </Directory>
 
         <Feature
@@ -226,15 +234,25 @@
 
         <!--
           Launches the setup shim when the ExitDialog checkbox is ticked.
-          Type-18 custom action (FileKey + ExeCommand) so no WixUtilExtension /
-          extra light.exe -ext flag is needed through the cargo-dist build.
-          Impersonate='yes' runs it unelevated as the installing user so the
-          device-code token lands under that user's profile (see login.rs);
-          asyncNoWait lets the paused console outlive msiexec.
+
+          This is a type-34 custom action (Directory + ExeCommand), NOT type-18
+          (FileKey + ExeCommand). Type-18 runs the target file via CreateProcess,
+          which cannot execute a .cmd/.bat directly (it is not a PE image), so it
+          would fail with error 193 and the checkbox would silently no-op. We
+          instead invoke cmd.exe explicitly as the batch host. Still no
+          WixUtilExtension / extra light.exe -ext flag, so nothing extra has to
+          be threaded through the cargo-dist build.
+
+          `start` opens the shim in its own console window that is not tied to
+          msiexec's lifetime, and asyncNoWait means msiexec does not wait, so the
+          paused console outlives the installer. Impersonate='yes' runs it
+          unelevated as the installing user so the device-code token lands under
+          that user's profile (see login.rs), not SYSTEM's.
         -->
         <CustomAction Id='LaunchPidashSetup'
-                      FileKey='setupCmd'
-                      ExeCommand=''
+                      Directory='Bin'
+                      ExeCommand='[System64Folder]cmd.exe /c start "Pi Dash setup" "[#setupCmd]"'
+                      Execute='immediate'
                       Return='asyncNoWait'
                       Impersonate='yes'/>
 

--- a/runner/wix/setup.cmd
+++ b/runner/wix/setup.cmd
@@ -1,0 +1,17 @@
+@echo off
+rem Pi Dash post-install setup shim.
+rem
+rem Launched from the MSI ExitDialog checkbox and the Start Menu shortcut so
+rem the device-code login runs unelevated as the installing user (the token
+rem and workspace binding land under that user's profile, not SYSTEM's).
+rem
+rem pidash.exe is a console-subsystem app; ShellExecute-ing it directly would
+rem allocate a console that vanishes the instant the process exits, so a
+rem failed login would show nothing. Running it from this shim keeps the
+rem window open via `pause` for the sign-in flow and any error output.
+rem
+rem %~dp0 expands to this script's directory (the install bin dir) with a
+rem trailing backslash, so the sibling pidash.exe is invoked by full path.
+"%~dp0pidash.exe" auth login
+echo.
+pause


### PR DESCRIPTION
## Problem

Every install path except the Windows MSI auto-starts the device-code login (`install.sh`, `install.ps1`, and bare `pidash`). The MSI just dropped `pidash.exe` and exited, forcing the user to open a terminal and type `pidash` themselves. An interactive double-click install should finish setup in the same sitting.

## Change

- **`runner/wix/setup.cmd`** (new) — a shim that runs `pidash auth login` then `pause`s. `pidash.exe` is a console-subsystem app; ShellExecute-ing it directly from the GUI installer would allocate a console that vanishes the instant the process exits, so a failed login would show nothing. The shim keeps the window open.
- **`runner/wix/main.wxs`**:
  - `SetupCmd` component/`File` installed alongside the binary in the `Bin` dir.
  - `WIXUI_EXITDIALOGOPTIONALCHECKBOX` + `...TEXT` ("Sign in to Pi Dash now"), rendered by `WixUI_FeatureTree`'s ExitDialog, ticked by default.
  - `LaunchPidashSetup` — a **type-18** custom action (`FileKey` + `ExeCommand`), chosen so no `WixUtilExtension` / extra `light.exe -ext` flag needs threading through the cargo-dist build. `Impersonate='yes'` runs it **unelevated as the installing user** so the token + workspace binding land under that user's profile (`login.rs:148-152`), not SYSTEM's. `Return='asyncNoWait'` lets the paused console outlive `msiexec`.
  - ExitDialog `Publish` gated on `WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1 and NOT Installed`.
  - "Sign in to Pi Dash" Start Menu shortcut (the `README.md:81` follow-up) — the fallback for silent installs where nothing can be popped.
- **`runner/README.md`** — MSI section rewritten to describe the checkbox + shortcut.

Silent installs (`msiexec /qn`, `/qb`) skip the UI sequence entirely, so nothing spawns; repairs/upgrades are excluded via `NOT Installed`.

## Verification status

XML well-formedness verified locally (`xmllint`). **A full WiX build + manual QA needs a Windows x64 host and the WiX toolchain — not available in the authoring environment** — so this is the In Test phase's job. Open questions to confirm on a real build:

1. Type-18 CA (`FileKey`→`.cmd`, `ExeCommand=""`) actually launches the shim. `CustomAction` type 18 uses CreateProcess semantics, which cannot exec a `.cmd` directly; if the CA no-ops on a real build, the fallback is a `WixShellExec` CA (adds `WixUtilExtension`) or converting the shim to a real `.exe`.
2. `Return="asyncNoWait"` + `pause` — the paused console must survive `msiexec` exiting.
3. `/qb` (basic UI) skips the ExitDialog like `/qn` does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
