### PR TITLE
PDASHOSS01-121 [MR-14] Web (apps/web): executor picker third option, "Runs on: this computer" affordance, pin-the-issue flow, reason copy

### DIFF
--- a/apps/web/app/(all)/[workspaceSlug]/runners/runs/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/runners/runs/page.tsx
@@ -16,6 +16,7 @@ import { AGENT_RUN_TERMINAL_STATUSES } from "@pi-dash/types";
 import type { TBadgeVariant } from "@pi-dash/ui";
 import { AlertModalCore, Badge, Button, Spinner } from "@pi-dash/ui";
 import { PageHead } from "@/components/core/page-title";
+import { executorKindLabel } from "@/components/dropdowns/pod/execution-target";
 import { RunnersTabs } from "@/components/runners/runners-tabs";
 import { useWorkspace } from "@/hooks/store/use-workspace";
 
@@ -62,6 +63,16 @@ function statusBadgeVariant(status: TAgentRunStatus): TBadgeVariant {
 
 function statusLabel(status: TAgentRunStatus, t: TranslationFn): string {
   return t((RUN_STATUS_I18N_LABELS as Partial<Record<string, string>>)[status] ?? status);
+}
+
+// A managed run that is queued because the owner's desktop is closed is not
+// "queued" in the capacity sense — it is waiting for that one machine to come
+// back. Surface the wait plainly (§8.5 / MR-6) rather than a generic badge.
+function runStatusLabel(run: Pick<IAgentRun, "status" | "executor_kind" | "error_code">, t: TranslationFn): string {
+  if (run.status === "queued" && run.executor_kind === "managed_runner" && run.error_code === "desktop_not_connected") {
+    return t("Waiting for your desktop");
+  }
+  return statusLabel(run.status, t);
 }
 
 const ERROR_SOURCE_BADGE_VARIANT: Record<TAgentRunErrorSource, TBadgeVariant> = {
@@ -215,7 +226,7 @@ export const RunnerRunsPage = observer(function RunnerRunsPage() {
                     <td className="px-3 py-2 whitespace-nowrap">{new Date(r.created_at).toLocaleString()}</td>
                     <td className="px-3 py-2">
                       <Badge variant={statusBadgeVariant(r.status)} size="sm">
-                        {statusLabel(r.status, t)}
+                        {runStatusLabel(r, t)}
                       </Badge>
                     </td>
                     <td className="font-mono max-w-[180px] truncate px-3 py-2 text-11">{r.prompt}</td>
@@ -270,13 +281,13 @@ export const RunnerRunsPage = observer(function RunnerRunsPage() {
                   <div className="font-mono text-11">{detail.id}</div>
                   <div className="mt-1 flex items-center gap-2">
                     <Badge variant={statusBadgeVariant(detail.status)} size="sm">
-                      {statusLabel(detail.status, t)}
+                      {runStatusLabel(detail, t)}
                     </Badge>
                     <Badge
                       variant={detail.executor_kind === "cloud_agent" ? "accent-primary" : "accent-neutral"}
                       size="sm"
                     >
-                      {detail.executor_kind === "cloud_agent" ? t("Pi Dash Cloud Agent") : t("Local Runner")}
+                      {executorKindLabel(detail.executor_kind, t)}
                     </Badge>
                   </div>
                 </div>

--- a/apps/web/core/components/dropdowns/pod/base.tsx
+++ b/apps/web/core/components/dropdowns/pod/base.tsx
@@ -21,7 +21,7 @@ import type { TDropdownProps } from "@/components/dropdowns/types";
 // hooks
 import { useDropdown } from "@/hooks/use-dropdown";
 // local imports
-import { CLOUD_AGENT_VALUE, MANAGED_AGENT_VALUE } from "./execution-target";
+import { CLOUD_AGENT_VALUE, MANAGED_AGENT_VALUE, managedRunnerReasonCopy } from "./execution-target";
 
 const matchesQuery = (label: string, query: string) =>
   query === "" || label.toLowerCase().includes(query.toLowerCase());
@@ -106,12 +106,9 @@ export function PodDropdownBase(props: TPodDropdownBaseProps) {
     : isCloudSelected
       ? t("Pi Dash Cloud Agent")
       : selectedPod?.name;
-  const managedUnavailableReason =
-    managedAgent?.reasonCode === "byok_not_supported_on_desktop"
-      ? t("Select OpenHub in AI Assistant settings to run on your desktop.")
-      : managedAgent?.reasonCode === "managed_runner_disabled"
-        ? t("Pi Dash Agent is not enabled on this server.")
-        : t("Open this project in Pi Dash Desktop to connect its agent.");
+  // `null` for reasons the desktop resolves silently (no_managed_runner_for_project);
+  // those render no explanation line at all.
+  const managedUnavailableReason = managedAgent ? managedRunnerReasonCopy(managedAgent.reasonCode, t) : null;
   const cloudUnavailableReason =
     cloudAgent?.reasonCode === "llm_config_missing"
       ? t("Configure your AI provider in Pi Dash AI settings to use the Cloud Agent.")
@@ -250,7 +247,9 @@ export function PodDropdownBase(props: TPodDropdownBaseProps) {
                     <Monitor className="size-3.5 flex-shrink-0" />
                     <div>
                       <p>{t("Pi Dash Agent (desktop)")}</p>
-                      {!managedAgent.available && <p className="text-9">{managedUnavailableReason}</p>}
+                      {!managedAgent.available && managedUnavailableReason && (
+                        <p className="text-9">{managedUnavailableReason}</p>
+                      )}
                     </div>
                   </div>
                   {isManagedSelected && <Check className="size-3.5 flex-shrink-0" />}

--- a/apps/web/core/components/dropdowns/pod/execution-target.ts
+++ b/apps/web/core/components/dropdowns/pod/execution-target.ts
@@ -60,3 +60,46 @@ export function managedAgentOption(project: IProject | undefined | null) {
   const option = project?.agent_executor_options?.find((o) => o.kind === MANAGED_AGENT_VALUE);
   return { available: option?.available ?? false, reasonCode: option?.reason_code ?? "desktop_not_connected" };
 }
+
+type TranslateFn = (key: string) => string;
+
+/**
+ * Why the managed runner ("Pi Dash Agent") is unavailable, keyed by the
+ * `reason_code` the server returned. `null` means render nothing: the desktop
+ * fixes `no_managed_runner_for_project` silently the moment it opens the
+ * project, so nagging the viewer about it would be noise. Copy mirrors the
+ * server-side detail map (`app/serializers/issue.py`) so the picker and a
+ * refused pin never explain one situation two different ways. Overlay-friendly:
+ * the desktop overlay imports this rather than re-deriving the copy.
+ */
+export function managedRunnerReasonCopy(reasonCode: string, t: TranslateFn): string | null {
+  switch (reasonCode) {
+    case "no_managed_runner_for_project":
+      return null;
+    case "byok_not_supported_on_desktop":
+      return t(
+        "Pi Dash Agent on desktop uses OpenHub; switch your AI provider to OpenHub to use it here. Pi Dash AI and the Cloud Agent keep using your own key."
+      );
+    case "managed_runner_disabled":
+      return t("Pi Dash Agent is not enabled on this server.");
+    case "llm_config_missing":
+      return t("Configure your AI provider in Pi Dash AI settings to run on your desktop.");
+    case "gateway_scopes_missing":
+      return t("Sign in to Pi Dash again to refresh your AI access.");
+    case "desktop_not_connected":
+    default:
+      return t("Open Pi Dash Desktop to run here.");
+  }
+}
+
+/** Human label for an executor kind, shared by the run list and issue panels. */
+export function executorKindLabel(kind: TAgentExecutorKind, t: TranslateFn): string {
+  switch (kind) {
+    case CLOUD_AGENT_VALUE:
+      return t("Pi Dash Cloud Agent");
+    case MANAGED_AGENT_VALUE:
+      return t("Pi Dash Agent");
+    default:
+      return t("Local Runner");
+  }
+}

--- a/apps/web/core/components/issues/issue-detail/agent-status.tsx
+++ b/apps/web/core/components/issues/issue-detail/agent-status.tsx
@@ -15,6 +15,8 @@ import { Button } from "@pi-dash/propel/button";
 import type { TAgentRunStatus, TIssue, TIssueAgentRunSummary, TIssueAgentTicker } from "@pi-dash/types";
 import { AlertModalCore } from "@pi-dash/ui";
 import { cn } from "@pi-dash/utils";
+// components
+import { executorKindLabel } from "@/components/dropdowns/pod/execution-target";
 // local imports
 import type { TIssueOperations } from "./root";
 import { useAbortRun } from "./use-abort-run";
@@ -161,18 +163,24 @@ function getRunView(
     getPayloadString(run.done_payload, "summary");
 
   switch (run.status) {
-    case "queued":
+    case "queued": {
+      // A managed run queues visibly when the owner's desktop is closed
+      // (§8.5): it is waiting for that one machine, not for shared capacity.
+      const queuedDetail =
+        run.executor_kind === "cloud_agent"
+          ? t("Waiting for Pi Dash Cloud Agent capacity.")
+          : run.executor_kind === "managed_runner" && run.error_code === "desktop_not_connected"
+            ? t("Waiting for your desktop")
+            : (runnerDetail ?? t("Waiting for an available runner."));
       return {
         title: t("AI agent is queued"),
-        detail:
-          run.executor_kind === "cloud_agent"
-            ? t("Waiting for Pi Dash Cloud Agent capacity.")
-            : (runnerDetail ?? t("Waiting for an available runner.")),
+        detail: queuedDetail,
         badge: t("Queued"),
         badgeVariant: "neutral",
         icon: Clock3,
         iconClassName: "text-tertiary",
       };
+    }
     case "assigned":
       return {
         title: t("AI agent is starting on this issue"),
@@ -446,9 +454,7 @@ export function IssueAgentStatusPanel({ workspaceSlug, projectId, issueId, issue
           {status?.latest_run ? (
             <div className="rounded-sm bg-layer-2 px-2 py-1">
               <span className="block text-placeholder">{t("Executor")}</span>
-              <span className="text-primary">
-                {status.latest_run.executor_kind === "cloud_agent" ? t("Pi Dash Cloud Agent") : t("Local Runner")}
-              </span>
+              <span className="text-primary">{executorKindLabel(status.latest_run.executor_kind, t)}</span>
             </div>
           ) : null}
           {nextTick ? (

--- a/apps/web/tests/issues/execution-target.test.ts
+++ b/apps/web/tests/issues/execution-target.test.ts
@@ -2,8 +2,12 @@ import { describe, expect, it } from "vitest";
 import {
   executionTargetPatch,
   executionTargetValue,
+  executorKindLabel,
   managedAgentOption,
+  managedRunnerReasonCopy,
 } from "../../core/components/dropdowns/pod/execution-target";
+
+const echo = (key: string) => key;
 
 describe("managed issue execution target", () => {
   it("shows a desktop pin even when the issue still has its local pod", () => {
@@ -20,5 +24,39 @@ describe("managed issue execution target", () => {
   });
   it("keeps desktop selection unavailable until the server reports it", () => {
     expect(managedAgentOption(null)).toEqual({ available: false, reasonCode: "desktop_not_connected" });
+  });
+});
+
+describe("managed runner reason copy", () => {
+  it("stays silent for a project the desktop enrolls on its own", () => {
+    expect(managedRunnerReasonCopy("no_managed_runner_for_project", echo)).toBeNull();
+  });
+  it("tells BYOK users to switch to OpenHub without stranding their key", () => {
+    const copy = managedRunnerReasonCopy("byok_not_supported_on_desktop", echo);
+    expect(copy).toContain("OpenHub");
+    expect(copy).toContain("your own key");
+  });
+  it("gives a distinct sentence per unavailable reason", () => {
+    const codes = [
+      "desktop_not_connected",
+      "managed_runner_disabled",
+      "llm_config_missing",
+      "gateway_scopes_missing",
+      "byok_not_supported_on_desktop",
+    ];
+    const messages = codes.map((c) => managedRunnerReasonCopy(c, echo));
+    expect(messages.every((m) => typeof m === "string" && m.length > 0)).toBe(true);
+    expect(new Set(messages).size).toBe(codes.length);
+  });
+  it("falls back to the desktop-not-connected copy for an unknown reason", () => {
+    expect(managedRunnerReasonCopy("something_new", echo)).toBe(managedRunnerReasonCopy("desktop_not_connected", echo));
+  });
+});
+
+describe("executor kind label", () => {
+  it("names the managed runner as Pi Dash Agent, not a local runner", () => {
+    expect(executorKindLabel("managed_runner", echo)).toBe("Pi Dash Agent");
+    expect(executorKindLabel("cloud_agent", echo)).toBe("Pi Dash Cloud Agent");
+    expect(executorKindLabel("local_runner", echo)).toBe("Local Runner");
   });
 });


### PR DESCRIPTION
## PDASHOSS01-121 [MR-14] Web: managed_runner reason copy + "Waiting for your desktop"

Design: `.ai_design/managed_runner/design.md` §8.6, §12.2, §17.

Finishes the OSS `apps/web` surface for the `managed_runner` ("Pi Dash Agent" / desktop) executor. The executor-picker third option, the issue-pinning patch helpers (`executionTargetPatch` → `Issue.agent_executor = managed_runner`, never the project default), and the project-form option already landed under the parent epic (`e2cd59c5`). This PR fills the remaining gaps.

### Changes

- **`dropdowns/pod/execution-target.ts`** — two pure, testable, overlay-friendly helpers:
  - `managedRunnerReasonCopy(reason_code, t)` renders a distinct sentence per reason code (`desktop_not_connected`, `byok_not_supported_on_desktop`, `managed_runner_disabled`, `llm_config_missing`, `gateway_scopes_missing`) and returns `null` (silent) for `no_managed_runner_for_project`, which the desktop resolves on its own. Copy mirrors the server-side detail map so the picker and a refused pin never explain one situation two ways.
  - `executorKindLabel(kind, t)` — shared human label for the run list and issue panels.
- **`dropdowns/pod/base.tsx`** — use `managedRunnerReasonCopy`; render no explanation line when it returns `null`.
- **`runners/runs/page.tsx`** and **issue `agent-status.tsx`** — label managed runs "Pi Dash Agent" (not "Local Runner"); render a `QUEUED` managed run whose `error_code` is `desktop_not_connected` as **"Waiting for your desktop"** (§8.5 / MR-6).
- **`tests/issues/execution-target.test.ts`** — coverage for both new helpers (silent reason, distinct copy per code, fallback, labels).

The desktop overlay imports these components; nothing here assumes a desktop-only environment (the hostname in "Pinned to Pi Dash Agent on `<hostname>`" is overlay-supplied — OSS shows the "Pi Dash Agent (desktop)" pin label).

### Validation

- `pnpm --filter web check:types` — clean (after rebuilding the stale `@pi-dash/types` dist).
- `pnpm --filter web test tests/issues/` — 17 passed.
- `oxlint` / `oxfmt` — clean on touched files (also enforced by the pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
