### PR TITLE
PDASHOSS01-140 Prefill project in "Add runner" modal when opened from the project-scoped AI Workers page

### DIFF
--- a/apps/web/app/(all)/[workspaceSlug]/runners/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/page.tsx
@@ -354,6 +354,7 @@ const RunnersListPage = observer(function RunnersListPage() {
           onClose={() => setAddOpen(false)}
           workspaceId={workspaceId}
           workspaceSlug={workspaceSlug}
+          projectId={projectId}
         />
       )}
       {workspaceSlug && (

--- a/apps/web/core/components/runners/add-runner-modal.tsx
+++ b/apps/web/core/components/runners/add-runner-modal.tsx
@@ -31,6 +31,13 @@ type Props = {
   onClose: () => void;
   workspaceId: string;
   workspaceSlug: string;
+  /**
+   * Route project UUID when the modal is opened from the project-scoped
+   * AI Workers page (/<workspace>/projects/<projectId>/runners). When set,
+   * the Project field is prefilled with the matching project and locked;
+   * left undefined on the workspace-wide page for today's pick-a-project flow.
+   */
+  projectId?: string;
 };
 
 // Mirrors the runner CLI's ``--agent`` value-enum (kebab-case). Keep in
@@ -93,7 +100,11 @@ const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve,
 const machineDisplayLabel = (machine: IDevMachine): string => machine.label || machine.host_label || machine.id;
 
 export const AddRunnerModal = observer(function AddRunnerModal(props: Props) {
-  const { isOpen, onClose, workspaceId, workspaceSlug } = props;
+  const { isOpen, onClose, workspaceId, workspaceSlug, projectId } = props;
+  // Lock the Project picker when the modal is scoped to a route project —
+  // creating a runner for a different project from inside a project page is
+  // confusing; the workspace-wide page covers the cross-project case.
+  const projectLocked = Boolean(projectId);
   const { t } = useTranslation();
   const [origin, setOrigin] = useState(() => (typeof window !== "undefined" ? window.location.origin : ""));
 
@@ -124,6 +135,9 @@ export const AddRunnerModal = observer(function AddRunnerModal(props: Props) {
   // One-shot per open: auto-select the first connected machine once the
   // machine list arrives, unless the user already touched the picker.
   const autoSelectedMachine = useRef(false);
+  // One-shot per open: prefill the project field from the route projectId
+  // once the projects list arrives (project-scoped page only).
+  const prefilledProject = useRef(false);
 
   // Reset everything on close→open. State persists between consecutive
   // opens otherwise (RHF + local command state would carry the stale
@@ -135,6 +149,7 @@ export const AddRunnerModal = observer(function AddRunnerModal(props: Props) {
     }
     pollCancelled.current = false;
     autoSelectedMachine.current = false;
+    prefilledProject.current = false;
     setRunnerCommand(null);
     setRemoteCreate(null);
     setLastSubmitted(null);
@@ -182,6 +197,19 @@ export const AddRunnerModal = observer(function AddRunnerModal(props: Props) {
   );
   const selectedProject = watch("projectIdentifier");
   const selectedPodName = watch("podName");
+
+  // Prefill the project field from the route projectId once the projects
+  // list arrives (project-scoped page). One-shot per open — the reset effect
+  // clears the ref so the prefill re-applies each time the modal reopens.
+  // The form stores the project *identifier* (e.g. PDASHOSS01), resolved from
+  // the projects-lite list by matching on the route UUID.
+  useEffect(() => {
+    if (prefilledProject.current || !isOpen || !projectId) return;
+    const match = projects?.find((p) => p.id === projectId);
+    if (!match) return;
+    prefilledProject.current = true;
+    setValue("projectIdentifier", match.identifier, { shouldValidate: true });
+  }, [isOpen, projectId, projects, setValue]);
   const { data: pods, error: podsError } = useSWR<IPod[]>(isOpen && workspaceId ? ["pods", workspaceId] : null, () =>
     podService.list(workspaceId)
   );
@@ -453,7 +481,7 @@ export const AddRunnerModal = observer(function AddRunnerModal(props: Props) {
                   input
                   maxHeight="lg"
                   placement="bottom-start"
-                  disabled={!projects || projects.length === 0}
+                  disabled={projectLocked || !projects || projects.length === 0}
                 >
                   <>
                     {(projects ?? []).map((p) => (

--- a/apps/web/tests/runners/add-runner-modal.test.tsx
+++ b/apps/web/tests/runners/add-runner-modal.test.tsx
@@ -4,7 +4,7 @@
  * See the LICENSE file for details.
  */
 
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -161,9 +161,11 @@ describe("AddRunnerModal", () => {
 
   // SWR caches by key across tests in this file; pass a unique
   // workspaceId when a test needs fresh dev-machine data.
-  function renderModal(workspaceId = "workspace-1") {
+  function renderModal(workspaceId = "workspace-1", projectId?: string) {
     const onClose = vi.fn();
-    const utils = render(<AddRunnerModal isOpen onClose={onClose} workspaceId={workspaceId} workspaceSlug="acme" />);
+    const utils = render(
+      <AddRunnerModal isOpen onClose={onClose} workspaceId={workspaceId} workspaceSlug="acme" projectId={projectId} />
+    );
     return { ...utils, onClose };
   }
 
@@ -198,6 +200,37 @@ describe("AddRunnerModal", () => {
     expect(command.textContent).toContain("--agent codex");
     expect(command.textContent).not.toContain("pidash connect");
     expect(command.textContent).not.toContain("--token");
+  });
+
+  it("prefills and locks the project when opened from a project-scoped page", async () => {
+    const user = userEvent.setup();
+    // ``project-1`` is the route UUID; the modal resolves it to the BROWSERX
+    // identifier from the projects-lite list.
+    renderModal("workspace-scoped", "project-1");
+
+    await screen.findByRole("option", { name: "BrowserX" });
+    const projectSelect = screen.getAllByTestId("select")[1];
+    await waitFor(() => expect(projectSelect).toHaveValue("BROWSERX"));
+    // Field is locked — creating a runner for another project from inside a
+    // project page is intentionally disallowed here.
+    expect(projectSelect).toBeDisabled();
+
+    // No user action on the Project field needed; the generated command
+    // carries the prefilled identifier.
+    await user.click(screen.getByRole("button", { name: "Generate Runner" }));
+    const command = await screen.findByText(
+      (_content: string, node: Element | null) => node?.tagName.toLowerCase() === "pre"
+    );
+    expect(command.textContent).toContain("--project BROWSERX");
+  });
+
+  it("leaves the project empty and editable when no projectId is supplied", async () => {
+    renderModal("workspace-unscoped");
+
+    await screen.findByRole("option", { name: "BrowserX" });
+    const projectSelect = screen.getAllByTestId("select")[1];
+    expect(projectSelect).toHaveValue("");
+    expect(projectSelect).not.toBeDisabled();
   });
 
   it("lets the user go back and edit the form after generating a command", async () => {


### PR DESCRIPTION
## What

Prefill (and lock) the **Project** field in the **Add runner** modal when it is opened from the project-scoped AI Workers page (`/<workspace>/projects/<projectId>/runners`). The workspace-wide AI Workers page (`/<workspace>/runners`) keeps today's empty, user-selected behavior.

Resolves **PDASHOSS01-140**.

## Why

Both routes render the same page module. On the project-scoped page the modal previously opened with an empty Project picker, forcing the user to re-select the project they were already inside. That context is in the route and should be filled automatically.

## Changes

- **`add-runner-modal.tsx`**
  - New optional `projectId?: string` prop (route project UUID).
  - One-shot-per-open effect resolves the UUID to the project *identifier* from the projects-lite SWR list (`project.id === projectId`) and `setValue("projectIdentifier", …)` — mirrors the existing pod→project auto-fill pattern. A `prefilledProject` ref is reset in the open effect so the prefill re-applies on every reopen.
  - The Project `CustomSelect` is disabled when `projectId` is supplied (`projectLocked`).
  - The pod picker auto-scopes to the project via the existing `podsForPicker` cascade once `projectIdentifier` is set; the generated CLI command and remote-create payload carry the same identifier with no separate code path.
- **`runners/page.tsx`** — passes the route `projectId` down. No-op on the workspace-wide route (undefined) and on `ai-dev-machines/page.tsx` (never passes it).
- **`add-runner-modal.test.tsx`** — project prefilled + locked when `projectId` is supplied; empty + editable when it is not.

## Testing

- `vitest run tests/runners/add-runner-modal.test.tsx` → 9 passed (2 new).
- `vitest run tests/runners/muse-code-runner.test.tsx` → 2 passed (regression).
- `oxlint` + `oxfmt --check` clean on changed files.

> Note: `pnpm run check:types` reports 9 pre-existing errors in `runs/page.tsx` / `agent-status.tsx` (leftover `waiting_for_worktree` / `queue_position` references) that are unrelated to this change — confirmed identical count on the clean base branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
