### PR TITLE
PDASHOSS01-147 Lint API gate blocks every PR into main on pre-existing ruff debt

### DIFF
--- a/apps/api/pi_dash/app/views/integration/git.py
+++ b/apps/api/pi_dash/app/views/integration/git.py
@@ -58,8 +58,13 @@ class GitProviderAccountListCreateEndpoint(BaseAPIView):
     @allow_permission(allowed_roles=[ROLE.ADMIN, ROLE.MEMBER], level="WORKSPACE")
     def get(self, request, slug):
         workspace = get_object_or_404(Workspace, slug=slug)
-        accounts = GitProviderAccount.objects.filter(workspace=workspace).order_by("provider", "host_url", "display_name")
-        return Response({"accounts": [serialize_provider_account(account) for account in accounts]}, status=status.HTTP_200_OK)
+        accounts = GitProviderAccount.objects.filter(workspace=workspace).order_by(
+            "provider", "host_url", "display_name"
+        )
+        return Response(
+            {"accounts": [serialize_provider_account(account) for account in accounts]},
+            status=status.HTTP_200_OK,
+        )
 
     @allow_permission(allowed_roles=[ROLE.ADMIN], level="WORKSPACE")
     def post(self, request, slug):
@@ -71,7 +76,9 @@ class GitProviderAccountListCreateEndpoint(BaseAPIView):
         if not token:
             return Response({"error": "token is required"}, status=status.HTTP_400_BAD_REQUEST)
         auth_type = (request.data.get("auth_type") or "pat").strip()
-        host_url = (request.data.get("host_url") or ("https://github.com" if provider == "github" else _gitlab_host())).rstrip("/")
+        host_url = (
+            request.data.get("host_url") or ("https://github.com" if provider == "github" else _gitlab_host())
+        ).rstrip("/")
         try:
             account = create_provider_account(
                 workspace=workspace,

--- a/apps/api/pi_dash/app/views/integration/github.py
+++ b/apps/api/pi_dash/app/views/integration/github.py
@@ -672,7 +672,10 @@ class GithubAppInstallStartEndpoint(BaseAPIView):
             return Response({"error": "workspace_slug is required"}, status=status.HTTP_400_BAD_REQUEST)
         workspace = get_object_or_404(Workspace, slug=workspace_slug)
         if not _is_workspace_admin(request.user, workspace):
-            return Response({"error": "You must be a workspace admin to install the GitHub App"}, status=status.HTTP_403_FORBIDDEN)
+            return Response(
+                {"error": "You must be a workspace admin to install the GitHub App"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
 
         state = secrets.token_urlsafe(32)
         install_session = GithubAppInstallSession.objects.create(
@@ -703,11 +706,17 @@ class GithubAppRefreshEndpoint(BaseAPIView):
             return Response({"error": "workspace_slug is required"}, status=status.HTTP_400_BAD_REQUEST)
         workspace = get_object_or_404(Workspace, slug=workspace_slug)
         if not _is_workspace_admin(request.user, workspace):
-            return Response({"error": "You must be a workspace admin to refresh this connection"}, status=status.HTTP_403_FORBIDDEN)
+            return Response(
+                {"error": "You must be a workspace admin to refresh this connection"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
         wi = _get_workspace_integration(workspace)
         app_installation = getattr(wi, "github_app_installation", None) if wi else None
         if app_installation is None:
-            return Response({"error": "GitHub App is not installed for this workspace"}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"error": "GitHub App is not installed for this workspace"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
         try:
             app_installation = _refresh_app_installation(app_installation, raise_on_error=True)
         except GithubAppAuthError:
@@ -739,7 +748,9 @@ class GithubAppCallbackEndpoint(BaseAPIView):
         if not state:
             return _redirect_to_profile_integrations({"github_app": "error", "error": "missing_state"})
 
-        install_session = GithubAppInstallSession.objects.filter(state=state).select_related("workspace", "actor").first()
+        install_session = (
+            GithubAppInstallSession.objects.filter(state=state).select_related("workspace", "actor").first()
+        )
         if install_session is None:
             return _redirect_to_profile_integrations({"github_app": "error", "error": "unknown_state"})
 

--- a/apps/api/pi_dash/app/views/issue/comment.py
+++ b/apps/api/pi_dash/app/views/issue/comment.py
@@ -19,7 +19,15 @@ from rest_framework import status
 from .. import BaseViewSet
 from pi_dash.app.serializers import IssueCommentSerializer, CommentReactionSerializer
 from pi_dash.app.permissions import allow_permission, ROLE
-from pi_dash.db.models import GitCommentSync, GithubCommentSync, IssueComment, ProjectMember, CommentReaction, Project, Issue
+from pi_dash.db.models import (
+    GitCommentSync,
+    GithubCommentSync,
+    IssueComment,
+    ProjectMember,
+    CommentReaction,
+    Project,
+    Issue,
+)
 from pi_dash.bgtasks.issue_activities_task import issue_activity
 from pi_dash.utils.host import base_host
 from pi_dash.bgtasks.webhook_task import model_activity

--- a/apps/api/pi_dash/app/views/issue/sub_issue.py
+++ b/apps/api/pi_dash/app/views/issue/sub_issue.py
@@ -7,7 +7,7 @@ import json
 
 # Django imports
 from django.utils import timezone
-from django.db.models import OuterRef, Func, F, Q, Value, UUIDField, Subquery, Count, IntegerField
+from django.db.models import OuterRef, F, Value, UUIDField, Subquery, Count, IntegerField
 from django.utils.decorators import method_decorator
 from django.views.decorators.gzip import gzip_page
 from django.contrib.postgres.aggregates import ArrayAgg

--- a/apps/api/pi_dash/assistant/tasks.py
+++ b/apps/api/pi_dash/assistant/tasks.py
@@ -446,7 +446,9 @@ def _classify_error(exc: Exception) -> tuple[str, str]:
         return "provider_out_of_credit", "The provider rejected the request for lack of credit."
     if any(s in text for s in ("401", "unauthorized", "api key", "authentication", "invalid_api_key")):
         return "provider_auth_failed", "Your API key was rejected by the provider."
-    if any(s in text for s in ("connection", "timeout", "timed out", "unreachable", "could not connect", "name resolution")):
+    if any(
+        s in text for s in ("connection", "timeout", "timed out", "unreachable", "could not connect", "name resolution")
+    ):
         return "provider_unreachable", "Could not reach the configured provider endpoint."
     if any(s in text for s in ("model_not_found", "does not exist", "unknown model", "no such model")):
         return "model_invalid", "The configured model name was not accepted by the provider."

--- a/apps/api/pi_dash/assistant/views/messages.py
+++ b/apps/api/pi_dash/assistant/views/messages.py
@@ -20,7 +20,6 @@ from pi_dash.assistant.models import (
 )
 from pi_dash.assistant.runtime import events
 from pi_dash.ee.assistant.model_provider import has_usable_llm_config
-from pi_dash.assistant.serializers import AssistantThreadSerializer
 from pi_dash.assistant.tasks import cancel_key, run_assistant_turn
 from pi_dash.assistant.views._base import AssistantBaseView
 from pi_dash.settings.redis import redis_instance

--- a/apps/api/pi_dash/bgtasks/_rrule.py
+++ b/apps/api/pi_dash/bgtasks/_rrule.py
@@ -69,7 +69,7 @@ def _parse_cron_field(spec: str, *, lo: int, hi: int) -> _CronField:
     ``N-M/K``, and comma-separated lists thereof."""
     spec = spec.strip()
     if not spec:
-        raise CronConversionError(f"empty cron field")
+        raise CronConversionError("empty cron field")
     if spec == "*":
         return _CronField(values=None)
 

--- a/apps/api/pi_dash/bgtasks/github_sync_task.py
+++ b/apps/api/pi_dash/bgtasks/github_sync_task.py
@@ -11,7 +11,6 @@ See .ai_design/github_sync/design.md §6.3 (full-scan sync) and §6.5
 from __future__ import annotations
 
 import logging
-from typing import Iterable
 
 from celery import shared_task
 from django.conf import settings

--- a/apps/api/pi_dash/db/models/integration/git.py
+++ b/apps/api/pi_dash/db/models/integration/git.py
@@ -281,7 +281,9 @@ class GitWebhookDelivery(BaseModel):
     delivery_id = models.CharField(max_length=255, db_index=True)
     event = models.CharField(max_length=100)
     action = models.CharField(max_length=100, blank=True, default="")
-    repository = models.ForeignKey("db.GitRepository", related_name="webhook_deliveries", null=True, blank=True, on_delete=models.SET_NULL)
+    repository = models.ForeignKey(
+        "db.GitRepository", related_name="webhook_deliveries", null=True, blank=True, on_delete=models.SET_NULL
+    )
     raw_headers = models.JSONField(default=dict)
     payload = models.JSONField(default=dict)
     status = models.CharField(max_length=16, choices=Status.choices, default=Status.RECEIVED)

--- a/apps/api/pi_dash/integrations/git/code_reviews.py
+++ b/apps/api/pi_dash/integrations/git/code_reviews.py
@@ -8,7 +8,6 @@ from django.db import IntegrityError
 
 from pi_dash.db.models import (
     GitCodeReviewLink,
-    GitProviderAccount,
     GitRepository,
     GitRepositoryBinding,
     GithubPullRequestLink,

--- a/apps/api/pi_dash/runner/services/pubsub.py
+++ b/apps/api/pi_dash/runner/services/pubsub.py
@@ -20,7 +20,6 @@ from typing import Any, Dict
 from uuid import UUID
 
 from pi_dash.runner.services.machine_outbox import (
-    MachineOfflineError,
     enqueue_for_machine,
 )
 from pi_dash.runner.services.outbox import (

--- a/apps/api/pi_dash/tests/contract/api/test_git_code_review_link.py
+++ b/apps/api/pi_dash/tests/contract/api/test_git_code_review_link.py
@@ -93,7 +93,9 @@ def test_attach_is_idempotent_for_same_issue(api_key_client, workspace, review_p
     assert GitCodeReviewLink.objects.filter(provider="gitlab", namespace="acme", repo_name="web").count() == 1
 
 
-def test_attach_conflict_when_review_linked_to_other_issue(api_key_client, workspace, review_project, issue, create_user):
+def test_attach_conflict_when_review_linked_to_other_issue(
+    api_key_client, workspace, review_project, issue, create_user
+):
     other_issue = Issue.objects.create(
         name="another issue",
         project=review_project,

--- a/apps/api/pi_dash/tests/contract/api/test_github_pr_link.py
+++ b/apps/api/pi_dash/tests/contract/api/test_github_pr_link.py
@@ -200,7 +200,13 @@ def test_attach_fills_snapshot_when_app_installed(api_key_client, workspace, pr_
     """When the workspace has an App installation covering the account, attach
     best-effort fetches the PR to pre-fill the display snapshot."""
     _install_app(workspace, create_user, account_login="acme")
-    fake_pr = {"title": "Make the button blue", "state": "open", "draft": True, "merged": False, "updated_at": "2026-06-17T09:00:00Z"}
+    fake_pr = {
+        "title": "Make the button blue",
+        "state": "open",
+        "draft": True,
+        "merged": False,
+        "updated_at": "2026-06-17T09:00:00Z",
+    }
 
     with patch(
         "pi_dash.utils.github_pr_links.GithubClient.for_installation",

--- a/apps/api/pi_dash/tests/contract/app/test_github_app_integration.py
+++ b/apps/api/pi_dash/tests/contract/app/test_github_app_integration.py
@@ -123,7 +123,9 @@ def test_github_app_status_excludes_non_admin_workspaces(session_client, create_
 def test_github_app_install_start_creates_session(session_client, workspace):
     url = reverse("github-app-install-start")
 
-    with patch("pi_dash.app.views.integration.github.require_github_app_config", return_value=_github_app_config()) as require_config:
+    with patch(
+        "pi_dash.app.views.integration.github.require_github_app_config", return_value=_github_app_config()
+    ) as require_config:
         response = session_client.post(url, {"workspace_slug": workspace.slug}, format="json")
 
     assert response.status_code == status.HTTP_201_CREATED

--- a/apps/api/pi_dash/tests/contract/assistant/test_events.py
+++ b/apps/api/pi_dash/tests/contract/assistant/test_events.py
@@ -6,7 +6,6 @@ import pytest
 
 from pi_dash.assistant.models import (
     AssistantEvent,
-    AssistantMessage,
     AssistantThread,
     AssistantTurn,
     MessageKind,

--- a/apps/api/pi_dash/tests/contract/assistant/test_serializers_ssrf.py
+++ b/apps/api/pi_dash/tests/contract/assistant/test_serializers_ssrf.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # See the LICENSE file for details.
 
-import pytest
 
 from pi_dash.assistant import ssrf
 from pi_dash.assistant.serializers import UserLLMConfigSerializer

--- a/apps/api/pi_dash/tests/unit/managed_runner/test_endpoints.py
+++ b/apps/api/pi_dash/tests/unit/managed_runner/test_endpoints.py
@@ -87,7 +87,12 @@ def test_issue_endpoints_persist_the_viewers_desktop_selection(
     from pi_dash.app.views.issue import base
     from pi_dash.db.models import Issue
 
-    for task in [base.issue_activity, base.model_activity, base.issue_description_version_task, base.recent_visited_task]:
+    for task in [
+        base.issue_activity,
+        base.model_activity,
+        base.issue_description_version_task,
+        base.recent_visited_task,
+    ]:
         monkeypatch.setattr(task, "delay", lambda **kwargs: None)
     path = f"/api/workspaces/{workspace.slug}/projects/{project.id}/issues/"
     if operation == "create":

--- a/apps/api/pi_dash/tests/unit/permissions/test_project_state.py
+++ b/apps/api/pi_dash/tests/unit/permissions/test_project_state.py
@@ -10,7 +10,6 @@ from pi_dash.db.models import (
     Project,
     ProjectMember,
     User,
-    Workspace,
     WorkspaceMember,
 )
 

--- a/apps/api/pi_dash/tests/unit/runner/test_https_transport_auth.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_https_transport_auth.py
@@ -11,7 +11,6 @@ access-token verification, and MachineToken bootstrap.
 from __future__ import annotations
 
 import pytest
-from django.utils import timezone
 
 from pi_dash.runner.models import (
     MachineToken,

--- a/apps/api/pi_dash/tests/unit/runner/test_issue_assigned_pod.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_issue_assigned_pod.py
@@ -19,9 +19,8 @@ See ``.ai_design/n_runners_in_same_machine/new_pod_project_relationship/design.m
 from __future__ import annotations
 
 import pytest
-from django.urls import reverse
 
-from pi_dash.app.serializers.issue import IssueCreateSerializer, IssueSerializer
+from pi_dash.app.serializers.issue import IssueCreateSerializer
 from pi_dash.db.models.issue import Issue
 from pi_dash.db.models.project import Project
 from pi_dash.db.models.state import State

--- a/apps/api/pi_dash/tests/unit/runner/test_issue_pod.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_issue_pod.py
@@ -6,14 +6,12 @@
 
 from __future__ import annotations
 
-from uuid import uuid4
 
 import pytest
 
 from pi_dash.db.models import (
     Project,
     State,
-    User,
     Workspace,
     WorkspaceMember,
 )

--- a/apps/api/pi_dash/tests/unit/runner/test_permissions.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_permissions.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import pytest
 
-from pi_dash.db.models import User, Workspace, WorkspaceMember
+from pi_dash.db.models import User, WorkspaceMember
 from pi_dash.runner.services.permissions import (
     ROLE_ADMIN,
     ROLE_MEMBER,

--- a/apps/api/pi_dash/tests/unit/runner/test_pod_views.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_pod_views.py
@@ -13,17 +13,15 @@ from __future__ import annotations
 from uuid import uuid4
 
 import pytest
-from django.urls import reverse
 from rest_framework import status
 
-from pi_dash.db.models import User, Workspace, WorkspaceMember
+from pi_dash.db.models import User, WorkspaceMember
 from pi_dash.db.models.project import Project
 from pi_dash.runner.models import (
     AgentRun,
     AgentRunStatus,
     Pod,
     Runner,
-    RunnerStatus,
 )
 
 

--- a/apps/api/pi_dash/tests/unit/runner/test_runners_project_filter.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_runners_project_filter.py
@@ -173,7 +173,9 @@ def test_chat_sessions_project_filter(db, session_client, workspace, project, se
     s1 = AgentChatSession.objects.create(workspace=workspace, runner=r1, created_by=workspace.owner, pod=p1)
     s2 = AgentChatSession.objects.create(workspace=workspace, runner=r2, created_by=workspace.owner, pod=p2)
 
-    resp = session_client.get("/api/runners/chat/sessions/", {"workspace": str(workspace.id), "project": str(project.id)})
+    resp = session_client.get(
+        "/api/runners/chat/sessions/", {"workspace": str(workspace.id), "project": str(project.id)}
+    )
 
     assert resp.status_code == status.HTTP_200_OK
     ids = {s["id"] for s in resp.data}

--- a/apps/api/pi_dash/tests/unit/scheduler/test_builtins.py
+++ b/apps/api/pi_dash/tests/unit/scheduler/test_builtins.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 from unittest import mock
 
 import pytest
-from django.db import IntegrityError
 
 from pi_dash.db.models import Scheduler
 from pi_dash.scheduler.builtins import (


### PR DESCRIPTION
## Problem

PDASHOSS01-132 (PR #367) enabled the **Build and lint API** workflow, which runs `ruff check apps/api`. `apps/api` already carried **35 pre-existing ruff violations on `main`**, so the check failed on every PR touching `apps/api` regardless of what the PR changed. First casualty was PDASHOSS01-134 / PR #363.

Confirmed pre-existing: `ruff check apps/api` against unmodified `origin/main` reports the identical `Found 35 errors. [*] 20 fixable`.

## Fix

One isolated PR that touches nothing but the lint debt:

1. `ruff check apps/api --fix` — cleared 19 `F401` (unused import) + 1 `F541` (f-string without placeholders). → *20 fixed, 15 remaining.*
2. Manually wrapped the 15 `E501` (line too long > 120) lines.
3. `ruff check apps/api` now reports **`All checks passed!`** (exit 0).

## No behavioural change

Only unused imports removed, one placeholder-free f-string de-prefixed (`f"empty cron field"` → `"empty cron field"`), and long lines wrapped across multiple lines. No logic changed. All 25 changed files pass `python -m py_compile`.

Scope note: the CI gate is `ruff check` only. `ruff format` is **not** enforced and shows broad pre-existing style drift across files not touched here, so it is deliberately left out of scope.

## Acceptance criteria

- [x] `ruff check apps/api` exits 0.
- [x] No behavioural change — pure lint cleanup.

Fixes PDASHOSS01-147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
