### PR TITLE
PDASHOSS01-119 [MR-11] managed_runner/checks.py startup checks and observability events/metrics

### DIFF
--- a/apps/api/pi_dash/managed_runner/signals.py
+++ b/apps/api/pi_dash/managed_runner/signals.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Structured observability events for managed-runner run creation.
+
+Two of the events in design §15.1 — ``managed_runner.run_pinned`` and
+``managed_runner.queued_waiting`` — describe a run the moment it is created, but
+the pinning decision is made in ``cloud_agent/creation.py`` *before* the row
+exists, and the fields it returns are splatted into ``AgentRun.objects.create``
+by five separate creation sites. A single ``post_save`` handler is the one place
+that sees both the run id and the resolved runner together, for every path,
+without threading a log call through each caller.
+
+Every managed run that is admitted carries a ``pinned_runner`` (an online one
+when available, the enrolled-but-offline one when an automatic run is parked to
+wait). The two cases are told apart by ``error_code``: a parked run carries
+``desktop_not_connected`` (``ManagedRunnerReason.NOT_CONNECTED``); a run pinned
+to a live desktop carries none.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from pi_dash.core.agent_execution import AgentExecutorKind
+from pi_dash.managed_runner.errors import ManagedRunnerReason
+from pi_dash.runner.models import AgentRun
+
+logger = logging.getLogger(__name__)
+
+
+@receiver(post_save, sender=AgentRun)
+def log_managed_run_pinning(sender, instance: AgentRun, created: bool, **kwargs):
+    """Emit ``run_pinned`` / ``queued_waiting`` for a newly created managed run.
+
+    A no-op for every other executor kind and for updates, so the cost on the
+    hot run-creation path is a single attribute comparison.
+    """
+    if not created or instance.executor_kind != AgentExecutorKind.MANAGED_RUNNER:
+        return
+    if instance.error_code == ManagedRunnerReason.NOT_CONNECTED:
+        logger.info(
+            "managed_runner.queued_waiting run=%s runner=%s",
+            instance.id,
+            instance.pinned_runner_id,
+        )
+    elif instance.pinned_runner_id is not None:
+        logger.info(
+            "managed_runner.run_pinned run=%s runner=%s",
+            instance.id,
+            instance.pinned_runner_id,
+        )

--- a/apps/api/pi_dash/runner/apps.py
+++ b/apps/api/pi_dash/runner/apps.py
@@ -17,3 +17,7 @@ class RunnerConfig(AppConfig):
         from pi_dash.runner import signals  # noqa: F401
         from pi_dash.cloud_agent import checks  # noqa: F401
         from pi_dash.managed_runner import checks as managed_checks  # noqa: F401
+
+        # Registers post_save(AgentRun) handler emitting managed_runner
+        # run_pinned / queued_waiting observability events (design §15.1).
+        from pi_dash.managed_runner import signals as managed_signals  # noqa: F401

--- a/apps/api/pi_dash/runner/views/metrics.py
+++ b/apps/api/pi_dash/runner/views/metrics.py
@@ -4,19 +4,30 @@
 
 """Prometheus text-format metrics endpoint.
 
-Exposes point-in-time gauges derived from DB queries. Scrape with
+Exposes point-in-time series derived from DB queries. Scrape with
 ``GET /api/v1/runner/metrics/``. No new dependencies — we emit the format
-ourselves so the endpoint works with any Prometheus-compatible scraper.
+ourselves so the endpoint works with any Prometheus-compatible scraper, and
+every series is a snapshot computed at scrape time rather than an in-process
+registry that would not survive a worker restart.
 
-Schema (all gauges):
-- ``pi_dash_runner_online``: count of runners in ``online`` state.
-- ``pi_dash_runner_busy``: count of runners in ``busy`` state.
-- ``pi_dash_runner_offline``: count of runners in ``offline`` state
+Schema:
+- ``pi_dash_runner_online`` (gauge): count of runners in ``online`` state.
+- ``pi_dash_runner_busy`` (gauge): count of runners in ``busy`` state.
+- ``pi_dash_runner_offline`` (gauge): count of runners in ``offline`` state
   (excludes revoked; revoked runners are retired, not a health signal).
-- ``pi_dash_runs_active``: count of AgentRuns in an in-flight status
+- ``pi_dash_managed_runner_online`` (gauge): online desktop-bundled (managed)
+  runners — a subset of ``pi_dash_runner_online`` scoped to the managed kind
+  (design §15.1).
+- ``pi_dash_runs_active`` (gauge): count of AgentRuns in an in-flight status
   (assigned / running / cancel_requested / awaiting_approval /
   awaiting_reauth).
-- ``pi_dash_approvals_pending``: count of ApprovalRequests with
+- ``pi_dash_runs_total`` (counter, label ``executor_kind``): AgentRuns ever
+  created, one series per executor kind. DB rows are never deleted in normal
+  operation, so the DB count is monotonic and reads as a counter (§15.1).
+- ``pi_dash_managed_runner_queued_wait_seconds`` (histogram): age of managed
+  runs currently ``QUEUED`` (waiting for a closed desktop), so the distribution
+  of how long managed work has been parked is visible (§8.5, §15.1).
+- ``pi_dash_approvals_pending`` (gauge): count of ApprovalRequests with
   ``status=pending``.
 """
 
@@ -24,15 +35,18 @@ from __future__ import annotations
 
 from django.db.models import Count
 from django.http import HttpResponse
+from django.utils import timezone
 from rest_framework.permissions import AllowAny
 from rest_framework.views import APIView
 
+from pi_dash.core.agent_execution import AgentExecutorKind
 from pi_dash.runner.models import (
     AgentRun,
     AgentRunStatus,
     ApprovalRequest,
     ApprovalStatus,
     Runner,
+    RunnerProvisioning,
     RunnerStatus,
 )
 
@@ -45,6 +59,12 @@ ACTIVE_RUN_STATUSES = (
     AgentRunStatus.AWAITING_REAUTH,
 )
 
+# Upper edges (seconds) for the managed queued-wait histogram: 1m, 5m, 15m, 1h,
+# 3h, 6h, 12h. The last finite bucket matches the default
+# ``MANAGED_RUNNER_QUEUED_MAX_AGE_SECS`` (12h) so a run about to be swept lands
+# in the top finite bucket rather than only in ``+Inf``.
+QUEUED_WAIT_BUCKETS_SECONDS = (60, 300, 900, 3600, 10800, 21600, 43200)
+
 
 def _gauge(name: str, help_text: str, value: int) -> str:
     return (
@@ -52,6 +72,26 @@ def _gauge(name: str, help_text: str, value: int) -> str:
         f"# TYPE {name} gauge\n"
         f"{name} {value}\n"
     )
+
+
+def _counter(name: str, help_text: str, samples: list[tuple[str, int]]) -> str:
+    """A counter with a single ``executor_kind`` label per sample."""
+    lines = [f"# HELP {name} {help_text}", f"# TYPE {name} counter"]
+    for label_value, value in samples:
+        lines.append(f'{name}{{executor_kind="{label_value}"}} {value}')
+    return "\n".join(lines) + "\n"
+
+
+def _histogram(name: str, help_text: str, buckets: tuple[int, ...], observations: list[float]) -> str:
+    """Cumulative-bucket histogram in Prometheus text format."""
+    lines = [f"# HELP {name} {help_text}", f"# TYPE {name} histogram"]
+    for edge in buckets:
+        count = sum(1 for obs in observations if obs <= edge)
+        lines.append(f'{name}_bucket{{le="{edge}"}} {count}')
+    lines.append(f'{name}_bucket{{le="+Inf"}} {len(observations)}')
+    lines.append(f"{name}_sum {sum(observations)}")
+    lines.append(f"{name}_count {len(observations)}")
+    return "\n".join(lines) + "\n"
 
 
 class MetricsEndpoint(APIView):
@@ -68,12 +108,35 @@ class MetricsEndpoint(APIView):
         busy = status_counts.get(RunnerStatus.BUSY, 0)
         offline = status_counts.get(RunnerStatus.OFFLINE, 0)
 
+        managed_online = Runner.objects.filter(
+            provisioning=RunnerProvisioning.DESKTOP_BUNDLED,
+            status=RunnerStatus.ONLINE,
+        ).count()
+
         active_runs = AgentRun.objects.filter(
             status__in=ACTIVE_RUN_STATUSES
         ).count()
         pending_approvals = ApprovalRequest.objects.filter(
             status=ApprovalStatus.PENDING
         ).count()
+
+        runs_by_kind = dict(
+            AgentRun.objects.values_list("executor_kind").annotate(c=Count("id"))
+        )
+        # Emit every known kind (zero-filled) so scrapers see a stable series
+        # set even before a given executor has run anything.
+        run_kind_samples = [
+            (kind, runs_by_kind.get(kind, 0)) for kind in AgentExecutorKind.values
+        ]
+
+        now = timezone.now()
+        queued_ages = [
+            (now - created).total_seconds()
+            for created in AgentRun.objects.filter(
+                executor_kind=AgentExecutorKind.MANAGED_RUNNER,
+                status=AgentRunStatus.QUEUED,
+            ).values_list("created_at", flat=True)
+        ]
 
         body = "".join([
             _gauge(
@@ -92,9 +155,25 @@ class MetricsEndpoint(APIView):
                 offline,
             ),
             _gauge(
+                "pi_dash_managed_runner_online",
+                "Desktop-bundled (managed) runners currently online.",
+                managed_online,
+            ),
+            _gauge(
                 "pi_dash_runs_active",
                 "AgentRuns in an in-flight status.",
                 active_runs,
+            ),
+            _counter(
+                "pi_dash_runs_total",
+                "AgentRuns created, by executor kind.",
+                run_kind_samples,
+            ),
+            _histogram(
+                "pi_dash_managed_runner_queued_wait_seconds",
+                "Age of managed runs currently queued waiting for a desktop.",
+                QUEUED_WAIT_BUCKETS_SECONDS,
+                queued_ages,
             ),
             _gauge(
                 "pi_dash_approvals_pending",

--- a/apps/api/pi_dash/tests/unit/managed_runner/test_observability.py
+++ b/apps/api/pi_dash/tests/unit/managed_runner/test_observability.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""The ``run_pinned`` / ``queued_waiting`` observability events (design §15.1).
+
+Both fire from a single ``post_save(AgentRun)`` handler, so the assertions
+create the same rows the real creation path writes and read the log the way an
+operator's aggregation would.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from pi_dash.core.agent_execution import AgentExecutorKind
+from pi_dash.managed_runner.errors import ManagedRunnerReason
+from pi_dash.runner.models import AgentRun, AgentRunStatus
+
+pytestmark = pytest.mark.unit
+
+SIGNAL_LOGGER = "pi_dash.managed_runner.signals"
+
+
+def _create_run(project, owner, *, executor_kind, pinned_runner=None, error_code=""):
+    return AgentRun.objects.create(
+        workspace=project.workspace,
+        created_by=owner,
+        pod=project.pods.get(is_default=True),
+        executor_kind=executor_kind,
+        pinned_runner=pinned_runner,
+        status=AgentRunStatus.QUEUED,
+        error_code=error_code,
+        prompt="",
+    )
+
+
+def test_run_pinned_logged_when_managed_run_pins_to_a_runner(
+    project, create_user, bundled_runner, caplog
+):
+    with caplog.at_level(logging.INFO, logger=SIGNAL_LOGGER):
+        run = _create_run(
+            project,
+            create_user,
+            executor_kind=AgentExecutorKind.MANAGED_RUNNER,
+            pinned_runner=bundled_runner,
+        )
+    assert f"managed_runner.run_pinned run={run.id} runner={bundled_runner.id}" in caplog.text
+    # A pinned live run is not also a waiting one.
+    assert "queued_waiting" not in caplog.text
+
+
+def test_queued_waiting_logged_for_a_parked_automatic_run(
+    project, create_user, bundled_runner, caplog
+):
+    with caplog.at_level(logging.INFO, logger=SIGNAL_LOGGER):
+        run = _create_run(
+            project,
+            create_user,
+            executor_kind=AgentExecutorKind.MANAGED_RUNNER,
+            pinned_runner=bundled_runner,
+            error_code=ManagedRunnerReason.NOT_CONNECTED,
+        )
+    assert f"managed_runner.queued_waiting run={run.id} runner={bundled_runner.id}" in caplog.text
+    # Waiting is not pinning: the two events are mutually exclusive.
+    assert "run_pinned" not in caplog.text
+
+
+def test_no_event_for_non_managed_runs(project, create_user, caplog):
+    with caplog.at_level(logging.INFO, logger=SIGNAL_LOGGER):
+        _create_run(
+            project,
+            create_user,
+            executor_kind=AgentExecutorKind.LOCAL_RUNNER,
+        )
+    assert caplog.text == ""
+
+
+def test_no_event_on_update_of_a_managed_run(project, create_user, bundled_runner, caplog):
+    run = _create_run(
+        project,
+        create_user,
+        executor_kind=AgentExecutorKind.MANAGED_RUNNER,
+        pinned_runner=bundled_runner,
+    )
+    with caplog.at_level(logging.INFO, logger=SIGNAL_LOGGER):
+        run.status = AgentRunStatus.RUNNING
+        run.save(update_fields=["status"])
+    # The events describe creation, not every subsequent save.
+    assert caplog.text == ""

--- a/apps/api/pi_dash/tests/unit/runner/test_metrics.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_metrics.py
@@ -1,0 +1,161 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""The Prometheus ``metrics/`` endpoint, including the managed-runner series.
+
+The endpoint is a snapshot over DB queries, so the tests assert the exposed
+text directly: a scraper reading these lines is exactly what these assertions
+stand in for.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+
+from pi_dash.core.agent_execution import AgentExecutorKind
+from pi_dash.runner.models import (
+    AgentRun,
+    AgentRunStatus,
+    Runner,
+    RunnerProvisioning,
+    RunnerStatus,
+)
+
+pytestmark = pytest.mark.unit
+
+METRICS_URL = "/api/v1/runner/metrics/"
+
+
+def _bundled_runner(project, owner, status=RunnerStatus.ONLINE):
+    return Runner.objects.create(
+        owner=owner,
+        workspace=project.workspace,
+        pod=project.pods.get(is_default=True),
+        name=f"desktop-{Runner.objects.count()}",
+        host_label="rich-laptop",
+        provisioning=RunnerProvisioning.DESKTOP_BUNDLED,
+        status=status,
+        last_heartbeat_at=timezone.now() if status == RunnerStatus.ONLINE else None,
+        enrolled_at=timezone.now(),
+    )
+
+
+def _queued_managed_run(project, owner, *, age_seconds):
+    run = AgentRun.objects.create(
+        workspace=project.workspace,
+        created_by=owner,
+        pod=project.pods.get(is_default=True),
+        executor_kind=AgentExecutorKind.MANAGED_RUNNER,
+        status=AgentRunStatus.QUEUED,
+        prompt="",
+    )
+    # ``created_at`` is auto_now_add, so backdate it explicitly to simulate a
+    # run that has been waiting for a closed desktop.
+    AgentRun.objects.filter(id=run.id).update(
+        created_at=timezone.now() - timedelta(seconds=age_seconds)
+    )
+    return run
+
+
+def _series_value(body: str, line_prefix: str) -> str:
+    for line in body.splitlines():
+        if line.startswith(line_prefix) and not line.startswith("#"):
+            return line[len(line_prefix):].strip()
+    raise AssertionError(f"no series line starting with {line_prefix!r} in:\n{body}")
+
+
+def test_endpoint_is_public_and_plain_text(api_client, db):
+    resp = api_client.get(METRICS_URL)
+    assert resp.status_code == 200
+    assert resp["Content-Type"].startswith("text/plain")
+    # The pre-existing gauges must still be present.
+    assert "pi_dash_runner_online" in resp.content.decode()
+    assert "pi_dash_approvals_pending" in resp.content.decode()
+
+
+def test_managed_runner_online_gauge_counts_only_bundled_online(project, create_user, api_client):
+    _bundled_runner(project, create_user, status=RunnerStatus.ONLINE)
+    _bundled_runner(project, create_user, status=RunnerStatus.OFFLINE)
+    # A manual online runner must NOT be counted by the managed gauge.
+    Runner.objects.create(
+        owner=create_user,
+        workspace=project.workspace,
+        pod=project.pods.get(is_default=True),
+        name="manual",
+        host_label="rich-laptop",
+        provisioning=RunnerProvisioning.MANUAL,
+        status=RunnerStatus.ONLINE,
+        last_heartbeat_at=timezone.now(),
+        enrolled_at=timezone.now(),
+    )
+    body = api_client.get(METRICS_URL).content.decode()
+    assert _series_value(body, "pi_dash_managed_runner_online ") == "1"
+    # HELP/TYPE lines are present so the scrape parses cleanly.
+    assert "# TYPE pi_dash_managed_runner_online gauge" in body
+
+
+def test_runs_total_counter_labels_every_executor_kind(project, create_user, api_client):
+    AgentRun.objects.create(
+        workspace=project.workspace,
+        created_by=create_user,
+        pod=project.pods.get(is_default=True),
+        executor_kind=AgentExecutorKind.MANAGED_RUNNER,
+        status=AgentRunStatus.QUEUED,
+        prompt="",
+    )
+    AgentRun.objects.create(
+        workspace=project.workspace,
+        created_by=create_user,
+        pod=project.pods.get(is_default=True),
+        executor_kind=AgentExecutorKind.LOCAL_RUNNER,
+        status=AgentRunStatus.QUEUED,
+        prompt="",
+    )
+    body = api_client.get(METRICS_URL).content.decode()
+    assert "# TYPE pi_dash_runs_total counter" in body
+    assert 'pi_dash_runs_total{executor_kind="managed_runner"} 1' in body
+    assert 'pi_dash_runs_total{executor_kind="local_runner"} 1' in body
+    # Every known kind is emitted zero-filled, even ones with no rows.
+    for kind in AgentExecutorKind.values:
+        assert f'pi_dash_runs_total{{executor_kind="{kind}"}}' in body
+
+
+def test_queued_wait_histogram_buckets_managed_runs(project, create_user, api_client):
+    # One run waiting ~2 minutes, one waiting ~2 hours.
+    _queued_managed_run(project, create_user, age_seconds=120)
+    _queued_managed_run(project, create_user, age_seconds=7200)
+    body = api_client.get(METRICS_URL).content.decode()
+    assert "# TYPE pi_dash_managed_runner_queued_wait_seconds histogram" in body
+    # Cumulative buckets: le=60 catches neither, le=300 catches the 120s run,
+    # le=10800 (3h) catches both.
+    assert 'pi_dash_managed_runner_queued_wait_seconds_bucket{le="60"} 0' in body
+    assert 'pi_dash_managed_runner_queued_wait_seconds_bucket{le="300"} 1' in body
+    assert 'pi_dash_managed_runner_queued_wait_seconds_bucket{le="10800"} 2' in body
+    assert 'pi_dash_managed_runner_queued_wait_seconds_bucket{le="+Inf"} 2' in body
+    assert _series_value(body, "pi_dash_managed_runner_queued_wait_seconds_count ") == "2"
+
+
+def test_queued_wait_histogram_ignores_non_managed_and_non_queued(project, create_user, api_client):
+    # A running managed run and a queued local run both fall outside the series.
+    AgentRun.objects.create(
+        workspace=project.workspace,
+        created_by=create_user,
+        pod=project.pods.get(is_default=True),
+        executor_kind=AgentExecutorKind.MANAGED_RUNNER,
+        status=AgentRunStatus.RUNNING,
+        prompt="",
+    )
+    AgentRun.objects.create(
+        workspace=project.workspace,
+        created_by=create_user,
+        pod=project.pods.get(is_default=True),
+        executor_kind=AgentExecutorKind.LOCAL_RUNNER,
+        status=AgentRunStatus.QUEUED,
+        prompt="",
+    )
+    body = api_client.get(METRICS_URL).content.decode()
+    assert _series_value(body, "pi_dash_managed_runner_queued_wait_seconds_count ") == "0"


### PR DESCRIPTION
## What

MR-11 of the Managed Runner epic (PDASHOSS01-107). Fills the remaining observability gaps for the `managed_runner` executor kind, per design `.ai_design/managed_runner/design.md` §15.1 / §17.

The startup checks (`managed.E001` / `E002`) and most log events (`enrolled`, `removed`, `token_issued` / `token_refresh_failed`, `engine_version`, `queued_expired`) already landed in earlier rows. This PR adds the two remaining log events and the three metrics.

## Log events

A single `post_save(AgentRun)` handler in `managed_runner/signals.py` (wired from `runner/apps.py:ready()` next to the existing checks import) emits, for a **newly created** managed run — the one place the run id and resolved runner exist together, covering all five AgentRun creation sites uniformly:

- `managed_runner.queued_waiting run=<id> runner=<id>` — an automatic run parked for a closed desktop (`error_code=desktop_not_connected`, §8.5)
- `managed_runner.run_pinned run=<id> runner=<id>` — a run pinned to a live desktop

Follows the house convention (dotted event name + `key=%s`, `logging.getLogger(__name__)`). Never logs a token or a home-directory path.

## Metrics (`GET /api/v1/runner/metrics/`)

Added in the endpoint's existing hand-rolled Prometheus text idiom — no new dependency, each series a DB snapshot at scrape time:

- `pi_dash_managed_runner_online` (gauge) — online desktop-bundled runners
- `pi_dash_runs_total{executor_kind="…"}` (counter) — AgentRuns by executor kind, zero-filled for every known kind
- `pi_dash_managed_runner_queued_wait_seconds` (histogram) — age of managed runs currently `QUEUED` waiting for a desktop

## Tests

- `tests/unit/runner/test_metrics.py` — endpoint output for each new series (establishes the metrics-endpoint test pattern, which did not exist before)
- `tests/unit/managed_runner/test_observability.py` — both events fire correctly; non-managed runs and plain updates emit nothing

`manage.py check` passes (E001/E002 still register). Full `managed_runner` suite (103) and `runner`/`orchestration` suites green; the one unrelated pre-existing failure (`test_valid_agents_matches_runner_schema`) only reproduces in the apps/api-only test container because it reads a Rust file outside the mount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
