### PR TITLE
Desktop: resolve shareable links against the web origin, not the bundle

### DIFF
--- a/desktop-overlay/README.md
+++ b/desktop-overlay/README.md
@@ -40,10 +40,10 @@ silently replaces the edition's version. So:
 
 Current seams:
 
-| Seam (`@/pi-dash-web/components/desktop/…`) | Used by | Community default |
-|---|---|---|
-| `sign-in-card.tsx` — `DesktopSignInCard` | `app/(home)/page.tsx` | Explains that desktop sign-in isn't available for this server yet and opens the web app |
-| `agent-runtime-edition.ts` — `AGENT_RUNTIME_REASON_MESSAGES`, `CSRF_TOKEN_PATH` | `core/services/agent-runtime.ts` | Generic messages for managed-runner reason codes; `/auth/get-csrf-token/` |
+| Seam (`@/pi-dash-web/components/desktop/…`)                                     | Used by                          | Community default                                                                       |
+| ------------------------------------------------------------------------------- | -------------------------------- | --------------------------------------------------------------------------------------- |
+| `sign-in-card.tsx` — `DesktopSignInCard`                                        | `app/(home)/page.tsx`            | Explains that desktop sign-in isn't available for this server yet and opens the web app |
+| `agent-runtime-edition.ts` — `AGENT_RUNTIME_REASON_MESSAGES`, `CSRF_TOKEN_PATH` | `core/services/agent-runtime.ts` | Generic messages for managed-runner reason codes; `/auth/get-csrf-token/`               |
 
 ## Path convention
 
@@ -75,6 +75,16 @@ desktop/src-tauri/dist/
   — the real implementations of the `apps/web` agent-runtime stubs: enroll
   this machine, write the engine config and model credential, supervise the
   bundled daemon.
+- `apps/web/core/utils/desktop-web-url.ts` — resolves an in-app path against
+  `VITE_WEB_BASE_URL` (baked by `dev-prep.sh`, defaulting to `PI_DASH_URL`).
+  Bundled pages run on a Tauri-owned origin, so anything that builds a
+  shareable link from `window.location.origin` would hand the user a
+  `tauri://localhost` URL.
+- `apps/web/core/components/issues/issue-detail/issue-detail-quick-actions.tsx`,
+  `issue-layouts/quick-action-dropdowns/helper.tsx` and
+  `peek-overview/header.tsx` — the three copy-link paths, routed through
+  `desktopWebUrl()` instead of the bundle origin. Each is otherwise identical
+  to its `apps/web` original; keep them in step when that original changes.
 - `apps/web/tests/desktop/` — tests for the above; run them with
   `bash desktop/scripts/test-overlay.sh`.
 

--- a/desktop-overlay/apps/web/core/components/issues/issue-detail/issue-detail-quick-actions.tsx
+++ b/desktop-overlay/apps/web/core/components/issues/issue-detail/issue-detail-quick-actions.tsx
@@ -1,0 +1,167 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useRef } from "react";
+import { observer } from "mobx-react";
+// pi dash imports
+import { useTranslation } from "@pi-dash/i18n";
+import { CopyLinkIcon } from "@pi-dash/propel/icons";
+import { IconButton } from "@pi-dash/propel/icon-button";
+import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
+import { Tooltip } from "@pi-dash/propel/tooltip";
+import { EIssuesStoreType } from "@pi-dash/types";
+import { generateWorkItemLink, copyTextToClipboard } from "@pi-dash/utils";
+import { desktopWebUrl } from "@/utils/desktop-web-url";
+// hooks
+import { useIssueDetail } from "@/hooks/store/use-issue-detail";
+import { useIssues } from "@/hooks/store/use-issues";
+import { useProject } from "@/hooks/store/use-project";
+import { useUser } from "@/hooks/store/user";
+import { useAppRouter } from "@/hooks/use-app-router";
+import { usePlatformOS } from "@/hooks/use-platform-os";
+// local imports
+import { WorkItemDetailQuickActions } from "../issue-layouts/quick-action-dropdowns";
+import { IssueSubscription } from "./subscription";
+
+type Props = {
+  workspaceSlug: string;
+  projectId: string;
+  issueId: string;
+};
+
+export const IssueDetailQuickActions = observer(function IssueDetailQuickActions(props: Props) {
+  const { workspaceSlug, projectId, issueId } = props;
+  const { t } = useTranslation();
+
+  // ref
+  const parentRef = useRef<HTMLDivElement>(null);
+
+  // router
+  const router = useAppRouter();
+
+  // hooks
+  const { data: currentUser } = useUser();
+  const { isMobile } = usePlatformOS();
+  const { getProjectIdentifierById } = useProject();
+  const {
+    issue: { getIssueById },
+    removeIssue,
+    archiveIssue,
+  } = useIssueDetail();
+  const {
+    issues: { restoreIssue },
+  } = useIssues(EIssuesStoreType.ARCHIVED);
+  const {
+    issues: { removeIssue: removeArchivedIssue },
+  } = useIssues(EIssuesStoreType.ARCHIVED);
+
+  // derived values
+  const issue = getIssueById(issueId);
+  if (!issue) return <></>;
+
+  const projectIdentifier = getProjectIdentifierById(projectId);
+
+  const workItemLink = generateWorkItemLink({
+    workspaceSlug: workspaceSlug,
+    projectId,
+    issueId,
+    projectIdentifier,
+    sequenceId: issue?.sequence_id,
+  });
+
+  // handlers
+  const handleCopyText = async () => {
+    try {
+      await copyTextToClipboard(desktopWebUrl(workItemLink));
+      setToast({
+        type: TOAST_TYPE.SUCCESS,
+        title: t("Link copied!"),
+        message: t("Work item link copied to clipboard"),
+      });
+    } catch (_error) {
+      setToast({
+        title: t("Error!"),
+        type: TOAST_TYPE.ERROR,
+      });
+    }
+  };
+
+  const handleDeleteIssue = async () => {
+    try {
+      const deleteIssue = issue?.archived_at ? removeArchivedIssue : removeIssue;
+      const redirectionPath = issue?.archived_at
+        ? `/${workspaceSlug}/projects/${projectId}/archives/issues`
+        : `/${workspaceSlug}/projects/${projectId}/issues`;
+
+      await deleteIssue(workspaceSlug, projectId, issueId);
+      router.push(redirectionPath);
+    } catch (_error) {
+      setToast({
+        title: t("Error!"),
+        type: TOAST_TYPE.ERROR,
+        message: t("{entity} delete failed", {
+          entity: t("{count, plural, one {Work item} other {Work items}}", { count: 1 }),
+        }),
+      });
+    }
+  };
+
+  const handleArchiveIssue = async () => {
+    try {
+      await archiveIssue(workspaceSlug, projectId, issueId);
+      router.push(`/${workspaceSlug}/projects/${projectId}/issues`);
+    } catch (_error) {
+      setToast({
+        title: t("Error!"),
+        type: TOAST_TYPE.ERROR,
+        message: t("Work item could not be archived. Please try again."),
+      });
+    }
+  };
+
+  const handleRestore = async () => {
+    if (!workspaceSlug || !projectId || !issueId) return;
+    try {
+      await restoreIssue(workspaceSlug.toString(), projectId.toString(), issueId.toString());
+      setToast({
+        type: TOAST_TYPE.SUCCESS,
+        title: t("Restore success"),
+        message: t("Your work item can be found in project work items."),
+      });
+      router.push(workItemLink);
+    } catch (_error) {
+      setToast({
+        title: t("Error!"),
+        type: TOAST_TYPE.ERROR,
+        message: t("Work item could not be restored. Please try again."),
+      });
+    }
+  };
+
+  return (
+    <>
+      <div className="flex flex-shrink-0 items-center justify-end">
+        <div className="flex flex-wrap items-center gap-2">
+          {currentUser && !issue?.archived_at && (
+            <IssueSubscription workspaceSlug={workspaceSlug} projectId={projectId} issueId={issueId} />
+          )}
+          <div className="flex flex-wrap items-center gap-2 text-tertiary">
+            <Tooltip tooltipContent={t("Copy link")} isMobile={isMobile}>
+              <IconButton variant="secondary" size="lg" onClick={handleCopyText} icon={CopyLinkIcon} />
+            </Tooltip>
+            <WorkItemDetailQuickActions
+              parentRef={parentRef}
+              issue={issue}
+              handleDelete={handleDeleteIssue}
+              handleArchive={handleArchiveIssue}
+              handleRestore={handleRestore}
+            />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+});

--- a/desktop-overlay/apps/web/core/components/issues/issue-layouts/quick-action-dropdowns/helper.tsx
+++ b/desktop-overlay/apps/web/core/components/issues/issue-layouts/quick-action-dropdowns/helper.tsx
@@ -1,0 +1,394 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useCallback, useMemo } from "react";
+import { XCircle, ArchiveRestoreIcon, FolderInput } from "lucide-react";
+// pi dash imports
+import { useTranslation } from "@pi-dash/i18n";
+import { LinkIcon, CopyIcon, NewTabIcon, EditIcon, ArchiveIcon, TrashIcon } from "@pi-dash/propel/icons";
+import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
+import type { EIssuesStoreType, TIssue } from "@pi-dash/types";
+import type { TContextMenuItem } from "@pi-dash/ui";
+import { copyTextToClipboard, generateWorkItemLink } from "@pi-dash/utils";
+// types
+import { createCopyMenuWithDuplication } from "@/pi-dash-web/components/issues/issue-layouts/quick-action-dropdowns";
+import { desktopWebUrl } from "@/utils/desktop-web-url";
+
+// Generic helper function to handle optional function calls gracefully
+// Overload for functions without parameters
+export function handleOptionalAction(
+  optionalFn: (() => void) | (() => Promise<void>) | undefined,
+  actionName: string
+): void;
+
+// Overload for functions with one parameter
+export function handleOptionalAction<T>(
+  optionalFn: ((param: T) => void) | ((param: T) => Promise<void>) | undefined,
+  actionName: string,
+  param: T
+): void;
+
+// Implementation
+export function handleOptionalAction<T>(
+  optionalFn: (() => void) | (() => Promise<void>) | ((param: T) => void) | ((param: T) => Promise<void>) | undefined,
+  actionName: string,
+  param?: T
+): void {
+  if (optionalFn) {
+    if (param !== undefined) {
+      (optionalFn as (param: T) => void | Promise<void>)(param);
+    } else {
+      (optionalFn as () => void | Promise<void>)();
+    }
+  } else {
+    setToast({
+      type: TOAST_TYPE.ERROR,
+      title: "Action not available",
+      message: `${actionName} action is not implemented.`,
+    });
+  }
+}
+
+export interface MenuItemFactoryProps {
+  issue: TIssue;
+  workspaceSlug?: string;
+  projectIdentifier?: string;
+  activeLayout?: string;
+  isEditingAllowed: boolean;
+  isArchivingAllowed?: boolean;
+  isDeletingAllowed: boolean;
+  isRestoringAllowed?: boolean;
+  isInArchivableGroup?: boolean;
+  issueTypeDetail?: { is_active?: boolean };
+  // Action handlers
+  setIssueToEdit: (issue: TIssue | undefined) => void;
+  setCreateUpdateIssueModal: (open: boolean) => void;
+  setDeleteIssueModal: (open: boolean) => void;
+  setArchiveIssueModal?: (open: boolean) => void;
+  setDuplicateWorkItemModal?: (open: boolean) => void;
+  setMoveIssueModal?: (open: boolean) => void;
+  handleRemoveFromView?: () => void;
+  handleRestore?: () => Promise<void>;
+  // External handlers
+  handleDelete?: () => Promise<void>;
+  handleUpdate?: (data: TIssue) => Promise<void>;
+  handleArchive?: () => Promise<void>;
+  // Context-specific data
+  cycleId?: string;
+  moduleId?: string;
+  storeType?: EIssuesStoreType;
+}
+
+// Common action handlers hook
+export const useIssueActionHandlers = (props: MenuItemFactoryProps) => {
+  const { issue, workspaceSlug, projectIdentifier, handleRestore } = props;
+
+  const workItemLink = useMemo(
+    () =>
+      generateWorkItemLink({
+        workspaceSlug,
+        projectId: issue?.project_id,
+        issueId: issue?.id,
+        projectIdentifier,
+        sequenceId: issue?.sequence_id,
+      }),
+    [workspaceSlug, projectIdentifier, issue]
+  );
+
+  const handleCopyIssueLink = () =>
+    copyTextToClipboard(desktopWebUrl(workItemLink)).then(() =>
+      setToast({
+        type: TOAST_TYPE.SUCCESS,
+        title: "Link copied",
+        message: "Work item link copied to clipboard",
+      })
+    );
+
+  const handleOpenInNewTab = () => window.open(workItemLink, "_blank");
+
+  const handleIssueRestore = async () => {
+    if (!handleRestore) {
+      handleOptionalAction(handleRestore, "Restore");
+      return;
+    }
+    try {
+      await handleRestore();
+      setToast({
+        type: TOAST_TYPE.SUCCESS,
+        title: "Restore success",
+        message: "Your work item can be found in project work items.",
+      });
+    } catch {
+      setToast({
+        type: TOAST_TYPE.ERROR,
+        title: "Error!",
+        message: "Work item could not be restored. Please try again.",
+      });
+    }
+  };
+
+  return {
+    workItemLink,
+    handleCopyIssueLink,
+    handleOpenInNewTab,
+    handleIssueRestore,
+  };
+};
+
+export const useMenuItemFactory = (props: MenuItemFactoryProps) => {
+  const { t } = useTranslation();
+  const actionHandlers = useIssueActionHandlers(props);
+
+  const {
+    issue,
+    activeLayout = "",
+    isEditingAllowed,
+    isArchivingAllowed = false,
+    isDeletingAllowed,
+    isRestoringAllowed = false,
+    isInArchivableGroup = false,
+    issueTypeDetail,
+    setIssueToEdit,
+    setCreateUpdateIssueModal,
+    setDeleteIssueModal,
+    setArchiveIssueModal,
+    setDuplicateWorkItemModal,
+    setMoveIssueModal,
+    handleRemoveFromView,
+  } = props;
+
+  const createEditMenuItem = (customEditAction?: () => void): TContextMenuItem => ({
+    key: "edit",
+    title: t("Edit"),
+    icon: EditIcon,
+    action:
+      customEditAction ||
+      (() => {
+        setIssueToEdit(issue);
+        setCreateUpdateIssueModal(true);
+      }),
+    shouldRender: isEditingAllowed,
+  });
+
+  const createCopyMenuItem = (workspaceSlug?: string): TContextMenuItem => {
+    const baseItem = {
+      key: "make-a-copy",
+      title: t("Make a copy"),
+      icon: CopyIcon,
+      action: () => {
+        setCreateUpdateIssueModal(true);
+      },
+      shouldRender: isEditingAllowed && (issueTypeDetail?.is_active ?? true),
+    };
+
+    return createCopyMenuWithDuplication({
+      baseItem,
+      activeLayout,
+      setCreateUpdateIssueModal,
+      setDuplicateWorkItemModal,
+      workspaceSlug,
+    });
+  };
+
+  const createOpenInNewTabMenuItem = (): TContextMenuItem => ({
+    key: "open-in-new-tab",
+    title: t("Open in new tab"),
+    icon: NewTabIcon,
+    action: actionHandlers.handleOpenInNewTab,
+  });
+
+  const createCopyLinkMenuItem = (): TContextMenuItem => ({
+    key: "copy-link",
+    title: t("Copy link"),
+    icon: LinkIcon,
+    action: actionHandlers.handleCopyIssueLink,
+  });
+
+  const createRemoveFromCycleMenuItem = (): TContextMenuItem => ({
+    key: "remove-from-cycle",
+    title: "Remove from cycle",
+    icon: XCircle,
+    action: () => handleOptionalAction(handleRemoveFromView, "Remove from cycle"),
+    shouldRender: isEditingAllowed,
+  });
+
+  const createRemoveFromModuleMenuItem = (): TContextMenuItem => ({
+    key: "remove-from-module",
+    title: "Remove from module",
+    icon: XCircle,
+    action: () => handleOptionalAction(handleRemoveFromView, "Remove from module"),
+    shouldRender: isEditingAllowed,
+  });
+
+  const createArchiveMenuItem = (): TContextMenuItem => ({
+    key: "archive",
+    title: t("Archive"),
+    description: isInArchivableGroup ? undefined : t("Only completed or canceled\nwork items can be archived"),
+    icon: ArchiveIcon,
+    className: "items-start",
+    iconClassName: "mt-1",
+    action: () => handleOptionalAction(setArchiveIssueModal, "Archive", true),
+    disabled: !isInArchivableGroup,
+    shouldRender: isArchivingAllowed,
+  });
+
+  const createRestoreMenuItem = (): TContextMenuItem => ({
+    key: "restore",
+    title: "Restore",
+    icon: ArchiveRestoreIcon,
+    action: actionHandlers.handleIssueRestore,
+    shouldRender: isRestoringAllowed,
+  });
+
+  const createMoveMenuItem = (): TContextMenuItem => ({
+    key: "move",
+    title: t("Move to project"),
+    icon: FolderInput,
+    action: () => handleOptionalAction(setMoveIssueModal, "Move", true),
+    shouldRender: isEditingAllowed,
+  });
+
+  const createDeleteMenuItem = (): TContextMenuItem => ({
+    key: "delete",
+    title: t("Delete"),
+    icon: TrashIcon,
+    action: () => {
+      setDeleteIssueModal(true);
+    },
+    shouldRender: isDeletingAllowed,
+  });
+
+  return {
+    ...actionHandlers,
+    createEditMenuItem,
+    createCopyMenuItem,
+    createOpenInNewTabMenuItem,
+    createCopyLinkMenuItem,
+    createRemoveFromCycleMenuItem,
+    createRemoveFromModuleMenuItem,
+    createArchiveMenuItem,
+    createRestoreMenuItem,
+    createMoveMenuItem,
+    createDeleteMenuItem,
+  };
+};
+
+// Predefined menu item sets for different contexts
+export const useProjectIssueMenuItems = (props: MenuItemFactoryProps): TContextMenuItem[] => {
+  const factory = useMenuItemFactory(props);
+
+  return useMemo(
+    () => [
+      factory.createEditMenuItem(),
+      factory.createCopyMenuItem(),
+      factory.createOpenInNewTabMenuItem(),
+      factory.createCopyLinkMenuItem(),
+      factory.createMoveMenuItem(),
+      factory.createArchiveMenuItem(),
+      factory.createDeleteMenuItem(),
+    ],
+    [factory]
+  );
+};
+
+export const useWorkItemDetailMenuItems = (props: MenuItemFactoryProps): TContextMenuItem[] => {
+  const factory = useMenuItemFactory(props);
+
+  return useMemo(
+    () => [
+      factory.createCopyMenuItem(props.workspaceSlug),
+      factory.createOpenInNewTabMenuItem(),
+      factory.createMoveMenuItem(),
+      factory.createArchiveMenuItem(),
+      factory.createRestoreMenuItem(),
+      factory.createDeleteMenuItem(),
+    ],
+    [factory, props.workspaceSlug]
+  );
+};
+
+export const useAllIssueMenuItems = (props: MenuItemFactoryProps): TContextMenuItem[] => {
+  const factory = useMenuItemFactory(props);
+
+  return useMemo(
+    () => [
+      factory.createEditMenuItem(),
+      factory.createCopyMenuItem(),
+      factory.createOpenInNewTabMenuItem(),
+      factory.createCopyLinkMenuItem(),
+      factory.createMoveMenuItem(),
+      factory.createArchiveMenuItem(),
+      factory.createDeleteMenuItem(),
+    ],
+    [factory]
+  );
+};
+
+export const useCycleIssueMenuItems = (props: MenuItemFactoryProps): TContextMenuItem[] => {
+  const factory = useMenuItemFactory(props);
+  const { cycleId, issue, setCreateUpdateIssueModal, setIssueToEdit } = props;
+
+  const customEditAction = useCallback(() => {
+    setIssueToEdit({
+      ...issue,
+      cycle_id: cycleId ?? null,
+    });
+    setCreateUpdateIssueModal(true);
+  }, [cycleId, issue, setCreateUpdateIssueModal, setIssueToEdit]);
+
+  return useMemo(
+    () => [
+      factory.createEditMenuItem(customEditAction),
+      factory.createCopyMenuItem(),
+      factory.createOpenInNewTabMenuItem(),
+      factory.createCopyLinkMenuItem(),
+      factory.createRemoveFromCycleMenuItem(),
+      factory.createArchiveMenuItem(),
+      factory.createDeleteMenuItem(),
+    ],
+    [customEditAction, factory]
+  );
+};
+
+export const useModuleIssueMenuItems = (props: MenuItemFactoryProps): TContextMenuItem[] => {
+  const factory = useMenuItemFactory(props);
+  const { issue, moduleId, setCreateUpdateIssueModal, setIssueToEdit } = props;
+
+  const customEditAction = useCallback(() => {
+    setIssueToEdit({
+      ...issue,
+      module_ids: moduleId ? [moduleId] : [],
+    });
+    setCreateUpdateIssueModal(true);
+  }, [issue, moduleId, setCreateUpdateIssueModal, setIssueToEdit]);
+
+  return useMemo(
+    () => [
+      factory.createEditMenuItem(customEditAction),
+      factory.createCopyMenuItem(),
+      factory.createOpenInNewTabMenuItem(),
+      factory.createCopyLinkMenuItem(),
+      factory.createRemoveFromModuleMenuItem(),
+      factory.createArchiveMenuItem(),
+      factory.createDeleteMenuItem(),
+    ],
+    [customEditAction, factory]
+  );
+};
+
+export const useArchivedIssueMenuItems = (props: MenuItemFactoryProps): TContextMenuItem[] => {
+  const factory = useMenuItemFactory(props);
+
+  return useMemo(
+    () => [
+      factory.createRestoreMenuItem(),
+      factory.createOpenInNewTabMenuItem(),
+      factory.createCopyLinkMenuItem(),
+      factory.createDeleteMenuItem(),
+    ],
+    [factory]
+  );
+};

--- a/desktop-overlay/apps/web/core/components/issues/peek-overview/header.tsx
+++ b/desktop-overlay/apps/web/core/components/issues/peek-overview/header.tsx
@@ -1,0 +1,234 @@
+/**
+ * Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useRef } from "react";
+import { observer } from "mobx-react";
+import Link from "next/link";
+import { MoveDiagonal, MoveRight } from "lucide-react";
+// pi dash imports
+import { useTranslation } from "@pi-dash/i18n";
+import { CenterPanelIcon, CopyLinkIcon, FullScreenPanelIcon, SidePanelIcon } from "@pi-dash/propel/icons";
+import { IconButton } from "@pi-dash/propel/icon-button";
+import { TOAST_TYPE, setToast } from "@pi-dash/propel/toast";
+import { Tooltip } from "@pi-dash/propel/tooltip";
+import type { TNameDescriptionLoader } from "@pi-dash/types";
+import { EIssuesStoreType } from "@pi-dash/types";
+import { CustomSelect } from "@pi-dash/ui";
+import { copyTextToClipboard, generateWorkItemLink } from "@pi-dash/utils";
+// hooks
+import { useIssueDetail } from "@/hooks/store/use-issue-detail";
+import { useIssues } from "@/hooks/store/use-issues";
+import { useProject } from "@/hooks/store/use-project";
+import { useUser } from "@/hooks/store/user";
+import { usePlatformOS } from "@/hooks/use-platform-os";
+import { desktopWebUrl } from "@/utils/desktop-web-url";
+// local imports
+import { IssueSubscription } from "../issue-detail/subscription";
+import { WorkItemDetailQuickActions } from "../issue-layouts/quick-action-dropdowns";
+import { NameDescriptionUpdateStatus } from "../issue-update-status";
+
+export type TPeekModes = "side-peek" | "modal" | "full-screen";
+
+const PEEK_OPTIONS: { key: TPeekModes; icon: any; i18n_title: string }[] = [
+  {
+    key: "side-peek",
+    icon: SidePanelIcon,
+    i18n_title: "Side Peek",
+  },
+  {
+    key: "modal",
+    icon: CenterPanelIcon,
+    i18n_title: "Modal",
+  },
+  {
+    key: "full-screen",
+    icon: FullScreenPanelIcon,
+    i18n_title: "Full Screen",
+  },
+];
+
+export type PeekOverviewHeaderProps = {
+  peekMode: TPeekModes;
+  setPeekMode: (value: TPeekModes) => void;
+  removeRoutePeekId: () => void;
+  workspaceSlug: string;
+  projectId: string;
+  issueId: string;
+  isArchived: boolean;
+  disabled: boolean;
+  embedIssue: boolean;
+  toggleDeleteIssueModal: (value: boolean) => void;
+  toggleArchiveIssueModal: (value: boolean) => void;
+  toggleDuplicateIssueModal: (value: boolean) => void;
+  toggleEditIssueModal: (value: boolean) => void;
+  toggleMoveIssueModal: (value: boolean) => void;
+  handleRestoreIssue: () => Promise<void>;
+  isSubmitting: TNameDescriptionLoader;
+};
+
+export const IssuePeekOverviewHeader = observer(function IssuePeekOverviewHeader(props: PeekOverviewHeaderProps) {
+  const {
+    peekMode,
+    setPeekMode,
+    workspaceSlug,
+    projectId,
+    issueId,
+    isArchived,
+    disabled,
+    embedIssue = false,
+    removeRoutePeekId,
+    toggleDeleteIssueModal,
+    toggleArchiveIssueModal,
+    toggleDuplicateIssueModal,
+    toggleEditIssueModal,
+    toggleMoveIssueModal,
+    handleRestoreIssue,
+    isSubmitting,
+  } = props;
+  // ref
+  const parentRef = useRef<HTMLDivElement>(null);
+  const { t } = useTranslation();
+  // store hooks
+  const { data: currentUser } = useUser();
+  const {
+    issue: { getIssueById },
+    setPeekIssue,
+    removeIssue,
+    archiveIssue,
+    getIsIssuePeeked,
+  } = useIssueDetail();
+  const { isMobile } = usePlatformOS();
+  const { getProjectIdentifierById } = useProject();
+  // derived values
+  const issueDetails = getIssueById(issueId);
+  const currentMode = PEEK_OPTIONS.find((m) => m.key === peekMode);
+  const projectIdentifier = getProjectIdentifierById(issueDetails?.project_id);
+  const {
+    issues: { removeIssue: removeArchivedIssue },
+  } = useIssues(EIssuesStoreType.ARCHIVED);
+
+  const workItemLink = generateWorkItemLink({
+    workspaceSlug,
+    projectId: issueDetails?.project_id,
+    issueId,
+    projectIdentifier,
+    sequenceId: issueDetails?.sequence_id,
+    isArchived,
+  });
+
+  const handleCopyText = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    e.preventDefault();
+    await copyTextToClipboard(desktopWebUrl(workItemLink));
+    setToast({
+      type: TOAST_TYPE.SUCCESS,
+      title: t("Link copied!"),
+      message: t("Link copied to clipboard"),
+    });
+  };
+
+  const handleDeleteIssue = async () => {
+    try {
+      const deleteIssue = issueDetails?.archived_at ? removeArchivedIssue : removeIssue;
+
+      await deleteIssue(workspaceSlug, projectId, issueId);
+      setPeekIssue(undefined);
+    } catch (_error) {
+      setToast({
+        title: t("Error!"),
+        type: TOAST_TYPE.ERROR,
+        message: t("{entity} delete failed", {
+          entity: t("{count, plural, one {Work item} other {Work items}}", { count: 1 }),
+        }),
+      });
+    }
+  };
+
+  const handleArchiveIssue = async () => {
+    await archiveIssue(workspaceSlug, projectId, issueId);
+    // check and remove if issue is peeked
+    if (getIsIssuePeeked(issueId)) {
+      removeRoutePeekId();
+    }
+  };
+
+  return (
+    <div
+      className={`relative flex items-center justify-between p-4 ${
+        currentMode?.key === "full-screen" ? "border-b border-subtle" : ""
+      }`}
+    >
+      <div className="flex items-center gap-4">
+        <Tooltip tooltipContent={t("Close the peek view")} isMobile={isMobile}>
+          <button onClick={removeRoutePeekId}>
+            <MoveRight className="h-4 w-4 text-tertiary hover:text-secondary" />
+          </button>
+        </Tooltip>
+
+        <Tooltip tooltipContent={t("Open work item in full screen")} isMobile={isMobile}>
+          <Link href={workItemLink} onClick={() => removeRoutePeekId()}>
+            <MoveDiagonal className="h-4 w-4 text-tertiary hover:text-secondary" />
+          </Link>
+        </Tooltip>
+        {currentMode && embedIssue === false && (
+          <div className="flex flex-shrink-0 items-center gap-2">
+            <CustomSelect
+              value={currentMode}
+              onChange={(val: any) => setPeekMode(val)}
+              customButton={
+                <Tooltip tooltipContent={t("Toggle peek view layout")} isMobile={isMobile}>
+                  <button type="button" className="">
+                    <currentMode.icon className="h-4 w-4 text-tertiary hover:text-secondary" />
+                  </button>
+                </Tooltip>
+              }
+            >
+              {PEEK_OPTIONS.map((mode) => (
+                <CustomSelect.Option key={mode.key} value={mode.key}>
+                  <div
+                    className={`flex items-center gap-1.5 ${
+                      currentMode.key === mode.key ? "text-secondary" : "text-placeholder hover:text-secondary"
+                    }`}
+                  >
+                    <mode.icon className="-my-1 h-4 w-4 flex-shrink-0" />
+                    {t(mode.i18n_title)}
+                  </div>
+                </CustomSelect.Option>
+              ))}
+            </CustomSelect>
+          </div>
+        )}
+      </div>
+      <div className="flex items-center gap-x-4">
+        <NameDescriptionUpdateStatus isSubmitting={isSubmitting} />
+        <div className="flex items-center gap-2">
+          {currentUser && !isArchived && (
+            <IssueSubscription workspaceSlug={workspaceSlug} projectId={projectId} issueId={issueId} />
+          )}
+          <Tooltip tooltipContent={t("Copy link")} isMobile={isMobile}>
+            <IconButton variant="secondary" size="lg" onClick={handleCopyText} icon={CopyLinkIcon} />
+          </Tooltip>
+          {issueDetails && (
+            <WorkItemDetailQuickActions
+              parentRef={parentRef}
+              issue={issueDetails}
+              handleDelete={handleDeleteIssue}
+              handleArchive={handleArchiveIssue}
+              handleRestore={handleRestoreIssue}
+              readOnly={disabled}
+              toggleDeleteIssueModal={toggleDeleteIssueModal}
+              toggleArchiveIssueModal={toggleArchiveIssueModal}
+              toggleDuplicateIssueModal={toggleDuplicateIssueModal}
+              toggleEditIssueModal={toggleEditIssueModal}
+              toggleMoveIssueModal={toggleMoveIssueModal}
+              isPeekMode
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+});

--- a/desktop-overlay/apps/web/core/utils/desktop-web-url.ts
+++ b/desktop-overlay/apps/web/core/utils/desktop-web-url.ts
@@ -1,0 +1,21 @@
+import { WEB_BASE_URL } from "@pi-dash/constants";
+
+/**
+ * Resolve an in-app path to the hosted Pi Dash frontend.
+ *
+ * Bundled desktop pages run on a Tauri-owned origin, so browser-relative
+ * sharing helpers otherwise expose `tauri://localhost` (or Tauri's Windows
+ * loopback origin). Desktop builds must always provide the public frontend
+ * origin through VITE_WEB_BASE_URL.
+ */
+export const desktopWebUrl = (path: string, webBaseUrl = WEB_BASE_URL): string => {
+  const baseUrl = webBaseUrl.trim();
+  if (!baseUrl) throw new Error("VITE_WEB_BASE_URL is required to create a shareable desktop link");
+
+  const parsedBaseUrl = new URL(baseUrl);
+  if (parsedBaseUrl.protocol !== "http:" && parsedBaseUrl.protocol !== "https:") {
+    throw new Error("VITE_WEB_BASE_URL must use http or https");
+  }
+
+  return new URL(path, `${baseUrl.replace(/\/+$/, "")}/`).toString();
+};

--- a/desktop-overlay/apps/web/tests/desktop/desktop-web-url.test.ts
+++ b/desktop-overlay/apps/web/tests/desktop/desktop-web-url.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { desktopWebUrl } from "../../core/utils/desktop-web-url";
+
+describe("desktopWebUrl", () => {
+  it("resolves an issue path against the configured hosted frontend", () => {
+    expect(desktopWebUrl("/ai-republic/projects/project-id/issues/issue-id", "https://pidash.airepublic.com")).toBe(
+      "https://pidash.airepublic.com/ai-republic/projects/project-id/issues/issue-id"
+    );
+  });
+
+  it("preserves query parameters and fragments", () => {
+    expect(desktopWebUrl("/workspace/issues/issue-id?peek=activity#comment", "https://pidash.example/")).toBe(
+      "https://pidash.example/workspace/issues/issue-id?peek=activity#comment"
+    );
+  });
+
+  it("rejects a missing hosted frontend origin instead of copying a Tauri URL", () => {
+    expect(() => desktopWebUrl("/workspace/issues/issue-id", "  ")).toThrow("VITE_WEB_BASE_URL is required");
+  });
+
+  it("rejects a Tauri origin even when one is configured accidentally", () => {
+    expect(() => desktopWebUrl("/workspace/issues/issue-id", "tauri://localhost")).toThrow("must use http or https");
+  });
+
+  it.each([
+    "../../core/components/issues/issue-detail/issue-detail-quick-actions.tsx",
+    "../../core/components/issues/peek-overview/header.tsx",
+    "../../core/components/issues/issue-layouts/quick-action-dropdowns/helper.tsx",
+  ])("routes the desktop copy-link call site in %s through the hosted origin", (relativePath) => {
+    const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+    expect(source).toContain("desktopWebUrl(workItemLink)");
+  });
+});

--- a/desktop/scripts/dev-prep.sh
+++ b/desktop/scripts/dev-prep.sh
@@ -60,7 +60,7 @@ print_bake_info() {
         sed 's/^/[dev-prep]   /' "$info"
     else
         echo "[dev-prep] WARNING: no $info sidecar — dist/ origin is unknown."
-        echo "[dev-prep] WARNING: if the SPA was baked against a different API base, every API call from the shipped binary will go to the wrong host."
+        echo "[dev-prep] WARNING: if the SPA was baked against different API/web bases, API calls or copied links from the shipped binary can target the wrong host."
     fi
 }
 
@@ -111,11 +111,13 @@ fi
 # applies when unset.
 API_BASE="${VITE_API_BASE_URL:-http://localhost:8000}"
 
-# The desktop sign-in card links the user at the web app (ce/components/
-# desktop/sign-in-card.tsx reads WEB_URL, i.e. VITE_WEB_BASE_URL). Nothing
-# else in a desktop build sets it, and an unset one renders a card with no
-# action at all, so default it to the sign-in origin — the same server the
-# deep-link hand-off targets. Already in turbo.json globalEnv, so the build
+# The public web origin baked into the SPA. Two things read it: the desktop
+# sign-in card (ce/components/desktop/sign-in-card.tsx, via WEB_URL) and
+# desktop-overlay's desktopWebUrl(), which builds shareable work-item links —
+# bundled pages run on a Tauri origin, so a link resolved against
+# window.location.origin would come out as tauri://localhost. Nothing else in a
+# desktop build sets it, so default it to the sign-in origin, the same server
+# the deep-link hand-off targets. Already in turbo.json globalEnv, so the build
 # cache key tracks it.
 WEB_BASE="${VITE_WEB_BASE_URL:-${PI_DASH_URL:-}}"
 
@@ -129,7 +131,7 @@ echo "[dev-prep] OSS source:  $OSS_DIR"
 echo "[dev-prep] Build tree:  $DEV_TREE"
 echo "[dev-prep] Dist target: $DIST"
 echo "[dev-prep] API base:    $API_BASE  (VITE_API_BASE_URL → baked into SPA)"
-echo "[dev-prep] Web base:    ${WEB_BASE:-<unset>}  (VITE_WEB_BASE_URL → sign-in card link)"
+echo "[dev-prep] Web base:    ${WEB_BASE:-<unset>}  (VITE_WEB_BASE_URL → sign-in card + shareable links)"
 echo "[dev-prep] Preparing bundled runner and agent engine"
 bash "$SCRIPT_DIR/prepare-agent.sh"
 echo "[dev-prep] Sign-in target: ${PI_DASH_URL:-<unset, main.rs default>}  (PI_DASH_URL → main.rs deep-link)"

--- a/desktop/src-tauri/build.rs
+++ b/desktop/src-tauri/build.rs
@@ -5,6 +5,7 @@
 fn main() {
     println!("cargo:rerun-if-env-changed=PI_DASH_URL");
     println!("cargo:rerun-if-env-changed=VITE_API_BASE_URL");
+    println!("cargo:rerun-if-env-changed=VITE_WEB_BASE_URL");
     println!("cargo:rerun-if-env-changed=PI_DASH_OSS_SHA");
     println!("cargo:rerun-if-env-changed=PIDASH_DESKTOP_EXTERNAL_SIGNIN");
     // PIDASH_DESKTOP_HOT_RELOAD is read by main.rs via option_env! at
@@ -76,6 +77,7 @@ fn main() {
             );
         }
         validate_baked_api_base(&dist);
+        validate_baked_web_base(&dist);
         // Editions whose sign-in hands off to the system browser (an OIDC
         // provider that must not run inside the webview) opt into checking
         // that the bundled sign-in screen actually does so.
@@ -103,6 +105,40 @@ fn validate_baked_api_base(dist: &std::path::Path) {
         panic!(
             "Release build but desktop/src-tauri/dist does not contain VITE_API_BASE_URL={expected:?}. \
             The SPA bundle may have been baked with the wrong backend URL or a stale artifact."
+        );
+    }
+}
+
+/// The public web origin the SPA builds shareable links from.
+///
+/// Bundled pages run on a Tauri-owned origin, so anything that resolves a
+/// shareable URL against `window.location.origin` would hand the user a
+/// `tauri://localhost` link. `desktop-overlay`'s `desktopWebUrl` resolves
+/// against `VITE_WEB_BASE_URL` instead, which only works if the value was
+/// actually baked into the bundle.
+///
+/// Falls back to `PI_DASH_URL`, which `dev-prep.sh` uses as the default and
+/// which `main.rs` requires via `env!` in release -- so in a release build
+/// this is never empty, and the panic below is reachable only from a
+/// hand-managed `dist/`.
+fn validate_baked_web_base(dist: &std::path::Path) {
+    let expected = std::env::var("VITE_WEB_BASE_URL")
+        .or_else(|_| std::env::var("PI_DASH_URL"))
+        .unwrap_or_default();
+    if expected.trim().is_empty() {
+        panic!(
+            "Release build but neither VITE_WEB_BASE_URL nor PI_DASH_URL is set. The bundled \
+             desktop SPA could expose its Tauri origin in copied links."
+        );
+    }
+
+    let mut saw_expected = false;
+    scan_text_assets(dist, &expected, &mut saw_expected);
+
+    if !saw_expected {
+        panic!(
+            "Release build but desktop/src-tauri/dist does not contain the configured web \
+             origin {expected:?}. The SPA bundle may have a stale or missing VITE_WEB_BASE_URL."
         );
     }
 }


### PR DESCRIPTION
Ports [private-pi-dash#123](https://github.com/The-AI-Republic/private-pi-dash/pull/123) (PRIVATEPI1-49) into OSS, where `desktop-overlay/` now lives after #377.

## Why this has to happen here

#123's behaviour was written entirely inside private's `desktop/` and `desktop-overlay/`. private-pi-dash#131 deletes both directories, so without this port the copy-link fix disappears from the desktop app the moment #131 lands. It also unblocks #131: three of its five merge conflicts are `modify/delete` on exactly these files.

## What it fixes

Bundled desktop pages run on a Tauri-owned origin, so every copy-link path that built a URL from `window.location.origin` handed the user `tauri://localhost/...`. `desktopWebUrl()` resolves against `VITE_WEB_BASE_URL`, which `dev-prep.sh` already bakes (defaulting to `PI_DASH_URL`).

## Contents

- **`desktop-overlay/`** — `core/utils/desktop-web-url.ts` plus the three copy-link overrides (issue-detail quick actions, quick-action-dropdowns helper, peek-overview header). Each is otherwise identical to its `apps/web` original; the only delta is the origin call.
- **`build.rs`** — `validate_baked_web_base` fails a release build whose `dist/` doesn't contain the configured web origin, mirroring the existing API-base guard.
- **`dev-prep.sh`** — no functional change. `VITE_WEB_BASE_URL` was already baked here by #377; comments widened now that the value feeds both the sign-in card and shareable links.
- **`desktop-overlay/README.md`** — documents the new files and notes the overrides must be kept in step with their `apps/web` originals.

## Reconciliations

- #123 and #377 independently added the same `VITE_WEB_BASE_URL` baking to `dev-prep.sh`. Reconciled to one; no duplicate.
- #123's version defaulted the web base to `https://testpidash.airepublic.com`. That's an AI Republic host and doesn't belong in OSS — the cloud default arrives via private-pi-dash's `tauri-cloud.sh`, which sets `PI_DASH_URL`.
- The new validator's empty-value panic is unreachable in a release build: `main.rs` requires `PI_DASH_URL` via `env!`. Community builds are unaffected.

## Verification

- `test-overlay.sh`: 3 files, **27 tests pass** (was 20 — the 7 ported `desktop-web-url` tests now run)
- `cargo test`: 19 pass, 0 warnings
- `unittest desktop/tests`: 11 pass
- `oxfmt` / `oxlint --deny-warnings`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Na8s7Bujhc7zd9bPiQt3E