### PR TITLE
PDASHOSS01-132 No CI runs on push to main — two green PRs can merge into a main that does not build

### DIFF
--- a/.github/workflows/pull-request-build-lint-api.yml
+++ b/.github/workflows/pull-request-build-lint-api.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   pull_request:
     branches:
+      - "main"
       - "preview"
     types:
       - "opened"

--- a/.github/workflows/pull-request-test-api.yml
+++ b/.github/workflows/pull-request-test-api.yml
@@ -18,6 +18,16 @@ on:
       # runner/ and apps/web but not apps/api, so without this path the
       # guard would not run on the one PR shape it exists to catch.
       - "runner/src/config/schema.rs"
+  # Post-merge validation: PR checks don't re-run when the base branch moves,
+  # so a main built from two independently-green PRs may still be broken.
+  # Run pytest again on push to main to surface it immediately.
+  push:
+    branches:
+      - "main"
+    paths:
+      - "apps/api/**"
+      - ".github/workflows/pull-request-test-api.yml"
+      - "runner/src/config/schema.rs"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/pull-request-test-runner.yml
+++ b/.github/workflows/pull-request-test-runner.yml
@@ -15,6 +15,19 @@ on:
       - "Cargo.lock"
       - "runner/**"
       - ".github/workflows/pull-request-test-runner.yml"
+  # Post-merge validation: GitHub re-runs PR checks on synchronize, not when
+  # the base moves, so two PRs green against an older main can merge into a
+  # main that does not build. Run again on push to main to report that
+  # immediately. The merge commit carries the merged PR's files, so these
+  # path filters still fire for the change that broke main.
+  push:
+    branches:
+      - "main"
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "runner/**"
+      - ".github/workflows/pull-request-test-runner.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/pull-request-test-web-apps.yml
+++ b/.github/workflows/pull-request-test-web-apps.yml
@@ -20,6 +20,23 @@ on:
       - "pnpm-workspace.yaml"
       - "turbo.json"
       - ".github/workflows/pull-request-test-web-apps.yml"
+  # Post-merge validation: PR checks don't re-run when the base branch moves,
+  # so a green PR can still merge into a broken main. Run again on push to
+  # main to report it immediately. On push there is no PR base SHA, so the
+  # test step below runs the full suite instead of --affected.
+  push:
+    branches:
+      - "main"
+    paths:
+      - "apps/web/**"
+      - "apps/admin/**"
+      - "apps/space/**"
+      - "apps/live/**"
+      - "packages/**"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "turbo.json"
+      - ".github/workflows/pull-request-test-web-apps.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -77,7 +94,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run tests
-        run: pnpm turbo run test --affected
+        # On a pull_request, scope to affected packages (base SHA available).
+        # On push to main there is no PR base SHA, so run the full suite as a
+        # complete post-merge validation of main.
+        run: pnpm turbo run test ${{ github.event_name == 'pull_request' && '--affected' || '' }}
 
       - name: Save Turbo cache
         uses: actions/cache/save@v5


### PR DESCRIPTION
## Problem

Nothing validated `main` after a merge. Every test workflow was `pull_request`-only, and the only `push:` triggers watched the wrong branches — `codeql.yml` on `preview`/`canary`/`master`, `release.yml` on tags. GitHub re-runs PR checks on `synchronize` (new commits), **not** when the base branch moves, so two PRs each green against their own older base can merge into a `main` that does not build.

This already happened on 2026-09-08: the runner crate failed to compile on `main` after #354 and #349 merged cleanly but produced a non-exhaustive `AgentKind` match. Fixed in #362, but the gap that let it through stayed open.

Separately, `pull-request-build-lint-api.yml` triggered only on PRs into `preview`, so ruff never gated any PR into `main`.

## Change

- Add a `push:` trigger on `main` to the three test workflows — `pull-request-test-runner.yml`, `pull-request-test-api.yml`, `pull-request-test-web-apps.yml` — mirroring each one's existing `pull_request` path filters. A merge to `main` carries the merged PR's changed files, so the relevant filtered workflow still fires on the commit that broke `main` (e.g. the runner incident: #349's `runner/**` files ⇒ runner test runs on the push to main). A broken `main` is now reported immediately after merge.
- The web test step runs the **full** suite on push to `main` (there is no PR base SHA for `--affected` on a `push` event) and stays scoped to affected packages on `pull_request`.
- Add `main` to `pull-request-build-lint-api.yml`'s PR branch list so ruff gates PRs into `main`, not just `preview`.

## Not in this PR (needs a human)

- **"Require branches to be up to date before merging"** on `main` — this is a branch-protection repo setting, not a repo file, so it can't ship in a PR. It's the direct fix for the semantic-merge-conflict class (at the cost of more rebases before landing). The `push:` triggers here report a broken `main` but don't *prevent* it; enabling that setting closes the prevention gap.
- **Auditing other path-filtered guards** for the same cross-cutting problem #362 hit (a check living in one tree that guards another) is worth a follow-up pass.

## Validation

- All four edited workflows parse as valid YAML.
- Trigger changes reviewed in isolation via `git diff`; no job logic changed except the web test step's conditional `--affected`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
