### PR TITLE
PDASHOSS01-127 Install Pi Dash CLI for AI Agent Integration

### DIFF
--- a/apps/web/core/components/onboarding/steps/cli-install/root.tsx
+++ b/apps/web/core/components/onboarding/steps/cli-install/root.tsx
@@ -31,8 +31,8 @@ export function CliInstallStep({ handleStepChange }: Props) {
   return (
     <div className="flex flex-col gap-10">
       <CommonOnboardingHeader
-        title="Install the Pi Dash CLI."
-        description="Run this on the machine where your coding agent will execute work."
+        title="Connect your AI agents with Pi Dash"
+        description="The Pi Dash CLI connects your AI agents to Pi Dash so you can delegate tasks to them. Install it on the machine where your coding agent will execute work."
       />
 
       <div className="flex gap-2 text-warning-primary">


### PR DESCRIPTION
## Summary

Rewords the onboarding **CLI-install** step copy (`apps/web/core/components/onboarding/steps/cli-install/root.tsx`):

- **Title:** `Install the Pi Dash CLI.` → `Connect your AI agents with Pi Dash`
- **Description:** `Run this on the machine where your coding agent will execute work.` → `The Pi Dash CLI connects your AI agents to Pi Dash so you can delegate tasks to them. Install it on the machine where your coding agent will execute work.`

The warning banner, install script, and buttons are unchanged.

Resolves PDASHOSS01-127.

## Test plan

- Open the onboarding flow and reach the CLI-install step.
- Verify the new title and description render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
