### PR TITLE
PDASHOSS01-137 Cloud: retire the worktree queue and capacity hint

### DIFF
--- a/apps/api/pi_dash/runner/services/matcher.py
+++ b/apps/api/pi_dash/runner/services/matcher.py
@@ -54,9 +54,10 @@ HEARTBEAT_GRACE = timedelta(seconds=90)
 NON_TERMINAL_STATUSES = (
     AgentRunStatus.QUEUED,
     AgentRunStatus.ASSIGNED,
-    # A run waiting on a worktree lease still occupies its single-tenant
-    # runner and must block pod deletion exactly like ASSIGNED. See
-    # .ai_design/worktree_pooling/design.md §6.2.
+    # WAITING_FOR_WORKTREE is retired (PDASHOSS01-137): no new run enters it,
+    # but historical rows may still hold it, and while non-terminal such a run
+    # must block pod deletion exactly like ASSIGNED. Kept in the set so those
+    # rows keep gating correctly. See .ai_design/worktree_pooling/design.md §6.2.
     AgentRunStatus.WAITING_FOR_WORKTREE,
     AgentRunStatus.RUNNING,
     AgentRunStatus.CANCEL_REQUESTED,
@@ -68,11 +69,10 @@ NON_TERMINAL_STATUSES = (
 # Statuses that indicate a runner is currently serving a run.
 BUSY_STATUSES = (
     AgentRunStatus.ASSIGNED,
-    # The runner has accepted the run and is queueing it locally for a
-    # worktree — it is committed to this run and cannot take other work.
-    # The single-tenant runner reports it as ``in_flight_run`` while it
-    # waits, so the heartbeat reaper (which fails BUSY runs the runner no
-    # longer claims) needs no change beyond this membership.
+    # Retired (PDASHOSS01-137): no new run enters WAITING_FOR_WORKTREE, but a
+    # historical row still occupies its runner and reports as ``in_flight_run``
+    # while active, so the heartbeat reaper keeps treating it as busy. Kept in
+    # the set for those rows.
     AgentRunStatus.WAITING_FOR_WORKTREE,
     AgentRunStatus.RUNNING,
     AgentRunStatus.CANCEL_REQUESTED,
@@ -111,30 +111,12 @@ def select_runner_in_pod(pod: Pod) -> Optional[Runner]:
         # An active chat no longer excludes a runner from issue assignment:
         # chat and issue runs are concurrent (design §3.4). BUSY_STATUSES still
         # keeps the assign lane single-tenant (one issue at a time).
-        # Capacity hint (design §6.4): among equally-eligible idle runners,
-        # prefer one whose work-dir pool reports a free desk. This is a
-        # PREFERENCE, never a gate — runners with ``free_worktrees`` of 0 or
-        # ``None`` (a runner that predates the hint) stay eligible and sort
-        # after free-desk runners, then fall back to freshest-heartbeat
-        # (``-last_heartbeat_at``, newest first). A
-        # stale hint costs at most some local queue time, never a stuck run.
-        .annotate(_has_free_desk=_free_desk_rank())
-        .order_by("_has_free_desk", "-last_heartbeat_at")
+        # The worktree pool is retired (PDASHOSS01-137): there is no per-runner
+        # desk capacity to prefer, so among equally-eligible idle runners the
+        # only ranking left is freshest heartbeat (``-last_heartbeat_at``,
+        # newest first). ``Runner.free_worktrees`` is no longer written or read.
+        .order_by("-last_heartbeat_at")
         .first()
-    )
-
-
-def _free_desk_rank() -> models.Case:
-    """Rank annotation: 0 when the runner reports a free desk, else 1.
-
-    ``free_worktrees > 0`` sorts first (rank 0); 0 and ``NULL`` share the
-    no-free-desk group (rank 1), so old runners without the hint never lose
-    eligibility. ``order_by`` ascending puts the free-desk group ahead.
-    """
-    return models.Case(
-        models.When(free_worktrees__gt=0, then=models.Value(0)),
-        default=models.Value(1),
-        output_field=models.IntegerField(),
     )
 
 

--- a/apps/api/pi_dash/runner/services/session_service.py
+++ b/apps/api/pi_dash/runner/services/session_service.py
@@ -370,32 +370,6 @@ def upsert_runner_live_state(runner: Runner, status_entry: Dict[str, Any]) -> No
         state.save(update_fields=sorted(set(update_fields)) + ["updated_at"])
 
 
-# ``Runner.free_worktrees`` is an IntegerField; Postgres rejects anything
-# above the signed-int32 ceiling, so out-of-range reports are clamped
-# rather than allowed to 500 the poll handler.
-FREE_WORKTREES_MAX = 2**31 - 1
-
-
-def parse_free_worktrees(raw: Any) -> Optional[int]:
-    """Coerce a reported ``free_worktrees`` hint to a non-negative int.
-
-    Returns ``None`` for a missing or malformed value so the poll handler
-    leaves the stored hint untouched (a pre-feature runner omits the field;
-    a malformed one should never wipe a known-good value). Values beyond the
-    column's int32 range are clamped rather than 500ing the poll. See
-    ``.ai_design/worktree_pooling/design.md`` §6.4.
-    """
-    if raw is None:
-        return None
-    try:
-        value = int(raw)
-    except (TypeError, ValueError):
-        return None
-    if value < 0:
-        return None
-    return min(value, FREE_WORKTREES_MAX)
-
-
 def build_session_open_redeliver(runner: Runner, in_flight_run_id: Optional[str]) -> Optional[Dict[str, Any]]:
     """Return an ``Assign``-shaped payload to redeliver at session open.
 

--- a/apps/api/pi_dash/runner/views/run_endpoints.py
+++ b/apps/api/pi_dash/runner/views/run_endpoints.py
@@ -128,74 +128,26 @@ class RunAcceptEndpoint(_RunEndpointBase):
 
 
 class RunQueuedEndpoint(_RunEndpointBase):
-    """``POST /runs/<run_id>/queued`` — runner reports the run is waiting.
+    """``POST /runs/<run_id>/queued`` — retired worktree-queue notice.
 
-    The runner accepted the run but cannot acquire a worktree lease yet, so it
-    sits in the daemon's local queue. Body carries ``queue_position`` (the
-    run's position in that queue). See
-    ``.ai_design/worktree_pooling/design.md`` §6.1.
-
-    Transition rules:
-
-    - ``ASSIGNED`` → ``WAITING_FOR_WORKTREE`` (and store the position).
-    - ``WAITING_FOR_WORKTREE`` → ``WAITING_FOR_WORKTREE`` (position refresh as
-      the queue drains; positions only decrease).
-    - ``RUNNING`` or any terminal status → acknowledged and dropped without a
-      state change. A late or duplicate ``queued`` post must never regress a
-      run that already started (or finished); the runner posts ``accept`` at
-      lease grant, which is what actually drives ``RUNNING``.
+    The worktree pool is retired (PDASHOSS01-137): a runner no longer queues
+    locally for a lease, so there is nothing to record and no new run may
+    enter ``WAITING_FOR_WORKTREE``. Pre-retirement daemons may still POST here
+    after this ships, so the endpoint stays and acknowledges the post (never
+    404s it and never makes the daemon retry), but it performs no state
+    transition and writes no ``queue_position``. A run simply stays
+    ``ASSIGNED`` until the runner posts ``accept`` (which drives ``RUNNING``).
+    Historical rows that already hold ``WAITING_FOR_WORKTREE`` are untouched
+    and keep rendering / redelivering via their status-set membership.
     """
 
     def post(self, request, run_id):
         run, err = self._resolve(request, run_id)
         if err:
             return err
-        with transaction.atomic():
-            if not _record_dedupe(run, _idempotency_key(request)):
-                return Response({"ok": True, "duplicate": True})
-            locked, closed = self._lock_non_terminal(run)
-            if closed:
-                # Terminal: acknowledge so the runner stops retrying; the
-                # ``_lock_non_terminal`` helper already returns ``terminal``.
-                return closed
-            if locked.status not in (
-                AgentRunStatus.ASSIGNED,
-                AgentRunStatus.WAITING_FOR_WORKTREE,
-            ):
-                # RUNNING (or any other non-terminal state): acknowledge and
-                # drop. A run that has already started must not regress to
-                # WAITING_FOR_WORKTREE on a late/duplicate queued post.
-                return Response({"ok": True, "ignored": True})
-            position = _parse_queue_position(request.data.get("queue_position"))
-            AgentRun.objects.filter(pk=locked.pk).update(
-                status=AgentRunStatus.WAITING_FOR_WORKTREE,
-                queue_position=position,
-            )
-        return Response({"ok": True})
-
-
-# ``AgentRun.queue_position`` is a PositiveSmallIntegerField; Postgres
-# rejects anything above the signed-int16 ceiling, so out-of-range reports
-# are clamped rather than allowed to 500 the endpoint.
-QUEUE_POSITION_MAX = 32767
-
-
-def _parse_queue_position(raw) -> Optional[int]:
-    """Coerce a reported queue position to a non-negative int, else ``None``.
-
-    A missing or malformed value clears the stored position rather than
-    erroring — the field is display-only and never load-bearing. Values
-    beyond the column's int16 range are clamped for the same reason.
-    """
-    if raw is None:
-        return None
-    try:
-        value = int(raw)
-    except (TypeError, ValueError):
-        return None
-    if value < 0:
-        return None
-    return min(value, QUEUE_POSITION_MAX)
+        # Acknowledge and drop. There is no side effect to guard, so the
+        # dedupe/lock machinery the transition used is no longer needed.
+        return Response({"ok": True, "ignored": True})
 
 
 class RunStartedEndpoint(_RunEndpointBase):

--- a/apps/api/pi_dash/runner/views/sessions.py
+++ b/apps/api/pi_dash/runner/views/sessions.py
@@ -388,13 +388,11 @@ def _poll_bookkeeping(runner, body: Dict[str, Any], sid):
                 "last_heartbeat_at": now_ts,
                 "status": RunnerStatus.BUSY if reports_busy else RunnerStatus.ONLINE,
             }
-            # Capacity hint (design §6.4): persist the free-desk count the
-            # runner reports for its work-dir pool so the matcher can prefer
-            # runners with spare worktrees. Additive + optional — old runners
-            # omit the field and we leave the column untouched.
-            free_worktrees = session_service.parse_free_worktrees(status_entry.get("free_worktrees"))
-            if free_worktrees is not None:
-                runner_updates["free_worktrees"] = free_worktrees
+            # The worktree pool is retired (PDASHOSS01-137): there is no
+            # per-runner desk capacity to track, so a reported ``free_worktrees``
+            # hint is no longer persisted. A post-retirement daemon omits the
+            # field and a pre-retirement daemon still sends it — either way it
+            # is simply ignored here, and the deprecated column is left untouched.
             Runner.objects.filter(pk=runner.id).update(**runner_updates)
             if status_entry:
                 session_service.reap_stale_busy_runs(runner, status_entry)

--- a/apps/api/pi_dash/tests/unit/runner/test_drain_pod.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_drain_pod.py
@@ -128,51 +128,35 @@ def test_select_runner_in_pod_skips_stale_heartbeat(db, create_user, workspace, 
         assert matcher.select_runner_in_pod(pod) is None
 
 
-# ---------------- free_worktrees capacity hint (design §6.4) ----------------
+# ---------- worktree capacity hint retired (PDASHOSS01-137) ----------
+# ``free_worktrees`` is no longer written or read; the matcher ranks eligible
+# idle runners by freshest heartbeat only. A leftover column value on a
+# historical row must not influence selection.
 
 
 @pytest.mark.unit
-def test_select_runner_in_pod_prefers_free_worktrees(db, create_user, workspace, pod):
-    """Among equally-eligible idle runners, the one whose pool reports a free
-    desk wins — even if its heartbeat is older."""
+def test_select_runner_in_pod_ranks_by_heartbeat_ignoring_free_worktrees(db, create_user, workspace, pod):
+    """The freshest-heartbeat runner wins even when an older runner carries a
+    non-zero ``free_worktrees`` value — the retired hint no longer ranks."""
     from django.db import transaction
 
-    # ``fresh_full`` has the newest heartbeat but no free desk; ``older_free``
-    # is older but reports a free worktree. The free-desk preference must
-    # override the heartbeat tiebreak.
-    fresh_full = _make_runner(create_user, workspace, pod, "fresh-full", heartbeat_ago_s=1)
-    fresh_full.free_worktrees = 0
-    fresh_full.save(update_fields=["free_worktrees"])
-
-    older_free = _make_runner(create_user, workspace, pod, "older-free", heartbeat_ago_s=20)
-    older_free.free_worktrees = 2
-    older_free.save(update_fields=["free_worktrees"])
-
-    with transaction.atomic():
-        picked = matcher.select_runner_in_pod(pod)
-    assert picked.pk == older_free.pk
-
-
-@pytest.mark.unit
-def test_select_runner_in_pod_none_hint_keeps_heartbeat_order(
-    db, create_user, workspace, pod
-):
-    """Two eligible runners both reporting no hint (``None``, e.g. old
-    runners) fall back to today's oldest-heartbeat-wins ordering."""
-    from django.db import transaction
-
-    _make_runner(create_user, workspace, pod, "old", heartbeat_ago_s=20)
     fresh = _make_runner(create_user, workspace, pod, "fresh", heartbeat_ago_s=1)
-    assert fresh.free_worktrees is None
+    fresh.free_worktrees = 0
+    fresh.save(update_fields=["free_worktrees"])
+
+    older_with_stale_hint = _make_runner(create_user, workspace, pod, "older", heartbeat_ago_s=20)
+    older_with_stale_hint.free_worktrees = 2
+    older_with_stale_hint.save(update_fields=["free_worktrees"])
+
     with transaction.atomic():
         picked = matcher.select_runner_in_pod(pod)
     assert picked.pk == fresh.pk
 
 
 @pytest.mark.unit
-def test_select_runner_in_pod_zero_free_not_excluded(db, create_user, workspace, pod):
-    """``free_worktrees == 0`` is a preference miss, never a gate — a runner
-    reporting a full pool is still selected when it's the only candidate."""
+def test_select_runner_in_pod_selects_runner_with_zero_free_worktrees(db, create_user, workspace, pod):
+    """A stale ``free_worktrees == 0`` is not a gate — the sole eligible idle
+    runner is still selected."""
     from django.db import transaction
 
     full = _make_runner(create_user, workspace, pod, "full")

--- a/apps/api/pi_dash/tests/unit/runner/test_worktree_pooling.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_worktree_pooling.py
@@ -13,7 +13,6 @@ plan phases 4–5.
 
 from __future__ import annotations
 
-import uuid as _uuid
 from unittest.mock import patch
 
 import pytest
@@ -90,18 +89,30 @@ def _post_queued(api_client, run, token, position, key=None):
 # ---------------------------------------------------------------------------
 
 
+# The worktree pool is retired (PDASHOSS01-137): ``POST /runs/<id>/queued`` no
+# longer transitions a run into WAITING_FOR_WORKTREE or records a position. It
+# stays only so pre-retirement daemons that still post it get an acknowledgement
+# instead of a 404. Every post is acknowledged-and-dropped, leaving the run's
+# status and (deprecated) queue_position untouched.
+
+
 @pytest.mark.unit
-def test_queued_assigned_to_waiting_with_position(db, api_client, runner_token, assigned_run):
+def test_queued_assigned_stays_assigned(db, api_client, runner_token, assigned_run):
+    """No new run may enter WAITING_FOR_WORKTREE: an ASSIGNED run posting
+    ``queued`` is acknowledged and left ASSIGNED with no position."""
     resp = _post_queued(api_client, assigned_run, runner_token, 3)
     assert resp.status_code == 200, resp.data
     assert resp.data.get("ok") is True
+    assert resp.data.get("ignored") is True
     assigned_run.refresh_from_db()
-    assert assigned_run.status == AgentRunStatus.WAITING_FOR_WORKTREE
-    assert assigned_run.queue_position == 3
+    assert assigned_run.status == AgentRunStatus.ASSIGNED
+    assert assigned_run.queue_position is None
 
 
 @pytest.mark.unit
-def test_queued_waiting_to_waiting_refreshes_position(db, api_client, runner_token, assigned_run):
+def test_queued_leaves_historical_waiting_row_untouched(db, api_client, runner_token, assigned_run):
+    """A pre-retirement row already in WAITING_FOR_WORKTREE keeps rendering:
+    a ``queued`` post neither advances nor clears its stored position."""
     assigned_run.status = AgentRunStatus.WAITING_FOR_WORKTREE
     assigned_run.queue_position = 5
     assigned_run.save(update_fields=["status", "queue_position"])
@@ -110,13 +121,13 @@ def test_queued_waiting_to_waiting_refreshes_position(db, api_client, runner_tok
     assert resp.status_code == 200, resp.data
     assigned_run.refresh_from_db()
     assert assigned_run.status == AgentRunStatus.WAITING_FOR_WORKTREE
-    assert assigned_run.queue_position == 2
+    assert assigned_run.queue_position == 5
 
 
 @pytest.mark.unit
 def test_queued_does_not_regress_running_run(db, api_client, runner_token, assigned_run):
-    """A late/duplicate queued post against a RUNNING run is acknowledged and
-    dropped — it must never pull a live run back to WAITING_FOR_WORKTREE."""
+    """A queued post against a RUNNING run is acknowledged and dropped — it
+    must never pull a live run back to WAITING_FOR_WORKTREE."""
     assigned_run.status = AgentRunStatus.RUNNING
     assigned_run.started_at = timezone.now()
     assigned_run.save(update_fields=["status", "started_at"])
@@ -137,23 +148,10 @@ def test_queued_terminal_is_acknowledged_and_dropped(db, api_client, runner_toke
 
     resp = _post_queued(api_client, assigned_run, runner_token, 1)
     assert resp.status_code == 200, resp.data
-    assert resp.data.get("terminal") is True
+    assert resp.data.get("ok") is True
     assigned_run.refresh_from_db()
     assert assigned_run.status == AgentRunStatus.COMPLETED
     assert assigned_run.queue_position is None
-
-
-@pytest.mark.unit
-def test_queued_dedupes_duplicate(db, api_client, runner_token, assigned_run):
-    msg_id = _uuid.uuid4().hex
-    first = _post_queued(api_client, assigned_run, runner_token, 4, key=msg_id)
-    second = _post_queued(api_client, assigned_run, runner_token, 1, key=msg_id)
-    assert first.status_code == 200
-    assert second.status_code == 200
-    assert second.data.get("duplicate") is True
-    assigned_run.refresh_from_db()
-    # The duplicate must not have applied the second (smaller) position.
-    assert assigned_run.queue_position == 4
 
 
 @pytest.mark.unit
@@ -521,13 +519,13 @@ def test_poll_still_reaps_old_unreported_waiting_run(db, api_client, runner_toke
 
 
 # ---------------------------------------------------------------------------
-# free_worktrees capacity hint persistence (Phase 7)
+# free_worktrees capacity hint retired (PDASHOSS01-137)
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.unit
-def test_poll_persists_free_worktrees(db, api_client, runner_token, enrolled_runner):
-    open_resp = _open_session(api_client, enrolled_runner, runner_token, in_flight=None)
+def _poll_with_status(api_client, runner, token, status_body):
+    """Open a session and issue one status poll, returning its response."""
+    open_resp = _open_session(api_client, runner, token, in_flight=None)
     assert open_resp.status_code == 201, open_resp.data
     sid = open_resp.data["session_id"]
 
@@ -547,52 +545,39 @@ def test_poll_persists_free_worktrees(db, api_client, runner_token, enrolled_run
         patch("pi_dash.settings.redis.async_redis_instance", return_value=None),
         patch("django.db.transaction.on_commit", side_effect=lambda fn, **kw: fn()),
     ):
-        poll_resp = api_client.post(
-            f"/api/v1/runner/runners/{enrolled_runner.id}/sessions/{sid}/poll",
-            {
-                "ack": [],
-                "status": {
-                    "status": "online",
-                    "free_worktrees": 1,
-                    "ts": timezone.now().isoformat(),
-                },
-            },
+        return api_client.post(
+            f"/api/v1/runner/runners/{runner.id}/sessions/{sid}/poll",
+            {"ack": [], "status": status_body},
             format="json",
-            HTTP_AUTHORIZATION=f"Bearer {runner_token}",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-    assert poll_resp.status_code == 200, poll_resp.data
-    enrolled_runner.refresh_from_db()
-    assert enrolled_runner.free_worktrees == 1
 
 
 @pytest.mark.unit
-def test_parse_free_worktrees_coercion():
-    assert session_service.parse_free_worktrees(None) is None
-    assert session_service.parse_free_worktrees("bad") is None
-    assert session_service.parse_free_worktrees(-1) is None
-    assert session_service.parse_free_worktrees(0) == 0
-    assert session_service.parse_free_worktrees("3") == 3
-    # Out-of-range reports are clamped to the column's int32 ceiling rather
-    # than raising (which would 500 the poll handler).
-    assert session_service.parse_free_worktrees(2**31 - 1) == 2**31 - 1
-    assert session_service.parse_free_worktrees(2**31) == session_service.FREE_WORKTREES_MAX
-    assert session_service.parse_free_worktrees(2**63) == session_service.FREE_WORKTREES_MAX
-
-
-@pytest.mark.unit
-def test_parse_queue_position_coercion():
-    from pi_dash.runner.views.run_endpoints import (
-        QUEUE_POSITION_MAX,
-        _parse_queue_position,
+def test_poll_ignores_reported_free_worktrees(db, api_client, runner_token, enrolled_runner):
+    """A pre-retirement daemon still reports ``free_worktrees``. The poll must
+    succeed and never persist it — the capacity hint is retired."""
+    resp = _poll_with_status(
+        api_client,
+        enrolled_runner,
+        runner_token,
+        {"status": "online", "free_worktrees": 1, "ts": timezone.now().isoformat()},
     )
+    assert resp.status_code == 200, resp.data
+    enrolled_runner.refresh_from_db()
+    assert enrolled_runner.free_worktrees is None
 
-    assert _parse_queue_position(None) is None
-    assert _parse_queue_position("bad") is None
-    assert _parse_queue_position(-1) is None
-    assert _parse_queue_position(0) == 0
-    assert _parse_queue_position("3") == 3
-    # Out-of-range reports are clamped to the PositiveSmallIntegerField
-    # ceiling rather than raising (which would 500 the endpoint).
-    assert _parse_queue_position(QUEUE_POSITION_MAX) == QUEUE_POSITION_MAX
-    assert _parse_queue_position(QUEUE_POSITION_MAX + 1) == QUEUE_POSITION_MAX
-    assert _parse_queue_position(2**31) == QUEUE_POSITION_MAX
+
+@pytest.mark.unit
+def test_poll_handles_daemon_without_free_worktrees(db, api_client, runner_token, enrolled_runner):
+    """A post-retirement daemon omits ``free_worktrees`` entirely; the session
+    poll handles it without error (acceptance criterion)."""
+    resp = _poll_with_status(
+        api_client,
+        enrolled_runner,
+        runner_token,
+        {"status": "online", "ts": timezone.now().isoformat()},
+    )
+    assert resp.status_code == 200, resp.data
+    enrolled_runner.refresh_from_db()
+    assert enrolled_runner.free_worktrees is None


### PR DESCRIPTION
## PDASHOSS01-137 — Cloud: retire the worktree queue and capacity hint

Parent: **PDASHOSS01-134** (runner side — delete the worktree pool). Pooling leaked into the cloud as a run status transition, a matcher ranking preference, and two write-only model fields. With no pool there is nothing to queue for and no capacity to report.

**This is not a pure deletion.** `WAITING_FOR_WORKTREE` is a persisted DB value; historical rows reference it and must keep rendering. The enum member and both columns are kept and only *stop being written*. The change is deliberately backward compatible with pre-retirement daemons, which makes it deploy-order safe.

### Changes

- **`run_endpoints.py`** — `RunQueuedEndpoint` (`POST /runs/<id>/queued`) now acknowledges-and-drops (`{"ok": true, "ignored": true}`). No run may enter `WAITING_FOR_WORKTREE`; a pre-retirement daemon that still POSTs `/queued` gets an OK (never a 404, never a retry loop) and the run stays `ASSIGNED` until `accept` drives it to `RUNNING`. Removed the now-dead `_parse_queue_position` / `QUEUE_POSITION_MAX`.
- **`matcher.py`** — dropped the `free_worktrees` free-desk ranking (`_free_desk_rank`); idle runners are ranked by freshest heartbeat only. Documented as a preference and never a gate, so this changes ordering, not correctness. `WAITING_FOR_WORKTREE` stays in `BUSY_STATUSES` / `NON_TERMINAL_STATUSES` so historical rows keep gating and redelivering.
- **`sessions.py`** — stopped persisting a reported `free_worktrees` hint. A daemon that reports it (old) and one that omits it (new) both poll without error. Removed the dead `parse_free_worktrees` / `FREE_WORKTREES_MAX`.

### Kept (deprecated, not deleted)

`AgentRunStatus.WAITING_FOR_WORKTREE`, `Runner.free_worktrees`, `AgentRun.queue_position`. **No migration** — migration `0017_worktree_pooling` stays applied; dropping the columns is a separate, irreversible decision with no urgency.

### Deploy ordering

The issue notes a dependency on PDASHOSS01-134 being deployed. This change is built to tolerate old daemons (endpoint acks instead of 404ing; ingestion ignores `free_worktrees` whether present or absent), so it is safe to merge and deploy independently of the runner change.

### Tests

Updated (not deleted) `test_worktree_pooling.py` (queued endpoint now acks-and-drops; historical `WAITING_FOR_WORKTREE` rows untouched; poll handles a daemon with and without `free_worktrees`) and `test_drain_pod.py` (matcher ranks by heartbeat, ignoring `free_worktrees`).

Verified in the local `pi-dash-api` container:
- `pytest test_worktree_pooling.py test_drain_pod.py` → 42 passed
- `pytest test_matcher.py test_poll_heartbeat_drain.py test_runs_views.py test_machine_sessions.py test_https_transport_run_endpoints.py orchestration/test_service.py` → 119 passed
- `ruff check` clean; `makemigrations --check` shows no migration for these fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)
