### PR TITLE
PDASHOSS01-131 Daemon never reports its AgentKind, so the cloud cannot identify or gate a runners agent

### DIFF
--- a/apps/api/pi_dash/runner/services/session_service.py
+++ b/apps/api/pi_dash/runner/services/session_service.py
@@ -12,6 +12,7 @@ Carved out of ``consumers.py`` per ``.ai_design/move_to_https/tasks.md``
 from __future__ import annotations
 
 import logging
+import re
 from datetime import datetime, timedelta
 from typing import Any, Dict, Optional
 from uuid import UUID
@@ -87,11 +88,37 @@ def _merge_dev_metadata(current: Any, body: Dict[str, Any]) -> Dict[str, Any]:
     return metadata
 
 
+_AGENT_KIND_RE = re.compile(r"^[a-z][a-z0-9_]{0,31}$")
+
+
+def _agent_capabilities(body: Dict[str, Any], current: Any) -> tuple[list, bool]:
+    """Derive the ``capabilities`` list from the Hello's ``agent_kind``.
+
+    The daemon reports the ``AgentKind`` it drives as a snake_case string
+    (``"claude_code"``, ``"muse_code"``); we persist it as an ``agent:<kind>``
+    capability so ``diagnostics.infer_agent_label`` reads an exact signal
+    instead of guessing from the model slug / runner name / host label.
+
+    Returns ``(capabilities, changed)``. An older daemon omits ``agent_kind``
+    entirely — leave any existing value untouched rather than clobbering it with
+    an empty list. The value is validated against a strict charset so a
+    malformed payload can never inject arbitrary text into the field.
+    """
+    raw = body.get("agent_kind")
+    if not isinstance(raw, str) or not _AGENT_KIND_RE.match(raw):
+        return list(current) if isinstance(current, list) else [], False
+    desired = [f"agent:{raw}"]
+    if isinstance(current, list) and current == desired:
+        return desired, False
+    return desired, True
+
+
 def apply_hello(runner: Runner, body: Dict[str, Any]) -> None:
     """Update runner metadata + reap stale busy runs.
 
     ``body`` is the session-open / Hello payload. Persists ``os``,
-    ``arch``, ``version``, known development metadata, and bumps
+    ``arch``, ``version``, the agent kind the daemon drives (as an
+    ``agent:<kind>`` capability), known development metadata, and bumps
     ``last_heartbeat_at``.
     """
     runner.os = body.get("os", "") or runner.os
@@ -99,15 +126,18 @@ def apply_hello(runner: Runner, body: Dict[str, Any]) -> None:
     runner.runner_version = body.get("version", "") or runner.runner_version
     runner.dev_metadata = _merge_dev_metadata(runner.dev_metadata, body)
     runner.last_heartbeat_at = timezone.now()
-    runner.save(
-        update_fields=[
-            "os",
-            "arch",
-            "runner_version",
-            "dev_metadata",
-            "last_heartbeat_at",
-        ]
-    )
+    update_fields = [
+        "os",
+        "arch",
+        "runner_version",
+        "dev_metadata",
+        "last_heartbeat_at",
+    ]
+    capabilities, capabilities_changed = _agent_capabilities(body, runner.capabilities)
+    if capabilities_changed:
+        runner.capabilities = capabilities
+        update_fields.append("capabilities")
+    runner.save(update_fields=update_fields)
     # Session open redelivers ASSIGNED / WAITING_FOR_WORKTREE runs the
     # restarted daemon no longer reports (design §6.3) — reaping them here
     # would fail the very runs ``build_session_open_redeliver`` is about to

--- a/apps/api/pi_dash/tests/unit/managed_runner/test_serializers_and_model.py
+++ b/apps/api/pi_dash/tests/unit/managed_runner/test_serializers_and_model.py
@@ -207,3 +207,35 @@ def test_engine_version_is_length_capped(bundled_runner):
     apply_hello(bundled_runner, {"engine_version": "v" * 500})
     bundled_runner.refresh_from_db()
     assert len(bundled_runner.dev_metadata["codex_version"]) <= 64
+
+
+def test_apply_hello_persists_agent_kind_capability(bundled_runner):
+    """The daemon reports the ``AgentKind`` it drives; we persist it as an
+    ``agent:<kind>`` capability so diagnostics can identify the agent exactly."""
+    from pi_dash.runner.services.session_service import apply_hello
+
+    apply_hello(bundled_runner, {"os": "linux", "agent_kind": "muse_code"})
+    bundled_runner.refresh_from_db()
+    assert bundled_runner.capabilities == ["agent:muse_code"]
+
+
+def test_apply_hello_without_agent_kind_leaves_capabilities_untouched(bundled_runner):
+    """An older daemon omits ``agent_kind`` — a missing field must not clobber a
+    previously-reported capability with an empty list."""
+    from pi_dash.runner.services.session_service import apply_hello
+
+    bundled_runner.capabilities = ["agent:codex"]
+    bundled_runner.save(update_fields=["capabilities"])
+
+    apply_hello(bundled_runner, {"os": "linux", "version": "0.1.21"})
+    bundled_runner.refresh_from_db()
+    assert bundled_runner.capabilities == ["agent:codex"]
+
+
+def test_apply_hello_rejects_malformed_agent_kind(bundled_runner):
+    """A malformed ``agent_kind`` cannot inject arbitrary text into the field."""
+    from pi_dash.runner.services.session_service import apply_hello
+
+    apply_hello(bundled_runner, {"agent_kind": "not a kind; drop table"})
+    bundled_runner.refresh_from_db()
+    assert bundled_runner.capabilities == []

--- a/apps/api/pi_dash/tests/unit/runner/test_run_diagnostics.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_run_diagnostics.py
@@ -72,9 +72,10 @@ def test_infer_agent_label_prefers_runner_over_error_mention():
 def test_infer_agent_label_covers_every_backend_from_runner_name(runner_name, expected):
     """Every backend is recognised from the runner name.
 
-    The name is asserted rather than ``capabilities`` because the name is a
-    signal production actually populates — see
-    ``test_capabilities_is_not_yet_populated_in_production`` below.
+    The name is asserted rather than ``capabilities`` to keep this a
+    name-only signal test; capabilities has its own coverage in
+    ``test_populated_capability_identifies_the_agent_over_neutral_signals``
+    below.
     """
     runner = SimpleNamespace(name=runner_name, host_label="", capabilities=[], dev_machine=None)
 
@@ -104,25 +105,32 @@ def test_infer_agent_label_reads_agent_capability_when_present(capability, expec
     assert infer_agent_label(runner=runner) == expected
 
 
-def test_capabilities_is_not_yet_populated_in_production():
-    """``Runner.capabilities`` has no writer, so it cannot identify an agent.
+def test_populated_capability_identifies_the_agent_over_neutral_signals():
+    """The daemon now reports its ``AgentKind``, so capabilities is a writer.
 
-    It is ``default=list`` on the model, listed in the serializer's
-    ``read_only_fields``, never set at enrollment, and never written by
-    ``apply_hello`` — the daemon does not report which ``AgentKind`` it
-    drives. So a Grok or Muse Code runner left on its agent's default model
-    (the modal's default for both) still falls through to the generic
-    label. Fixing that needs a daemon-side change; this test documents the
-    gap so the capability tests above are not mistaken for production
-    coverage.
+    ``apply_hello`` persists the reported kind as an ``agent:<kind>``
+    capability (see ``session_service._agent_capabilities`` and its
+    ``test_apply_hello_persists_agent_kind_capability`` coverage). It stays
+    listed in the serializer's ``read_only_fields`` — an API *client* still
+    cannot set it; the value is written server-side from the Hello payload.
+
+    This closes the gap the old ``test_capabilities_is_not_yet_populated_in_production``
+    pinned: a Grok / Muse Code runner left on its agent's default model, with a
+    neutral host name and no model slug, previously fell through to the generic
+    label. With the capability populated it is now identified exactly.
     """
     from pi_dash.runner.serializers import RunnerSerializer
 
     assert "capabilities" in RunnerSerializer.Meta.read_only_fields
 
-    runner = SimpleNamespace(name="mini-build", host_label="host-01", capabilities=[], dev_machine=None)
+    runner = SimpleNamespace(
+        name="mini-build",
+        host_label="host-01",
+        capabilities=["agent:muse_code"],
+        dev_machine=None,
+    )
 
-    assert infer_agent_label(runner=runner) == ""
+    assert infer_agent_label(runner=runner) == "Muse Code"
 
 
 @pytest.mark.parametrize(

--- a/apps/api/pi_dash/tests/unit/runner/test_run_diagnostics.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_run_diagnostics.py
@@ -97,8 +97,9 @@ def test_infer_agent_label_reads_agent_capability_when_present(capability, expec
     """Forward-compatible: the matcher handles the serde snake_case spelling.
 
     ``open_claw`` and ``muse_code`` are the spellings an ``agent:<kind>``
-    capability would carry, and neither was matched before. Note this path
-    is not yet exercised in production — see the test below.
+    capability would carry, and neither was matched before. This path is now
+    exercised in production — ``apply_hello`` writes the capability; see
+    ``test_populated_capability_identifies_the_agent_over_neutral_signals``.
     """
     runner = SimpleNamespace(name="", host_label="", capabilities=[capability], dev_machine=None)
 

--- a/runner/src/cloud/http.rs
+++ b/runner/src/cloud/http.rs
@@ -31,6 +31,7 @@ use uuid::Uuid;
 use crate::cloud::protocol::{
     ClientMsg, Envelope, RunnerStatus as WireStatus, ServerMsg, WIRE_VERSION,
 };
+use crate::config::schema::AgentKind;
 
 // ---------------------------------------------------------------------------
 // Errors
@@ -317,6 +318,13 @@ pub struct AttachBody {
     /// persists it on the Runner row and surfaces it in runner detail.
     pub working_dir: String,
     pub agent_versions: HashMap<String, String>,
+    /// The `AgentKind` this runner is configured to drive, so the cloud can
+    /// identify the agent exactly instead of guessing from the model slug /
+    /// runner name / host label (`session_service.apply_hello` persists it as an
+    /// `agent:<kind>` capability). Serialised snake_case (`"claude_code"`,
+    /// `"muse_code"`) — the same spelling the diagnostics matcher expects. A
+    /// cloud that predates this field simply ignores it.
+    pub agent_kind: AgentKind,
 }
 
 // ---------------------------------------------------------------------------
@@ -2498,6 +2506,7 @@ mod tests {
             host_label: "h".into(),
             working_dir: "/tmp/wd".into(),
             agent_versions: std::collections::HashMap::new(),
+            agent_kind: AgentKind::default(),
         }
     }
 
@@ -2536,7 +2545,8 @@ mod tests {
         // Regression: AttachBody must NOT carry any observability fields.
         // The poll path is the single ingestion site for the
         // per-active-run snapshot; session-open stays a thin
-        // identity/resume body.
+        // identity/resume body. `agent_kind` is identity, not observability —
+        // which agent this runner drives, persisted once on session-open.
         let body = sample_attach_body();
         let v = serde_json::to_value(&body).unwrap();
         let keys: std::collections::BTreeSet<_> = v.as_object().unwrap().keys().cloned().collect();
@@ -2550,6 +2560,7 @@ mod tests {
             "host_label",
             "working_dir",
             "agent_versions",
+            "agent_kind",
         ]
         .iter()
         .map(|s| s.to_string())
@@ -2558,6 +2569,18 @@ mod tests {
             keys, expected,
             "AttachBody serialised key set drifted: {keys:?}"
         );
+    }
+
+    #[test]
+    fn attach_body_reports_agent_kind_snake_case() {
+        // Contract with `session_service.apply_hello`, which persists the
+        // value as an `agent:<kind>` capability the diagnostics matcher reads.
+        // The spelling must stay snake_case (`muse_code`, not `musecode` /
+        // `muse-code`) so `infer_agent_label` matches it.
+        let mut body = sample_attach_body();
+        body.agent_kind = AgentKind::MuseCode;
+        let v = serde_json::to_value(&body).unwrap();
+        assert_eq!(v["agent_kind"], serde_json::json!("muse_code"));
     }
 
     #[test]

--- a/runner/src/daemon/supervisor.rs
+++ b/runner/src/daemon/supervisor.rs
@@ -788,6 +788,7 @@ fn attach_body_for_instance(
             .map(|path| path.to_string_lossy().into_owned())
             .unwrap_or_default(),
         agent_versions,
+        agent_kind: inst.config.agent.kind,
     }
 }
 


### PR DESCRIPTION
## Problem

The cloud had no idea which agent CLI a given runner drives. `Runner.capabilities` is the field shaped for it, but nothing ever wrote it — so failure diagnostics (`infer_agent_label`) had to guess the agent from the model slug, the runner name, the host label, and finally the raw error text. That guessing is unreliable in both directions (a Grok/Muse Code runner on its default model with a neutral host name renders the generic auth message; an ambiguous model slug can name the wrong vendor and send an operator to re-authenticate the wrong account).

## Fix (issue Consequence 1)

Have the daemon report, in the session-open (Hello) payload, the `AgentKind` the runner is configured with, and persist it as an exact signal:

- **Runner (Rust):** add `agent_kind` to `AttachBody` (`runner/src/cloud/http.rs`), populated from `inst.config.agent.kind` in `attach_body_for_instance` (`runner/src/daemon/supervisor.rs`). Serde renders it snake_case (`claude_code`, `muse_code`) — the spelling the diagnostics matcher already expects.
- **API (Python):** `apply_hello` (`session_service.py`) persists it as an `agent:<kind>` capability, which `infer_agent_label` already reads. An older daemon that omits the field leaves any existing capability untouched (no clobber); a malformed value is rejected by a strict charset check.
- Updated the pinned `test_capabilities_is_not_yet_populated_in_production` (the gap is now closed) and added `apply_hello` coverage for the populate / no-clobber / reject-malformed paths, plus a Rust test locking the snake_case wire spelling.

## Deferred (issue Consequence 2)

Gating the "Add runner" modal on the kinds a daemon supports (with an "upgrade this runner" hint instead of a raw parse error) is a larger, mostly-frontend change on a *different* transport — the dev-machine machine-control path, not the runner Hello — plus cloud persistence and web UI work. Recommend tracking it as a separate follow-up issue; flagged on the Pi Dash issue for triage.

## Testing

- `cargo build` + `cargo test` (runner): AttachBody key-set + snake_case spelling tests pass; the one unrelated `workspace::git::tests` failure is pre-existing on `main`.
- `pytest` (api): `test_run_diagnostics.py` (25) and `test_serializers_and_model.py` (16) pass, plus session-open view tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)