### PR TITLE
PDASHOSS01-155 pidash CLI: auto-install missing agent via its official install script when adding a runner

### DIFF
--- a/docs/wiki/17-cli-reference.md
+++ b/docs/wiki/17-cli-reference.md
@@ -82,16 +82,21 @@ pidash runner add --project <PROJECT> [--name <NAME>] [--workspace <SLUG>]
                   [--pod <POD>] [--working-dir <PATH>] [--agent codex|claude-code]
 ```
 
-| Flag                | Purpose                                                            |
-| ------------------- | ------------------------------------------------------------------ |
-| `--project <P>`     | Project identifier (slug or UUID). **Required.**                   |
-| `--name <N>`        | Human-friendly runner name. Auto-generated if omitted.             |
-| `--workspace <S>`   | Workspace slug. Required if you belong to multiple workspaces.     |
-| `--pod <P>`         | Pod within the project. Defaults to project's default pod.         |
-| `--working-dir <P>` | Local working dir for clones. Defaults to a path under `data_dir`. |
-| `--agent <K>`       | `codex` (default) or `claude-code`.                                |
+| Flag                     | Purpose                                                                                                                |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| `--project <P>`          | Project identifier (slug or UUID). **Required.**                                                                       |
+| `--name <N>`             | Human-friendly runner name. Auto-generated if omitted.                                                                 |
+| `--workspace <S>`        | Workspace slug. Required if you belong to multiple workspaces.                                                         |
+| `--pod <P>`              | Pod within the project. Defaults to project's default pod.                                                             |
+| `--working-dir <P>`      | Local working dir for clones. Defaults to a path under `data_dir`.                                                     |
+| `--agent <K>`            | Which agent CLI the runner drives: `codex` (default), `claude-code`, `cursor-agent`, `open-claw`, `grok`, `muse-code`. |
+| `--model <M>`            | Default LLM model for the agent. Omit to use the agent's own default.                                                  |
+| `--reasoning-effort <T>` | Codex reasoning tier (`low`/`medium`/`high`/`xhigh`). `--agent codex` only.                                            |
+| `--skip-agent-install`   | Don't auto-install the agent CLI if it's missing; you'll install it yourself.                                          |
 
 On the first runner: installs the OS service (systemd user unit / launchd agent / Windows scheduled task) and starts the daemon.
+
+If the selected agent's CLI isn't installed, `runner add` installs it by invoking the vendor's own official install script (never a bundled binary), records the installed binary's absolute path in the runner config, and prints the one login step still needed. On any install failure it falls back to opening the vendor's install page. Pass `--skip-agent-install` to opt out. See the [runner README](../../runner/README.md#agent-cli-auto-install) for details.
 
 ### `pidash runner list`
 

--- a/runner/README.md
+++ b/runner/README.md
@@ -143,6 +143,47 @@ pidash runner add --project X    # add another runner
 pidash runner list / remove      # manage runners
 ```
 
+### Agent CLI auto-install
+
+`--agent` selects which coding agent the runner drives (`codex` by default;
+also `claude-code`, `cursor-agent`, `open-claw`, `grok`, `muse-code`). If the
+selected agent's CLI isn't present on the machine, `pidash runner add` installs
+it for you by invoking **the vendor's own official install script** — Pi Dash
+never bundles, mirrors, or ships an agent binary, so you always get the vendor's
+latest supported build:
+
+```bash
+pidash runner add --project WEB --agent claude-code
+```
+
+What happens when the agent is missing:
+
+1. Pi Dash prints which agent is missing and the exact official command it's
+   about to run, then runs it with output streamed to your terminal
+   (`curl … | bash` on macOS/Linux/WSL, PowerShell on Windows).
+2. After the installer finishes, Pi Dash re-detects the binary, resolves its
+   **absolute path** (installers often drop it in `~/.local/bin`, which may not
+   be on the current `PATH` yet), and records that path in the runner's config.
+3. Installers don't authenticate the agent, so Pi Dash prints the one login step
+   still needed (e.g. run `claude` and follow `/login`, or `codex login`) before
+   the runner can pick up work.
+
+`runner add` never hard-fails on an install error: if the installer can't run
+(no network, no scriptable installer for that agent), Pi Dash prints the error,
+falls back to opening the vendor's install page in your browser, and leaves
+`pidash doctor` reporting the agent as missing. Agents that are already
+installed are left untouched.
+
+Verified official installers exist for `claude-code`, `codex`, and
+`cursor-agent`; `open-claw`, `grok`, and `muse-code` currently use the
+open-install-page fallback until a vendor script is confirmed.
+
+Pass `--skip-agent-install` if you manage agent installs yourself:
+
+```bash
+pidash runner add --project WEB --agent claude-code --skip-agent-install
+```
+
 ## Task folders and Git
 
 Direct-mode runners can execute coding and non-coding tasks in an ordinary

--- a/runner/src/cli/agent_install.rs
+++ b/runner/src/cli/agent_install.rs
@@ -1,0 +1,384 @@
+//! Auto-install a runner's selected agent CLI via the vendor's *own* official
+//! install script (PDASHOSS01-155).
+//!
+//! When `pidash runner add` registers a runner whose agent binary isn't present
+//! on this dev machine, we install it for the operator by invoking the vendor's
+//! official installer — never a bundled/vendored copy. The command table lives
+//! in [`crate::config::schema::AgentKind::official_installer`] so adding a new
+//! agent means adding one row there; this module is only the *execution* half:
+//! run the command with output streamed to the terminal, then re-detect the
+//! binary and record its absolute path in the runner's config (the installer
+//! usually drops the binary in a dir like `~/.local/bin` that isn't yet on this
+//! process's PATH, so we resolve the real path rather than trust PATH).
+//!
+//! Everything here is best-effort: `pidash runner add` must still succeed even
+//! if the install fails. On any failure we fall back to the previous behaviour
+//! — print and open the vendor's install page — and leave `pidash doctor`
+//! reporting the agent as missing.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use std::io::IsTerminal;
+use uuid::Uuid;
+
+use crate::config::file;
+use crate::config::schema::{AgentKind, RunnerConfig};
+use crate::util::paths::Paths;
+
+/// Ensure the runner's selected agent CLI is installed on this machine.
+///
+/// Called at the tail of `pidash runner add`, after enrollment and service
+/// setup have succeeded. Non-fatal by design — every path returns `()`; the
+/// binary only has to exist by the time the daemon spawns a run, and
+/// `pidash doctor` re-checks it.
+///
+/// Flow:
+///   1. If the binary already runs, do nothing.
+///   2. If `skip_install` (the `--skip-agent-install` opt-out), just remind +
+///      open the install page.
+///   3. Otherwise run the vendor's official installer (streamed), then
+///      re-detect the binary, resolve its absolute path, and persist it to the
+///      runner's agent-section `binary` config.
+///   4. On any failure, fall back to opening the install page.
+pub async fn ensure_agent_installed(
+    paths: &Paths,
+    runner_id: Uuid,
+    agent: AgentKind,
+    skip_install: bool,
+) {
+    let binary = agent.default_binary();
+    if crate::util::shell::binary_runs_version(binary).await {
+        return;
+    }
+
+    let name = agent.display_name();
+    println!();
+    println!("⚠ Pi Dash could not run the {name} CLI (`{binary}`) on this machine.");
+    println!(
+        "  This runner drives {name}, so its runs will fail until `{binary}` is installed."
+    );
+
+    if skip_install {
+        println!("  --skip-agent-install was set, so Pi Dash won't install it for you.");
+        open_install_page(agent);
+        return;
+    }
+
+    // Pick the vendor installer for this agent + platform, or fall back.
+    let installer = match agent.official_installer() {
+        Some(i) => i,
+        None => {
+            println!("  Pi Dash has no verified official installer wired up for {name}.");
+            open_install_page(agent);
+            return;
+        }
+    };
+    let cmd = match installer.command_for_host() {
+        Some(c) => c,
+        None => {
+            println!("  {name} has no official one-line installer for this platform.");
+            open_install_page(agent);
+            return;
+        }
+    };
+
+    println!(
+        "  Installing {name} with its official installer (see {}).",
+        installer.doc_url
+    );
+    println!("  Running: {cmd}");
+    println!();
+
+    if let Err(e) = run_install_command(cmd).await {
+        println!();
+        println!("  {name} install failed: {e:#}");
+        open_install_page(agent);
+        return;
+    }
+
+    // Re-detect: the installer usually drops the binary in a dir like
+    // ~/.local/bin that isn't on this process's PATH yet, so resolve the
+    // absolute path rather than assume PATH is updated.
+    match resolve_installed_binary(binary).await {
+        Some(path) => {
+            println!();
+            println!("  ✓ Installed {name}: {}", path.display());
+            match persist_binary_path(paths, runner_id, agent, &path) {
+                Ok(()) => println!("    Recorded its path in this runner's config."),
+                Err(e) => println!(
+                    "    (Installed, but recording the path in config failed: {e:#}. \
+                     `pidash doctor` will still find it if it's on PATH.)"
+                ),
+            }
+            // Installers place the binary but never authenticate it — remind the
+            // operator of the one login step still required before runs start.
+            if let Some(hint) = agent.post_install_login_hint() {
+                println!("    One step left before runs start — log in: {hint}");
+            }
+        }
+        None => {
+            println!();
+            println!(
+                "  {name} installer finished but `{binary}` still isn't resolvable from here."
+            );
+            println!("  Open a new terminal so your PATH picks it up, then run `pidash doctor`.");
+            open_install_page(agent);
+        }
+    }
+}
+
+/// Run one install command with its output streamed straight to the operator's
+/// terminal. macOS/Linux/WSL run it in a login `bash` (so profile PATH
+/// additions like Homebrew are visible); Windows runs it in PowerShell.
+async fn run_install_command(cmd: &str) -> Result<()> {
+    let mut command = if cfg!(target_os = "windows") {
+        let mut c = tokio::process::Command::new("powershell");
+        c.arg("-NoProfile").arg("-Command").arg(cmd);
+        c
+    } else {
+        let mut c = tokio::process::Command::new("bash");
+        // `-l` sources the operator's profile so `curl` / `npm` resolve exactly
+        // as they do in their interactive shell. stdio is inherited (the
+        // default), so the vendor installer streams directly to the terminal.
+        c.arg("-lc").arg(cmd);
+        c
+    };
+    let status = command
+        .status()
+        .await
+        .with_context(|| format!("spawning install command: {cmd}"))?;
+    if !status.success() {
+        anyhow::bail!("install command exited with {status}");
+    }
+    Ok(())
+}
+
+/// Find the absolute path of `binary` after an install, without trusting this
+/// process's PATH (the installer's bin dir may only be wired into a *new*
+/// shell). Tries, in order:
+///   1. a fresh login shell's `command -v` — picks up any PATH line the
+///      installer appended to the operator's shell rc;
+///   2. the well-known per-user bin dirs the vendor scripts drop binaries into.
+pub async fn resolve_installed_binary(binary: &str) -> Option<PathBuf> {
+    if let Some(p) = which_via_login_shell(binary).await {
+        return Some(p);
+    }
+    candidate_install_paths(binary)
+        .into_iter()
+        .find(|p| p.is_file())
+}
+
+/// Ask a fresh login shell where `binary` resolves *now*. Returns the path only
+/// when it's absolute and points at an existing file.
+async fn which_via_login_shell(binary: &str) -> Option<PathBuf> {
+    let out = if cfg!(target_os = "windows") {
+        tokio::process::Command::new("powershell")
+            .arg("-NoProfile")
+            .arg("-Command")
+            .arg(format!(
+                "(Get-Command {binary} -ErrorAction SilentlyContinue).Source"
+            ))
+            .output()
+            .await
+            .ok()?
+    } else {
+        // `command -v -- "$0"` prints the resolved path; `$0` is the first
+        // positional after the `-c` script, so the binary name is passed as an
+        // argument rather than interpolated into the script text.
+        tokio::process::Command::new("bash")
+            .arg("-lc")
+            .arg(r#"command -v -- "$0""#)
+            .arg(binary)
+            .output()
+            .await
+            .ok()?
+    };
+    if !out.status.success() {
+        return None;
+    }
+    let line = String::from_utf8_lossy(&out.stdout);
+    let path = line.lines().find(|l| !l.trim().is_empty())?.trim();
+    let path = PathBuf::from(path);
+    if path.is_absolute() && path.is_file() {
+        Some(path)
+    } else {
+        None
+    }
+}
+
+/// Well-known per-user directories the supported vendor installers drop their
+/// binary into, in priority order. Used as a fallback when a fresh login shell
+/// can't yet resolve the binary (PATH not wired up until a new terminal).
+fn candidate_install_paths(binary: &str) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    if cfg!(target_os = "windows") {
+        if let Some(home) = std::env::var_os("USERPROFILE") {
+            let base = PathBuf::from(home).join(".local").join("bin");
+            paths.push(base.join(format!("{binary}.exe")));
+            paths.push(base.join(binary));
+        }
+    } else if let Some(home) = std::env::var_os("HOME") {
+        let home = PathBuf::from(home);
+        // claude, codex, and cursor-agent all install here today.
+        paths.push(home.join(".local").join("bin").join(binary));
+    }
+    paths
+}
+
+/// Write the resolved absolute path into the runner's agent-section `binary`
+/// config so the daemon runs the freshly installed binary regardless of PATH.
+fn persist_binary_path(
+    paths: &Paths,
+    runner_id: Uuid,
+    agent: AgentKind,
+    path: &Path,
+) -> Result<()> {
+    file::mutate_config(paths, |cfg| {
+        if let Some(runner) = cfg.runners.iter_mut().find(|r| r.runner_id == runner_id) {
+            set_runner_agent_binary(runner, agent, path);
+        }
+        Ok(())
+    })
+    .map(|_| ())
+}
+
+/// Set the `binary` field of the config section that matches `agent`.
+pub fn set_runner_agent_binary(runner: &mut RunnerConfig, agent: AgentKind, path: &Path) {
+    let p = path.display().to_string();
+    match agent {
+        AgentKind::Codex => runner.codex.binary = p,
+        AgentKind::ClaudeCode => runner.claude_code.binary = p,
+        AgentKind::CursorAgent => runner.cursor_agent.binary = p,
+        AgentKind::OpenClaw => runner.openclaw.binary = p,
+        AgentKind::Grok => runner.grok.binary = p,
+        AgentKind::MuseCode => runner.muse_code.binary = p,
+    }
+}
+
+/// Print the vendor install page and, when attached to an interactive
+/// terminal, open it in the operator's browser. This is the fallback whenever
+/// the auto-install path can't run or fails — the same behaviour
+/// `pidash runner add` had before PDASHOSS01-155.
+fn open_install_page(agent: AgentKind) {
+    let url = agent.install_page_url();
+    println!("  Install it yourself from: {url}");
+    if std::io::stdout().is_terminal() && std::io::stdin().is_terminal() {
+        match crate::util::browser::open_url(url) {
+            Ok(()) => println!("  (Opened the install page in your default browser.)"),
+            Err(_) => println!("  (Open the link above to install, then re-run if needed.)"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::schema::{
+        AgentKind, ClaudeCodeSection, CodexSection, CursorAgentSection, GrokSection,
+        MuseCodeSection, OpenClawSection, RunnerConfig, WorkspaceSection,
+    };
+    use std::path::PathBuf;
+
+    fn blank_runner() -> RunnerConfig {
+        RunnerConfig {
+            name: "solo".into(),
+            runner_id: Uuid::new_v4(),
+            workspace_slug: Some("WS".into()),
+            project_slug: Some("PRJ".into()),
+            pod_id: None,
+            workspace: WorkspaceSection {
+                working_dir: PathBuf::from("/tmp/pi-dash-agent-install-test"),
+            },
+            agent: Default::default(),
+            codex: CodexSection::default(),
+            claude_code: ClaudeCodeSection::default(),
+            cursor_agent: CursorAgentSection::default(),
+            openclaw: OpenClawSection::default(),
+            grok: GrokSection::default(),
+            muse_code: MuseCodeSection::default(),
+            approval_policy: Default::default(),
+        }
+    }
+
+    #[test]
+    fn set_runner_agent_binary_targets_the_right_section() {
+        let path = PathBuf::from("/home/dev/.local/bin/claude");
+
+        let mut r = blank_runner();
+        set_runner_agent_binary(&mut r, AgentKind::ClaudeCode, &path);
+        assert_eq!(r.claude_code.binary, "/home/dev/.local/bin/claude");
+        // Only the matching section is touched.
+        assert_eq!(r.codex.binary, CodexSection::default().binary);
+        assert_eq!(r.cursor_agent.binary, CursorAgentSection::default().binary);
+
+        let mut r = blank_runner();
+        set_runner_agent_binary(&mut r, AgentKind::Codex, &PathBuf::from("/opt/codex"));
+        assert_eq!(r.codex.binary, "/opt/codex");
+        assert_eq!(r.claude_code.binary, ClaudeCodeSection::default().binary);
+
+        let mut r = blank_runner();
+        set_runner_agent_binary(
+            &mut r,
+            AgentKind::CursorAgent,
+            &PathBuf::from("/opt/cursor-agent"),
+        );
+        assert_eq!(r.cursor_agent.binary, "/opt/cursor-agent");
+
+        let mut r = blank_runner();
+        set_runner_agent_binary(&mut r, AgentKind::MuseCode, &PathBuf::from("/opt/muse"));
+        assert_eq!(r.muse_code.binary, "/opt/muse");
+    }
+
+    #[test]
+    fn candidate_install_paths_are_absolute_and_named_for_the_binary() {
+        // Regardless of platform, every candidate must be an absolute path that
+        // ends in the requested binary name — that's what we probe on disk.
+        // Guard the env-dependent branch: only assert when the relevant home
+        // var is set on this host.
+        let home_set = if cfg!(target_os = "windows") {
+            std::env::var_os("USERPROFILE").is_some()
+        } else {
+            std::env::var_os("HOME").is_some()
+        };
+        let cands = candidate_install_paths("claude");
+        if home_set {
+            assert!(!cands.is_empty(), "expected at least one candidate path");
+        }
+        for p in cands {
+            assert!(p.is_absolute(), "candidate not absolute: {}", p.display());
+            let name = p.file_name().unwrap().to_string_lossy();
+            assert!(
+                name == "claude" || name == "claude.exe",
+                "candidate not named for the binary: {}",
+                p.display()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_installed_binary_finds_a_present_binary() {
+        // A binary that's genuinely on PATH must resolve to an absolute path.
+        let binary = if cfg!(target_os = "windows") {
+            "cargo"
+        } else {
+            "sh"
+        };
+        let resolved = resolve_installed_binary(binary).await;
+        assert!(
+            resolved.is_some(),
+            "expected to resolve a present binary {binary:?}"
+        );
+        let p = resolved.unwrap();
+        assert!(p.is_absolute(), "resolved path not absolute: {}", p.display());
+    }
+
+    #[tokio::test]
+    async fn resolve_installed_binary_none_for_missing_binary() {
+        assert!(
+            resolve_installed_binary("pidash-no-such-agent-binary-xyz")
+                .await
+                .is_none()
+        );
+    }
+}

--- a/runner/src/cli/mod.rs
+++ b/runner/src/cli/mod.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use clap::{CommandFactory, Parser, Subcommand};
 
+mod agent_install;
 mod ai;
 pub mod auth;
 mod comment;

--- a/runner/src/cli/runner.rs
+++ b/runner/src/cli/runner.rs
@@ -108,6 +108,12 @@ pub struct AddArgs {
     /// Only applies when `--agent codex`; ignored for other agents.
     #[arg(long)]
     pub reasoning_effort: Option<String>,
+
+    /// Don't auto-install the selected agent's CLI when it's missing. Use this
+    /// if you manage agent installs yourself. The runner is still registered;
+    /// `pidash doctor` reports the agent as missing until you install it.
+    #[arg(long)]
+    pub skip_agent_install: bool,
 }
 
 #[derive(Debug, ClapArgs)]
@@ -309,14 +315,19 @@ pub async fn add(args: AddArgs, paths: &Paths) -> Result<RunnerConfig> {
         }
     }
 
-    // Nudge the operator to install the agent CLI — done LAST, after login +
-    // enrollment + service setup have all succeeded. Opening the install page
-    // up front fought the device-login browser tab (and made the operator wait
-    // out the countdown before auth even started); deferring it means the page
-    // opens cleanly once the runner is actually registered. Non-fatal: the
-    // binary only has to exist by the time the daemon picks up a run, and
-    // `pidash doctor` re-checks it.
-    remind_if_agent_missing(args.agent).await;
+    // Install the agent CLI if it's missing — done LAST, after login +
+    // enrollment + service setup have all succeeded. Running it up front fought
+    // the device-login browser tab; deferring it means the install runs cleanly
+    // once the runner is actually registered. Non-fatal: the binary only has to
+    // exist by the time the daemon picks up a run, and `pidash doctor` re-checks
+    // it. On failure this falls back to opening the vendor's install page.
+    crate::cli::agent_install::ensure_agent_installed(
+        paths,
+        applied.runner.runner_id,
+        args.agent,
+        args.skip_agent_install,
+    )
+    .await;
 
     Ok(applied.runner)
 }
@@ -359,58 +370,6 @@ fn hostname_or_unknown() -> String {
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "unknown-host".to_string())
-}
-
-/// When Pi Dash can't run the selected agent's CLI on this dev machine,
-/// remind the operator how to install it and open the agent's official
-/// install page in their browser.
-///
-/// Non-fatal by design: `pidash runner add` still registers the runner.
-/// The agent binary only has to exist by the time the daemon spawns a run,
-/// and `pidash doctor` re-checks it — so we nudge rather than block. The
-/// presence probe goes through the same platform spawn helper the daemon uses
-/// (see [`crate::util::shell::binary_runs_version`]) so this reminder matches
-/// whether a real run can launch the agent.
-///
-/// The browser is only opened when attached to a terminal; in CI / piped
-/// invocations we just print the URL (spawning a browser there is noise and
-/// usually fails silently anyway). Both `add` call sites are CLI flows
-/// (`pidash runner add` and `pidash auth login`'s onboarding prompt); the
-/// TUI add-runner modal uses a different path, so printing here is safe.
-async fn remind_if_agent_missing(agent: AgentKind) {
-    let binary = agent.default_binary();
-    if crate::util::shell::binary_runs_version(binary).await {
-        return;
-    }
-
-    let name = agent.display_name();
-    let url = agent.install_page_url();
-    println!();
-    println!("⚠ Pi Dash could not run the {name} CLI (`{binary}`) on this machine.");
-    println!(
-        "  This runner drives {name}, so its runs will fail until `{binary}` is installed and runnable on PATH."
-    );
-    println!("  Install it from: {url}");
-
-    if std::io::stdout().is_terminal() && std::io::stdin().is_terminal() {
-        use std::io::Write;
-        // Give the operator a few seconds to read the warning before the
-        // browser grabs window focus. Counts down in place; Ctrl-C during the
-        // wait still aborts `runner add`.
-        const COUNTDOWN_SECS: u32 = 5;
-        print!("  Opening the install page in your browser in ");
-        let _ = std::io::stdout().flush();
-        for n in (1..=COUNTDOWN_SECS).rev() {
-            print!("{n}… ");
-            let _ = std::io::stdout().flush();
-            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-        }
-        println!();
-        match crate::util::browser::open_url(url) {
-            Ok(()) => println!("  (Opened the install page in your default browser.)"),
-            Err(_) => println!("  (Open the link above to install, then re-run if needed.)"),
-        }
-    }
 }
 
 pub fn list(paths: &Paths) -> Result<()> {

--- a/runner/src/config/schema.rs
+++ b/runner/src/config/schema.rs
@@ -352,6 +352,96 @@ impl AgentKind {
             AgentKind::MuseCode => "https://developer.meta.com/ai/products/muse-code/",
         }
     }
+
+    /// The agent's *official* install command(s), or `None` when the vendor
+    /// ships no scriptable installer we've verified (in which case
+    /// `pidash runner add` falls back to opening [`install_page_url`]).
+    ///
+    /// This is the single data table the issue (PDASHOSS01-155) calls for:
+    /// each agent that has an installer contributes exactly one [`AgentInstaller`]
+    /// row here, so adding a new agent kind means adding a row — not editing
+    /// several match arms across the codebase. **Key principle:** we never
+    /// vendor, mirror, pin, or ship an agent binary; we only invoke the vendor's
+    /// own script at runtime, so pidash always tracks the vendor's latest
+    /// supported build. Only official vendor domains are allowed here.
+    ///
+    /// Every command below was verified against the vendor's current docs
+    /// (linked per row). Re-verify before changing any command.
+    pub fn official_installer(self) -> Option<AgentInstaller> {
+        match self {
+            // Anthropic Claude Code — https://code.claude.com/docs/en/setup
+            AgentKind::ClaudeCode => Some(AgentInstaller {
+                unix: Some("curl -fsSL https://claude.ai/install.sh | bash"),
+                windows: Some("irm https://claude.ai/install.ps1 | iex"),
+                doc_url: "https://code.claude.com/docs/en/setup",
+            }),
+            // OpenAI Codex — https://learn.chatgpt.com/docs/codex/cli
+            // The standalone installer is macOS/Linux only; on Windows the
+            // official method is the npm package (requires Node.js).
+            AgentKind::Codex => Some(AgentInstaller {
+                unix: Some("curl -fsSL https://chatgpt.com/codex/install.sh | sh"),
+                windows: Some("npm install -g @openai/codex"),
+                doc_url: "https://learn.chatgpt.com/docs/codex/cli",
+            }),
+            // Cursor CLI — https://cursor.com/docs/cli/installation
+            AgentKind::CursorAgent => Some(AgentInstaller {
+                unix: Some("curl https://cursor.com/install -fsS | bash"),
+                windows: Some("irm 'https://cursor.com/install?win32=true' | iex"),
+                doc_url: "https://cursor.com/docs/cli/installation",
+            }),
+            // OpenClaw (acpx), Grok, and Muse Code do not (yet) publish a
+            // verified official one-line installer, so we keep the
+            // open-install-page fallback for these agents rather than guess a
+            // command. Add a row here once a vendor script is confirmed.
+            AgentKind::OpenClaw | AgentKind::Grok | AgentKind::MuseCode => None,
+        }
+    }
+
+    /// The one login step still required after a successful install, phrased as
+    /// a command the operator can run. Installers place the binary but never
+    /// authenticate it, so `pidash runner add` prints this so the runner can
+    /// actually pick up work. `None` means auth is via an env var / no explicit
+    /// login command, in which case the doctor's per-agent auth hint covers it.
+    pub fn post_install_login_hint(self) -> Option<&'static str> {
+        match self {
+            AgentKind::ClaudeCode => Some("claude  (then follow the /login prompts)"),
+            AgentKind::Codex => Some("codex login"),
+            AgentKind::CursorAgent => Some("cursor-agent login  (or set CURSOR_API_KEY)"),
+            AgentKind::OpenClaw => None,
+            AgentKind::Grok => Some("set XAI_API_KEY  (or run `grok` and log in)"),
+            AgentKind::MuseCode => Some("set META_API_KEY"),
+        }
+    }
+}
+
+/// One agent's official installer command(s), returned by
+/// [`AgentKind::official_installer`]. The command strings are shown to the
+/// operator verbatim *and* executed, so they must be exactly the vendor's
+/// documented one-liner. `unix` covers macOS/Linux/WSL; `windows` is run in
+/// PowerShell. A `None` for a platform means "no verified installer on this
+/// platform" and the caller falls back to opening the install page there.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AgentInstaller {
+    /// Command run in a login shell on macOS/Linux/WSL, or `None` if the vendor
+    /// has no scriptable macOS/Linux installer.
+    pub unix: Option<&'static str>,
+    /// Command run in PowerShell on Windows, or `None` if the vendor has no
+    /// scriptable Windows installer.
+    pub windows: Option<&'static str>,
+    /// Vendor documentation URL the command was verified against.
+    pub doc_url: &'static str,
+}
+
+impl AgentInstaller {
+    /// The install command for the host platform this binary is running on:
+    /// [`windows`](Self::windows) on Windows, [`unix`](Self::unix) elsewhere.
+    pub fn command_for_host(&self) -> Option<&'static str> {
+        if cfg!(target_os = "windows") {
+            self.windows
+        } else {
+            self.unix
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -996,6 +1086,99 @@ mod tests {
             let url = kind.install_page_url();
             assert!(url.starts_with("https://"), "{kind:?} url not https: {url}");
             assert!(!kind.display_name().is_empty());
+        }
+    }
+
+    #[test]
+    fn official_installers_only_use_https_and_official_domains() {
+        // The install commands are printed verbatim and executed, so a typo'd
+        // scheme or a non-vendor host is a serious defect. Assert every
+        // command begins with the vendor's https one-liner and cites an https
+        // doc URL, and that no command references a non-official domain.
+        let ok_hosts = [
+            "claude.ai",
+            "code.claude.com",
+            "chatgpt.com",
+            "learn.chatgpt.com",
+            "cursor.com",
+            "@openai/codex", // npm package name, not a URL host
+        ];
+        for kind in [
+            AgentKind::Codex,
+            AgentKind::ClaudeCode,
+            AgentKind::CursorAgent,
+            AgentKind::OpenClaw,
+            AgentKind::Grok,
+            AgentKind::MuseCode,
+        ] {
+            let Some(installer) = kind.official_installer() else {
+                continue;
+            };
+            assert!(
+                installer.doc_url.starts_with("https://"),
+                "{kind:?} doc_url not https: {}",
+                installer.doc_url
+            );
+            for cmd in [installer.unix, installer.windows].into_iter().flatten() {
+                // Any http:// (non-TLS) reference is forbidden.
+                assert!(
+                    !cmd.contains("http://"),
+                    "{kind:?} command uses plaintext http: {cmd}"
+                );
+                // Any URL in the command must point at an official host.
+                for tok in cmd.split_whitespace() {
+                    if tok.contains("https://") {
+                        assert!(
+                            ok_hosts.iter().any(|h| tok.contains(h)),
+                            "{kind:?} command references non-official host: {tok}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn agents_with_verified_installers_have_them_others_fall_back() {
+        // The three agents whose vendor scripts we verified must expose an
+        // installer; the rest deliberately return None so `runner add` keeps
+        // the open-install-page fallback.
+        assert!(AgentKind::ClaudeCode.official_installer().is_some());
+        assert!(AgentKind::Codex.official_installer().is_some());
+        assert!(AgentKind::CursorAgent.official_installer().is_some());
+        assert!(AgentKind::OpenClaw.official_installer().is_none());
+        assert!(AgentKind::Grok.official_installer().is_none());
+        assert!(AgentKind::MuseCode.official_installer().is_none());
+    }
+
+    #[test]
+    fn command_for_host_picks_the_running_platform() {
+        // Platform selection must match the host: Windows → PowerShell command,
+        // everything else → the unix curl|sh command.
+        let claude = AgentKind::ClaudeCode.official_installer().unwrap();
+        let picked = claude.command_for_host().unwrap();
+        if cfg!(target_os = "windows") {
+            assert_eq!(picked, claude.windows.unwrap());
+            assert!(picked.contains("install.ps1"), "win cmd should be ps1");
+        } else {
+            assert_eq!(picked, claude.unix.unwrap());
+            assert!(picked.contains("install.sh"), "unix cmd should be sh");
+        }
+    }
+
+    #[test]
+    fn installer_agents_carry_a_login_hint() {
+        // Every agent with an installer must tell the operator how to log in,
+        // since installers never authenticate the agent.
+        for kind in [
+            AgentKind::ClaudeCode,
+            AgentKind::Codex,
+            AgentKind::CursorAgent,
+        ] {
+            assert!(
+                kind.post_install_login_hint().is_some(),
+                "{kind:?} should carry a post-install login hint"
+            );
         }
     }
 

--- a/runner/tests/pidash_runner_add_auth.rs
+++ b/runner/tests/pidash_runner_add_auth.rs
@@ -211,6 +211,7 @@ async fn runner_add_checks_local_cap_before_auth_bootstrap() {
             agent: AgentKind::Codex,
             model: None,
             reasoning_effort: None,
+            skip_agent_install: true,
         },
         &paths,
     )
@@ -247,6 +248,7 @@ async fn runner_add_rejects_invalid_name_before_auth_bootstrap() {
             agent: AgentKind::Codex,
             model: None,
             reasoning_effort: None,
+            skip_agent_install: true,
         },
         &paths,
     )
@@ -288,6 +290,7 @@ async fn runner_add_bootstraps_auth_when_cli_token_is_missing() {
             agent: AgentKind::Codex,
             model: None,
             reasoning_effort: None,
+            skip_agent_install: true,
         },
         &paths,
     )
@@ -357,6 +360,7 @@ async fn runner_add_auth_bootstrap_uses_explicit_workspace_without_prompt() {
             agent: AgentKind::Codex,
             model: None,
             reasoning_effort: None,
+            skip_agent_install: true,
         },
         &paths,
     )


### PR DESCRIPTION
## What & why

`PDASHOSS01-155`. When `pidash runner add` registers a runner whose selected
agent CLI isn't installed on the machine, Pi Dash now **installs it by invoking
the vendor's own official install script** instead of only opening the install
page (the prior PDASHOSS01-13/-15 behaviour). The runner then reaches a ready
state after the one login step installers can't do.

**Key principle preserved:** Pi Dash never bundles, mirrors, pins, or ships an
agent binary. We only call the vendor's own script at runtime, so hosts always
track the vendor's latest supported build and there's no redistribution/licensing
concern.

## How it works

On `runner add`, after enrollment + service setup succeed, for the selected agent:

1. Probe binary presence via the same `util::shell::binary_runs_version` helper
   the doctor path uses. If present, do nothing.
2. If missing, print which agent is missing and the **exact official command**
   about to run, then run it with output streamed to the terminal
   (`curl … | bash` on macOS/Linux/WSL, PowerShell on Windows).
3. Re-detect the binary and resolve its **absolute path** — installers usually
   drop it in a dir like `~/.local/bin` not yet on this process's PATH — then
   write that path into the runner's agent-section `binary` config.
4. Print the one login step still required (installers don't authenticate).

Never hard-fails: on any install error (no network, no scriptable installer for
that agent), it prints the error, falls back to opening the vendor install page,
and leaves `pidash doctor` reporting the agent as missing.

## Agent → official install command (single data table)

Lives in one place: `AgentKind::official_installer()` in `schema.rs`. Each row
links the vendor doc it was verified against. Only official vendor domains.

| Agent | macOS/Linux/WSL | Windows | Verified against |
| --- | --- | --- | --- |
| `claude-code` | `curl -fsSL https://claude.ai/install.sh \| bash` | `irm https://claude.ai/install.ps1 \| iex` | code.claude.com/docs/en/setup |
| `codex` | `curl -fsSL https://chatgpt.com/codex/install.sh \| sh` | `npm install -g @openai/codex` | learn.chatgpt.com/docs/codex/cli |
| `cursor-agent` | `curl https://cursor.com/install -fsS \| bash` | `irm 'https://cursor.com/install?win32=true' \| iex` | cursor.com/docs/cli/installation |
| `open-claw`, `grok`, `muse-code` | — (open-install-page fallback) | — | no verified vendor script yet |

## Opt-out & non-interactive

- `--skip-agent-install` skips the install step for operators who manage installs
  themselves.
- The vendor scripts are non-interactive, so CI shells don't hang; the
  browser-open fallback only fires when attached to a terminal.

## Changes

- `runner/src/config/schema.rs` — `AgentInstaller` struct + `official_installer()`
  data table + `post_install_login_hint()`; unit tests (mapping, platform
  selection, https/official-domain enforcement, login hints).
- `runner/src/cli/agent_install.rs` (new) — install execution, absolute-path
  resolution, config persistence; unit tests.
- `runner/src/cli/runner.rs` — `ensure_agent_installed` flow replacing the
  open-page-only reminder; `--skip-agent-install` flag.
- `runner/src/cli/mod.rs` — register module.
- Docs: `runner/README.md` (new "Agent CLI auto-install" section) + CLI reference.

## Tests

- `cargo build`, `cargo clippy --all-targets` — clean.
- `cargo test --lib` — 467 pass; `cargo test --test pidash_runner_add_auth` — 4 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
