### PR TITLE
PDASHOSS01-141 Rename the "Add runner" button to "Add AI Worker" (first step of Runner → AI Worker terminology migration)

### DIFF
--- a/apps/web/app/(all)/[workspaceSlug]/ai-dev-machines/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/ai-dev-machines/page.tsx
@@ -144,22 +144,32 @@ const AiDevMachinesPage = observer(function AiDevMachinesPage() {
       {/* Intro — what the CLI / daemon / runner each are */}
       <section className="flex flex-col gap-4">
         <h2 className="text-14 font-semibold text-primary">{t("What is the pidash CLI, daemon, and runner?")}</h2>
-        <p className="text-13 text-secondary">{t("Pi Dash hands AI agents (Claude Code, Codex, …) the keys to a real dev machine so they can pick up work items, write code, and open changes. Three pieces work together to make that possible:")}</p>
+        <p className="text-13 text-secondary">
+          {t(
+            "Pi Dash hands AI agents (Claude Code, Codex, …) the keys to a real dev machine so they can pick up work items, write code, and open changes. Three pieces work together to make that possible:"
+          )}
+        </p>
         <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
           <ConceptCard
             icon={<Terminal className="size-4" />}
             title={t("pidash CLI")}
-            body={t("The command-line tool installed on each dev machine. Handles authentication with the cloud, manages local config (`~/.pidash/config.toml`), and exposes commands for issues, comments, and runner management (`pidash auth login`, `pidash runner add`, `pidash doctor`, …).")}
+            body={t(
+              "The command-line tool installed on each dev machine. Handles authentication with the cloud, manages local config (`~/.pidash/config.toml`), and exposes commands for issues, comments, and runner management (`pidash auth login`, `pidash runner add`, `pidash doctor`, …)."
+            )}
           />
           <ConceptCard
             icon={<Cpu className="size-4" />}
             title={t("pidash daemon")}
-            body={t("A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine.")}
+            body={t(
+              "A long-running background process that maintains the WebSocket session with Pi Dash cloud, dispatches work to the configured agent, and streams approvals + heartbeats back. One daemon per machine."
+            )}
           />
           <ConceptCard
             icon={<Laptop className="size-4" />}
             title={t("AI Agent runner")}
-            body={t("A cloud-side row that represents one agent instance bound to a project (and optionally a pod). Running `pidash runner add` on a logged-in machine creates the row and binds that machine as the host. A machine can host many runners.")}
+            body={t(
+              "A cloud-side row that represents one agent instance bound to a project (and optionally a pod). Running `pidash runner add` on a logged-in machine creates the row and binds that machine as the host. A machine can host many runners."
+            )}
           />
         </div>
       </section>
@@ -168,10 +178,12 @@ const AiDevMachinesPage = observer(function AiDevMachinesPage() {
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div>
             <h2 className="text-14 font-semibold text-primary">{t("Dev machines")}</h2>
-            <p className="mt-1 text-13 text-secondary">{t("Machines that have authenticated with Pi Dash or host runners for this workspace.")}</p>
+            <p className="mt-1 text-13 text-secondary">
+              {t("Machines that have authenticated with Pi Dash or host runners for this workspace.")}
+            </p>
           </div>
           <Button onClick={() => setAddOpen(true)} disabled={!workspaceId}>
-            {t("Add runner")}
+            {t("Add AI Worker")}
           </Button>
         </div>
         <div className="overflow-x-auto rounded-md border border-subtle">
@@ -225,12 +237,8 @@ const AiDevMachinesPage = observer(function AiDevMachinesPage() {
                           total: machine.runner_count,
                         })}
                       </td>
-                      <td className="px-3 py-2">
-                        {formatDateTime(machine.last_seen_at, t("Never"))}
-                      </td>
-                      <td className="px-3 py-2">
-                        {formatDateTime(machine.last_heartbeat_at, t("Never"))}
-                      </td>
+                      <td className="px-3 py-2">{formatDateTime(machine.last_seen_at, t("Never"))}</td>
+                      <td className="px-3 py-2">{formatDateTime(machine.last_heartbeat_at, t("Never"))}</td>
                       <td className="px-3 py-2 text-right">
                         <div className="flex justify-end gap-2">
                           {!machine.revoked_at && (
@@ -273,7 +281,11 @@ const AiDevMachinesPage = observer(function AiDevMachinesPage() {
       {/* Install command — copy / paste */}
       <section className="flex flex-col gap-3">
         <h2 className="text-14 font-semibold text-primary">{t("Install the pidash CLI")}</h2>
-        <p className="text-13 text-secondary">{t("Run an installer on the machine that will host your AI agent. The wrapper commands download the latest signed binary, drop `pidash` on your PATH, and walk you through the device-code login.")}</p>
+        <p className="text-13 text-secondary">
+          {t(
+            "Run an installer on the machine that will host your AI agent. The wrapper commands download the latest signed binary, drop `pidash` on your PATH, and walk you through the device-code login."
+          )}
+        </p>
 
         <InstallCommand label={t("macOS / Linux")} command={INSTALL_CMD_UNIX} />
         <InstallCommand label={t("Windows (PowerShell)")} command={INSTALL_CMD_WINDOWS} />
@@ -284,7 +296,11 @@ const AiDevMachinesPage = observer(function AiDevMachinesPage() {
           hrefLabel={t("Download MSI")}
         />
 
-        <p className="text-12 text-secondary">{t("Prerequisite: the agent CLI you plan to use (`codex` or `claude`) must already be installed and on PATH. Run `pidash doctor` after install to verify.")}</p>
+        <p className="text-12 text-secondary">
+          {t(
+            "Prerequisite: the agent CLI you plan to use (`codex` or `claude`) must already be installed and on PATH. Run `pidash doctor` after install to verify."
+          )}
+        </p>
       </section>
 
       {workspaceId && workspaceSlug && (
@@ -301,7 +317,9 @@ const AiDevMachinesPage = observer(function AiDevMachinesPage() {
         handleSubmit={confirmRotateMachine}
         isSubmitting={rotating}
         title={t("Rotate dev machine token?")}
-        content={t("The active auth token for this dev machine will be invalidated. Runners on that machine will stop connecting until `pidash auth login` is run there again.")}
+        content={t(
+          "The active auth token for this dev machine will be invalidated. Runners on that machine will stop connecting until `pidash auth login` is run there again."
+        )}
         variant="primary"
         primaryButtonText={{ default: t("Rotate"), loading: t("Rotate") }}
       />
@@ -311,7 +329,9 @@ const AiDevMachinesPage = observer(function AiDevMachinesPage() {
         handleSubmit={confirmRevokeMachine}
         isSubmitting={revoking}
         title={t("Revoke dev machine?")}
-        content={t("This permanently revokes the dev machine, invalidates its auth token, and revokes runners hosted on it. Use this when the machine should no longer be trusted.")}
+        content={t(
+          "This permanently revokes the dev machine, invalidates its auth token, and revokes runners hosted on it. Use this when the machine should no longer be trusted."
+        )}
         primaryButtonText={{ default: t("Revoke"), loading: t("Revoke") }}
       />
     </div>

--- a/apps/web/app/(all)/[workspaceSlug]/runners/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/page.tsx
@@ -154,7 +154,7 @@ const RunnersListPage = observer(function RunnersListPage() {
         <div className="flex items-start justify-between gap-3">
           <div>
             <div className="flex items-center gap-1.5">
-              <div className="text-13 font-medium text-primary">{t("Add runner")}</div>
+              <div className="text-13 font-medium text-primary">{t("Add AI Worker")}</div>
               <Tooltip
                 position="bottom"
                 tooltipContent={
@@ -184,7 +184,7 @@ const RunnersListPage = observer(function RunnersListPage() {
             </div>
           </div>
           <Button onClick={() => setAddOpen(true)} disabled={!workspaceId}>
-            {t("Add runner")}
+            {t("Add AI Worker")}
           </Button>
         </div>
       </section>

--- a/packages/i18n/src/locales/en/translations.ts
+++ b/packages/i18n/src/locales/en/translations.ts
@@ -82,6 +82,7 @@ export default {
   "Active Projects": "Active Projects",
   Activity: "Activity",
   Add: "Add",
+  "Add AI Worker": "Add AI Worker",
   "Add API token": "Add API token",
   "Add assignees": "Add assignees",
   "Add assignees to work items to see a breakdown of work by assignees.":


### PR DESCRIPTION
## What

First step of the gradual **Runner → AI Worker** user-facing terminology migration. Renames only the primary **"Add runner"** CTA label to **"Add AI Worker"** on the three surfaces that carry it:

- `apps/web/app/(all)/[workspaceSlug]/runners/page.tsx` — the AI Workers page CTA button and the small header label above the how-it-works tooltip (this component serves both the workspace-wide `/<ws>/runners` and the project-scoped `/<ws>/projects/<id>/runners` routes).
- `apps/web/app/(all)/[workspaceSlug]/ai-dev-machines/page.tsx` — the same CTA on the dev-machines page.

The page header already reads "AI Workers", so the button was inconsistent with the nav label right above it.

## i18n

Translation keys in this repo are the English source strings, so this is a **key change**, not just a value change:

- Added `"Add AI Worker": "Add AI Worker"` to `packages/i18n/src/locales/en/translations.ts`.
- Kept the old `"Add runner"` key — the add-runner modal internals still use it and it will be retired in a later migration step.
- Non-English overlay locales (private repo) fall back to the English text until translated — acceptable for this step, tracked as follow-up.
- `packages/i18n/dist/` is gitignored build output; regenerated locally via the i18n build, not hand-edited.

## Out of scope (later migration steps)

Modal heading/success text, empty-state copy, the how-it-works tooltip body, the mobile app, and all internal/technical naming (routes, API paths, the `pidash runner add` CLI, types, services, DB columns) — those stay "runner". This change is user-facing copy only.

## Testing

- `pnpm turbo run check:types --filter=web` — passes.
- `pnpm turbo run build --filter=@pi-dash/i18n` — regenerates dist; new key resolves.
- No page-level test asserts the CTA label; existing modal tests intentionally stay on "Add runner".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
