### PR TITLE
PDASHOSS01-161 Two-tier .pidash/context.md: machine-level workspace context + per-working-dir project context

### DIFF
--- a/apps/api/pi_dash/prompting/fragments/03_pidash_cli.md
+++ b/apps/api/pi_dash/prompting/fragments/03_pidash_cli.md
@@ -11,6 +11,15 @@ The CLI reads the following from the process environment — never pass them as 
 - `PIDASH_TOKEN` — session-scoped credential. Treat it like any other secret.
 - `PIDASH_ISSUE_IDENTIFIER` — the current issue identifier (`{{ issue.identifier }}`). When set, `pidash state list` defaults to this issue's project so you can call it with no args.
 
+### Working context files (`context.md`)
+
+Two `context.md` files on the dev machine describe the Pi Dash projects available to you. Both carry a `generated_at` RFC 3339 UTC stamp so you can judge staleness, and each project entry carries a `repo_url` you can match against a local checkout.
+
+- **Working-dir** `<working_dir>/.pidash/context.md` (`scope: "project"`) — the single project this working directory belongs to. This is **authoritative for "which project am I working in"**.
+- **Machine-level** `~/.pidash/context.md` (`scope: "machine"`) — every project in every workspace this machine is bound to, grouped under a `workspaces:` list keyed by slug. This is the **lookup table for "what else exists in this workspace"** — use it to find a related issue's project or file a follow-up in a different project — and the **fallback** when there is no working-dir file.
+
+Precedence: trust the working-dir file for your current project; consult the machine-level file for everything else. If the machine-level file looks stale or is missing, run `pidash context refresh` to rewrite it for the bound workspace. (Its path follows `PIDASH_CONFIG_DIR` when set, otherwise `~/.pidash`.)
+
 ### Output contract
 
 On success every command prints a single JSON document to stdout and exits `0`. On failure, a JSON object with an `error` field is printed to stderr and the exit code is non-zero. Parse the stderr JSON rather than pattern-matching the human message. Retry only transient failures; never retry the same command more than twice.

--- a/apps/api/pi_dash/prompting/sections/pidash-cli.md
+++ b/apps/api/pi_dash/prompting/sections/pidash-cli.md
@@ -17,6 +17,15 @@ The CLI reads the following from the process environment — never pass them as 
 {% if run.kind != "scheduler" %}- `PIDASH_ISSUE_IDENTIFIER` — the current issue identifier (`{{ issue.identifier }}`). When set, `pidash state list` defaults to this issue's project so you can call it with no args.
 {% else %}- `PIDASH_PROJECT` — the project (`{{ project.identifier }}`) this scheduled run is scoped to. There is no single current issue — you operate across the project. Pass `--project {{ project.identifier }}` explicitly to commands that need it.
 {% endif %}
+### Working context files (`context.md`)
+
+Two `context.md` files on the dev machine describe the Pi Dash projects available to you. Both carry a `generated_at` RFC 3339 UTC stamp so you can judge staleness, and each project entry carries a `repo_url` you can match against a local checkout.
+
+- **Working-dir** `<working_dir>/.pidash/context.md` (`scope: "project"`) — the single project this working directory belongs to. This is **authoritative for "which project am I working in"**.
+- **Machine-level** `~/.pidash/context.md` (`scope: "machine"`) — every project in every workspace this machine is bound to, grouped under a `workspaces:` list keyed by slug. This is the **lookup table for "what else exists in this workspace"** — use it to find a related issue's project or file a follow-up in a different project — and the **fallback** when there is no working-dir file.
+
+Precedence: trust the working-dir file for your current project; consult the machine-level file for everything else. If the machine-level file looks stale or is missing, run `pidash context refresh` to rewrite it for the bound workspace. (Its path follows `PIDASH_CONFIG_DIR` when set, otherwise `~/.pidash`.)
+
 ### Output contract
 
 On success every command prints a single JSON document to stdout and exits `0`. On failure, a JSON object with an `error` field is printed to stderr and the exit code is non-zero. Parse the stderr JSON rather than pattern-matching the human message. Retry only transient failures; never retry the same command more than twice.

--- a/docs/wiki/17-cli-reference.md
+++ b/docs/wiki/17-cli-reference.md
@@ -242,9 +242,28 @@ List projects in the active workspace. Prints JSON.
 pidash project list
 ```
 
+Pi Dash writes two `context.md` files so an agent can tell which project a
+directory belongs to and what else exists in the workspace:
+
+- **Working-dir** `<working_dir>/.pidash/context.md` (`scope: "project"`) — the
+  single project that working directory belongs to. Authoritative for "which
+  project am I working in". Written at `runner add` and when the daemon resolves
+  a workspace, and excluded from the repo via `$GIT_DIR/info/exclude` (never
+  `.gitignore`).
+- **Machine-level** `~/.pidash/context.md` (`scope: "machine"`) — every project
+  in every workspace this machine is bound to, keyed by workspace slug. The
+  lookup table for "what else exists in this workspace" and the fallback when
+  there is no working-dir file. Written on `auth login` and refreshable with
+  `pidash context refresh`. Its location follows `PIDASH_CONFIG_DIR` when set,
+  otherwise `~/.pidash`.
+
+Both files carry a `generated_at` RFC 3339 UTC stamp, and each project carries a
+`repo_url`.
+
 ### `pidash context init`
 
-Write `.pidash/context.md` for a local workspace directory.
+Write the working-dir `.pidash/context.md` for a local directory, scoped to one
+project.
 
 ```
 pidash context init --project <PROJECT> [--workspace <PATH>]
@@ -254,6 +273,16 @@ pidash context init --project <PROJECT> [--workspace <PATH>]
 | ----------------- | --------------------------------------------------- |
 | `--project <P>`   | Project identifier or UUID. **Required.**           |
 | `--workspace <P>` | Local workspace dir. Defaults to current directory. |
+
+### `pidash context refresh`
+
+Rewrite the machine-level `~/.pidash/context.md` for the bound workspace,
+replacing that workspace's project list wholesale (pruning deleted projects) and
+leaving other workspaces intact.
+
+```
+pidash context refresh
+```
 
 ---
 

--- a/runner/src/api_client.rs
+++ b/runner/src/api_client.rs
@@ -301,6 +301,7 @@ mod resolve_tests {
             config_dir: root.join("config"),
             data_dir: root.join("data"),
             runtime_dir: root.join("runtime"),
+            machine_context_dir: root.join("config"),
         }
     }
 

--- a/runner/src/cli/auth/login.rs
+++ b/runner/src/cli/auth/login.rs
@@ -153,6 +153,15 @@ async fn login_and_bind_workspace(args: &Args, paths: &Paths) -> Result<LoginOut
     }
     println!("  Workspace: {}", machine_token.workspace_slug);
 
+    // Best-effort: write the machine-level ~/.pidash/context.md now that the
+    // dev-machine token and workspace binding are persisted. A failure here is
+    // a note, not a login failure — the file can be refreshed later with
+    // `pidash context refresh`.
+    match crate::cli::context::write_machine_context_for_paths(paths).await {
+        Ok(path) => println!("  Machine context: {}", path.display()),
+        Err(err) => println!("  (Machine context was not written: {err})"),
+    }
+
     Ok(LoginOutcome { cloud_url })
 }
 

--- a/runner/src/cli/context.rs
+++ b/runner/src/cli/context.rs
@@ -2,17 +2,38 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // See the LICENSE file for details.
 
-//! `pidash context …` subcommands.
+//! `pidash context …` subcommands and the two-tier `context.md` files.
+//!
+//! There are two context files, written at different scopes:
+//!
+//! - **Machine-level** `~/.pidash/context.md` (see [`Paths::machine_context_path`]):
+//!   every project in every workspace this dev machine is bound to, keyed by
+//!   workspace slug. Written on `auth login`, `runner add`, daemon workspace
+//!   resolution, and `pidash context refresh`. This is the lookup table for
+//!   "what else exists in this workspace".
+//! - **Per-working-dir** `<working_dir>/.pidash/context.md`: the single project
+//!   this working dir belongs to. This is authoritative for "which project am I
+//!   working in".
+//!
+//! Both carry a `scope`, a `generated_at` RFC 3339 UTC stamp, and each project
+//! carries a `repo_url`. The front-matter is parsed by one hand-rolled,
+//! indentation-aware line scanner ([`scan_front_matter`]) shared by both
+//! documents; adding a field is one line in the struct and one arm in
+//! [`apply_project_field`]. The scanner tolerates missing keys so files already
+//! on disk (no `scope` / `generated_at` / `repo_url`) keep parsing.
+//!
+//! [`Paths::machine_context_path`]: crate::util::paths::Paths::machine_context_path
 
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use chrono::{SecondsFormat, Utc};
 use clap::{Args, Subcommand};
 use serde::Serialize;
 
 use crate::api_client::{ApiClient, CliEnv, CliError, EXIT_INVALID, EXIT_UNKNOWN, report_error};
 
-use super::project::{ProjectRow, resolve_project};
+use super::project::{ProjectRow, list_projects, resolve_project};
 
 #[derive(Debug, Args)]
 pub struct ContextArgs {
@@ -22,8 +43,10 @@ pub struct ContextArgs {
 
 #[derive(Debug, Subcommand)]
 pub enum ContextCommand {
-    /// Write .pidash/context.md for this workspace.
+    /// Write the per-working-dir .pidash/context.md for a project.
     Init(InitArgs),
+    /// Rewrite the machine-level ~/.pidash/context.md for the bound workspace.
+    Refresh,
 }
 
 #[derive(Debug, Args)]
@@ -37,20 +60,38 @@ pub struct InitArgs {
     pub workspace: Option<PathBuf>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Default, Serialize)]
 struct ContextProject {
     id: String,
     identifier: String,
     name: String,
     description: String,
+    repo_url: String,
     is_default: bool,
 }
 
+/// A working-dir `context.md`: the one project this directory belongs to.
 #[derive(Debug, Clone, Default)]
-struct ContextDoc {
+struct ProjectDoc {
     workspace_slug: String,
     default_project_id: String,
+    generated_at: String,
     projects: Vec<ContextProject>,
+}
+
+/// One workspace entry inside the machine-level document.
+#[derive(Debug, Clone, Default)]
+struct MachineWorkspace {
+    slug: String,
+    default_project_id: String,
+    projects: Vec<ContextProject>,
+}
+
+/// The machine-level `context.md`: every workspace this machine is bound to.
+#[derive(Debug, Clone, Default)]
+struct MachineDoc {
+    generated_at: String,
+    workspaces: Vec<MachineWorkspace>,
 }
 
 pub async fn run(args: ContextArgs, paths: &crate::util::paths::Paths) -> i32 {
@@ -65,6 +106,7 @@ pub async fn run(args: ContextArgs, paths: &crate::util::paths::Paths) -> i32 {
 
     let result = match args.command {
         ContextCommand::Init(a) => cmd_init(&client, a).await,
+        ContextCommand::Refresh => cmd_refresh(paths, &client).await,
     };
     match result {
         Ok(()) => 0,
@@ -72,6 +114,9 @@ pub async fn run(args: ContextArgs, paths: &crate::util::paths::Paths) -> i32 {
     }
 }
 
+/// Write `<workspace_dir>/.pidash/context.md` scoped to a single project, and
+/// best-effort exclude `.pidash/` from git. Callers: `runner add` and the daemon
+/// after it resolves a workspace.
 pub async fn write_context_for_project(
     paths: &crate::util::paths::Paths,
     workspace_dir: &Path,
@@ -80,7 +125,19 @@ pub async fn write_context_for_project(
     let env = CliEnv::resolve(paths)?;
     let client = ApiClient::new(env).map_err(|e| CliError::new(EXIT_UNKNOWN, format!("{e}")))?;
     let project = resolve_project(&client, project_ref).await?;
-    write_context_file(workspace_dir, &client.env.workspace_slug, &project)
+    write_project_context_file(workspace_dir, &client.env.workspace_slug, &project)
+}
+
+/// Rewrite `~/.pidash/context.md` for the currently-bound workspace, listing all
+/// of its projects. Upserts this workspace into the file by slug, leaving other
+/// workspaces intact. Resolves its own API client from `paths`; used by
+/// `auth login` (best-effort) where no client is threaded in.
+pub async fn write_machine_context_for_paths(
+    paths: &crate::util::paths::Paths,
+) -> Result<PathBuf, CliError> {
+    let env = CliEnv::resolve(paths)?;
+    let client = ApiClient::new(env).map_err(|e| CliError::new(EXIT_UNKNOWN, format!("{e}")))?;
+    write_machine_context(paths, &client).await
 }
 
 async fn cmd_init(client: &ApiClient, args: InitArgs) -> Result<(), CliError> {
@@ -94,12 +151,27 @@ async fn cmd_init(client: &ApiClient, args: InitArgs) -> Result<(), CliError> {
         })?,
     };
     let project = resolve_project(client, &args.project).await?;
-    let path = write_context_file(&workspace, &client.env.workspace_slug, &project)?;
+    let path = write_project_context_file(&workspace, &client.env.workspace_slug, &project)?;
     println!("{}", serde_json::json!({"path": path, "project": project}));
     Ok(())
 }
 
-fn write_context_file(
+async fn cmd_refresh(
+    paths: &crate::util::paths::Paths,
+    client: &ApiClient,
+) -> Result<(), CliError> {
+    let path = write_machine_context(paths, client).await?;
+    println!(
+        "{}",
+        serde_json::json!({"path": path, "workspace": client.env.workspace_slug})
+    );
+    Ok(())
+}
+
+/// Write the working-dir document. This **replaces** the file wholesale: a
+/// working dir belongs to exactly one project, so there is nothing to preserve
+/// and nothing accumulates.
+fn write_project_context_file(
     workspace_dir: &Path,
     workspace_slug: &str,
     project: &ProjectRow,
@@ -108,15 +180,50 @@ fn write_context_file(
     fs::create_dir_all(&pidash_dir)
         .map_err(|e| CliError::new(EXIT_UNKNOWN, format!("creating {:?}: {e}", pidash_dir)))?;
     let path = pidash_dir.join("context.md");
+    let doc = ProjectDoc {
+        workspace_slug: workspace_slug.to_string(),
+        default_project_id: project.id.clone(),
+        generated_at: now_stamp(),
+        projects: vec![ContextProject::from(project)],
+    };
+    fs::write(&path, render_project_context(&doc))
+        .map_err(|e| CliError::new(EXIT_UNKNOWN, format!("writing {:?}: {e}", path)))?;
+    // Best-effort: keep the file out of the repo's diff without touching the
+    // tracked `.gitignore`.
+    if let Err(err) = exclude_pidash_from_git(workspace_dir) {
+        tracing::debug!(error = %err, "could not add .pidash/ to git exclude");
+    }
+    Ok(path)
+}
+
+async fn write_machine_context(
+    paths: &crate::util::paths::Paths,
+    client: &ApiClient,
+) -> Result<PathBuf, CliError> {
+    let projects = list_projects(client).await?;
+    let default_project_id = projects
+        .iter()
+        .find(|p| p.is_default)
+        .map(|p| p.id.clone())
+        .unwrap_or_default();
+    let workspace = MachineWorkspace {
+        slug: client.env.workspace_slug.clone(),
+        default_project_id,
+        projects: projects.iter().map(ContextProject::from).collect(),
+    };
+
+    let path = paths.machine_context_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| CliError::new(EXIT_UNKNOWN, format!("creating {:?}: {e}", parent)))?;
+    }
     let mut doc = fs::read_to_string(&path)
         .ok()
-        .and_then(|body| parse_context(&body))
+        .map(|body| parse_machine_context(&body))
         .unwrap_or_default();
-    doc.workspace_slug = workspace_slug.to_string();
-    doc.default_project_id = project.id.clone();
-    upsert_project(&mut doc.projects, ContextProject::from(project));
-    let body = render_context(&doc);
-    fs::write(&path, body)
+    upsert_workspace(&mut doc.workspaces, workspace);
+    doc.generated_at = now_stamp();
+    fs::write(&path, render_machine_context(&doc))
         .map_err(|e| CliError::new(EXIT_UNKNOWN, format!("writing {:?}: {e}", path)))?;
     Ok(path)
 }
@@ -128,86 +235,251 @@ impl From<&ProjectRow> for ContextProject {
             identifier: project.identifier.clone(),
             name: project.name.clone(),
             description: project.description.clone(),
+            repo_url: project.repo_url.clone(),
             is_default: project.is_default,
         }
     }
 }
 
-fn upsert_project(projects: &mut Vec<ContextProject>, project: ContextProject) {
-    if let Some(existing) = projects.iter_mut().find(|p| p.id == project.id) {
-        *existing = project;
+fn upsert_workspace(workspaces: &mut Vec<MachineWorkspace>, workspace: MachineWorkspace) {
+    if let Some(existing) = workspaces.iter_mut().find(|w| w.slug == workspace.slug) {
+        *existing = workspace;
     } else {
-        projects.push(project);
+        workspaces.push(workspace);
     }
 }
 
-fn render_context(doc: &ContextDoc) -> String {
+fn now_stamp() -> String {
+    Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+fn render_project_context(doc: &ProjectDoc) -> String {
     let mut out = format!(
-        "---\nworkspace_slug: {}\ndefault_project_id: {}\nprojects:\n",
+        "---\nscope: \"project\"\nworkspace_slug: {}\ndefault_project_id: {}\ngenerated_at: {}\nprojects:\n",
         yaml_string(&doc.workspace_slug),
         yaml_string(&doc.default_project_id),
+        yaml_string(&doc.generated_at),
     );
     for project in &doc.projects {
-        out.push_str(&format!(
-            "  - id: {}\n    identifier: {}\n    name: {}\n    description: {}\n    is_default: {}\n",
-            yaml_string(&project.id),
-            yaml_string(&project.identifier),
-            yaml_string(&project.name),
-            yaml_string(&project.description),
-            project.is_default,
-        ));
+        render_project_block(&mut out, project, "  ");
     }
     out.push_str(
-        "---\n\n# Pi Dash Workspace Context\n\nThis workspace is linked to the Pi Dash projects above.\n",
+        "---\n\n# Pi Dash Workspace Context\n\n\
+         This working directory is linked to the Pi Dash project above. For the \
+         full list of projects in this and other workspaces on this machine, see \
+         the machine-level `~/.pidash/context.md`.\n",
     );
     out
 }
 
-fn parse_context(body: &str) -> Option<ContextDoc> {
+fn render_machine_context(doc: &MachineDoc) -> String {
+    let mut out = format!(
+        "---\nscope: \"machine\"\ngenerated_at: {}\nworkspaces:\n",
+        yaml_string(&doc.generated_at),
+    );
+    for workspace in &doc.workspaces {
+        out.push_str(&format!(
+            "  - slug: {}\n    default_project_id: {}\n    projects:\n",
+            yaml_string(&workspace.slug),
+            yaml_string(&workspace.default_project_id),
+        ));
+        for project in &workspace.projects {
+            render_project_block(&mut out, project, "      ");
+        }
+    }
+    out.push_str(
+        "---\n\n# Pi Dash Machine Context\n\n\
+         Every Pi Dash project in each workspace this machine is bound to. Use it \
+         to look up projects other than the one in the current working directory's \
+         `.pidash/context.md`.\n",
+    );
+    out
+}
+
+/// Render one project as a YAML list item. `item_indent` is the indentation of
+/// the opening `- id:` line; fields are indented two spaces further.
+fn render_project_block(out: &mut String, project: &ContextProject, item_indent: &str) {
+    let field_indent = format!("{item_indent}  ");
+    out.push_str(&format!(
+        "{item_indent}- id: {}\n",
+        yaml_string(&project.id)
+    ));
+    out.push_str(&format!(
+        "{field_indent}identifier: {}\n",
+        yaml_string(&project.identifier)
+    ));
+    out.push_str(&format!(
+        "{field_indent}name: {}\n",
+        yaml_string(&project.name)
+    ));
+    out.push_str(&format!(
+        "{field_indent}description: {}\n",
+        yaml_string(&project.description)
+    ));
+    out.push_str(&format!(
+        "{field_indent}repo_url: {}\n",
+        yaml_string(&project.repo_url)
+    ));
+    out.push_str(&format!(
+        "{field_indent}is_default: {}\n",
+        project.is_default
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// Parsing — one shared, indentation-aware line scanner (D4)
+// ---------------------------------------------------------------------------
+
+/// One meaningful line of the YAML front-matter, decomposed. Nesting is
+/// unambiguous from `is_list_item` + `key`: `- slug:` opens a workspace,
+/// `- id:` opens a project.
+struct ScanLine {
+    is_list_item: bool,
+    key: String,
+    value: String,
+}
+
+/// Scan the `---`-fenced front matter into `(is_list_item, key, value)` tuples.
+/// Returns `None` when the body does not open with a `---` fence.
+fn scan_front_matter(body: &str) -> Option<Vec<ScanLine>> {
     let mut lines = body.lines();
     if lines.next()? != "---" {
         return None;
     }
-
-    let mut doc = ContextDoc::default();
-    let mut current: Option<ContextProject> = None;
-
+    let mut out = Vec::new();
     for line in lines {
         if line == "---" {
             break;
         }
         let trimmed = line.trim_start();
-        if let Some(raw) = trimmed.strip_prefix("workspace_slug:") {
-            doc.workspace_slug = parse_scalar(raw);
-        } else if let Some(raw) = trimmed.strip_prefix("default_project_id:") {
-            doc.default_project_id = parse_scalar(raw);
-        } else if let Some(raw) = trimmed.strip_prefix("- id:") {
+        if trimmed.is_empty() {
+            continue;
+        }
+        let (rest, is_list_item) = match trimmed.strip_prefix("- ") {
+            Some(after) => (after, true),
+            None => (trimmed, false),
+        };
+        // Split on the first colon only: a value like a repo URL contains
+        // colons, but the key/value boundary is always the first one and the
+        // value is rendered quoted.
+        let (key, value) = match rest.split_once(':') {
+            Some((k, v)) => (k.trim().to_string(), parse_scalar(v)),
+            None => (rest.trim().to_string(), String::new()),
+        };
+        out.push(ScanLine {
+            is_list_item,
+            key,
+            value,
+        });
+    }
+    Some(out)
+}
+
+/// Symmetric reader for the working-dir document. The working-dir write
+/// replaces the file wholesale (D3), so nothing in the runner reads it back
+/// today; this parser exists to round-trip the format in tests and for any
+/// future reader. Kept single-sourced with the machine parser via
+/// [`scan_front_matter`] / [`apply_project_field`] (D4).
+#[cfg(test)]
+fn parse_project_context(body: &str) -> ProjectDoc {
+    let Some(lines) = scan_front_matter(body) else {
+        return ProjectDoc::default();
+    };
+    let mut doc = ProjectDoc::default();
+    let mut current: Option<ContextProject> = None;
+
+    for line in lines {
+        if line.is_list_item && line.key == "id" {
             if let Some(project) = current.take() {
                 doc.projects.push(project);
             }
             current = Some(ContextProject {
-                id: parse_scalar(raw),
-                identifier: String::new(),
-                name: String::new(),
-                description: String::new(),
-                is_default: false,
+                id: line.value,
+                ..Default::default()
             });
         } else if let Some(project) = current.as_mut() {
-            if let Some(raw) = trimmed.strip_prefix("identifier:") {
-                project.identifier = parse_scalar(raw);
-            } else if let Some(raw) = trimmed.strip_prefix("name:") {
-                project.name = parse_scalar(raw);
-            } else if let Some(raw) = trimmed.strip_prefix("description:") {
-                project.description = parse_scalar(raw);
-            } else if let Some(raw) = trimmed.strip_prefix("is_default:") {
-                project.is_default = parse_scalar(raw).eq_ignore_ascii_case("true");
+            apply_project_field(project, &line.key, &line.value);
+        } else {
+            match line.key.as_str() {
+                "workspace_slug" => doc.workspace_slug = line.value,
+                "default_project_id" => doc.default_project_id = line.value,
+                "generated_at" => doc.generated_at = line.value,
+                _ => {}
             }
         }
     }
     if let Some(project) = current {
         doc.projects.push(project);
     }
-    Some(doc)
+    doc
+}
+
+fn parse_machine_context(body: &str) -> MachineDoc {
+    let Some(lines) = scan_front_matter(body) else {
+        return MachineDoc::default();
+    };
+    let mut doc = MachineDoc::default();
+    let mut workspace: Option<MachineWorkspace> = None;
+    let mut project: Option<ContextProject> = None;
+
+    // Close the open project (if any) into the open workspace.
+    fn flush_project(
+        workspace: &mut Option<MachineWorkspace>,
+        project: &mut Option<ContextProject>,
+    ) {
+        if let (Some(p), Some(w)) = (project.take(), workspace.as_mut()) {
+            w.projects.push(p);
+        }
+    }
+
+    for line in lines {
+        if line.is_list_item && line.key == "slug" {
+            flush_project(&mut workspace, &mut project);
+            if let Some(w) = workspace.take() {
+                doc.workspaces.push(w);
+            }
+            workspace = Some(MachineWorkspace {
+                slug: line.value,
+                ..Default::default()
+            });
+        } else if line.is_list_item && line.key == "id" {
+            flush_project(&mut workspace, &mut project);
+            project = Some(ContextProject {
+                id: line.value,
+                ..Default::default()
+            });
+        } else if let Some(p) = project.as_mut() {
+            apply_project_field(p, &line.key, &line.value);
+        } else if let Some(w) = workspace.as_mut() {
+            if line.key == "default_project_id" {
+                w.default_project_id = line.value;
+            }
+        } else if line.key == "generated_at" {
+            doc.generated_at = line.value;
+        }
+    }
+    flush_project(&mut workspace, &mut project);
+    if let Some(w) = workspace {
+        doc.workspaces.push(w);
+    }
+    doc
+}
+
+/// Apply one scalar field to a project. The single place a new project field is
+/// wired into parsing.
+fn apply_project_field(project: &mut ContextProject, key: &str, value: &str) {
+    match key {
+        "identifier" => project.identifier = value.to_string(),
+        "name" => project.name = value.to_string(),
+        "description" => project.description = value.to_string(),
+        "repo_url" => project.repo_url = value.to_string(),
+        "is_default" => project.is_default = value.eq_ignore_ascii_case("true"),
+        _ => {}
+    }
 }
 
 fn parse_scalar(value: &str) -> String {
@@ -222,6 +494,56 @@ fn yaml_string(value: &str) -> String {
     serde_json::to_string(value).expect("serializing YAML scalar")
 }
 
+// ---------------------------------------------------------------------------
+// Git exclude (D5)
+// ---------------------------------------------------------------------------
+
+/// Append `.pidash/` to `$GIT_DIR/info/exclude` when `workspace_dir` is a git
+/// repo, so the context file never shows up in the repo's diff. Deliberately
+/// avoids `.gitignore` — that is a tracked file in someone else's repo. A no-op
+/// when the directory is not a git repo or the line is already present.
+fn exclude_pidash_from_git(workspace_dir: &Path) -> std::io::Result<()> {
+    let Some(git_dir) = resolve_git_dir(workspace_dir) else {
+        return Ok(());
+    };
+    let info_dir = git_dir.join("info");
+    fs::create_dir_all(&info_dir)?;
+    let exclude_path = info_dir.join("exclude");
+    let existing = fs::read_to_string(&exclude_path).unwrap_or_default();
+    if existing.lines().any(|l| l.trim() == ".pidash/") {
+        return Ok(());
+    }
+    let mut body = existing;
+    if !body.is_empty() && !body.ends_with('\n') {
+        body.push('\n');
+    }
+    body.push_str(".pidash/\n");
+    fs::write(&exclude_path, body)
+}
+
+/// Resolve the git directory for `workspace_dir`, handling both a `.git`
+/// directory and a `.git` *file* (worktree / submodule gitdir pointer).
+fn resolve_git_dir(workspace_dir: &Path) -> Option<PathBuf> {
+    let dot_git = workspace_dir.join(".git");
+    let meta = fs::metadata(&dot_git).ok()?;
+    if meta.is_dir() {
+        return Some(dot_git);
+    }
+    if meta.is_file() {
+        // A `.git` file points at the real gitdir: `gitdir: <path>`.
+        let contents = fs::read_to_string(&dot_git).ok()?;
+        let target = contents.lines().find_map(|l| l.strip_prefix("gitdir:"))?;
+        let target = PathBuf::from(target.trim());
+        let resolved = if target.is_absolute() {
+            target
+        } else {
+            workspace_dir.join(target)
+        };
+        return Some(resolved);
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -232,51 +554,199 @@ mod tests {
             identifier: identifier.to_string(),
             name: name.to_string(),
             description: String::new(),
+            repo_url: format!("https://github.com/acme/{identifier}"),
             is_default: false,
         }
     }
 
     #[test]
-    fn render_parse_round_trips_multiple_projects() {
-        let doc = ContextDoc {
+    fn project_doc_round_trips() {
+        let doc = ProjectDoc {
             workspace_slug: "acme".to_string(),
-            default_project_id: "p2".to_string(),
-            projects: vec![project("p1", "WEB", "Website"), project("p2", "API", "API")],
+            default_project_id: "p1".to_string(),
+            generated_at: "2026-09-12T20:38:38Z".to_string(),
+            projects: vec![project("p1", "WEB", "Website")],
         };
 
-        let parsed = parse_context(&render_context(&doc)).expect("context parses");
+        let parsed = parse_project_context(&render_project_context(&doc));
 
         assert_eq!(parsed.workspace_slug, "acme");
-        assert_eq!(parsed.default_project_id, "p2");
-        assert_eq!(parsed.projects.len(), 2);
+        assert_eq!(parsed.default_project_id, "p1");
+        assert_eq!(parsed.generated_at, "2026-09-12T20:38:38Z");
+        assert_eq!(parsed.projects.len(), 1);
         assert_eq!(parsed.projects[0].identifier, "WEB");
-        assert_eq!(parsed.projects[1].identifier, "API");
+        assert_eq!(
+            parsed.projects[0].repo_url,
+            "https://github.com/acme/WEB"
+        );
     }
 
     #[test]
-    fn render_parse_round_trips_escaped_strings() {
-        let mut project = project("p1", "WEB", "Website");
-        project.description = "line 1\nline \"2\" \\ path".to_string();
-        let doc = ContextDoc {
+    fn project_doc_round_trips_escaped_strings() {
+        let mut p = project("p1", "WEB", "Website");
+        p.description = "line 1\nline \"2\" \\ path: with colon".to_string();
+        let doc = ProjectDoc {
             workspace_slug: "acme\nworkspace".to_string(),
             default_project_id: "p1".to_string(),
-            projects: vec![project],
+            generated_at: "2026-09-12T20:38:38Z".to_string(),
+            projects: vec![p],
         };
 
-        let parsed = parse_context(&render_context(&doc)).expect("context parses");
+        let parsed = parse_project_context(&render_project_context(&doc));
 
         assert_eq!(parsed.workspace_slug, "acme\nworkspace");
-        assert_eq!(parsed.projects[0].description, "line 1\nline \"2\" \\ path");
+        assert_eq!(
+            parsed.projects[0].description,
+            "line 1\nline \"2\" \\ path: with colon"
+        );
     }
 
     #[test]
-    fn upsert_project_replaces_existing_project_without_dropping_others() {
-        let mut projects = vec![project("p1", "WEB", "Website"), project("p2", "API", "API")];
+    fn machine_doc_round_trips_multiple_workspaces() {
+        let doc = MachineDoc {
+            generated_at: "2026-09-12T20:38:38Z".to_string(),
+            workspaces: vec![
+                MachineWorkspace {
+                    slug: "acme".to_string(),
+                    default_project_id: "p2".to_string(),
+                    projects: vec![project("p1", "WEB", "Website"), project("p2", "API", "API")],
+                },
+                MachineWorkspace {
+                    slug: "other".to_string(),
+                    default_project_id: "p3".to_string(),
+                    projects: vec![project("p3", "OPS", "Ops")],
+                },
+            ],
+        };
 
-        upsert_project(&mut projects, project("p1", "APP", "App"));
+        let parsed = parse_machine_context(&render_machine_context(&doc));
 
-        assert_eq!(projects.len(), 2);
-        assert_eq!(projects[0].identifier, "APP");
-        assert_eq!(projects[1].identifier, "API");
+        assert_eq!(parsed.generated_at, "2026-09-12T20:38:38Z");
+        assert_eq!(parsed.workspaces.len(), 2);
+        assert_eq!(parsed.workspaces[0].slug, "acme");
+        assert_eq!(parsed.workspaces[0].default_project_id, "p2");
+        assert_eq!(parsed.workspaces[0].projects.len(), 2);
+        assert_eq!(parsed.workspaces[0].projects[1].identifier, "API");
+        assert_eq!(parsed.workspaces[1].slug, "other");
+        assert_eq!(parsed.workspaces[1].projects[0].identifier, "OPS");
+    }
+
+    #[test]
+    fn parses_legacy_project_file_without_scope_generated_at_or_repo_url() {
+        // The shape written before this change: no `scope`, no `generated_at`,
+        // no `repo_url`, `projects` a list.
+        let legacy = "---\nworkspace_slug: \"acme\"\ndefault_project_id: \"p1\"\nprojects:\n  - id: \"p1\"\n    identifier: \"WEB\"\n    name: \"Website\"\n    description: \"\"\n    is_default: true\n---\n\n# Pi Dash Workspace Context\n";
+
+        let parsed = parse_project_context(legacy);
+
+        assert_eq!(parsed.workspace_slug, "acme");
+        assert_eq!(parsed.default_project_id, "p1");
+        assert_eq!(parsed.generated_at, "");
+        assert_eq!(parsed.projects.len(), 1);
+        assert_eq!(parsed.projects[0].identifier, "WEB");
+        assert_eq!(parsed.projects[0].repo_url, "");
+        assert!(parsed.projects[0].is_default);
+    }
+
+    #[test]
+    fn upsert_workspace_replaces_by_slug_without_dropping_others() {
+        let mut workspaces = vec![
+            MachineWorkspace {
+                slug: "acme".to_string(),
+                default_project_id: "p1".to_string(),
+                projects: vec![project("p1", "WEB", "Website")],
+            },
+            MachineWorkspace {
+                slug: "other".to_string(),
+                default_project_id: "p3".to_string(),
+                projects: vec![project("p3", "OPS", "Ops")],
+            },
+        ];
+
+        upsert_workspace(
+            &mut workspaces,
+            MachineWorkspace {
+                slug: "acme".to_string(),
+                default_project_id: "p2".to_string(),
+                projects: vec![project("p2", "API", "API")],
+            },
+        );
+
+        assert_eq!(workspaces.len(), 2);
+        assert_eq!(workspaces[0].slug, "acme");
+        assert_eq!(workspaces[0].default_project_id, "p2");
+        assert_eq!(workspaces[0].projects.len(), 1);
+        assert_eq!(workspaces[0].projects[0].identifier, "API");
+        assert_eq!(workspaces[1].slug, "other");
+    }
+
+    #[test]
+    fn write_project_context_replaces_previous_project() {
+        let tmp = tempfile::tempdir().unwrap();
+        let row_a = ProjectRow {
+            id: "p1".to_string(),
+            identifier: "WEB".to_string(),
+            name: "Website".to_string(),
+            description: String::new(),
+            repo_url: "https://github.com/acme/web".to_string(),
+            is_default: true,
+        };
+        let row_b = ProjectRow {
+            id: "p2".to_string(),
+            identifier: "API".to_string(),
+            name: "API".to_string(),
+            description: String::new(),
+            repo_url: "https://github.com/acme/api".to_string(),
+            is_default: false,
+        };
+
+        write_project_context_file(tmp.path(), "acme", &row_a).unwrap();
+        write_project_context_file(tmp.path(), "acme", &row_b).unwrap();
+
+        let body = fs::read_to_string(tmp.path().join(".pidash/context.md")).unwrap();
+        let parsed = parse_project_context(&body);
+        // The second write replaced the first — the working dir belongs to one
+        // project, so nothing accumulates.
+        assert_eq!(parsed.projects.len(), 1);
+        assert_eq!(parsed.projects[0].identifier, "API");
+        assert_eq!(parsed.default_project_id, "p2");
+    }
+
+    #[test]
+    fn exclude_added_to_git_dir_info_exclude_once() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Simulate a `.git` directory.
+        fs::create_dir_all(tmp.path().join(".git")).unwrap();
+
+        exclude_pidash_from_git(tmp.path()).unwrap();
+        exclude_pidash_from_git(tmp.path()).unwrap();
+
+        let exclude = fs::read_to_string(tmp.path().join(".git/info/exclude")).unwrap();
+        assert_eq!(exclude.matches(".pidash/").count(), 1, "added exactly once");
+    }
+
+    #[test]
+    fn exclude_handles_dot_git_file_worktree_pointer() {
+        let tmp = tempfile::tempdir().unwrap();
+        let real_git = tmp.path().join("real-gitdir");
+        fs::create_dir_all(&real_git).unwrap();
+        fs::write(
+            tmp.path().join(".git"),
+            format!("gitdir: {}\n", real_git.display()),
+        )
+        .unwrap();
+
+        exclude_pidash_from_git(tmp.path()).unwrap();
+
+        let exclude = fs::read_to_string(real_git.join("info/exclude")).unwrap();
+        assert!(exclude.contains(".pidash/"));
+    }
+
+    #[test]
+    fn exclude_is_noop_when_not_a_git_repo() {
+        let tmp = tempfile::tempdir().unwrap();
+        // No `.git` at all — must not error and must not create anything.
+        exclude_pidash_from_git(tmp.path()).unwrap();
+        assert!(!tmp.path().join(".git").exists());
     }
 }

--- a/runner/src/cli/doctor.rs
+++ b/runner/src/cli/doctor.rs
@@ -449,6 +449,7 @@ mod tests {
             config_dir: dir.path().join("config"),
             data_dir: dir.path().join("data"),
             runtime_dir: dir.path().join("runtime"),
+            machine_context_dir: dir.path().join("config"),
         };
         paths.ensure().unwrap();
         (dir, paths)

--- a/runner/src/cli/project.rs
+++ b/runner/src/cli/project.rs
@@ -29,6 +29,10 @@ pub struct ProjectRow {
     pub name: String,
     #[serde(default)]
     pub description: String,
+    /// Bound git remote for the project, if any. Lets an agent match a local
+    /// checkout to a project. Empty when the project has no repository bound.
+    #[serde(default)]
+    pub repo_url: String,
     #[serde(default)]
     pub is_default: bool,
 }

--- a/runner/src/cli/runner_ops.rs
+++ b/runner/src/cli/runner_ops.rs
@@ -665,6 +665,7 @@ mod tests {
             config_dir: root.join("config"),
             data_dir: root.join("data"),
             runtime_dir: root.join("runtime"),
+            machine_context_dir: root.join("config"),
         }
     }
 

--- a/runner/src/config/file.rs
+++ b/runner/src/config/file.rs
@@ -249,6 +249,7 @@ mod tests {
             config_dir: root.join("config"),
             data_dir: root.join("data"),
             runtime_dir: root.join("runtime"),
+            machine_context_dir: root.join("config"),
         }
     }
 

--- a/runner/src/daemon/runner_instance.rs
+++ b/runner/src/daemon/runner_instance.rs
@@ -183,6 +183,7 @@ mod tests {
             config_dir: base.join("config"),
             data_dir: base.join("data"),
             runtime_dir: base.join("runtime"),
+            machine_context_dir: base.join("config"),
         }
     }
 

--- a/runner/src/daemon/supervisor.rs
+++ b/runner/src/daemon/supervisor.rs
@@ -3386,6 +3386,7 @@ mod tests {
             config_dir: root.join("config"),
             data_dir: root.join("data"),
             runtime_dir: root.join("runtime"),
+            machine_context_dir: root.join("config"),
         }
     }
 

--- a/runner/src/tui/views/general.rs
+++ b/runner/src/tui/views/general.rs
@@ -973,6 +973,7 @@ mod paste_tests {
             config_dir: root.join("config"),
             data_dir: root.join("data"),
             runtime_dir: root.join("runtime"),
+            machine_context_dir: root.join("config"),
         }
     }
 

--- a/runner/src/tui/views/modals/add_runner.rs
+++ b/runner/src/tui/views/modals/add_runner.rs
@@ -343,6 +343,7 @@ mod tests {
             config_dir: root.join("config"),
             data_dir: root.join("data"),
             runtime_dir: root.join("runtime"),
+            machine_context_dir: root.join("config"),
         }
     }
 

--- a/runner/src/tui/views/runner_status.rs
+++ b/runner/src/tui/views/runner_status.rs
@@ -674,6 +674,7 @@ mod tests {
             config_dir: root.join("config"),
             data_dir: root.join("data"),
             runtime_dir: root.join("runtime"),
+            machine_context_dir: root.join("config"),
         }
     }
 

--- a/runner/src/util/paths.rs
+++ b/runner/src/util/paths.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use directories::ProjectDirs;
+use directories::{BaseDirs, ProjectDirs};
 use std::path::{Path, PathBuf};
 use uuid::Uuid;
 
@@ -12,6 +12,13 @@ pub struct Paths {
     pub config_dir: PathBuf,
     pub data_dir: PathBuf,
     pub runtime_dir: PathBuf,
+    /// Directory holding the machine-level `context.md` (all projects in every
+    /// bound workspace). Follows `PIDASH_CONFIG_DIR` / `--config-dir` when an
+    /// override is set, otherwise `~/.pidash`. A hardcoded `~/.pidash` would be
+    /// a second, non-overridable location; the desktop app and CI both run
+    /// isolated installs that pass an override and must not write into the real
+    /// home directory.
+    pub machine_context_dir: PathBuf,
 }
 
 /// Per-instance filesystem paths under `data_dir/runners/<runner_id>/`. Each
@@ -31,7 +38,19 @@ impl Paths {
     ) -> Result<Self> {
         let dirs = ProjectDirs::from(QUALIFIER, ORG, APP)
             .context("unable to resolve XDG project directories")?;
-        let config_dir = config_override.unwrap_or_else(|| dirs.config_dir().to_path_buf());
+        let config_dir = config_override
+            .clone()
+            .unwrap_or_else(|| dirs.config_dir().to_path_buf());
+        // Machine-context location (D1): an explicit override wins so isolated
+        // installs (desktop, CI) stay self-contained; otherwise the real home
+        // directory's `.pidash`; and if the home directory can't be resolved,
+        // fall back to the config directory rather than an unwritable path.
+        let machine_context_dir = match config_override {
+            Some(dir) => dir,
+            None => BaseDirs::new()
+                .map(|base| base.home_dir().join(".pidash"))
+                .unwrap_or_else(|| config_dir.clone()),
+        };
         // An isolated daemon must also get an isolated PID and IPC socket.
         // Otherwise the desktop and a personal installation claim the same
         // XDG runtime path even though their configuration and data differ.
@@ -48,11 +67,19 @@ impl Paths {
             config_dir,
             data_dir,
             runtime_dir,
+            machine_context_dir,
         })
     }
 
     pub fn config_path(&self) -> PathBuf {
         self.config_dir.join("config.toml")
+    }
+
+    /// Machine-level `context.md`: the workspace-wide lookup table listing every
+    /// project in every bound workspace. See `machine_context_dir` for the
+    /// location rule.
+    pub fn machine_context_path(&self) -> PathBuf {
+        self.machine_context_dir.join("context.md")
     }
 
     pub fn credentials_path(&self) -> PathBuf {
@@ -175,7 +202,32 @@ mod tests {
             config_dir: base.join("config"),
             data_dir: base.join("data"),
             runtime_dir: base.join("runtime"),
+            machine_context_dir: base.join("config"),
         }
+    }
+
+    #[test]
+    fn machine_context_dir_follows_config_override() {
+        let tmp = tempfile::tempdir().unwrap();
+        let override_dir = tmp.path().join("isolated-config");
+        let paths = Paths::resolve(Some(override_dir.clone()), None).unwrap();
+        assert_eq!(paths.machine_context_dir, override_dir);
+        assert_eq!(
+            paths.machine_context_path(),
+            override_dir.join("context.md")
+        );
+    }
+
+    #[test]
+    fn machine_context_dir_defaults_to_home_pidash() {
+        // No override: the machine file lives in the real home directory's
+        // `.pidash`, not the XDG config dir.
+        let paths = Paths::resolve(None, None).unwrap();
+        let expected = BaseDirs::new()
+            .map(|base| base.home_dir().join(".pidash"))
+            .unwrap_or_else(|| paths.config_dir.clone());
+        assert_eq!(paths.machine_context_dir, expected);
+        assert_eq!(paths.machine_context_path(), expected.join("context.md"));
     }
 
     #[test]

--- a/runner/tests/pidash_agent_package.rs
+++ b/runner/tests/pidash_agent_package.rs
@@ -27,6 +27,7 @@ fn setup(root: &Path) -> Paths {
         config_dir: root.join("config"),
         data_dir: root.join("data"),
         runtime_dir: root.join("runtime"),
+        machine_context_dir: root.join("config"),
     };
     paths.ensure().unwrap();
     let config: Config = serde_json::from_value(serde_json::json!({

--- a/runner/tests/pidash_run_errors.rs
+++ b/runner/tests/pidash_run_errors.rs
@@ -14,6 +14,7 @@ fn empty_paths(root: &std::path::Path) -> Paths {
         config_dir: root.join("config"),
         data_dir: root.join("data"),
         runtime_dir: root.join("runtime"),
+        machine_context_dir: root.join("config"),
     }
 }
 

--- a/runner/tests/pidash_runner_add_auth.rs
+++ b/runner/tests/pidash_runner_add_auth.rs
@@ -160,6 +160,7 @@ fn paths(root: &std::path::Path) -> Paths {
         config_dir: root.join("config"),
         data_dir: root.join("data"),
         runtime_dir: root.join("runtime"),
+        machine_context_dir: root.join("config"),
     }
 }
 


### PR DESCRIPTION
## Summary

Splits `.pidash/context.md` into two tiers (PDASHOSS01-161):

- **Machine-level** `~/.pidash/context.md` (`scope: "machine"`) — every project in every bound workspace, keyed by workspace slug. Written best-effort on `auth login` and rewritable with the new `pidash context refresh`. Location follows `PIDASH_CONFIG_DIR` / `--config-dir`, else `~/.pidash`, else the config dir (**D1**), so isolated installs (desktop, CI) never write into the real home directory.
- **Per-working-dir** `<working_dir>/.pidash/context.md` (`scope: "project"`) — the single project this dir belongs to. Now **replaces** rather than upserts (fixing the one-way accumulation) and carries `repo_url`.

Both files carry `scope` + a `generated_at` RFC 3339 UTC stamp; each project carries `repo_url` (already returned by the projects API). The hand-rolled parser is refactored into **one indentation-aware line scanner** shared by both documents (**D4**), tolerating legacy files with no `scope` / `generated_at` / `repo_url`. The working-dir file is excluded from git via `$GIT_DIR/info/exclude` — handling both a `.git` directory and a `.git`-file worktree pointer — never `.gitignore` (**D5**). Machine file is keyed by workspace and upserted by slug (**D3**).

Prompt fragments (`fragments/03_pidash_cli.md` + `sections/pidash-cli.md`) and the CLI reference now describe both files and the precedence between them.

## Scope note

The `pi-dash-skill/` and `private-pi-dash/` skill trees named in the issue are **not present in this OSS repo** — only the API prompt fragments and CLI docs are here. Those were updated; the private plugin copies must be updated in their own repo.

## Testing

- `cargo test --locked` (runner) — full suite green; new tests: D1 path override/default branches, project/machine round-trips, legacy-file parse, workspace upsert-by-slug, working-dir replace, git-exclude (dir + `.git`-file + non-repo).
- `cargo clippy --all-targets --locked -- -D warnings` — clean.
- API prompting unit tests (`test_registry`, `test_validation`, `test_composer`, `test_recipes`) — 72 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
