### PR TITLE
PDASHOSS01-118 [MR-10] Whitelist engine_version → dev_metadata.codex_version in session-open

### DIFF
--- a/apps/api/pi_dash/runner/admin.py
+++ b/apps/api/pi_dash/runner/admin.py
@@ -44,13 +44,25 @@ class RunnerAdmin(admin.ModelAdmin):
         "dev_machine",
         "visibility",
         "status",
+        "provisioning",
+        "runner_version",
+        "codex_version",
         "host_label",
         "refresh_token_generation",
         "last_heartbeat_at",
         "revoked_at",
     )
-    list_filter = ("status", "visibility", "workspace")
+    list_filter = ("status", "visibility", "provisioning", "workspace")
     search_fields = ("name", "owner__email", "host_label")
+
+    @admin.display(description="codex version")
+    def codex_version(self, obj):
+        # Support's "which build is this user on" signal (design §15.1). The
+        # engine version is whitelisted into ``dev_metadata.codex_version`` at
+        # session open (see ``session_service._merge_dev_metadata``).
+        if isinstance(obj.dev_metadata, dict):
+            return obj.dev_metadata.get("codex_version") or "—"
+        return "—"
     readonly_fields = (
         "refresh_token_hash",
         "refresh_token_fingerprint",

--- a/apps/api/pi_dash/runner/services/session_service.py
+++ b/apps/api/pi_dash/runner/services/session_service.py
@@ -126,6 +126,18 @@ def apply_hello(runner: Runner, body: Dict[str, Any]) -> None:
     runner.runner_version = body.get("version", "") or runner.runner_version
     runner.dev_metadata = _merge_dev_metadata(runner.dev_metadata, body)
     runner.last_heartbeat_at = timezone.now()
+    # Observability (design §15.1): a bundled runner ships its agent binary
+    # inside the desktop app, so the engine version it self-reports at session
+    # open is support's only signal for "which build is this user on". Emit it
+    # only when the runner actually reports a non-empty value this open — a
+    # legacy or non-managed daemon that never sends it produces no noise.
+    reported_engine_version = body.get("engine_version")
+    if isinstance(reported_engine_version, str) and reported_engine_version:
+        logger.info(
+            "managed_runner.engine_version runner=%s version=%s",
+            runner.id,
+            reported_engine_version[:64],
+        )
     update_fields = [
         "os",
         "arch",

--- a/apps/api/pi_dash/tests/unit/managed_runner/test_serializers_and_model.py
+++ b/apps/api/pi_dash/tests/unit/managed_runner/test_serializers_and_model.py
@@ -209,6 +209,34 @@ def test_engine_version_is_length_capped(bundled_runner):
     assert len(bundled_runner.dev_metadata["codex_version"]) <= 64
 
 
+def test_apply_hello_emits_engine_version_log_event(bundled_runner, caplog):
+    """Design §15.1: a ``managed_runner.engine_version`` structured event is
+    logged at session open so support can see which bundled build reported in."""
+    import logging
+
+    from pi_dash.runner.services.session_service import apply_hello
+
+    with caplog.at_level(logging.INFO, logger="pi_dash.runner.services.session_service"):
+        apply_hello(bundled_runner, {"os": "linux", "engine_version": "codex 1.2.3"})
+
+    events = [r.getMessage() for r in caplog.records if "managed_runner.engine_version" in r.getMessage()]
+    assert len(events) == 1
+    assert f"runner={bundled_runner.id}" in events[0]
+    assert "version=codex 1.2.3" in events[0]
+
+
+def test_apply_hello_omits_engine_version_log_when_not_reported(bundled_runner, caplog):
+    """A daemon that never sends ``engine_version`` produces no log noise."""
+    import logging
+
+    from pi_dash.runner.services.session_service import apply_hello
+
+    with caplog.at_level(logging.INFO, logger="pi_dash.runner.services.session_service"):
+        apply_hello(bundled_runner, {"os": "linux", "version": "0.1.21"})
+
+    assert not [r for r in caplog.records if "managed_runner.engine_version" in r.getMessage()]
+
+
 def test_apply_hello_persists_agent_kind_capability(bundled_runner):
     """The daemon reports the ``AgentKind`` it drives; we persist it as an
     ``agent:<kind>`` capability so diagnostics can identify the agent exactly."""


### PR DESCRIPTION
## PDASHOSS01-118 — [MR-10] Whitelist engine_version → dev_metadata.codex_version in session-open

Design refs: managed_runner §12.3 (last bullet), §15 (Support row), §15.1.

The `engine_version` → `dev_metadata.codex_version` whitelist (≤64 chars) in `session_service._merge_dev_metadata` already landed alongside the `managed_runner` executor. This PR completes the remaining MR-10 items:

- **Log event** — `apply_hello` now emits a `managed_runner.engine_version` structured event (runner id + capped version) at session open, following the `managed_runner.*` logger conventions. It fires only when the runner reports a non-empty `engine_version` this open, so legacy / non-managed daemons that never send it produce no noise.
- **Admin runner list** — `RunnerAdmin` surfaces support's "which build is this user on" signals: adds `provisioning` and `runner_version` columns, a `codex_version` column reading `dev_metadata.codex_version`, and a `provisioning` list filter.

The runner side sends the value in MR-12 (out of scope here).

## Testing

- `pi_dash/tests/unit/managed_runner/test_serializers_and_model.py` — 18 passed (includes 2 new: log emitted when reported, omitted when not).
- `pi_dash/tests/unit/runner/test_runner_dev_metadata.py` — 3 passed.
- `python manage.py check` — no issues (validates the admin `list_display` method column).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
