### PR TITLE
PDASHOSS01-139 State transitions: 15s debounce before dispatch, and supersede the in-flight run on a phase change

### DIFF
--- a/.ai_design/state_transition_debounce/design.md
+++ b/.ai_design/state_transition_debounce/design.md
@@ -1,0 +1,187 @@
+# State-transition Debounce + Phase-change Supersede
+
+> Directory: `.ai_design/state_transition_debounce/`
+>
+> **Status:** implemented (PDASHOSS01-139).
+>
+> **Scope:** two changes to how an Issue state change drives an agent run.
+>
+> 1. **15s debounce** — a transition that targets a _ticking_ state no
+>    longer dispatches inline. It records the intent and fires after a 15s
+>    quiet period; a further transition inside the window replaces the
+>    intent and restarts the clock, so a rapid `Todo → In Progress → In
+Review` mis-drop coalesces into a single dispatch on the final state.
+> 2. **Phase-change supersede** — a phase change _after_ a run is already
+>    in flight cancels that run and hands off to the new phase's run once
+>    the old run terminates, mirroring the existing cross-project move
+>    handoff.
+
+Related designs: `.ai_design/issue_ticking_system/` (the per-issue
+ticker), `.ai_design/create_review_state/` (phase registry, fresh-session
+entry, terminal-signal disarm).
+
+## 1. Problem
+
+`orchestration/signals.py` fires `post_save(Issue)` →
+`orchestration/service.handle_issue_state_transition`, which armed the
+ticker and dispatched a run **synchronously, in the same request**. Two
+failures followed, both visible on `Todo → In Progress → In Review`:
+
+1. **No settling window.** Dragging a card to In Progress started a coding
+   run instantly. A correction to In Review seconds later could not stop
+   the already-queued coding run.
+2. **The second transition was swallowed.** On `In Progress → In Review`
+   the ticker was re-armed on the review cadence and `resume_parent_run`
+   was set, but the inline dispatch hit the single-active-run guardrail
+   (`service.py`) and the DB constraint `agent_run_one_active_per_work_item`
+   — so **no review run was created**. The impl run kept running on the
+   coding prompt while the card read In Review, and when it terminated its
+   done-payload disarmed the freshly review-armed ticker
+   (`maybe_disarm_on_terminal_signal`), parking the issue with no agent
+   scheduled at all.
+
+## 2. Design
+
+### 2.1 Where the debounce lives
+
+The debounce is layered in the **signal**, not in
+`handle_issue_state_transition`. That function stays the synchronous
+dispatcher used directly by tests, by the debounce job, by Comment & Run
+(`dispatch_immediate=False`), and by the project-move handoff. The signal's
+`dispatch_immediate=True` path now routes through
+`service.route_state_transition`.
+
+`route_state_transition` decides:
+
+| condition                                                    | action                                                                                                       |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| `from_state is None` (issue just created / prior state gone) | dispatch inline (no transition to settle)                                                                    |
+| active run + cross-phase ticking change                      | **supersede** (Part 2)                                                                                       |
+| active run, otherwise                                        | inline `handle_issue_state_transition` (a debounce would only no-op on active-run; arm/disarm still resolve) |
+| target non-ticking, no active run                            | clear pending + inline disarm (settling-window cancel; bounce-to-Backlog)                                    |
+| target ticking, no active run                                | **debounce** (Part 1)                                                                                        |
+
+Issue **creation** into a ticking state is _not_ debounced (`from_state is
+None`): there is no mis-drop to correct and many call sites rely on
+immediate arming.
+
+### 2.2 Part 1 — the debounce
+
+New side table `IssuePendingDispatch` (one row per issue):
+
+```python
+token       BigIntegerField   # monotonic; bumped on every transition
+dispatch_at DateTimeField      # when the armed job should fire (advisory)
+from_state  FK(State, null)    # source of the latest transition
+to_state    FK(State, null)    # target of the latest transition (advisory)
+```
+
+- **Schedule** (`_schedule_pending_dispatch`): bump `token`, set
+  `dispatch_at = now + DEBOUNCE_SECONDS`, record `from_state` / `to_state`,
+  and `transaction.on_commit` enqueue
+  `bgtasks.state_transition_debounce.dispatch_debounced_transition(issue_id,
+token)` with `countdown=DEBOUNCE_SECONDS`.
+- **Cancel** (`_clear_pending_dispatch`): bump `token`, clear `dispatch_at`.
+  Any already-scheduled job now carries a stale token.
+- **Fire** (`run_debounced_dispatch`): re-read issue + pending row under a
+  row lock; no-op on `issue-gone` (deletion / cross-project move bumped the
+  token) or `stale-token`; else consume the row (bump token, clear
+  `dispatch_at`) and call `handle_issue_state_transition(from_state=<stored>,
+to_state=<current issue state>)`. The stored `from_state` preserves the
+  cross-phase session-shape decision; the current state is authoritative.
+
+`DEBOUNCE_SECONDS = 15`, a module constant in `orchestration.service`. A
+project-level override is a possible future refinement; it is deliberately
+out of scope here.
+
+Because the whole transition body runs at fire time against the final
+state, ticker arm/disarm resolve once, on the settled state — intermediate
+arms never churn `tick_count` / `next_run_at`.
+
+### 2.3 Part 2 — phase-change supersede
+
+Mirrors the cross-project move handoff exactly (`utils/issue_move.py` +
+`service._create_project_move_handoff_run` /
+`complete_project_move_handoff`). New config key
+`PHASE_CHANGE_HANDOFF_CONFIG_KEY = "_phase_change_handoff"`.
+
+`supersede_active_run` (called from `route_state_transition` when an active
+run exists and the transition crosses to a different ticking phase):
+
+1. Disarm the old phase's ticker, arm the new phase's ticker (cadence
+   resolves against the target state), capture `resume_parent_run` on the
+   `started → review/test` forward transition.
+2. Stash the marker on the run: `target_state_id`, `target_group`,
+   `fresh_session`, `parent_run_id` (the successor's session shape —
+   `fresh_session` for In Review / In Test, resume-parent for the review →
+   In Progress hand-back).
+3. **Inert** run (QUEUED / PAUSED, no runner): cancel and create the
+   successor in the same transaction. **Executing** run: set
+   `CANCEL_REQUESTED`, send a `cancel` frame after commit
+   (`reason=issue_phase_changed`); the successor is created by
+   `complete_phase_change_handoff` once the runner acknowledges and the run
+   goes terminal.
+
+`complete_phase_change_handoff` (called from the terminal callback) locks
+issue → run, is idempotent via `replacement_run_id`, suppresses itself if
+the issue moved phase again, and reuses `_create_and_dispatch_run` so the
+successor renders the target phase's template with the resolved session
+shape.
+
+### 2.4 Suppressing the terminal-signal disarm
+
+`agent_run_finalization.apply_terminal_effects` already skipped
+`_apply_post_run_orchestration` (and the failure comment) when
+`_has_project_move_handoff(run)`. That guard is extended to
+`_has_phase_change_handoff(run)`; `pending_handoff` now carries the kind
+(`"project_move"` / `"phase_change"`) and routes to the matching completer.
+This keeps the cancelled old run's `completed` / `blocked` done-payload from
+disarming the newly-armed phase ticker. The reap
+(`session_service`) and runner-revoke (`runner/models`) recovery paths call
+both completers (each is idempotent).
+
+## 3. Invariants preserved
+
+- **Single-active-run** and `agent_run_one_active_per_work_item`: the
+  successor is only created after the old run reaches a terminal status
+  (inert runs are cancelled first, in the same transaction), so the slot is
+  never double-occupied.
+- **`X-Pi-Dash-Skip-Immediate-Dispatch: 1`** (Comment & Run): still routes
+  `dispatch_immediate=False` → `handle_issue_state_transition`, never
+  debounced.
+- **Bounce to Backlog** on no-eligible-runner: Backlog is non-ticking, so
+  `route_state_transition` clears any pending dispatch and disarms — it
+  cannot re-enter the debounce and loop.
+- **Deletion / cross-project move inside the window**: the delayed job
+  no-ops (`issue-gone` / `stale-token`).
+
+## 4. Open question (deferred to a human decision)
+
+What should happen when the new state is **non-ticking** (Paused / Done /
+Backlog / Cancelled) and a run is in flight? Options: (a) leave the run
+running — today's behavior; (b) cancel on any exit from the spawning phase;
+(c) cancel only on Paused / Cancelled. The rest of Part 2 does not depend on
+this. **Implemented as (a)** for now (the run continues, the ticker
+disarms, no handoff marker) and flagged for a product decision; switching to
+(b) or (c) is a localized change in the "target non-ticking, active run"
+branch of `route_state_transition`.
+
+## 5. Touchpoints
+
+- `db/models/issue_pending_dispatch.py` + migration `0163` — the side table.
+- `orchestration/service.py` — `route_state_transition`,
+  `_schedule_pending_dispatch`, `_clear_pending_dispatch`,
+  `run_debounced_dispatch`, `supersede_active_run`,
+  `_create_phase_change_successor_run`, `complete_phase_change_handoff`,
+  `_send_phase_change_cancel`, `PHASE_CHANGE_HANDOFF_CONFIG_KEY`,
+  `DEBOUNCE_SECONDS`.
+- `orchestration/signals.py` — route `dispatch_immediate=True` through
+  `route_state_transition`.
+- `bgtasks/state_transition_debounce.py` — the delayed worker.
+- `runner/services/agent_run_finalization.py`,
+  `runner/services/run_lifecycle.py` — extend the handoff guard.
+- `runner/services/session_service.py`, `runner/models.py` — belt-and-braces
+  handoff completion on reap / revoke.
+- Tests: `tests/unit/orchestration/test_service.py`,
+  `tests/unit/runner/test_runs_views.py`,
+  `tests/unit/runner/test_issue_move_run_repoint.py`.

--- a/apps/api/pi_dash/bgtasks/apps.py
+++ b/apps/api/pi_dash/bgtasks/apps.py
@@ -15,5 +15,6 @@ class BgtasksConfig(AppConfig):
         # so their @shared_task decorators register with Celery at worker boot.
         from pi_dash.bgtasks import agent_ticker  # noqa: F401
         from pi_dash.bgtasks import scheduler  # noqa: F401
+        from pi_dash.bgtasks import state_transition_debounce  # noqa: F401
         # Wire the project-scheduler seed-on-workspace-create signal.
         from pi_dash.scheduler import signals as _scheduler_signals  # noqa: F401

--- a/apps/api/pi_dash/bgtasks/state_transition_debounce.py
+++ b/apps/api/pi_dash/bgtasks/state_transition_debounce.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Debounced state-transition dispatch worker.
+
+A state change that targets a ticking state schedules one of these tasks
+via ``apply_async(countdown=DEBOUNCE_SECONDS)`` (see
+``orchestration.service._schedule_pending_dispatch``). When it fires it
+re-reads the issue under a row lock, validates the debounce token, and
+dispatches against the issue's *current* state — coalescing any rapid
+sequence of transitions into a single dispatch on the final state.
+
+A further transition inside the window bumps the token, so a stale task is
+a harmless no-op.
+
+See ``.ai_design/state_transition_debounce/design.md``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from celery import shared_task
+
+logger = logging.getLogger("pi_dash.worker")
+
+
+@shared_task(name="pi_dash.bgtasks.state_transition_debounce.dispatch_debounced_transition")
+def dispatch_debounced_transition(issue_id: str, token: int) -> str:
+    """Fire the debounced dispatch for ``issue_id`` if ``token`` is current.
+
+    Returns the :class:`~pi_dash.orchestration.service.TransitionOutcome`
+    reason string (for logging / tests).
+    """
+    from pi_dash.orchestration.service import run_debounced_dispatch
+
+    outcome = run_debounced_dispatch(issue_id, token)
+    logger.info(
+        "state_transition_debounce: issue=%s token=%s reason=%s",
+        issue_id,
+        token,
+        outcome.reason,
+    )
+    return outcome.reason

--- a/apps/api/pi_dash/db/migrations/0163_issue_pending_dispatch.py
+++ b/apps/api/pi_dash/db/migrations/0163_issue_pending_dispatch.py
@@ -1,0 +1,111 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Debounced state-transition dispatch.
+
+Adds ``IssuePendingDispatch`` — one row per issue holding the pending
+(debounced) dispatch intent: a monotonic ``token``, the target fire time,
+and the transition's source/target states so the delayed job can resolve
+the cross-phase session shape.
+
+See ``.ai_design/state_transition_debounce/design.md``.
+"""
+
+import uuid
+
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("db", "0162_merge_complexity_and_profile_settings"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="IssuePendingDispatch",
+            fields=[
+                (
+                    "created_at",
+                    models.DateTimeField(auto_now_add=True, verbose_name="Created At"),
+                ),
+                (
+                    "updated_at",
+                    models.DateTimeField(auto_now=True, verbose_name="Last Modified At"),
+                ),
+                (
+                    "deleted_at",
+                    models.DateTimeField(blank=True, null=True, verbose_name="Deleted At"),
+                ),
+                (
+                    "id",
+                    models.UUIDField(
+                        db_index=True,
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                        unique=True,
+                    ),
+                ),
+                ("token", models.BigIntegerField(default=0)),
+                ("dispatch_at", models.DateTimeField(blank=True, null=True)),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="%(class)s_created_by",
+                        to=settings.AUTH_USER_MODEL,
+                        verbose_name="Created By",
+                    ),
+                ),
+                (
+                    "updated_by",
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="%(class)s_updated_by",
+                        to=settings.AUTH_USER_MODEL,
+                        verbose_name="Last Modified By",
+                    ),
+                ),
+                (
+                    "issue",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="pending_dispatch",
+                        to="db.issue",
+                    ),
+                ),
+                (
+                    "from_state",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to="db.state",
+                    ),
+                ),
+                (
+                    "to_state",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to="db.state",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Issue Pending Dispatch",
+                "verbose_name_plural": "Issue Pending Dispatches",
+                "db_table": "issue_pending_dispatch",
+            },
+        ),
+    ]

--- a/apps/api/pi_dash/db/models/__init__.py
+++ b/apps/api/pi_dash/db/models/__init__.py
@@ -106,6 +106,8 @@ from .description import Description, DescriptionVersion
 
 from .issue_agent_ticker import IssueAgentTicker
 
+from .issue_pending_dispatch import IssuePendingDispatch
+
 from .scheduler import Scheduler, SchedulerBinding, SchedulerSource
 
 from .loop import LoopJob, LoopTarget, LoopUserPreference, SkipReason

--- a/apps/api/pi_dash/db/models/issue_pending_dispatch.py
+++ b/apps/api/pi_dash/db/models/issue_pending_dispatch.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Per-issue pending (debounced) state-transition dispatch intent.
+
+A state change that targets a ticking state no longer dispatches an agent
+run inline. Instead the transition records its intent here and schedules a
+delayed job that fires after a short quiet period (see
+``orchestration.service.DEBOUNCE_SECONDS``). A further state change within
+the window replaces the intent and bumps ``token``; the earlier delayed job
+becomes a no-op because its token no longer matches the row.
+
+Exactly one row per issue (``issue`` is unique). Rapid transitions mutate
+this row in place rather than creating additional rows.
+
+See ``.ai_design/state_transition_debounce/design.md``.
+"""
+
+from __future__ import annotations
+
+from django.db import models
+
+from .base import BaseModel
+from .issue import Issue
+from .state import State
+
+
+class IssuePendingDispatch(BaseModel):
+    """The debounce record for one issue's pending dispatch."""
+
+    issue = models.OneToOneField(
+        Issue,
+        on_delete=models.CASCADE,
+        related_name="pending_dispatch",
+    )
+
+    #: Monotonically increasing per-issue token. Every state transition
+    #: bumps it; a delayed dispatch job carries the token it was scheduled
+    #: with and no-ops when the persisted token has moved on. Also bumped
+    #: (without scheduling a job) when a transition lands on a non-ticking
+    #: state, which cancels any pending dispatch.
+    token = models.BigIntegerField(default=0)
+
+    #: When the currently-armed delayed job should fire. ``None`` means no
+    #: dispatch is pending (the last transition cancelled it). Advisory —
+    #: the ``token`` match is authoritative.
+    dispatch_at = models.DateTimeField(null=True, blank=True)
+
+    #: The transition's source/target states, captured so the delayed job
+    #: can resolve the cross-phase session shape (fresh-session vs
+    #: resume-parent) exactly as an inline transition would. ``to_state``
+    #: is advisory; the job re-reads the issue's current state as
+    #: authoritative. Both use ``SET_NULL`` so state deletion can't cascade
+    #: a debounce row away mid-window.
+    from_state = models.ForeignKey(
+        State,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="+",
+    )
+    to_state = models.ForeignKey(
+        State,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="+",
+    )
+
+    class Meta:
+        db_table = "issue_pending_dispatch"
+        verbose_name = "Issue Pending Dispatch"
+        verbose_name_plural = "Issue Pending Dispatches"
+
+    def __str__(self) -> str:
+        return f"IssuePendingDispatch(issue={self.issue_id}, token={self.token})"

--- a/apps/api/pi_dash/orchestration/service.py
+++ b/apps/api/pi_dash/orchestration/service.py
@@ -16,9 +16,12 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import Optional
 
 from django.db import transaction
+from django.db.models import F
+from django.utils import timezone
 
 from pi_dash.core.agent_execution import AgentExecutorKind
 from pi_dash.db.models.issue import Issue, IssueComment
@@ -54,6 +57,23 @@ _PROMPT_BUILD_ERRORS = (PromptRenderError, RecipeNotFound, PromptRegistryError)
 # locked run makes the terminal callback idempotent without introducing a
 # second coordination table.
 PROJECT_MOVE_HANDOFF_CONFIG_KEY = "_project_move_handoff"
+
+# Stored on the source run while a phase-change supersede waits for the
+# source runner to acknowledge cancellation. Mirrors the project-move
+# handoff exactly (see :func:`supersede_active_run` /
+# :func:`complete_phase_change_handoff`): the marker carries the new
+# phase's target state and the successor's session shape so the terminal
+# callback can create the replacement once the old run reaches a terminal
+# status, without violating the single-active-run guardrail.
+PHASE_CHANGE_HANDOFF_CONFIG_KEY = "_phase_change_handoff"
+
+# Quiet period, in seconds, before a state transition that targets a
+# ticking state actually dispatches. A further transition within the
+# window replaces the pending intent and restarts the clock (see
+# :func:`route_state_transition`). A project-level override is a possible
+# future refinement; today this is a single constant.
+# See ``.ai_design/state_transition_debounce/design.md``.
+DEBOUNCE_SECONDS = 15
 
 #: DEPRECATED: retained only for backward compatibility with external
 #: importers (tests, integrations). Internal callers must use
@@ -256,6 +276,470 @@ def handle_issue_state_transition(
         fresh_session=fresh_session,
         trigger=AgentRunTrigger.STATE_TRANSITION,
     )
+
+
+# ----------------------------------------------------------------------
+# Debounced dispatch + phase-change supersede (PDASHOSS01-139)
+#
+# The ``post_save(Issue)`` signal routes every ``dispatch_immediate=True``
+# transition through :func:`route_state_transition`, which either:
+#
+# - supersedes an in-flight run when the transition crosses to a different
+#   ticking phase while a run is active (Part 2), or
+# - schedules a 15s-debounced dispatch when the target is a ticking state
+#   and no run is active yet (Part 1), or
+# - falls back to synchronous :func:`handle_issue_state_transition` when a
+#   run already holds the slot (dispatch would be a no-op) or the target is
+#   non-ticking (disarm only).
+#
+# ``dispatch_immediate=False`` callers (Comment & Run, project move, the
+# no-eligible-runner bounce) never enter this router — they own their own
+# dispatch and call :func:`handle_issue_state_transition` directly.
+#
+# See ``.ai_design/state_transition_debounce/design.md``.
+# ----------------------------------------------------------------------
+
+
+def route_state_transition(
+    issue: Issue,
+    from_state: Optional[State],
+    to_state: Optional[State],
+    actor=None,
+) -> None:
+    """Signal-side entry point for a user-driven state transition.
+
+    Decides between phase-change supersede, debounced dispatch, and
+    synchronous fall-through. Never dispatches inline for the common
+    "enter a ticking state" case — that is deferred to the debounce job.
+    """
+    # No prior state (issue just created, or the prior state was deleted):
+    # there is nothing to "settle" against and no mis-drop to correct, so
+    # keep the pre-debounce behavior — arm/dispatch inline. The debounce is
+    # about *transitions* between existing states.
+    if from_state is None:
+        handle_issue_state_transition(issue, from_state, to_state, actor)
+        return
+
+    active = _active_run_for(issue)
+
+    # Part 2 — a phase change while a run is in flight supersedes it.
+    if (
+        active is not None
+        and is_ticking_state(from_state)
+        and is_ticking_state(to_state)
+        and from_state.group != to_state.group
+    ):
+        _clear_pending_dispatch(issue)
+        supersede_active_run(
+            issue,
+            from_state=from_state,
+            to_state=to_state,
+            active=active,
+            actor=actor,
+        )
+        return
+
+    # A run already holds the single-active-run slot: a debounced dispatch
+    # would only ever return ``active-run-exists``. Fall through to the
+    # synchronous handler so arm/disarm still resolve (today's behavior);
+    # it will not create a second run.
+    if active is not None:
+        _clear_pending_dispatch(issue)
+        handle_issue_state_transition(issue, from_state, to_state, actor)
+        return
+
+    # Non-ticking target, no active run: nothing to dispatch. Cancel any
+    # pending debounce and disarm synchronously. This is the settling-window
+    # cancel path (Todo → In Progress → Todo ends with no run, no armed
+    # ticker) and the bounce-to-Backlog path (which must not re-enter the
+    # debounce and loop).
+    if not is_ticking_state(to_state):
+        _clear_pending_dispatch(issue)
+        handle_issue_state_transition(issue, from_state, to_state, actor)
+        return
+
+    # Part 1 — ticking target, no active run: debounce the dispatch.
+    _schedule_pending_dispatch(issue, from_state, to_state)
+
+
+def _schedule_pending_dispatch(
+    issue: Issue,
+    from_state: Optional[State],
+    to_state: Optional[State],
+) -> None:
+    """Record the pending dispatch intent and schedule the delayed job.
+
+    Bumps the issue's debounce ``token`` and (re)arms the delayed job for
+    ``DEBOUNCE_SECONDS`` from now. A prior scheduled job for the same issue
+    becomes a no-op because it carries the old token. The job is dispatched
+    on transaction commit so it can never read the row before it lands.
+    """
+    from pi_dash.db.models.issue_pending_dispatch import IssuePendingDispatch
+
+    with transaction.atomic():
+        pending, _ = IssuePendingDispatch.objects.select_for_update().get_or_create(
+            issue=issue
+        )
+        pending.token = (pending.token or 0) + 1
+        pending.dispatch_at = timezone.now() + timedelta(seconds=DEBOUNCE_SECONDS)
+        pending.from_state = from_state
+        pending.to_state = to_state
+        pending.save(
+            update_fields=["token", "dispatch_at", "from_state", "to_state", "updated_at"]
+        )
+        token = pending.token
+
+    def _enqueue(issue_id=str(issue.id), tok=token):
+        from pi_dash.bgtasks.state_transition_debounce import (
+            dispatch_debounced_transition,
+        )
+
+        dispatch_debounced_transition.apply_async(
+            args=[issue_id, tok],
+            countdown=DEBOUNCE_SECONDS,
+        )
+
+    transaction.on_commit(_enqueue)
+    logger.info(
+        "orchestration.debounce: scheduled issue=%s token=%s in %ss",
+        issue.pk,
+        token,
+        DEBOUNCE_SECONDS,
+    )
+
+
+def _clear_pending_dispatch(issue: Issue) -> None:
+    """Invalidate any pending debounced dispatch for ``issue``.
+
+    Bumps the token (so an already-scheduled job no-ops) and clears
+    ``dispatch_at``. Cheap no-op when no row exists.
+    """
+    from pi_dash.db.models.issue_pending_dispatch import IssuePendingDispatch
+
+    IssuePendingDispatch.objects.filter(issue=issue).update(
+        token=F("token") + 1,
+        dispatch_at=None,
+    )
+
+
+def run_debounced_dispatch(issue_id, token) -> TransitionOutcome:
+    """Fire a debounced dispatch, or no-op if it has been superseded.
+
+    Re-reads the issue and its pending-dispatch row under a row lock,
+    validates the token, consumes the pending intent, then delegates to the
+    unchanged :func:`handle_issue_state_transition` against the issue's
+    *current* state. The stored ``from_state`` preserves the cross-phase
+    session-shape decision the inline path would have made.
+    """
+    from pi_dash.db.models.issue_pending_dispatch import IssuePendingDispatch
+
+    with transaction.atomic():
+        issue = (
+            Issue.all_objects.select_for_update(of=("self",))
+            .select_related("state", "project", "workspace", "assigned_pod")
+            .filter(pk=issue_id)
+            .first()
+        )
+        if issue is None:
+            # Issue deleted (or moved) inside the window — nothing to do.
+            return TransitionOutcome(reason="issue-gone")
+        pending = IssuePendingDispatch.objects.select_for_update().filter(issue=issue).first()
+        if pending is None or pending.token != token:
+            # A later transition (or a clear) bumped the token; this job is
+            # stale.
+            return TransitionOutcome(reason="stale-token")
+        from_state = pending.from_state
+        # Consume: bump the token so a duplicate delivery of *this* job
+        # no-ops, and drop the armed marker.
+        pending.token = (pending.token or 0) + 1
+        pending.dispatch_at = None
+        pending.save(update_fields=["token", "dispatch_at", "updated_at"])
+
+    # Resolve against the issue's authoritative current state. Dispatch is
+    # done outside the issue row lock so the prompt build / dispatch work
+    # does not hold it. ``from_state`` may be stale relative to the current
+    # state, but it only feeds the cross-phase session-shape branch, which
+    # ``handle_issue_state_transition`` re-guards against the current state.
+    to_state = issue.state
+    return handle_issue_state_transition(
+        issue=issue,
+        from_state=from_state,
+        to_state=to_state,
+        actor=None,
+        dispatch_immediate=True,
+    )
+
+
+def _send_phase_change_cancel(runner_id, run_id) -> None:
+    """Best-effort cancellation request for a phase-change handoff.
+
+    Mirrors ``utils.issue_move._send_project_move_cancel``: the persisted
+    CANCEL_REQUESTED status is authoritative, so a transient delivery
+    failure cannot lose the handoff intent — the runner re-receives the
+    cancel frame at session open.
+    """
+    from pi_dash.runner.services.outbox import RunnerOfflineError
+    from pi_dash.runner.services.pubsub import send_to_runner
+
+    try:
+        send_to_runner(
+            runner_id,
+            {
+                "v": 1,
+                "type": "cancel",
+                "run_id": str(run_id),
+                "reason": "issue_phase_changed",
+            },
+        )
+    except RunnerOfflineError:
+        logger.info(
+            "orchestration.phase_change: runner %s offline; cancel for run %s "
+            "will be redelivered at session open",
+            runner_id,
+            run_id,
+        )
+    except Exception:
+        logger.exception(
+            "orchestration.phase_change: failed to deliver cancel for run %s",
+            run_id,
+        )
+
+
+#: Active statuses whose run has no executing agent process yet — safe to
+#: cancel and hand off in the same transaction. Anything else is executing
+#: on a runner and must go through CANCEL_REQUESTED → runner-ack first.
+_INERT_HANDOFF_STATUSES = (
+    AgentRunStatus.QUEUED,
+    AgentRunStatus.PAUSED_AWAITING_INPUT,
+)
+
+
+def supersede_active_run(
+    issue: Issue,
+    *,
+    from_state: State,
+    to_state: State,
+    active: AgentRun,
+    actor=None,
+) -> None:
+    """Cancel the in-flight run and hand off to the new phase's run.
+
+    Mirrors the cross-project move handoff:
+
+    - Disarm the old phase's ticker and arm the new phase's ticker
+      (resolving cadence against ``to_state``), capturing the resume parent
+      on the started → review/test forward transition.
+    - Stash the phase-change handoff marker (target state, session shape)
+      on the run.
+    - An inert run (QUEUED / PAUSED, no runner) is cancelled and its
+      successor created in the same transaction. An executing run enters
+      CANCEL_REQUESTED; the successor is created by
+      :func:`complete_phase_change_handoff` once the runner acknowledges.
+
+    The successor's session shape matches a clean phase entry:
+    ``fresh_session`` for In Review / In Test, resume-parent for the
+    review → In Progress hand-back.
+    """
+    from pi_dash.db.models.issue_agent_ticker import IssueAgentTicker
+    from pi_dash.orchestration import scheduling
+
+    to_cfg = phase_config_for(to_state)
+
+    # Capture the pre-review implementation run so a later review → In
+    # Progress hand-back resumes that exact session (matches the inline
+    # cross-phase capture in ``handle_issue_state_transition``).
+    resume_parent = active if from_state.group == StateGroup.STARTED.value else None
+
+    # Resolve the successor's session shape against the target phase.
+    fresh_session = False
+    parent_run_id: Optional[str] = None
+    if to_cfg is not None and to_cfg.fresh_session_on_entry:
+        fresh_session = True
+    else:
+        ticker = IssueAgentTicker.objects.filter(issue=issue).first()
+        if ticker is not None and ticker.resume_parent_run_id is not None:
+            parent_run_id = str(ticker.resume_parent_run_id)
+        else:
+            # No resume target (e.g. forward path skipped the impl phase).
+            # A fresh session is correct rather than parenting off a
+            # review run.
+            fresh_session = True
+
+    cancel_after_commit = None
+    create_successor_now = False
+
+    with transaction.atomic():
+        src = AgentRun.objects.select_for_update(of=("self",)).filter(pk=active.pk).first()
+        if src is None or src.is_terminal:
+            # The run finished on its own between the signal read and here.
+            # Fall back to the ordinary inline handler, which will arm the
+            # new phase and dispatch a fresh run.
+            handle_issue_state_transition(issue, from_state, to_state, actor)
+            return
+
+        # Ticker: disarm the old phase, arm the new phase against the
+        # current (target) state.
+        scheduling.disarm_ticker(issue)
+        scheduling.arm_ticker(issue, dispatch_immediate=True)
+        if resume_parent is not None:
+            IssueAgentTicker.objects.filter(issue=issue).update(resume_parent_run=resume_parent)
+
+        marker = {
+            "target_state_id": str(to_state.id),
+            "target_group": to_state.group,
+            "fresh_session": fresh_session,
+            "parent_run_id": parent_run_id,
+        }
+        config = dict(src.run_config or {})
+        config[PHASE_CHANGE_HANDOFF_CONFIG_KEY] = marker
+        src.run_config = config
+
+        now = timezone.now()
+        if src.status in _INERT_HANDOFF_STATUSES and src.runner_id is None:
+            # No executing agent — cancel and hand off in this transaction.
+            src.status = AgentRunStatus.CANCELLED
+            src.ended_at = now
+            src.queue_position = None
+            src.save(update_fields=["status", "ended_at", "queue_position", "run_config"])
+            create_successor_now = True
+        else:
+            src.status = AgentRunStatus.CANCEL_REQUESTED
+            src.queue_position = None
+            src.save(update_fields=["status", "queue_position", "run_config"])
+            if src.runner_id is not None:
+                cancel_after_commit = (src.runner_id, src.id)
+
+        source_id = src.id
+
+    if create_successor_now:
+        complete_phase_change_handoff(source_id)
+    if cancel_after_commit is not None:
+        runner_id, run_id = cancel_after_commit
+        transaction.on_commit(lambda rid=runner_id, run=run_id: _send_phase_change_cancel(rid, run))
+    logger.info(
+        "orchestration.phase_change: superseded run=%s issue=%s %s→%s "
+        "(fresh_session=%s)",
+        active.pk,
+        issue.pk,
+        from_state.group,
+        to_state.group,
+        fresh_session,
+    )
+
+
+def _create_phase_change_successor_run(*, issue: Issue, source: AgentRun, pod: Pod, marker: dict) -> Optional[AgentRun]:
+    """Create + dispatch the new phase's run after the source has stopped.
+
+    Reuses :func:`_create_and_dispatch_run` so the successor renders the
+    target phase's template (chosen by ``issue.state``) with the resolved
+    session shape and a fresh repository snapshot.
+    """
+    parent = None
+    if not marker.get("fresh_session") and marker.get("parent_run_id"):
+        parent = AgentRun.objects.filter(pk=marker["parent_run_id"]).first()
+
+    with transaction.atomic():
+        existing = _active_run_for(issue)
+        if existing is not None:
+            return existing
+        outcome = _create_and_dispatch_run(
+            issue=issue,
+            parent=parent,
+            creator=source.created_by,
+            pod=pod,
+            fresh_session=bool(marker.get("fresh_session")),
+            trigger=source.trigger or AgentRunTrigger.STATE_TRANSITION,
+        )
+    return outcome.created_run
+
+
+def complete_phase_change_handoff(run_id) -> Optional[AgentRun]:
+    """Create the new-phase successor for a stopped superseded run.
+
+    Called from the terminal callback once the old run reaches a terminal
+    status. Locks issue → run (matching issue moves and
+    ``complete_project_move_handoff``) so duplicate lifecycle deliveries
+    cannot create two successors.
+
+    Suppressed when the issue has since moved to yet another phase (a
+    second supersede owns the newer transition), or when another active run
+    already holds the slot.
+    """
+    with transaction.atomic():
+        work_item_id = (
+            AgentRun.objects.filter(pk=run_id).values_list("work_item_id", flat=True).first()
+        )
+        if work_item_id is None:
+            return None
+
+        issue = (
+            Issue.all_objects.select_for_update(of=("self",))
+            .select_related("project", "workspace", "state", "assigned_pod")
+            .filter(pk=work_item_id)
+            .first()
+        )
+        if issue is None:
+            return None
+
+        source = (
+            AgentRun.objects.select_for_update(of=("self",))
+            .select_related("created_by")
+            .filter(pk=run_id)
+            .first()
+        )
+        if source is None or not source.is_terminal:
+            return None
+
+        config = dict(source.run_config or {})
+        marker = dict(config.get(PHASE_CHANGE_HANDOFF_CONFIG_KEY) or {})
+        if not marker:
+            return None
+
+        replacement_id = marker.get("replacement_run_id")
+        if replacement_id:
+            return AgentRun.objects.filter(pk=replacement_id).first()
+
+        # The issue changed phase again during cancellation — a newer
+        # supersede (or debounce) owns that transition; do not create a run
+        # for a phase the issue has already left.
+        target_state_id = marker.get("target_state_id")
+        current_state_id = str(issue.state_id) if issue.state_id else None
+        if target_state_id and current_state_id != str(target_state_id):
+            marker["suppressed"] = "phase_changed_again"
+            config[PHASE_CHANGE_HANDOFF_CONFIG_KEY] = marker
+            source.run_config = config
+            source.save(update_fields=["run_config"])
+            return None
+
+        active = _active_run_for(issue)
+        if active is not None:
+            # A concurrent Run AI / debounce won the slot; treat it as the
+            # replacement rather than violating one-active-run.
+            marker["replacement_run_id"] = str(active.id)
+            config[PHASE_CHANGE_HANDOFF_CONFIG_KEY] = marker
+            source.run_config = config
+            source.save(update_fields=["run_config"])
+            return active
+
+        pod = _resolve_pod_for_issue(issue)
+        if pod is None:
+            logger.error(
+                "orchestration.phase_change: no pod for issue %s; cannot hand off",
+                issue.id,
+            )
+            return None
+
+        replacement = _create_phase_change_successor_run(
+            issue=issue,
+            source=source,
+            pod=pod,
+            marker=marker,
+        )
+        marker["replacement_run_id"] = str(replacement.id) if replacement is not None else None
+        config[PHASE_CHANGE_HANDOFF_CONFIG_KEY] = marker
+        source.run_config = config
+        source.save(update_fields=["run_config"])
+        return replacement
 
 
 def _resolve_fallback_creator(issue: Issue):

--- a/apps/api/pi_dash/orchestration/signals.py
+++ b/apps/api/pi_dash/orchestration/signals.py
@@ -25,7 +25,10 @@ from django.dispatch import receiver
 
 from pi_dash.db.models.issue import Issue
 from pi_dash.db.models.state import State
-from pi_dash.orchestration.service import handle_issue_state_transition
+from pi_dash.orchestration.service import (
+    handle_issue_state_transition,
+    route_state_transition,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -71,13 +74,26 @@ def fire_state_transition(sender, instance: Issue, created: bool, **kwargs) -> N
     )
 
     try:
-        handle_issue_state_transition(
-            issue=instance,
-            from_state=from_state,
-            to_state=to_state,
-            actor=None,
-            dispatch_immediate=dispatch_immediate,
-        )
+        if dispatch_immediate:
+            # Normal user-driven transition: route through the debounce /
+            # phase-change-supersede layer instead of dispatching inline.
+            route_state_transition(
+                issue=instance,
+                from_state=from_state,
+                to_state=to_state,
+                actor=None,
+            )
+        else:
+            # Caller owns its own dispatch (Comment & Run, project move,
+            # the no-eligible-runner bounce): arm/disarm synchronously with
+            # no debounced dispatch of our own.
+            handle_issue_state_transition(
+                issue=instance,
+                from_state=from_state,
+                to_state=to_state,
+                actor=None,
+                dispatch_immediate=False,
+            )
     except Exception:  # noqa: BLE001 — never let orchestration crash issue save
         global orchestration_error_count
         orchestration_error_count += 1

--- a/apps/api/pi_dash/runner/models.py
+++ b/apps/api/pi_dash/runner/models.py
@@ -642,23 +642,25 @@ class Runner(models.Model):
 
         def _complete_project_move_handoffs(run_ids=tuple(affected_run_ids)):
             from pi_dash.orchestration.service import (
+                complete_phase_change_handoff,
                 complete_project_move_handoff,
             )
 
             for run_id in run_ids:
-                try:
-                    complete_project_move_handoff(run_id)
-                except Exception:
-                    # Revocation is already committed. A handoff recovery
-                    # failure must not prevent source-pod draining or delayed
-                    # stream cleanup; leave the durable marker in place and
-                    # log enough context for reconciliation.
-                    _logger.exception(
-                        "failed to complete project-move handoff after "
-                        "revoking runner %s (run %s)",
-                        self.pk,
-                        run_id,
-                    )
+                for completer in (complete_project_move_handoff, complete_phase_change_handoff):
+                    try:
+                        completer(run_id)
+                    except Exception:
+                        # Revocation is already committed. A handoff recovery
+                        # failure must not prevent source-pod draining or
+                        # delayed stream cleanup; leave the durable marker in
+                        # place and log enough context for reconciliation.
+                        _logger.exception(
+                            "failed to complete handoff after revoking "
+                            "runner %s (run %s)",
+                            self.pk,
+                            run_id,
+                        )
 
         if affected_run_ids:
             transaction.on_commit(_complete_project_move_handoffs)

--- a/apps/api/pi_dash/runner/services/agent_run_finalization.py
+++ b/apps/api/pi_dash/runner/services/agent_run_finalization.py
@@ -79,12 +79,15 @@ def apply_terminal_effects(run_id) -> bool:
     """Apply orchestration hooks once, then deliver capacity release at least once."""
     from pi_dash.runner.services.run_lifecycle import (
         _apply_post_run_orchestration,
+        _has_phase_change_handoff,
         _has_project_move_handoff,
         _post_failure_comment,
     )
     from pi_dash.runner.services.scheduler_hook import update_scheduler_binding_on_terminate
 
-    pending_handoff = False
+    # ``None`` = no handoff; otherwise the handoff kind whose completer runs
+    # after this transaction (respecting the issue → run lock order).
+    pending_handoff = None
     with transaction.atomic():
         # Lock order: issue → run, matching issue moves and
         # complete_project_move_handoff. The post-run hooks below lock the
@@ -105,7 +108,9 @@ def apply_terminal_effects(run_id) -> bool:
         if run is None:
             return False
         if run.terminal_hooks_applied_at is None:
-            has_handoff = _has_project_move_handoff(run)
+            has_project_move = _has_project_move_handoff(run)
+            has_phase_change = _has_phase_change_handoff(run)
+            has_handoff = has_project_move or has_phase_change
             if run.status == AgentRunStatus.FAILED and not has_handoff:
                 try:
                     # Keep this best-effort side effect behind a savepoint: a
@@ -119,12 +124,13 @@ def apply_terminal_effects(run_id) -> bool:
                         run.id,
                     )
             if has_handoff:
-                # A source-project run stopped for a move must not
-                # disarm/pause the issue after it already belongs to the
-                # target project; the handoff completion (below, after
-                # this transaction to respect the issue → run lock order)
-                # creates the target-project replacement instead.
-                pending_handoff = True
+                # A run stopped for a handoff must not disarm/pause the
+                # issue: for a project move it already belongs to the target
+                # project, and for a phase change the new phase's ticker was
+                # just armed and its successor is still to be created. The
+                # completer (below, after this transaction to respect the
+                # issue → run lock order) creates the replacement instead.
+                pending_handoff = "project_move" if has_project_move else "phase_change"
             else:
                 _apply_post_run_orchestration(run)
             if run.scheduler_binding_id:
@@ -139,17 +145,26 @@ def apply_terminal_effects(run_id) -> bool:
             run.terminal_hooks_applied_at = timezone.now()
             run.save(update_fields=["terminal_hooks_applied_at"])
 
-    if pending_handoff:
-        from pi_dash.orchestration.service import complete_project_move_handoff
+    if pending_handoff is not None:
+        from pi_dash.orchestration.service import (
+            complete_phase_change_handoff,
+            complete_project_move_handoff,
+        )
 
+        completer = (
+            complete_project_move_handoff
+            if pending_handoff == "project_move"
+            else complete_phase_change_handoff
+        )
         try:
-            complete_project_move_handoff(run_id)
+            completer(run_id)
         except Exception:
             # The terminal transition is already committed; a handoff
             # recovery failure must not strand capacity release. The durable
             # marker stays on the run for reconciliation.
             logger.exception(
-                "failed to complete project-move handoff for run %s",
+                "failed to complete %s handoff for run %s",
+                pending_handoff,
                 run_id,
             )
 

--- a/apps/api/pi_dash/runner/services/run_lifecycle.py
+++ b/apps/api/pi_dash/runner/services/run_lifecycle.py
@@ -53,6 +53,12 @@ def _has_project_move_handoff(run: AgentRun) -> bool:
     return bool((run.run_config or {}).get(PROJECT_MOVE_HANDOFF_CONFIG_KEY))
 
 
+def _has_phase_change_handoff(run: AgentRun) -> bool:
+    from pi_dash.orchestration.service import PHASE_CHANGE_HANDOFF_CONFIG_KEY
+
+    return bool((run.run_config or {}).get(PHASE_CHANGE_HANDOFF_CONFIG_KEY))
+
+
 def _normalize_model(raw: Any) -> str:
     return str(raw or "").strip()[:128]
 

--- a/apps/api/pi_dash/runner/services/session_service.py
+++ b/apps/api/pi_dash/runner/services/session_service.py
@@ -248,10 +248,14 @@ def reap_stale_busy_runs(runner: Runner, body: Dict[str, Any], *, exclude_redeli
         pids=pod_ids,
         handoff_ids=tuple(stopped_cancel_ids),
     ):
-        from pi_dash.orchestration.service import complete_project_move_handoff
+        from pi_dash.orchestration.service import (
+            complete_phase_change_handoff,
+            complete_project_move_handoff,
+        )
 
         for handoff_id in handoff_ids:
             complete_project_move_handoff(handoff_id)
+            complete_phase_change_handoff(handoff_id)
         drain_for_runner_by_id(rid)
         for pid in pids:
             drain_pod_by_id(pid)

--- a/apps/api/pi_dash/tests/unit/orchestration/test_service.py
+++ b/apps/api/pi_dash/tests/unit/orchestration/test_service.py
@@ -903,3 +903,323 @@ def test_review_to_in_progress_with_no_resume_target_uses_fresh_session(
     assert outcome.created_run.parent_run_id is None
     assert outcome.created_run.parent_run_id != review_run.id
     assert outcome.created_run.pinned_runner_id is None
+
+
+# ---------------------------------------------------------------------------
+# State-transition debounce + phase-change supersede (PDASHOSS01-139).
+#
+# See ``.ai_design/state_transition_debounce/design.md``.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def capture_debounce(monkeypatch):
+    """Capture debounced-dispatch enqueues instead of hitting Celery.
+
+    ``no_runner_dispatch`` forces ``transaction.on_commit`` to fire inline,
+    so ``_schedule_pending_dispatch``'s enqueue runs synchronously — we just
+    record ``(issue_id, token)`` rather than shipping a task to the broker.
+    """
+    from pi_dash.bgtasks import state_transition_debounce as deb
+
+    calls = []
+    monkeypatch.setattr(
+        deb.dispatch_debounced_transition,
+        "apply_async",
+        lambda args, countdown=None: calls.append((args[0], args[1], countdown)),
+    )
+    return calls
+
+
+def _make_running_run(issue, runner):
+    from django.utils import timezone
+
+    return AgentRun.objects.create(
+        workspace=issue.workspace,
+        owner=runner.owner,
+        pod=runner.pod,
+        work_item=issue,
+        runner=runner,
+        status=AgentRunStatus.RUNNING,
+        prompt="impl work",
+        started_at=timezone.now() - timezone.timedelta(minutes=2),
+    )
+
+
+@pytest.mark.unit
+def test_route_ticking_entry_debounces_no_inline_dispatch(
+    seeded, issue, states, runner_for_workspace, capture_debounce
+):
+    """Entering a ticking state schedules a debounce and does NOT dispatch
+    inline or arm the ticker."""
+    from pi_dash.db.models.issue_agent_ticker import IssueAgentTicker
+    from pi_dash.db.models.issue_pending_dispatch import IssuePendingDispatch
+
+    service.route_state_transition(
+        issue=issue,
+        from_state=states["todo"],
+        to_state=states["in_progress"],
+    )
+
+    assert AgentRun.objects.filter(work_item=issue).count() == 0
+    assert IssueAgentTicker.objects.filter(issue=issue).exists() is False
+    pending = IssuePendingDispatch.objects.get(issue=issue)
+    assert pending.token == 1
+    assert pending.dispatch_at is not None
+    # One enqueue, carrying the current token, at the debounce delay.
+    assert capture_debounce == [(str(issue.id), 1, service.DEBOUNCE_SECONDS)]
+
+
+@pytest.mark.unit
+def test_debounce_coalesces_rapid_transitions_into_one_review_run(
+    seeded, issue, states, runner_for_workspace, capture_debounce
+):
+    """Todo → In Progress → In Review inside the window produces exactly one
+    run, on the review template, when the final debounce fires."""
+    service.route_state_transition(
+        issue=issue, from_state=states["todo"], to_state=states["in_progress"]
+    )
+    service.route_state_transition(
+        issue=issue, from_state=states["in_progress"], to_state=states["in_review"]
+    )
+    # The card now reads In Review.
+    Issue.all_objects.filter(pk=issue.pk).update(state=states["in_review"])
+
+    tokens = [tok for (_iid, tok, _cd) in capture_debounce]
+    assert tokens == [1, 2]
+
+    # The stale first job is a no-op.
+    stale = service.run_debounced_dispatch(str(issue.id), 1)
+    assert stale.reason == "stale-token"
+    assert AgentRun.objects.filter(work_item=issue).count() == 0
+
+    # The final job dispatches a single fresh review run.
+    outcome = service.run_debounced_dispatch(str(issue.id), 2)
+    assert outcome.reason == "created"
+    assert AgentRun.objects.filter(work_item=issue).count() == 1
+    # Fresh session = review-template entry (parent + pin cleared).
+    assert outcome.created_run.parent_run_id is None
+    assert outcome.created_run.pinned_runner_id is None
+
+
+@pytest.mark.unit
+def test_debounce_cancelled_when_landing_on_non_ticking_state(
+    seeded, issue, states, runner_for_workspace, capture_debounce
+):
+    """Todo → In Progress → Todo inside the window produces zero runs and
+    leaves no armed ticker."""
+    from pi_dash.db.models.issue_agent_ticker import IssueAgentTicker
+    from pi_dash.db.models.issue_pending_dispatch import IssuePendingDispatch
+
+    service.route_state_transition(
+        issue=issue, from_state=states["todo"], to_state=states["in_progress"]
+    )
+    service.route_state_transition(
+        issue=issue, from_state=states["in_progress"], to_state=states["todo"]
+    )
+    Issue.all_objects.filter(pk=issue.pk).update(state=states["todo"])
+
+    # The clear bumped the token past the scheduled job's token.
+    pending = IssuePendingDispatch.objects.get(issue=issue)
+    assert pending.token == 2
+    assert pending.dispatch_at is None
+
+    # Firing the (stale) scheduled job is a no-op.
+    outcome = service.run_debounced_dispatch(str(issue.id), 1)
+    assert outcome.reason == "stale-token"
+    assert AgentRun.objects.filter(work_item=issue).count() == 0
+    ticker = IssueAgentTicker.objects.filter(issue=issue).first()
+    assert ticker is None or ticker.enabled is False
+
+
+@pytest.mark.unit
+def test_debounce_job_stale_token_is_noop(
+    seeded, issue, states, runner_for_workspace, capture_debounce
+):
+    """A delayed job whose token no longer matches never dispatches."""
+    service.route_state_transition(
+        issue=issue, from_state=states["todo"], to_state=states["in_progress"]
+    )
+    # A newer transition bumps the token to 2.
+    service.route_state_transition(
+        issue=issue, from_state=states["in_progress"], to_state=states["in_review"]
+    )
+    Issue.all_objects.filter(pk=issue.pk).update(state=states["in_review"])
+
+    outcome = service.run_debounced_dispatch(str(issue.id), 1)
+    assert outcome.reason == "stale-token"
+    assert AgentRun.objects.filter(work_item=issue).count() == 0
+
+
+@pytest.mark.unit
+def test_debounce_job_noop_when_issue_deleted(
+    seeded, issue, states, runner_for_workspace, capture_debounce
+):
+    """Issue deletion inside the window cancels the pending dispatch."""
+    service.route_state_transition(
+        issue=issue, from_state=states["todo"], to_state=states["in_progress"]
+    )
+    issue_id = str(issue.id)
+    Issue.all_objects.filter(pk=issue.pk).delete()
+
+    outcome = service.run_debounced_dispatch(issue_id, 1)
+    assert outcome.reason == "issue-gone"
+
+
+@pytest.mark.unit
+def test_phase_change_supersedes_executing_run(
+    seeded, issue, states, runner_for_workspace, monkeypatch
+):
+    """A phase change while a run is executing requests cancellation, stashes
+    the handoff marker, and arms the new phase's ticker."""
+    from pi_dash.db.models.issue_agent_ticker import IssueAgentTicker
+
+    monkeypatch.setattr(service, "_send_phase_change_cancel", lambda *a, **k: None)
+
+    Issue.all_objects.filter(pk=issue.pk).update(state=states["in_progress"])
+    issue.refresh_from_db()
+    impl_run = _make_running_run(issue, runner_for_workspace)
+
+    Issue.all_objects.filter(pk=issue.pk).update(state=states["in_review"])
+    issue.refresh_from_db()
+    service.route_state_transition(
+        issue=issue,
+        from_state=states["in_progress"],
+        to_state=states["in_review"],
+    )
+
+    impl_run.refresh_from_db()
+    assert impl_run.status == AgentRunStatus.CANCEL_REQUESTED
+    marker = (impl_run.run_config or {}).get(service.PHASE_CHANGE_HANDOFF_CONFIG_KEY)
+    assert marker is not None
+    assert marker["target_state_id"] == str(states["in_review"].id)
+    assert marker["fresh_session"] is True
+    # New phase ticker armed; impl run captured as the resume parent.
+    ticker = IssueAgentTicker.objects.get(issue=issue)
+    assert ticker.enabled is True
+    assert ticker.resume_parent_run_id == impl_run.pk
+    # No successor yet — the slot is still held by the cancel-requested run.
+    assert (
+        AgentRun.objects.filter(work_item=issue).exclude(pk=impl_run.pk).count() == 0
+    )
+
+
+@pytest.mark.unit
+def test_phase_change_successor_created_on_terminal_and_ticker_survives(
+    seeded, issue, states, runner_for_workspace, monkeypatch
+):
+    """Once the superseded run terminates, the successor is created and the
+    new phase's ticker is NOT disarmed by the old run's completed payload."""
+    from pi_dash.db.models.issue_agent_ticker import IssueAgentTicker
+    from pi_dash.runner.services import matcher
+    from pi_dash.runner.services.agent_run_finalization import apply_terminal_effects
+
+    monkeypatch.setattr(service, "_send_phase_change_cancel", lambda *a, **k: None)
+    monkeypatch.setattr(matcher, "drain_for_runner_by_id", mock.Mock())
+
+    Issue.all_objects.filter(pk=issue.pk).update(state=states["in_progress"])
+    issue.refresh_from_db()
+    impl_run = _make_running_run(issue, runner_for_workspace)
+
+    # The card now reads In Review (the signal persists this before firing).
+    Issue.all_objects.filter(pk=issue.pk).update(state=states["in_review"])
+    issue.refresh_from_db()
+    service.route_state_transition(
+        issue=issue,
+        from_state=states["in_progress"],
+        to_state=states["in_review"],
+    )
+    impl_run.refresh_from_db()
+    assert impl_run.status == AgentRunStatus.CANCEL_REQUESTED
+
+    # The runner acknowledges: the run terminates with a completed payload
+    # that, absent the handoff guard, would disarm the freshly-armed ticker.
+    from django.utils import timezone
+
+    AgentRun.objects.filter(pk=impl_run.pk).update(
+        status=AgentRunStatus.CANCELLED,
+        done_payload={"status": "completed"},
+        ended_at=timezone.now(),
+        terminal_hooks_applied_at=None,
+    )
+    apply_terminal_effects(impl_run.id)
+
+    # A fresh review successor now exists and holds the slot.
+    successor = (
+        AgentRun.objects.filter(work_item=issue)
+        .exclude(pk=impl_run.pk)
+        .order_by("-created_at")
+        .first()
+    )
+    assert successor is not None
+    assert successor.parent_run_id is None
+    assert successor.pinned_runner_id is None
+    # The review ticker survived the cancelled run's completed payload.
+    ticker = IssueAgentTicker.objects.get(issue=issue)
+    assert ticker.enabled is True
+    # The marker records the replacement for idempotency.
+    impl_run.refresh_from_db()
+    marker = impl_run.run_config[service.PHASE_CHANGE_HANDOFF_CONFIG_KEY]
+    assert marker["replacement_run_id"] == str(successor.id)
+
+
+@pytest.mark.unit
+def test_phase_change_supersedes_queued_run_immediately(
+    seeded, issue, states, runner_for_workspace, monkeypatch
+):
+    """A QUEUED (not-yet-executing) run is cancelled and its successor
+    created in the same transaction — there is no runner to acknowledge."""
+    monkeypatch.setattr(service, "_send_phase_change_cancel", lambda *a, **k: None)
+
+    Issue.all_objects.filter(pk=issue.pk).update(state=states["in_progress"])
+    issue.refresh_from_db()
+    queued = AgentRun.objects.create(
+        workspace=issue.workspace,
+        owner=runner_for_workspace.owner,
+        pod=runner_for_workspace.pod,
+        work_item=issue,
+        status=AgentRunStatus.QUEUED,
+        prompt="impl work",
+    )
+
+    Issue.all_objects.filter(pk=issue.pk).update(state=states["in_review"])
+    issue.refresh_from_db()
+    service.route_state_transition(
+        issue=issue,
+        from_state=states["in_progress"],
+        to_state=states["in_review"],
+    )
+
+    queued.refresh_from_db()
+    assert queued.status == AgentRunStatus.CANCELLED
+    successor = (
+        AgentRun.objects.filter(work_item=issue).exclude(pk=queued.pk).first()
+    )
+    assert successor is not None
+    assert successor.parent_run_id is None
+
+
+@pytest.mark.unit
+def test_active_run_non_ticking_exit_leaves_run_untouched(
+    seeded, issue, states, runner_for_workspace, paused_state
+):
+    """Open-question default (option a): moving to a non-ticking state while
+    a run is in flight leaves the run running (today's behavior) and disarms
+    the ticker. No handoff marker, no cancellation."""
+    from pi_dash.db.models.issue_agent_ticker import IssueAgentTicker
+
+    Issue.all_objects.filter(pk=issue.pk).update(state=states["in_progress"])
+    issue.refresh_from_db()
+    IssueAgentTicker.objects.create(issue=issue, enabled=True, next_run_at=None)
+    impl_run = _make_running_run(issue, runner_for_workspace)
+
+    service.route_state_transition(
+        issue=issue,
+        from_state=states["in_progress"],
+        to_state=paused_state,
+    )
+
+    impl_run.refresh_from_db()
+    assert impl_run.status == AgentRunStatus.RUNNING
+    assert service.PHASE_CHANGE_HANDOFF_CONFIG_KEY not in (impl_run.run_config or {})
+    assert IssueAgentTicker.objects.get(issue=issue).enabled is False

--- a/apps/api/pi_dash/tests/unit/runner/test_issue_move_run_repoint.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_issue_move_run_repoint.py
@@ -362,7 +362,15 @@ def test_move_without_active_run_does_not_require_target_pod(
     target_pod.save(update_fields=["deleted_at"])
     issue = _make_issue(source_project, create_user)
 
+    # Without active runs the move must NOT suppress immediate dispatch, so
+    # the post-save signal takes the ``dispatch_immediate=True`` branch —
+    # which now routes through ``route_state_transition`` (the debounce /
+    # phase-change-supersede layer), not a direct inline dispatch. The
+    # suppressed branch (a move *with* active runs) would call
+    # ``handle_issue_state_transition(dispatch_immediate=False)`` instead.
     with patch(
+        "pi_dash.orchestration.signals.route_state_transition"
+    ) as route, patch(
         "pi_dash.orchestration.signals.handle_issue_state_transition"
     ) as transition:
         moved = _move(
@@ -375,7 +383,9 @@ def test_move_without_active_run_does_not_require_target_pod(
 
     assert moved.project_id == target_project.id
     assert moved.assigned_pod_id is None
-    assert transition.call_args.kwargs["dispatch_immediate"] is True
+    assert route.called is True
+    # The suppressed inline path must not have been taken.
+    assert transition.called is False
 
 
 @pytest.mark.unit

--- a/apps/api/pi_dash/tests/unit/runner/test_runs_views.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_runs_views.py
@@ -980,12 +980,16 @@ def test_skip_immediate_dispatch_header_suppresses_run_creation_on_state_change(
 
 
 @pytest.mark.unit
-def test_no_skip_header_creates_run_on_state_change(db, session_client, workspace, project):
-    """Sanity: without the header, the existing immediate-dispatch path
-    fires. This guards against accidentally inverting the default."""
+def test_no_skip_header_debounces_dispatch_on_state_change(db, session_client, workspace, project):
+    """Sanity: without the header, the transition schedules the 15s debounce
+    (rather than dispatching inline), and firing that debounce creates the
+    run. This guards against accidentally inverting the default while
+    reflecting the PDASHOSS01-139 debounce behavior."""
     from crum import impersonate
 
     from pi_dash.db.models import Issue, Project, State
+    from pi_dash.db.models.issue_pending_dispatch import IssuePendingDispatch
+    from pi_dash.orchestration.service import run_debounced_dispatch
     from pi_dash.prompting.seed import seed_default_template
 
     seed_default_template()
@@ -1013,6 +1017,14 @@ def test_no_skip_header_creates_run_on_state_change(db, session_client, workspac
         format="json",
     )
     assert resp.status_code == status.HTTP_204_NO_CONTENT
+    # Deferred, not inline: no run yet, but a debounce is armed.
+    assert AgentRun.objects.filter(work_item=issue).count() == 0
+    pending = IssuePendingDispatch.objects.get(issue=issue)
+    assert pending.token >= 1
+
+    # Firing the debounced job dispatches exactly one run.
+    outcome = run_debounced_dispatch(str(issue.id), pending.token)
+    assert outcome.reason == "created"
     assert AgentRun.objects.filter(work_item=issue).count() == 1
 
 


### PR DESCRIPTION
## What & why

Today a state change dispatches an agent run **synchronously and irrevocably**, and a second quick change is wasted or silently dropped. On `Todo → In Progress → In Review` a correcting drag can't stop the already-queued coding run, and the review run is swallowed by the single-active-run guardrail — leaving the impl run pushing commits on the wrong prompt and, on terminate, disarming the freshly review-armed ticker so the issue parks with no agent scheduled.

Fixes `PDASHOSS01-139`.

## Part 1 — 15s debounce

- New side table `IssuePendingDispatch` (one row per issue): monotonic `token`, `dispatch_at`, `from_state`/`to_state`.
- `signals.py` routes the `dispatch_immediate=True` path through the new `service.route_state_transition`. Entering a ticking state now records the intent and schedules `bgtasks.state_transition_debounce.dispatch_debounced_transition` with a 15s countdown instead of dispatching inline.
- A further transition inside the window bumps the token; the earlier delayed job no-ops. The job re-reads the issue under a row lock and dispatches against the **settled** state, so `Todo → In Progress → In Review` coalesces to one review-template run and `Todo → In Progress → Todo` yields no run and no armed ticker.
- `handle_issue_state_transition` stays the synchronous dispatcher (used by the debounce job, Comment & Run, project move, and tests). Issue **creation** into a ticking state is not debounced (`from_state is None`).

## Part 2 — phase-change supersede

- When a phase change lands while a run is in flight, `supersede_active_run` cancels it (immediately for QUEUED/PAUSED; via `CANCEL_REQUESTED` + a runner cancel frame otherwise), arms the new phase's ticker, and stashes a `_phase_change_handoff` marker — mirroring the cross-project move handoff.
- `complete_phase_change_handoff` creates the successor from the terminal callback once the old run stops, so the single-active-run guardrail / `agent_run_one_active_per_work_item` are never violated.
- The terminal-effects handoff guard is extended (`_has_phase_change_handoff`) so the cancelled run's `completed`/`blocked` done payload can't disarm the newly armed ticker. Reap / runner-revoke recovery paths call both completers (idempotent).

## Open question (deferred)

What to do when the new state is **non-ticking** (Paused/Done/Backlog/Cancelled) and a run is in flight. The issue reserved this for a human decision; implemented as **(a) leave the run running** (today's behavior, ticker disarms, no handoff) and flagged in an issue comment. Switching to (b)/(c) is a localized change in one branch of `route_state_transition`.

## Tests

- `tests/unit/orchestration/test_service.py`: debounce coalescing → one review run; cancel-on-leave → zero runs / no armed ticker; stale-token and issue-deleted no-ops; supersede (cancel-requested, marker, resume-parent capture); successor created on terminal with the ticker surviving the cancelled run's completed payload; QUEUED immediate supersede; non-ticking-exit leaves the run untouched.
- Updated `test_runs_views.py` (`test_no_skip_header_debounces_dispatch_on_state_change`) and `test_issue_move_run_repoint.py` to reflect the new signal wiring. Regression: the skip-immediate-dispatch header and Comment & Run tests still pass.
- Full `pi_dash/tests/unit/` suite: **1280 passed** (only the pre-existing environmental `test_valid_agents_matches_runner_schema`, which reads the repo-root `runner/` tree absent from the API test container, deselected). `ruff check` clean.

Design: `.ai_design/state_transition_debounce/design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
