### PR TITLE
fix: allow grok and muse-code runners, and restore the runner build

### DIFF
--- a/.github/workflows/pull-request-test-api.yml
+++ b/.github/workflows/pull-request-test-api.yml
@@ -13,6 +13,11 @@ on:
     paths:
       - "apps/api/**"
       - ".github/workflows/pull-request-test-api.yml"
+      # test_valid_agents_matches_runner_schema pins the API's agent
+      # allowlist to this enum. A PR adding an AgentKind variant touches
+      # runner/ and apps/web but not apps/api, so without this path the
+      # guard would not run on the one PR shape it exists to catch.
+      - "runner/src/config/schema.rs"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/apps/api/pi_dash/runner/diagnostics.py
+++ b/apps/api/pi_dash/runner/diagnostics.py
@@ -55,7 +55,18 @@ def _iter_text_values(value: Any):
             yield from _iter_text_values(item)
 
 
-def _match_agent_label(value: str) -> str:
+def _match_agent_label(value: str, *, from_model: bool = False) -> str:
+    """Map one text signal to an agent display name, "" when it says nothing.
+
+    ``from_model`` marks the value as a model slug rather than a
+    runner-scoped signal. Agents that drive another vendor's models make a
+    slug weak evidence: Cursor's own catalog ships ``grok-4.3``
+    (see ``runner-models.ts:CURSOR_OPTIONS``), so a Grok slug does not mean
+    the run used the Grok CLI. Naming the wrong vendor actively misdirects
+    an operator to re-authenticate the wrong account, which is worse than
+    falling through to the generic label, so Grok is not inferred from a
+    model. Genuine Grok runners are still matched on name / host label.
+    """
     lowered = value.lower()
     if "claude_code" in lowered or "claude-code" in lowered or "claude code" in lowered or "claude" in lowered:
         return "Claude Code"
@@ -65,7 +76,7 @@ def _match_agent_label(value: str) -> str:
         return "Cursor"
     if "openclaw" in lowered or "open-claw" in lowered or "open_claw" in lowered or "acpx" in lowered:
         return "OpenClaw"
-    if re.search(r"\bgrok\b", lowered):
+    if not from_model and re.search(r"\bgrok\b", lowered):
         return "Grok"
     # "muse" is a common English substring ("museum", "amused" — the latter
     # shows up in generated host names), so the bare form needs a word
@@ -99,7 +110,7 @@ def infer_agent_label(*, runner: Any = None, error: str = "", model: Any = None)
     misattribute the run; it is only consulted as a last resort.
     """
 
-    label = _match_agent_label(str(model or ""))
+    label = _match_agent_label(str(model or ""), from_model=True)
     if label:
         return label
 

--- a/apps/api/pi_dash/runner/diagnostics.py
+++ b/apps/api/pi_dash/runner/diagnostics.py
@@ -65,9 +65,13 @@ def _match_agent_label(value: str) -> str:
         return "Cursor"
     if "openclaw" in lowered or "open-claw" in lowered or "open_claw" in lowered or "acpx" in lowered:
         return "OpenClaw"
-    if "grok" in lowered:
+    if re.search(r"\bgrok\b", lowered):
         return "Grok"
-    if "muse_code" in lowered or "muse-code" in lowered or "muse code" in lowered or "muse" in lowered:
+    # "muse" is a common English substring ("museum", "amused" — the latter
+    # shows up in generated host names), so the bare form needs a word
+    # boundary. The explicit spellings stay substring matches because
+    # "muse_code" has no boundary between "muse" and "_code".
+    if "muse_code" in lowered or "muse-code" in lowered or "muse code" in lowered or re.search(r"\bmuse\b", lowered):
         return "Muse Code"
     return ""
 

--- a/apps/api/pi_dash/runner/diagnostics.py
+++ b/apps/api/pi_dash/runner/diagnostics.py
@@ -63,8 +63,12 @@ def _match_agent_label(value: str) -> str:
         return "Codex"
     if "cursor_agent" in lowered or "cursor-agent" in lowered or "cursor" in lowered:
         return "Cursor"
-    if "openclaw" in lowered or "open-claw" in lowered or "acpx" in lowered:
+    if "openclaw" in lowered or "open-claw" in lowered or "open_claw" in lowered or "acpx" in lowered:
         return "OpenClaw"
+    if "grok" in lowered:
+        return "Grok"
+    if "muse_code" in lowered or "muse-code" in lowered or "muse code" in lowered or "muse" in lowered:
+        return "Muse Code"
     return ""
 
 

--- a/apps/api/pi_dash/runner/views/machine_commands.py
+++ b/apps/api/pi_dash/runner/views/machine_commands.py
@@ -49,8 +49,13 @@ from pi_dash.runner.views.runners import (
 logger = logging.getLogger(__name__)
 
 # Mirrors runner/src/config/schema.rs:AgentKind (kebab-case wire values)
-# and the web modal's AGENT_OPTIONS.
-_VALID_AGENTS = frozenset({"claude-code", "codex", "cursor-agent", "open-claw"})
+# and the web modal's AGENT_OPTIONS. Every agent the modal offers must be
+# listed here or "Add runner" fails with invalid_agent before the command
+# ever reaches the machine — see test_valid_agents_matches_runner_schema,
+# which pins this set to the Rust enum so a new backend can't drift again.
+_VALID_AGENTS = frozenset(
+    {"claude-code", "codex", "cursor-agent", "open-claw", "grok", "muse-code"}
+)
 
 _RESULT_STATUSES = frozenset({"ok", "error"})
 

--- a/apps/api/pi_dash/tests/unit/runner/test_machine_commands.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_machine_commands.py
@@ -12,6 +12,8 @@ machine auth boundary), and the status poll loop the modal runs.
 from __future__ import annotations
 
 import json
+import pathlib
+import re
 
 import pytest
 from django.urls import reverse
@@ -20,6 +22,7 @@ from django.utils import timezone
 from pi_dash.runner.models import DevMachine, MachineSession, MachineToken
 from pi_dash.runner.services import machine_outbox
 from pi_dash.runner.services import tokens
+from pi_dash.runner.views.machine_commands import _VALID_AGENTS
 
 
 class _FakeRedis:
@@ -221,6 +224,39 @@ def test_enqueue_rejects_unknown_agent(
     resp = _enqueue(session_client, dev_machine, workspace, agent="skynet")
     assert resp.status_code == 400
     assert resp.data["error"] == "invalid_agent"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("agent", sorted(_VALID_AGENTS))
+def test_enqueue_accepts_every_supported_agent(
+    db, session_client, workspace, dev_machine, machine_token, live_session, _fake_redis, agent
+):
+    """Each allowlisted agent enqueues and reaches the machine verbatim."""
+    resp = _enqueue(session_client, dev_machine, workspace, agent=agent)
+    assert resp.status_code == 202, resp.data
+    entries = _fake_redis.streams[machine_outbox.stream_key(dev_machine.id)]
+    payload = json.loads(entries[-1][1]["payload"])
+    assert payload["agent"] == agent
+
+
+@pytest.mark.unit
+def test_valid_agents_matches_runner_schema():
+    """The allowlist must track runner/src/config/schema.rs:AgentKind.
+
+    Grok (PDASHOSS01-33) and Muse Code (PDASHOSS01-101) were each added to
+    the Rust enum and the web modal without this set, so selecting them in
+    "Add runner" 400'd with invalid_agent. Pin the two together so the next
+    backend can't drift the same way.
+    """
+    schema = pathlib.Path(__file__).resolve().parents[6] / "runner/src/config/schema.rs"
+    if not schema.is_file():
+        pytest.skip("runner source tree not present in this checkout")
+    body = re.search(r"pub enum AgentKind \{(.*?)\n\}", schema.read_text(), re.S)
+    assert body, "AgentKind enum not found in schema.rs"
+    variants = re.findall(r"^\s{4}([A-Z][A-Za-z0-9]*),", body.group(1), re.M)
+    assert variants, "no AgentKind variants parsed"
+    kebab = {re.sub(r"(?<!^)(?=[A-Z])", "-", v).lower() for v in variants}
+    assert kebab == set(_VALID_AGENTS)
 
 
 @pytest.mark.unit

--- a/apps/api/pi_dash/tests/unit/runner/test_run_diagnostics.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_run_diagnostics.py
@@ -59,6 +59,29 @@ def test_infer_agent_label_prefers_runner_over_error_mention():
 
 
 @pytest.mark.parametrize(
+    ("runner_name", "expected"),
+    [
+        ("workx_codex01", "Codex"),
+        ("workx-claude-code-01", "Claude Code"),
+        ("workx-cursor-agent-01", "Cursor"),
+        ("workx-open-claw-01", "OpenClaw"),
+        ("workx-grok-01", "Grok"),
+        ("workx-muse-code-01", "Muse Code"),
+    ],
+)
+def test_infer_agent_label_covers_every_backend_from_runner_name(runner_name, expected):
+    """Every backend is recognised from the runner name.
+
+    The name is asserted rather than ``capabilities`` because the name is a
+    signal production actually populates — see
+    ``test_capabilities_is_not_yet_populated_in_production`` below.
+    """
+    runner = SimpleNamespace(name=runner_name, host_label="", capabilities=[], dev_machine=None)
+
+    assert infer_agent_label(runner=runner) == expected
+
+
+@pytest.mark.parametrize(
     ("capability", "expected"),
     [
         ("agent:codex", "Codex"),
@@ -69,16 +92,37 @@ def test_infer_agent_label_prefers_runner_over_error_mention():
         ("agent:muse_code", "Muse Code"),
     ],
 )
-def test_infer_agent_label_covers_every_backend(capability, expected):
-    """Grok and Muse Code runs were labelled '' because the map lagged."""
-    runner = SimpleNamespace(
-        name="workx_runner01",
-        host_label="mini-build",
-        capabilities=[capability],
-        dev_machine=None,
-    )
+def test_infer_agent_label_reads_agent_capability_when_present(capability, expected):
+    """Forward-compatible: the matcher handles the serde snake_case spelling.
+
+    ``open_claw`` and ``muse_code`` are the spellings an ``agent:<kind>``
+    capability would carry, and neither was matched before. Note this path
+    is not yet exercised in production — see the test below.
+    """
+    runner = SimpleNamespace(name="", host_label="", capabilities=[capability], dev_machine=None)
 
     assert infer_agent_label(runner=runner) == expected
+
+
+def test_capabilities_is_not_yet_populated_in_production():
+    """``Runner.capabilities`` has no writer, so it cannot identify an agent.
+
+    It is ``default=list`` on the model, listed in the serializer's
+    ``read_only_fields``, never set at enrollment, and never written by
+    ``apply_hello`` — the daemon does not report which ``AgentKind`` it
+    drives. So a Grok or Muse Code runner left on its agent's default model
+    (the modal's default for both) still falls through to the generic
+    label. Fixing that needs a daemon-side change; this test documents the
+    gap so the capability tests above are not mistaken for production
+    coverage.
+    """
+    from pi_dash.runner.serializers import RunnerSerializer
+
+    assert "capabilities" in RunnerSerializer.Meta.read_only_fields
+
+    runner = SimpleNamespace(name="mini-build", host_label="host-01", capabilities=[], dev_machine=None)
+
+    assert infer_agent_label(runner=runner) == ""
 
 
 @pytest.mark.parametrize(

--- a/apps/api/pi_dash/tests/unit/runner/test_run_diagnostics.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_run_diagnostics.py
@@ -81,6 +81,21 @@ def test_infer_agent_label_covers_every_backend(capability, expected):
     assert infer_agent_label(runner=runner) == expected
 
 
+@pytest.mark.parametrize(
+    "host_label",
+    ["museum-pi", "amused-badger", "grokking-notes", "provoked-box"],
+)
+def test_infer_agent_label_ignores_incidental_substrings(host_label):
+    """A host name that merely contains "muse"/"grok" is not that agent.
+
+    Generated host names really do produce words like "amused", so the bare
+    forms match on a word boundary rather than as substrings.
+    """
+    runner = SimpleNamespace(name="", host_label=host_label, capabilities=[], dev_machine=None)
+
+    assert infer_agent_label(runner=runner) == ""
+
+
 def test_classify_agent_model_access_error():
     diagnostic = classify_run_error("Selected model 'claude-fable-5' may not exist or you may not have access to it.")
 

--- a/apps/api/pi_dash/tests/unit/runner/test_run_diagnostics.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_run_diagnostics.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from pi_dash.runner.diagnostics import classify_run_error, enrich_run_error
+from pi_dash.runner.diagnostics import classify_run_error, enrich_run_error, infer_agent_label
 
 
 pytestmark = pytest.mark.unit
@@ -56,6 +56,29 @@ def test_infer_agent_label_prefers_runner_over_error_mention():
     diagnostic = classify_run_error(enriched)
     assert diagnostic is not None
     assert diagnostic["source_label"] == "Codex"
+
+
+@pytest.mark.parametrize(
+    ("capability", "expected"),
+    [
+        ("agent:codex", "Codex"),
+        ("agent:claude_code", "Claude Code"),
+        ("agent:cursor_agent", "Cursor"),
+        ("agent:open_claw", "OpenClaw"),
+        ("agent:grok", "Grok"),
+        ("agent:muse_code", "Muse Code"),
+    ],
+)
+def test_infer_agent_label_covers_every_backend(capability, expected):
+    """Grok and Muse Code runs were labelled '' because the map lagged."""
+    runner = SimpleNamespace(
+        name="workx_runner01",
+        host_label="mini-build",
+        capabilities=[capability],
+        dev_machine=None,
+    )
+
+    assert infer_agent_label(runner=runner) == expected
 
 
 def test_classify_agent_model_access_error():

--- a/packages/i18n/src/locales/en/translations.ts
+++ b/packages/i18n/src/locales/en/translations.ts
@@ -1122,6 +1122,7 @@ export default {
   "Open work item in full screen": "Open work item in full screen",
   "Open workspace switcher": "Open workspace switcher",
   OpenClaw: "OpenClaw",
+  Grok: "Grok",
   "Muse Code": "Muse Code",
   Optional: "Optional",
   Options: "Options",

--- a/runner/src/agent/package.rs
+++ b/runner/src/agent/package.rs
@@ -103,6 +103,7 @@ impl AgentPackage {
             AgentKind::CursorAgent => runner.cursor_agent.binary = executable,
             AgentKind::OpenClaw => runner.openclaw.binary = executable,
             AgentKind::Grok => runner.grok.binary = executable,
+            AgentKind::MuseCode => runner.muse_code.binary = executable,
         }
         runner.agent.kind = self.protocol;
         Ok(())

--- a/runner/src/daemon/machine_control.rs
+++ b/runner/src/daemon/machine_control.rs
@@ -321,6 +321,8 @@ mod tests {
             AgentKind::CursorAgent
         );
         assert_eq!(parse_agent_kind("open-claw").unwrap(), AgentKind::OpenClaw);
+        assert_eq!(parse_agent_kind("grok").unwrap(), AgentKind::Grok);
+        assert_eq!(parse_agent_kind("muse-code").unwrap(), AgentKind::MuseCode);
         assert_eq!(parse_agent_kind("").unwrap(), AgentKind::default());
         assert!(parse_agent_kind("skynet").is_err());
     }

--- a/runner/src/daemon/supervisor.rs
+++ b/runner/src/daemon/supervisor.rs
@@ -467,6 +467,7 @@ fn agent_binary_for(config: &crate::config::schema::RunnerConfig) -> &str {
         crate::config::schema::AgentKind::CursorAgent => &config.cursor_agent.binary,
         crate::config::schema::AgentKind::OpenClaw => &config.openclaw.binary,
         crate::config::schema::AgentKind::Grok => &config.grok.binary,
+        crate::config::schema::AgentKind::MuseCode => &config.muse_code.binary,
     }
 }
 

--- a/runner/tests/pidash_agent_package.rs
+++ b/runner/tests/pidash_agent_package.rs
@@ -74,6 +74,7 @@ fn configures_every_supported_protocol_without_changing_other_runner_fields() {
         ("cursor_agent", AgentKind::CursorAgent),
         ("open_claw", AgentKind::OpenClaw),
         ("grok", AgentKind::Grok),
+        ("muse_code", AgentKind::MuseCode),
     ] {
         let path = manifest(
             root.path(),
@@ -90,6 +91,7 @@ fn configures_every_supported_protocol_without_changing_other_runner_fields() {
             AgentKind::CursorAgent => expected.cursor_agent.binary = binary,
             AgentKind::OpenClaw => expected.openclaw.binary = binary,
             AgentKind::Grok => expected.grok.binary = binary,
+            AgentKind::MuseCode => expected.muse_code.binary = binary,
         }
         package.apply_to_runner(&mut actual).unwrap();
         assert_eq!(


### PR DESCRIPTION
## Why

Creating a runner from the web "Add runner" modal against a connected dev machine failed with `Runner creation failed: invalid_agent` for **Muse Code** — and identically for **Grok**. Nothing to do with whether the agent CLI was installed on the machine: the 400 fires in the cloud before the `create_runner` command is ever enqueued.

While fixing that, `cargo check` revealed the runner crate **does not compile on `main`**.

## What was wrong

### 1. Stale server-side allowlist (the reported bug)

`_VALID_AGENTS` in `apps/api/pi_dash/runner/views/machine_commands.py` still listed only the original four backends. Grok (PDASHOSS01-33) and Muse Code (PDASHOSS01-101) each added their kind to `AgentKind` and to the web modal's `AGENT_OPTIONS`, but not to this set.

The daemon side was always fine — `parse_agent_kind` goes through clap's `ValueEnum`, so it accepts every variant automatically.

### 2. `main` doesn't build

PR #354 (`feat/managed-runner`) branched before Muse Code landed and added two matches on `AgentKind`; PR #349 added the `MuseCode` variant. They merged in that order, git merged both cleanly, and the result is a semantic conflict:

```
error[E0004]: non-exhaustive patterns: `AgentKind::MuseCode` not covered
  runner/src/agent/package.rs:100
  runner/src/daemon/supervisor.rs:464
  runner/tests/pidash_agent_package.rs:87   (--all-targets)
```

Verified on a clean `origin/main` worktree, not just this branch.

Neither PR's CI caught it: `pull-request-test-runner.yml` is `pull_request`-only, each PR was green against its own older base, and **no workflow runs on push to `main`** (`codeql.yml` watches `preview`/`canary`/`master`). Nothing revalidates `main` after a merge — worth fixing separately, either with "Require branches to be up to date before merging" or a push-to-`main` job.

### 3. Same drift, other spellings

- `_match_agent_label` had no Grok or Muse Code branch, so runs on those backends were labelled `""` in failure diagnostics. It also missed `open_claw` — the serde snake_case spelling capabilities actually carry — so **OpenClaw was mislabelled too** (pre-existing, unrelated to the new agents).
- The `en` locale had no `Grok` key for the modal's `t("Grok")`.

## What this changes

- Add `grok` and `muse-code` to `_VALID_AGENTS`, and pin that set to the Rust enum with a test that parses `AgentKind` out of `schema.rs`. Verified it fails when a variant is missing and passes when in sync.
- Add the three missing `AgentKind::MuseCode` arms; cover `muse_code` in the use-package integration test's protocol table.
- Add the Grok / Muse Code / `open_claw` diagnostic labels, with a parametrized test over all six backends.
- Add the `Grok` en key, and extend `parses_kebab_case_agent_kinds` to the two newest wire spellings.

## Testing

- `cargo check --all-targets` and `cargo clippy --all-targets` clean
- 497 Rust tests pass (491 lib + 6 `pidash_agent_package`)
- 419 API runner tests pass

Two failures in `apps/api/pi_dash/tests/unit/runner/test_runs_views.py` (`test_skip_immediate_dispatch_header_suppresses_run_creation_on_state_change`, `test_no_skip_header_creates_run_on_state_change`) are **pre-existing** — confirmed failing identically on a clean `origin/main` checkout — and are left alone here.

## Deploy note

testpidash keeps rejecting Muse Code and Grok until this is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HU5XYDD4cJ6jE4Pi7kEGFJ