### PR TITLE
PDASHOSS01-130 Dev machine status should reflect the machine's own connection, not its runner count

### DIFF
--- a/apps/web/app/(all)/[workspaceSlug]/ai-dev-machines/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/ai-dev-machines/page.tsx
@@ -35,17 +35,22 @@ Start-Process msiexec.exe -Wait -ArgumentList "/i \`"$msi\`""`;
 
 const service = new RunnerService();
 
-type DevMachineStatus = "active" | "offline" | "registered" | "revoked";
+// Status describes the *machine's* own connection, not its runners. Runner
+// health lives in the separate active/total runner column. "Connected" means
+// the daemon holds a recently-seen machine control session (``control_online``)
+// and can execute cloud-pushed commands right now — independent of whether any
+// runners are registered.
+type DevMachineStatus = "connected" | "offline" | "registered" | "revoked";
 
 const DEV_MACHINE_STATUS_BADGE_VARIANT: Record<DevMachineStatus, TBadgeVariant> = {
-  active: "accent-success",
+  connected: "accent-success",
   offline: "accent-neutral",
   registered: "accent-primary",
   revoked: "accent-warning",
 };
 
 const DEV_MACHINE_STATUS_I18N_LABELS: Record<DevMachineStatus, string> = {
-  active: "Active",
+  connected: "Connected",
   offline: "Offline",
   registered: "Registered",
   revoked: "Revoked",
@@ -53,8 +58,8 @@ const DEV_MACHINE_STATUS_I18N_LABELS: Record<DevMachineStatus, string> = {
 
 function getDevMachineStatus(machine: IDevMachine): DevMachineStatus {
   if (machine.revoked_at) return "revoked";
-  if (machine.online_runner_count > 0) return "active";
-  if (machine.runner_count > 0) return "offline";
+  if (machine.control_online) return "connected";
+  if (machine.last_seen_at) return "offline";
   return "registered";
 }
 
@@ -144,22 +149,32 @@ const AiDevMachinesPage = observer(function AiDevMachinesPage() {
       {/* Intro — what the CLI / daemon / runner each are */}
       <section className="flex flex-col gap-4">
         <h2 className="text-14 font-semibold text-primary">{t("What is the pidash CLI, daemon, and runner?")}</h2>
-        <p className="text-13 text-secondary">{t("Pi Dash hands AI agents (Claude Code, Codex, …) the keys to a real dev machine so they can pick up work items, write code, and open changes. Three pieces work together to make that possible:")}</p>
+        <p className="text-13 text-secondary">
+          {t(
+            "Pi Dash hands AI agents (Claude Code, Codex, …) the keys to a real dev machine so they can pick up work items, write code, and open changes. Three pieces work together to make that possible:"
+          )}
+        </p>
         <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
           <ConceptCard
             icon={<Terminal className="size-4" />}
             title={t("pidash CLI")}
-            body={t("The command-line tool installed on each dev machine. Handles authentication with the cloud, manages local config (`~/.pidash/config.toml`), and exposes commands for issues, comments, and runner management (`pidash auth login`, `pidash runner add`, `pidash doctor`, …).")}
+            body={t(
+              "The command-line tool installed on each dev machine. Handles authentication with the cloud, manages local config (`~/.pidash/config.toml`), and exposes commands for issues, comments, and runner management (`pidash auth login`, `pidash runner add`, `pidash doctor`, …)."
+            )}
           />
           <ConceptCard
             icon={<Cpu className="size-4" />}
             title={t("pidash daemon")}
-            body={t("A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.")}
+            body={t(
+              "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine."
+            )}
           />
           <ConceptCard
             icon={<Laptop className="size-4" />}
             title={t("AI Agent runner")}
-            body={t("A cloud-side row that represents one agent instance bound to a project (and optionally a pod). Running `pidash runner add` on a logged-in machine creates the row and binds that machine as the host. A machine can host many runners.")}
+            body={t(
+              "A cloud-side row that represents one agent instance bound to a project (and optionally a pod). Running `pidash runner add` on a logged-in machine creates the row and binds that machine as the host. A machine can host many runners."
+            )}
           />
         </div>
       </section>
@@ -168,7 +183,9 @@ const AiDevMachinesPage = observer(function AiDevMachinesPage() {
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div>
             <h2 className="text-14 font-semibold text-primary">{t("Dev machines")}</h2>
-            <p className="mt-1 text-13 text-secondary">{t("Machines that have authenticated with Pi Dash or host runners for this workspace.")}</p>
+            <p className="mt-1 text-13 text-secondary">
+              {t("Machines that have authenticated with Pi Dash or host runners for this workspace.")}
+            </p>
           </div>
           <Button onClick={() => setAddOpen(true)} disabled={!workspaceId}>
             {t("Add runner")}
@@ -225,12 +242,8 @@ const AiDevMachinesPage = observer(function AiDevMachinesPage() {
                           total: machine.runner_count,
                         })}
                       </td>
-                      <td className="px-3 py-2">
-                        {formatDateTime(machine.last_seen_at, t("Never"))}
-                      </td>
-                      <td className="px-3 py-2">
-                        {formatDateTime(machine.last_heartbeat_at, t("Never"))}
-                      </td>
+                      <td className="px-3 py-2">{formatDateTime(machine.last_seen_at, t("Never"))}</td>
+                      <td className="px-3 py-2">{formatDateTime(machine.last_heartbeat_at, t("Never"))}</td>
                       <td className="px-3 py-2 text-right">
                         <div className="flex justify-end gap-2">
                           {!machine.revoked_at && (
@@ -273,7 +286,11 @@ const AiDevMachinesPage = observer(function AiDevMachinesPage() {
       {/* Install command — copy / paste */}
       <section className="flex flex-col gap-3">
         <h2 className="text-14 font-semibold text-primary">{t("Install the pidash CLI")}</h2>
-        <p className="text-13 text-secondary">{t("Run an installer on the machine that will host your AI agent. The wrapper commands download the latest signed binary, drop `pidash` on your PATH, and walk you through the device-code login.")}</p>
+        <p className="text-13 text-secondary">
+          {t(
+            "Run an installer on the machine that will host your AI agent. The wrapper commands download the latest signed binary, drop `pidash` on your PATH, and walk you through the device-code login."
+          )}
+        </p>
 
         <InstallCommand label={t("macOS / Linux")} command={INSTALL_CMD_UNIX} />
         <InstallCommand label={t("Windows (PowerShell)")} command={INSTALL_CMD_WINDOWS} />
@@ -284,7 +301,11 @@ const AiDevMachinesPage = observer(function AiDevMachinesPage() {
           hrefLabel={t("Download MSI")}
         />
 
-        <p className="text-12 text-secondary">{t("Prerequisite: the agent CLI you plan to use (`codex` or `claude`) must already be installed and on PATH. Run `pidash doctor` after install to verify.")}</p>
+        <p className="text-12 text-secondary">
+          {t(
+            "Prerequisite: the agent CLI you plan to use (`codex` or `claude`) must already be installed and on PATH. Run `pidash doctor` after install to verify."
+          )}
+        </p>
       </section>
 
       {workspaceId && workspaceSlug && (
@@ -301,7 +322,9 @@ const AiDevMachinesPage = observer(function AiDevMachinesPage() {
         handleSubmit={confirmRotateMachine}
         isSubmitting={rotating}
         title={t("Rotate dev machine token?")}
-        content={t("The active auth token for this dev machine will be invalidated. Runners on that machine will stop connecting until `pidash auth login` is run there again.")}
+        content={t(
+          "The active auth token for this dev machine will be invalidated. Runners on that machine will stop connecting until `pidash auth login` is run there again."
+        )}
         variant="primary"
         primaryButtonText={{ default: t("Rotate"), loading: t("Rotate") }}
       />
@@ -311,7 +334,9 @@ const AiDevMachinesPage = observer(function AiDevMachinesPage() {
         handleSubmit={confirmRevokeMachine}
         isSubmitting={revoking}
         title={t("Revoke dev machine?")}
-        content={t("This permanently revokes the dev machine, invalidates its auth token, and revokes runners hosted on it. Use this when the machine should no longer be trusted.")}
+        content={t(
+          "This permanently revokes the dev machine, invalidates its auth token, and revokes runners hosted on it. Use this when the machine should no longer be trusted."
+        )}
         primaryButtonText={{ default: t("Revoke"), loading: t("Revoke") }}
       />
     </div>

--- a/packages/i18n/src/locales/en/translations.ts
+++ b/packages/i18n/src/locales/en/translations.ts
@@ -341,6 +341,7 @@ export default {
   "Confirm password": "Confirm password",
   Confirming: "Confirming",
   "Congrats!": "Congrats!",
+  Connected: "Connected",
   Connection: "Connection",
   "Consider and discuss work items before you add them to your project.":
     "Consider and discuss work items before you add them to your project.",


### PR DESCRIPTION
## Problem

On `/:workspaceSlug/ai-dev-machines/`, a dev machine's status badge was derived **entirely from runner counts**. A machine with a live, connected daemon but zero runners showed **"Registered"** — visually identical to a machine enrolled long ago that has never connected. The status is supposed to describe the *machine* (is the daemon reachable right now?), not its runners — runner health already has its own column.

## Root cause

`getDevMachineStatus` (`apps/web/app/(all)/[workspaceSlug]/ai-dev-machines/page.tsx`) branched on `online_runner_count` / `runner_count`, so a runner-less machine always fell through to `registered`. The connection signal (`control_online`, an `Exists()` over recently-seen `MachineSession` rows) was already computed and serialized on `DevMachineSerializer` but never read by the frontend.

## Change

Frontend-only. Status now reflects the machine's own connection:

- `revoked_at` → **Revoked**
- `control_online` → **Connected** (daemon reachable now)
- `last_seen_at` → **Offline** (seen before, not connected now)
- otherwise → **Registered** (enrolled, never connected)

The new **Connected** status replaces the runner-count-based **Active** machine status, so the badge no longer overloads the meaning of "Active" — runner health stays in the existing active/total runner column. Adds the `Connected` string to the `en` locale (the only locale under `packages/i18n/src/locales/`).

## Validation

- `oxlint` clean on the changed page.
- `pnpm run check:types`: no new errors in the touched files (remaining errors are pre-existing in unrelated files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
