### PR TITLE
PDASHOSS01-136 Runner: remove residual platform git enforcement, keep git as prompt context

### DIFF
--- a/apps/api/pi_dash/prompting/sections/implementation.md
+++ b/apps/api/pi_dash/prompting/sections/implementation.md
@@ -6,6 +6,9 @@ customizable: overridable
 
 ## Step 2 — Implementation and validation
 
+Before editing any files, make sure you are on the work branch — the platform performs **no** branch checkout for you; every git operation is yours to run.
+{% if repo.work_branch %}This issue pins `{{ repo.work_branch }}`: commit directly onto it. You checked it out in Step 1's repository sync; if you are not on it, `git checkout {{ repo.work_branch }}` (creating it from `origin/{{ repo.work_branch }}` when it is not yet local).{% else %}No branch is pinned: derive and commit onto the fresh feature branch you created from {% if repo.base_branch %}`{{ repo.base_branch }}`{% else %}the base branch{% endif %} in Step 1 — never onto the base branch itself.{% endif %}
+
 1. Implement against the hierarchical TODOs. Update the workpad after each meaningful milestone and keep `### Phase`, `### Progress Checkpoints`, and `### Autonomy / Escalation` current:
    - `investigation_complete`
    - `design_choice_recorded`

--- a/runner/src/cloud/protocol.rs
+++ b/runner/src/cloud/protocol.rs
@@ -278,9 +278,11 @@ pub enum ServerMsg {
         prompt: String,
         repo_url: Option<String>,
         repo_ref: Option<String>,
-        /// Existing branch the agent must check out and commit onto. When
-        /// `None`, the runner creates a fresh feature branch off `repo_ref`
-        /// (or the remote default if `repo_ref` is also `None`).
+        /// Existing branch for this issue, forwarded to the agent via the
+        /// prompt context. The agent checks it out itself; when `None`, the
+        /// agent creates a fresh feature branch off the base branch. The
+        /// runner no longer acts on this field — it performs no branch
+        /// checkout of its own (PDASHOSS01-136).
         #[serde(default)]
         git_work_branch: Option<String>,
         expected_codex_model: Option<String>,

--- a/runner/src/config/schema.rs
+++ b/runner/src/config/schema.rs
@@ -178,24 +178,6 @@ pub struct WorkspaceSection {
     pub working_dir: PathBuf,
 }
 
-/// How a working directory is scrubbed between runs. Retained for
-/// `workspace::git::reset_clean`, whose removal is scoped to PDASHOSS01-136
-/// ("remove residual platform git enforcement").
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq, clap::ValueEnum)]
-#[serde(rename_all = "kebab-case")]
-pub enum CleanMode {
-    /// `git reset --hard` + `git clean -fd`: drop tracked changes and stray
-    /// untracked files, but KEEP gitignored files (`node_modules`, caches,
-    /// `.env`). Default.
-    #[default]
-    KeepIgnored,
-    /// Like `full`, but preserve `keep_paths` globs. Warm where it matters,
-    /// pristine everywhere else.
-    Allowlist,
-    /// `git reset --hard` + `git clean -fdx`: pristine but cold.
-    Full,
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CodexSection {
     pub binary: String,

--- a/runner/src/daemon/supervisor.rs
+++ b/runner/src/daemon/supervisor.rs
@@ -1049,7 +1049,6 @@ impl RunnerLoop {
                     run_id,
                     prompt,
                     repo_url,
-                    git_work_branch,
                     expected_codex_model,
                     ..
                 } => {
@@ -1143,13 +1142,7 @@ impl RunnerLoop {
                             cancel,
                         };
                         if let Err(e) = worker
-                            .run(
-                                run_id,
-                                prompt,
-                                repo_url,
-                                git_work_branch,
-                                expected_codex_model,
-                            )
+                            .run(run_id, prompt, repo_url, expected_codex_model)
                             .await
                         {
                             tracing::error!("run {run_id} failed: {e:#}");
@@ -2662,17 +2655,10 @@ impl AssignWorker {
         run_id: uuid::Uuid,
         prompt: String,
         repo_url: Option<String>,
-        git_work_branch: Option<String>,
         expected_codex_model: Option<String>,
     ) -> Result<()> {
-        self.handle_assign(
-            run_id,
-            prompt,
-            repo_url,
-            git_work_branch,
-            expected_codex_model,
-        )
-        .await
+        self.handle_assign(run_id, prompt, repo_url, expected_codex_model)
+            .await
     }
 
     async fn handle_assign(
@@ -2680,7 +2666,6 @@ impl AssignWorker {
         run_id: uuid::Uuid,
         prompt: String,
         repo_url: Option<String>,
-        git_work_branch: Option<String>,
         expected_codex_model: Option<String>,
     ) -> Result<()> {
         // Resolve the directory the agent runs in: this runner's single,
@@ -2733,28 +2718,10 @@ impl AssignWorker {
             );
         }
 
-        // Pre-flight checkout: if the issue pins an existing branch, land on
-        // it before the agent runs so it commits onto that branch directly.
-        // When not set, the agent handles branch creation per the prompt.
-        // (Removing this platform-side checkout is scoped to PDASHOSS01-136.)
-        if crate::workspace::git::is_git_repo(&workspace_path)
-            && let Some(branch) = git_work_branch.as_deref().filter(|s| !s.is_empty())
-            && let Err(e) =
-                crate::workspace::git::checkout_work_branch(&workspace_path, branch).await
-        {
-            self.send(ClientMsg::RunFailed {
-                run_id,
-                reason: FailureReason::WorkspaceSetup,
-                detail: Some(format!("checkout {branch}: {e:#}")),
-                ended_at: Utc::now(),
-                tokens: None,
-                model: None,
-            })
-            .await;
-            // Same reason as above: clear the early-stamp on failure.
-            self.state.set_current_run(None).await;
-            return Ok(());
-        }
+        // No platform-side branch checkout: the cloud supplies the work branch
+        // in the prompt context and the agent checks it out (or creates one off
+        // the base branch) itself. The platform supplies git information; the
+        // agent performs git operations (PDASHOSS01-136).
 
         let ws_state = crate::workspace::git::workspace_state(&workspace_path)
             .await
@@ -3489,7 +3456,6 @@ mod tests {
                     uuid::Uuid::new_v4(),
                     "Summarize these notes".into(),
                     None,
-                    Some("irrelevant-without-git".into()),
                     None,
                 )
                 .await

--- a/runner/src/workspace/git.rs
+++ b/runner/src/workspace/git.rs
@@ -2,7 +2,6 @@ use anyhow::{Context, Result};
 use std::path::Path;
 use std::process::Stdio;
 use tokio::process::Command;
-use uuid::Uuid;
 
 use crate::cloud::protocol::WorkspaceState;
 
@@ -45,6 +44,8 @@ pub fn is_empty_dir(path: &Path) -> bool {
     }
 }
 
+/// Read-only snapshot of the working directory reported to the cloud on
+/// `Accept`. Runs no mutation — only `rev-parse` and `status --porcelain`.
 pub async fn workspace_state(path: &Path) -> Result<WorkspaceState> {
     let branch = git_output(path, &["rev-parse", "--abbrev-ref", "HEAD"])
         .await
@@ -57,167 +58,6 @@ pub async fn workspace_state(path: &Path) -> Result<WorkspaceState> {
         head,
         dirty,
     })
-}
-
-/// Fetch from origin and check out the given branch so the agent can commit
-/// directly onto an existing feature branch. Called before the agent process
-/// spawns when an issue specifies `git_work_branch`.
-///
-/// Resets the local branch to `origin/<branch>` unless the local ref is
-/// strictly ahead of origin (e.g. a WIP commit whose push failed) —
-/// resetting then would silently destroy the only copy of that work.
-///
-/// (Removing this platform-side checkout is scoped to PDASHOSS01-136.)
-pub async fn checkout_work_branch(path: &Path, branch: &str) -> Result<()> {
-    validate_branch_name(branch)?;
-
-    git_output(path, &["fetch", "origin", branch])
-        .await
-        .with_context(|| format!("git fetch origin {branch}"))?;
-    let remote_ref = format!("origin/{branch}");
-    // Preserve a local branch that is strictly ahead of origin (salvage
-    // commits whose push failed live there). `merge-base --is-ancestor`
-    // exits 0 when origin/<branch> is an ancestor of the local ref.
-    let local_exists = git_output(path, &["rev-parse", "--verify", "--quiet", &format!("refs/heads/{branch}")])
-        .await
-        .is_ok();
-    if local_exists
-        && git_output(path, &["merge-base", "--is-ancestor", remote_ref.as_str(), branch]).await.is_ok()
-    {
-        git_output(path, &["checkout", branch])
-            .await
-            .with_context(|| format!("git checkout {branch}"))?;
-        return Ok(());
-    }
-    if local_exists {
-        // Diverged local ref: about to be reset to origin. The old tip stays
-        // reachable via the reflog; record it so operators can recover.
-        if let Ok(old) = git_output(path, &["rev-parse", branch]).await {
-            tracing::warn!(%branch, old_tip = %old, "local branch diverged from origin; resetting (old tip kept in reflog)");
-        }
-    }
-    // `git checkout -B <branch> <start_point>` always lands us on a local
-    // branch that points at `origin/<branch>`, creating it if necessary.
-    git_output(path, &["checkout", "-B", branch, remote_ref.as_str()])
-        .await
-        .with_context(|| format!("git checkout {branch}"))?;
-    Ok(())
-}
-
-/// The branch HEAD is on, or `None` when detached.
-pub async fn current_branch(worktree: &Path) -> Result<Option<String>> {
-    let name = git_output(worktree, &["rev-parse", "--abbrev-ref", "HEAD"]).await?;
-    if name == "HEAD" { Ok(None) } else { Ok(Some(name)) }
-}
-
-/// Scrub a working directory between runs, per `mode`:
-/// - `KeepIgnored`: `reset --hard` + `clean -fd` (keep gitignored files).
-/// - `Allowlist`: like `Full` but `--exclude`s each `keep_paths` glob.
-/// - `Full`: `reset --hard` + `clean -fdx` (pristine).
-pub async fn reset_clean(
-    worktree: &Path,
-    mode: crate::config::schema::CleanMode,
-    keep_paths: &[String],
-) -> Result<()> {
-    use crate::config::schema::CleanMode;
-    git_output(worktree, &["reset", "--hard"])
-        .await
-        .context("git reset --hard")?;
-    match mode {
-        CleanMode::KeepIgnored => {
-            git_output(worktree, &["clean", "-fd"])
-                .await
-                .context("git clean -fd")?;
-        }
-        CleanMode::Full => {
-            git_output(worktree, &["clean", "-fdx"])
-                .await
-                .context("git clean -fdx")?;
-        }
-        CleanMode::Allowlist => {
-            // Build `clean -fdx -e <glob> -e <glob> …`. Reject globs that look
-            // like flags so a malicious config can't smuggle one past `git`.
-            let mut args: Vec<String> =
-                vec!["clean".into(), "-fdx".into()];
-            for g in keep_paths {
-                if g.starts_with('-') || g.contains(['\n', '\0']) {
-                    anyhow::bail!("invalid keep_paths glob: {g:?}");
-                }
-                args.push("-e".into());
-                args.push(g.clone());
-            }
-            let argref: Vec<&str> = args.iter().map(String::as_str).collect();
-            git_output(worktree, &argref)
-                .await
-                .context("git clean -fdx (allowlist)")?;
-        }
-    }
-    Ok(())
-}
-
-/// Best-effort salvage of a dirty working directory. Commits everything as a
-/// WIP commit and tries to push it.
-///
-/// The commit lands on whatever branch HEAD is actually on — the truthful
-/// location of the work, even if the agent switched branches mid-run. When
-/// HEAD is detached (so a plain commit would be orphaned), the WIP is parked on
-/// a dedicated `pidash/salvage/<holder>` branch instead; no existing branch ref
-/// is ever moved. The commit is left on the local branch even if the push
-/// fails. Returns `Ok(Some(sha))` if a WIP commit was made, `Ok(None)` if the
-/// tree was clean (nothing to salvage).
-///
-/// (Removing this platform-side salvage is scoped to PDASHOSS01-136.)
-pub async fn salvage_wip(worktree: &Path, holder: Uuid, label: &str) -> Result<Option<String>> {
-    // Nothing to do if the tree is clean.
-    let status = git_output(worktree, &["status", "--porcelain"]).await?;
-    if status.trim().is_empty() {
-        return Ok(None);
-    }
-    let target = match current_branch(worktree).await? {
-        Some(b) => b,
-        None => {
-            // Detached HEAD: park the WIP on a fresh salvage branch. Never
-            // `checkout -B` an existing branch here — that would move a ref
-            // that may point at someone else's work.
-            let name = format!("pidash/salvage/{holder}");
-            git_output(worktree, &["checkout", "-b", &name])
-                .await
-                .with_context(|| format!("git checkout -b {name} (salvage)"))?;
-            name
-        }
-    };
-    git_output(worktree, &["add", "-A"])
-        .await
-        .context("git add -A (salvage)")?;
-    let msg = format!("wip(pidash): salvaged working state from {label}");
-    // `--no-verify` so a repo's commit hooks can't block salvage; `-q` quiets.
-    git_output(worktree, &["commit", "-q", "--no-verify", "-m", &msg])
-        .await
-        .context("git commit (salvage)")?;
-    let sha = git_output(worktree, &["rev-parse", "HEAD"]).await.ok();
-    // Push is best-effort: salvage's value is the local commit; the push is a
-    // convenience. A push failure (auth/network) must not block desk recycle.
-    // Push `HEAD:` explicitly so the remote ref updated is the branch the
-    // commit actually sits on, not a stale local ref of the same name.
-    let refspec = format!("HEAD:refs/heads/{target}");
-    if let Err(e) = git_output(worktree, &["push", "origin", &refspec]).await {
-        tracing::warn!(branch = %target, error = %e, "salvage push failed; WIP commit kept locally");
-    }
-    Ok(sha)
-}
-
-/// Injection-level validation: reject names that could be mistaken for a git
-/// flag or contain characters that don't belong in a branch name. Does not
-/// enforce the full `git check-ref-format` rules — git itself catches those
-/// when the command runs and surfaces the error via `WorkspaceSetup`.
-fn validate_branch_name(branch: &str) -> Result<()> {
-    if branch.is_empty()
-        || branch.starts_with('-')
-        || branch.chars().any(|c| c.is_control() || c == ' ')
-    {
-        anyhow::bail!("invalid work branch name: {branch:?}");
-    }
-    Ok(())
 }
 
 async fn git_output(path: &Path, args: &[&str]) -> Result<String> {
@@ -234,38 +74,4 @@ async fn git_output(path: &Path, args: &[&str]) -> Result<String> {
         );
     }
     Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn rejects_empty() {
-        assert!(validate_branch_name("").is_err());
-    }
-
-    #[test]
-    fn rejects_leading_dash() {
-        // `-rf`, `--upload-pack=...` could otherwise smuggle a flag past `git`.
-        assert!(validate_branch_name("-rf").is_err());
-        assert!(validate_branch_name("--upload-pack=evil").is_err());
-    }
-
-    #[test]
-    fn rejects_whitespace_and_control_chars() {
-        assert!(validate_branch_name(" ").is_err());
-        assert!(validate_branch_name("feat/with space").is_err());
-        assert!(validate_branch_name("feat\tname").is_err());
-        assert!(validate_branch_name("feat\nname").is_err());
-        assert!(validate_branch_name("feat\0name").is_err());
-    }
-
-    #[test]
-    fn accepts_normal_branch_names() {
-        assert!(validate_branch_name("main").is_ok());
-        assert!(validate_branch_name("feat/pinned-branch").is_ok());
-        assert!(validate_branch_name("release/1.2.3").is_ok());
-        assert!(validate_branch_name("user/jdoe/fix_42").is_ok());
-    }
 }


### PR DESCRIPTION
## What

Removes the residual platform-side git mutations that survived the worktree-pool deletion (PDASHOSS01-134/135). The platform now only *supplies* git information (the work branch, via prompt context); the agent *performs* all git operations.

Issue: PDASHOSS01-136 (sub-issue of PDASHOSS01-134).

> **Base branch:** targets `pi-dash/pdashoss01-135`, not `main`. This work depends on the pool deletion (134/135) — the deleted helpers still have pool callers on `main`, so the change only builds on top of the 135 stack. Review/merge after 134/135 land.

## Changes

- **`runner/src/daemon/supervisor.rs`** — Remove the pre-flight `checkout_work_branch`. If an issue pinned `git_work_branch`, the runner used to check it out before the agent spawned; now the cloud forwards the branch in prompt context and the agent checks it out itself (its own comment already said "When not set, the agent handles branch creation per the prompt" — that is now the only path). `git_work_branch` is threaded out of `run`/`handle_assign`; the `ServerMsg::Assign` protocol field stays (the cloud still sends it, and an `http.rs` test reads it).
- **`runner/src/workspace/git.rs`** — Delete the state-mutating helpers left unused once the pool was gone: `checkout_work_branch`, `reset_clean`, `salvage_wip`, plus their now-orphaned support (`current_branch`, `validate_branch_name` + its tests). The remaining surface is `clone` (the only mutation), `is_git_repo`, `is_empty_dir`, and the read-only `workspace_state`. (The other helpers the design named — `detach_head`, `start_chat_session`, `commit_and_push_all`, `checked_out_branches`, `worktree_*`, `default_branch` — were already removed by 134/135.)
- **`runner/src/config/schema.rs`** — Delete `CleanMode`, orphaned once `reset_clean` is gone (its own doc comment scoped its removal to this issue).
- **`runner/src/cloud/protocol.rs`** — Update the now-stale `git_work_branch` doc comment on `ServerMsg::Assign` to reflect that the runner no longer acts on it.
- **`apps/api/pi_dash/prompting/sections/implementation.md`** — Reinforce agent-driven branch handling at the top of the implementation step. (The mechanical checkout/creation is already covered by the `workpad-setup` section: check out `repo.work_branch` when set, else derive a fresh branch from the base branch — this closes the gap left by removing the pre-flight checkout.)

## Acceptance criteria

- ✅ `workspace/git.rs` contains no state-mutating git op other than the initial `clone` (verified: only `clone`, plus read-only `rev-parse`/`status --porcelain`).
- ✅ A run with `git_work_branch` set lands commits on that branch — now agent-driven (prompt: `workpad-setup.md` checks it out; `intro.md` reinforces).
- ✅ A run with no pinned branch creates one from the base branch and pushes it (prompt: `workpad-setup.md`).
- ✅ No salvage commits produced anywhere (`salvage_wip` deleted; nothing else commits). An aborted run leaves its work uncommitted in the runner's directory.

## Testing

- `cargo build` (runner) — clean.
- `cargo clippy --all-targets --locked -- -D warnings` (runner) — clean.
- `cargo test --lib` (runner) — 458 passed, incl. `repo_free_assignment_reaches_agent_spawn_and_skips_branch_checkout` and the `Assign` redeliver decode.
- API prompting tests (run in `pi-dash-api-1`) — 106 unit + 30 contract passed; the `implementation.md` Jinja renders cleanly for pinned / unpinned / no-base contexts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
