### PR TITLE
fix(runner): self-heal a missing service unit on every OS, not just macOS

### DIFF
--- a/runner/src/service/launchd.rs
+++ b/runner/src/service/launchd.rs
@@ -567,24 +567,19 @@ fn ensure_plist_present(plist: &Path) -> Result<()> {
 /// a plist-less machine recover transparently instead of bailing with the
 /// `ensure_plist_present` error the operator would have to act on by hand.
 ///
-/// We only rewrite when missing (not unconditionally on every restart) so
-/// operators hand-editing the plist for debugging don't get clobbered.
+/// The "rewrite only when missing" rule lives in `service::rewrite_unit_if_absent`
+/// so all three backends state it once; see there for why we never clobber an
+/// existing plist.
 ///
 /// Gated to `target_os = "macos"` (not the module's broader `macos || test`
-/// gate) because the only call site is also `cfg(target_os = "macos")`. The
-/// module's `test` arm exists so the path/exit-status parsers are unit-
-/// testable on Linux CI runners; this self-heal does macOS-specific I/O
-/// (`write_unit` renders the launchd plist) and has no Linux test path of
-/// its own, so compiling it on Linux would just produce a dead-code warning
-/// under `-D dead-code`.
+/// gate) because the `Service::Launchd` arm that calls it is too. The module's
+/// `test` arm exists so the path/exit-status parsers are unit-testable on Linux
+/// CI runners; this self-heal does macOS-specific I/O (`write_unit` renders the
+/// launchd plist), so compiling it on Linux would just produce a dead-code
+/// warning under `-D dead-code`.
 #[cfg(target_os = "macos")]
 pub(crate) async fn rewrite_unit_if_missing(paths: &Paths) -> Result<bool> {
-    let plist = plist_path()?;
-    if plist.exists() {
-        return Ok(false);
-    }
-    write_unit(paths).await?;
-    Ok(true)
+    super::rewrite_unit_if_absent(&plist_path()?, || write_unit(paths)).await
 }
 
 fn plist_path() -> Result<PathBuf> {

--- a/runner/src/service/mod.rs
+++ b/runner/src/service/mod.rs
@@ -75,6 +75,28 @@ pub(crate) fn capture_install_time_path() -> Option<String> {
     Some(value)
 }
 
+/// Shared self-heal rule: rewrite the unit only when it is absent.
+///
+/// Stated once here rather than three times because the invariant is the
+/// interesting part, not the per-backend plumbing — we rewrite a *missing*
+/// unit, never an existing one, so an operator hand-editing their unit for
+/// debugging doesn't get clobbered on the next `pidash restart`.
+///
+/// Backends whose "unit" is a file (systemd, launchd) pass its path.
+/// `windows` can't: a scheduled task has no file to stat, so it implements
+/// the same contract against `schtasks /Query` directly.
+pub(crate) async fn rewrite_unit_if_absent<F, Fut>(unit: &Path, write: F) -> Result<bool>
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = Result<()>>,
+{
+    if unit.exists() {
+        return Ok(false);
+    }
+    write().await?;
+    Ok(true)
+}
+
 pub enum Service {
     #[cfg(target_os = "linux")]
     Systemd,
@@ -131,6 +153,25 @@ impl Service {
             Service::Launchd => launchd::write_unit(paths).await,
             #[cfg(windows)]
             Service::WindowsTask => windows::write_unit(paths).await,
+        }
+    }
+
+    /// Rewrite the unit if the service manager no longer has one, returning
+    /// whether it was rewritten. Every backend implements this: a unit can go
+    /// missing on any OS (`pidash uninstall`/`remove`, manual cleanup, or a
+    /// `pidash update` that swapped the binary without ever writing one), and
+    /// on every OS the result is a `restart` that can't recover on its own.
+    ///
+    /// Callers treat a failure here as non-fatal — it's a best-effort repair
+    /// before the real start attempt, which produces the actionable error.
+    pub async fn rewrite_unit_if_missing(&self, paths: &Paths) -> Result<bool> {
+        match self {
+            #[cfg(target_os = "linux")]
+            Service::Systemd => systemd::rewrite_unit_if_missing(paths).await,
+            #[cfg(target_os = "macos")]
+            Service::Launchd => launchd::rewrite_unit_if_missing(paths).await,
+            #[cfg(windows)]
+            Service::WindowsTask => windows::rewrite_unit_if_missing(paths).await,
         }
     }
 
@@ -221,5 +262,68 @@ impl Service {
             #[cfg(windows)]
             Service::WindowsTask => windows::diagnose_recent_exit().await,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// An existing unit is left alone — the rule that keeps `pidash restart`
+    /// from clobbering a plist/unit an operator edited by hand.
+    #[tokio::test]
+    async fn absent_helper_does_not_rewrite_existing_unit() {
+        let dir = tempfile::tempdir().unwrap();
+        let unit = dir.path().join("pidash.service");
+        std::fs::write(&unit, "[Unit]\n").unwrap();
+        let writes = AtomicUsize::new(0);
+
+        let rewrote = rewrite_unit_if_absent(&unit, || async {
+            writes.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        })
+        .await
+        .unwrap();
+
+        assert!(!rewrote);
+        assert_eq!(writes.load(Ordering::SeqCst), 0, "must not rewrite");
+        assert_eq!(std::fs::read_to_string(&unit).unwrap(), "[Unit]\n");
+    }
+
+    /// The regression this exists for: a missing unit is rewritten rather
+    /// than left for `enable`/`bootstrap` to fail on.
+    #[tokio::test]
+    async fn absent_helper_rewrites_missing_unit() {
+        let dir = tempfile::tempdir().unwrap();
+        let unit = dir.path().join("pidash.service");
+        let writes = AtomicUsize::new(0);
+
+        let rewrote = rewrite_unit_if_absent(&unit, || async {
+            writes.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        })
+        .await
+        .unwrap();
+
+        assert!(rewrote);
+        assert_eq!(writes.load(Ordering::SeqCst), 1);
+    }
+
+    /// A failing write propagates instead of reporting a repair that didn't
+    /// happen — the caller logs it and lets the start attempt produce the
+    /// actionable error.
+    #[tokio::test]
+    async fn absent_helper_propagates_write_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let unit = dir.path().join("pidash.service");
+
+        let err = rewrite_unit_if_absent(&unit, || async {
+            anyhow::bail!("permission denied");
+        })
+        .await
+        .unwrap_err();
+
+        assert!(err.to_string().contains("permission denied"));
     }
 }

--- a/runner/src/service/mod.rs
+++ b/runner/src/service/mod.rs
@@ -83,8 +83,14 @@ pub(crate) fn capture_install_time_path() -> Option<String> {
 /// debugging doesn't get clobbered on the next `pidash restart`.
 ///
 /// Backends whose "unit" is a file (systemd, launchd) pass its path.
-/// `windows` can't: a scheduled task has no file to stat, so it implements
-/// the same contract against `schtasks /Query` directly.
+/// `windows` can't — a scheduled task has no file to stat — so it applies the
+/// same rule against `schtasks /Query` directly.
+///
+/// Both resolve an *unreadable* unit the same way, toward rewriting:
+/// `Path::exists()` reports `false` when a permission or IO error hides the
+/// file, and Windows treats only a clean `/Query` exit as proof of existence.
+/// Guessing "absent" there is the safe guess — the write that follows either
+/// repairs the install or fails with the real reason.
 pub(crate) async fn rewrite_unit_if_absent<F, Fut>(unit: &Path, write: F) -> Result<bool>
 where
     F: FnOnce() -> Fut,

--- a/runner/src/service/reload.rs
+++ b/runner/src/service/reload.rs
@@ -63,25 +63,26 @@ where
 {
     let svc = crate::service::detect();
 
-    // Self-heal: rewrite the service unit if it's gone (manual cleanup, an
-    // older `pidash uninstall`, or never written for the current install
-    // location). Without this, `pidash restart` after `pidash update` on a
-    // unit-less machine hard-fails — `pidash update` only swaps the binary
-    // and doesn't touch the unit, and operators should not need to know
-    // that `pidash install` is the magic recovery command.
+    // Self-heal: rewrite the service unit if it's gone (manual cleanup, a
+    // `pidash uninstall`/`remove`, or never written for the current install
+    // location). Without this, `pidash restart` on a unit-less machine
+    // hard-fails — `pidash update` only swaps the binary and doesn't touch
+    // the unit, and operators should not need to know that `pidash install`
+    // is the magic recovery command.
     //
-    // macOS-only today: the reported case is launchctl bootstrap returning
-    // EIO for a missing plist. systemd surfaces the same kind of failure
-    // with a clearer "Unit not found" message and Windows uses schtasks
-    // which has its own recovery path — extend per backend when we hit
-    // them. `launchd::start` keeps its precondition check as a last-line-
-    // of-defense for direct `pidash start` callers that don't pass through
-    // this self-heal.
-    #[cfg(target_os = "macos")]
-    match crate::service::launchd::rewrite_unit_if_missing(paths).await {
-        Ok(true) => progress("rewrote missing launchd plist".into()),
+    // All backends, not just launchd. This started as a launchd fix because
+    // that's where it was first reported (launchctl bootstrap returning a
+    // cryptic EIO), on the theory that systemd's clearer "Unit file does not
+    // exist" left the operator able to recover unaided. It doesn't: a
+    // legible error is still a hard failure, it names what's missing but not
+    // the fix, and the fix isn't guessable — `pidash install` writes the unit
+    // but then declines to start it when no runner is enrolled. `launchd::start`
+    // keeps its precondition check as a last line of defense for direct
+    // `pidash start` callers that don't pass through this self-heal.
+    match svc.rewrite_unit_if_missing(paths).await {
+        Ok(true) => progress("rewrote missing service unit".into()),
         Ok(false) => {}
-        Err(e) => tracing::warn!("pre-restart launchd unit check failed: {e:#}"),
+        Err(e) => tracing::warn!("pre-restart service unit check failed: {e:#}"),
     }
 
     progress("starting runner service".into());

--- a/runner/src/service/systemd.rs
+++ b/runner/src/service/systemd.rs
@@ -115,6 +115,16 @@ pub async fn uninstall(_: &Paths) -> Result<()> {
     Ok(())
 }
 
+/// Self-heal for `pidash restart`: rewrite the unit when it's gone.
+///
+/// `write_unit` already runs `daemon-reload`, so a unit rewritten here is
+/// visible to the manager by the time the caller reaches `enable_and_start`
+/// — which matters, because that step runs `systemctl --user enable`, and
+/// enable is what fails with "Unit file pidash.service does not exist."
+pub(crate) async fn rewrite_unit_if_missing(paths: &Paths) -> Result<bool> {
+    super::rewrite_unit_if_absent(&unit_path()?, || write_unit(paths)).await
+}
+
 pub async fn start() -> Result<()> {
     run_systemctl(&["start", UNIT_NAME]).await
 }

--- a/runner/src/service/windows.rs
+++ b/runner/src/service/windows.rs
@@ -39,6 +39,31 @@ pub async fn uninstall(_paths: &Paths) -> Result<()> {
     }
 }
 
+/// Self-heal for `pidash restart`: re-register the task when it's gone.
+///
+/// Unlike systemd/launchd there is no file to stat, so "missing" is decided
+/// by `schtasks /Query` failing with a not-found error. An *ambiguous*
+/// failure (access denied, schtasks.exe unavailable) deliberately does not
+/// rewrite: `write_unit` passes `/F`, which would overwrite a task the
+/// operator may have tuned by hand, and the subsequent start attempt will
+/// surface the real error anyway.
+pub(crate) async fn rewrite_unit_if_missing(paths: &Paths) -> Result<bool> {
+    match run_schtasks(&["/Query", "/TN", TASK_NAME]).await {
+        Ok(_) => Ok(false),
+        Err(e) if looks_task_missing(&e) => {
+            write_unit(paths).await?;
+            Ok(true)
+        }
+        Err(e) => {
+            tracing::warn!(
+                "could not determine whether scheduled task {TASK_NAME} exists ({e:#}); \
+                 leaving it as-is"
+            );
+            Ok(false)
+        }
+    }
+}
+
 pub async fn start() -> Result<()> {
     run_schtasks(&["/Run", "/TN", TASK_NAME]).await?;
     Ok(())

--- a/runner/src/service/windows.rs
+++ b/runner/src/service/windows.rs
@@ -41,27 +41,24 @@ pub async fn uninstall(_paths: &Paths) -> Result<()> {
 
 /// Self-heal for `pidash restart`: re-register the task when it's gone.
 ///
-/// Unlike systemd/launchd there is no file to stat, so "missing" is decided
-/// by `schtasks /Query` failing with a not-found error. An *ambiguous*
-/// failure (access denied, schtasks.exe unavailable) deliberately does not
-/// rewrite: `write_unit` passes `/F`, which would overwrite a task the
-/// operator may have tuned by hand, and the subsequent start attempt will
-/// surface the real error anyway.
+/// Unlike systemd/launchd there is no file to stat, so existence is decided
+/// by `schtasks /Query` succeeding. Deliberately *not* by classifying its
+/// error text: schtasks.exe localizes its messages, so matching the English
+/// "cannot find" (as `looks_task_missing` does, acceptably, for the tolerant
+/// `uninstall` path) would leave this self-heal a silent no-op on a German or
+/// Japanese host — precisely the machines it exists to repair.
+///
+/// So a clean exit means "present, leave it alone" and anything else means
+/// "try the repair". That errs toward rewriting when the query fails for some
+/// other reason (access denied, schtasks.exe missing), which is the safe
+/// direction: `/Create /F` either restores a working task or fails with the
+/// real reason, which the caller logs before the start attempt reports it.
 pub(crate) async fn rewrite_unit_if_missing(paths: &Paths) -> Result<bool> {
-    match run_schtasks(&["/Query", "/TN", TASK_NAME]).await {
-        Ok(_) => Ok(false),
-        Err(e) if looks_task_missing(&e) => {
-            write_unit(paths).await?;
-            Ok(true)
-        }
-        Err(e) => {
-            tracing::warn!(
-                "could not determine whether scheduled task {TASK_NAME} exists ({e:#}); \
-                 leaving it as-is"
-            );
-            Ok(false)
-        }
+    if run_schtasks(&["/Query", "/TN", TASK_NAME]).await.is_ok() {
+        return Ok(false);
     }
+    write_unit(paths).await?;
+    Ok(true)
 }
 
 pub async fn start() -> Result<()> {


### PR DESCRIPTION
## The bug

`pidash restart` already knows how to rewrite a service unit that has gone missing — but the call site was `#[cfg(target_os = "macos")]`, so on Linux and Windows it fell straight through to `enable_and_start` and hard-failed:

```
$ pidash restart
restarting daemon...
starting runner service
Failed to enable unit: Unit file pidash.service does not exist.
Error: daemon restart did not complete cleanly: failed to start runner service
service manager rejected start/restart: systemctl ["--user", "enable", "pidash.service"] failed: exit status: 1
current state: inactive
```

Hit on Linux while re-pointing a dev machine at a different cloud. The path there is ordinary, not exotic:

1. `pidash remove` / `pidash uninstall` stops the daemon **and deletes the unit** (`cli/uninstall.rs`).
2. `pidash auth login --url <new>` re-enrolls the machine, writing config only — it never touches the unit.
3. `pidash restart` → unrecoverable.

Unrecoverable because the fix isn't guessable: `pidash install` writes the unit but then *declines to start it* when no runner is enrolled (`cli/install.rs`, `machine_is_configured`), so the real recovery is two steps and neither is named in the error.

## Why it was macOS-only

`942611e4` (#201) fixed a reported launchd symptom — `launchctl bootstrap` returning a cryptic `EIO` — and scoped itself to that report. The rationale is in the comment it left behind:

> systemd surfaces the same kind of failure with a clearer "Unit not found" message and Windows uses schtasks which has its own recovery path — extend per backend when we hit them.

That doesn't hold. A legible error is still a hard failure; it names what's missing, not the fix. The self-heal isn't a launchd workaround, it's what `restart` should do anywhere.

## The change

`rewrite_unit_if_missing` was the only service operation not dispatched through `Service` — every other one (`write_unit`, `enable_and_start`, `uninstall`, `start`, `stop`, `status`, `ensure_boot_start`) already has all three arms. Making it a method is what lets the `cfg` come off the call site; the rest follows.

- **`service/mod.rs`** — `Service::rewrite_unit_if_missing`, plus a shared `rewrite_unit_if_absent(unit, write)` helper holding the "rewrite only when absent" rule (the one that keeps a hand-edited unit from being clobbered) so all three backends state it once.
- **`systemd.rs`** — new. `write_unit` already runs `daemon-reload`, so the rewritten unit is visible before `enable` runs.
- **`launchd.rs`** — unchanged behavior, routed through the shared helper. Stays `cfg(macos)` because the `Service::Launchd` arm calling it is too; the doc comment's old justification (*"the only call site is also cfg macos"*) is updated.
- **`windows.rs`** — new. No file to stat, so "missing" comes from `schtasks /Query` returning not-found. An **ambiguous** failure (access denied, schtasks unavailable) deliberately does *not* rewrite, because `write_unit` passes `/F` and would overwrite a task the operator may have tuned.
- **`reload.rs`** — `cfg` dropped; progress message generalized to "rewrote missing service unit".

## Testing

- `cargo test --all-targets --locked` — 464 + 39 pass, 0 fail. `cargo clippy --all-targets --locked -- -D warnings` clean.
- Three new tests in `service/mod.rs` covering the shared rule: existing unit is left untouched, missing unit is rewritten, write failure propagates. These run on Linux CI.
- **Linux, end to end**: reproduced the original failure on a machine with no unit, then confirmed the new path fires:
  ```
  restarting daemon...
  installed systemd unit at .../.config/systemd/user/pidash.service
  rewrote missing service unit
  ```
  Run under a sandboxed `$HOME` so a real unit wasn't touched — the subsequent `enable` still fails there, because `systemd --user` reads the login session's config dir and can't see a unit written under a spoofed `HOME`. That's an artifact of the sandbox; `enable_and_start` itself is unmodified.

## Reviewer notes

- **`windows.rs` is not compiled by CI** (`pull-request-test-runner.yml` is `ubuntu-latest` only), and I have no mingw toolchain locally to cross-compile against. I type-checked the new function body on Linux against stub definitions matching the real signatures of `run_schtasks` / `write_unit` / `looks_task_missing` — that covers syntax and the `{TASK_NAME}` / `{e:#}` format capture, but **the schtasks behavior itself is unverified**. A Windows reviewer confirming that `schtasks /Query /TN PiDash` on a missing task produces stderr matching the existing `looks_task_missing` ("cannot find") would close the last gap.
- **launchd is untested here** — no Mac. Its behavior is unchanged apart from delegating to the shared helper.
