### PR TITLE
PDASHOSS01-124 MCP tool servers: include_instructions can never be True in production

### DIFF
--- a/apps/api/pi_dash/assistant/runtime/mcp.py
+++ b/apps/api/pi_dash/assistant/runtime/mcp.py
@@ -185,9 +185,18 @@ def build_toolset(
     """Build one streamable-HTTP MCP toolset.
 
     ``include_instructions`` forwards the server's ``instructions`` to the
-    model. It defaults to False in pydantic-ai; a server that uses
-    instructions to describe a discovery protocol needs it on or the model
-    never learns the protocol exists.
+    model. It is left at its pydantic-ai default of False and stays there:
+    ``build_toolsets`` never overrides it and there is no user-facing setting
+    or per-server column that could, so in production it is always False. That
+    is deliberate. Instructions are free-form text supplied by a third-party
+    server, and the assistant already treats tool *results* as untrusted; a
+    server's instructions would enter the model's context as untrusted content
+    too, so turning them on globally is a prompt-injection surface we do not
+    accept without a per-server opt-in that puts the trust decision with the
+    person who added the server. Until that opt-in exists, servers that rely on
+    instructions to advertise a discovery protocol are unsupported: the model
+    never sees those instructions. The parameter is kept for that future opt-in
+    and for tests. (See PDASHOSS01-124 for the product discussion.)
 
     Uses ``MCPToolset`` rather than the deprecated ``MCPServerStreamableHTTP``
     (removed in pydantic-ai v2); streamable HTTP is its default for http URLs.


### PR DESCRIPTION
## What

`build_toolset` in `apps/api/pi_dash/assistant/runtime/mcp.py` takes an `include_instructions` parameter defaulting to `False`. Its docstring argued the case for turning it on — but the parameter has no path to `True` in production: the only caller, `build_toolsets`, never passes it, and there is no setting or per-server column that could reach it. So the docstring described a capability the product does not have.

## Decision

Per the product decision on PDASHOSS01-124 (comment: *"Leave it off, fix the docstring."*), this is a **docstring-only** change — the cheapest and most honest of the three options discussed on the issue. The two heavier options (flip the default for everyone; add a per-server opt-in column + UI) were explicitly not chosen.

## Change

Rewrite the `include_instructions` paragraph in `build_toolset`'s docstring to state honestly that:
- the flag is always `False` in production,
- instruction-driven discovery servers are therefore unsupported (the model never sees a server's instructions), and
- why it is not simply flipped on: server instructions are untrusted third-party content, so enabling them globally is a prompt-injection surface that warrants a per-server opt-in.

The parameter is retained for that future opt-in and for tests.

**No behavior change.** `include_instructions` still defaults to `False` and no caller flips it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)