### PR TITLE
fix(runner): stop soft-deleted assignees granting runner eligibility

### DIFF
--- a/apps/api/pi_dash/orchestration/scheduling.py
+++ b/apps/api/pi_dash/orchestration/scheduling.py
@@ -462,7 +462,18 @@ def _resolve_creator_for_trigger(issue: Issue, *, triggered_by: str, actor=None)
         candidates = [actor]
     else:
         candidates = [issue.created_by, issue.project.project_lead, issue.project.default_assignee]
-        candidates.extend(issue.assignees.all().order_by("id"))
+        # Live assignees only. ``Issue.assignees`` is a plain M2M over the
+        # soft-deleted ``IssueAssignee`` through-model, so it would also offer
+        # up users who were un-assigned — making a former assignee the
+        # execution principal (and LLM-config owner) for a cloud run.
+        from pi_dash.db.models.issue import IssueAssignee
+        from pi_dash.db.models.user import User
+
+        candidates.extend(
+            User.objects.filter(
+                pk__in=IssueAssignee.objects.filter(issue=issue).values_list("assignee_id", flat=True)
+            ).order_by("id")
+        )
     from pi_dash.core.agent_execution import user_has_llm_config
 
     seen = set()

--- a/apps/api/pi_dash/runner/services/matcher.py
+++ b/apps/api/pi_dash/runner/services/matcher.py
@@ -383,11 +383,14 @@ def pod_has_runner_for_issue_principal(pod, issue, run_creator_id) -> bool:
 
     - ``run_creator_id`` (the user the dispatch is being attributed to),
     - ``issue.created_by_id`` (the issue creator),
-    - any current ``issue.assignees``.
+    - any current (non-soft-deleted) issue assignee.
 
-    ``issue.assignees`` is the M2M live manager; the existing matcher
-    (``filter_runs_usable_by_runner``) traverses it the same way, so
-    the preflight stays consistent with the dispatch gate it shadows.
+    Assignees are read through ``IssueAssignee.objects`` — the soft-delete
+    manager — rather than the ``Issue.assignees`` M2M. The un-assign path
+    only stamps ``deleted_at`` on the through row, and a plain M2M join does
+    not honour that, so the M2M would report every user ever assigned. The
+    dispatch gate it shadows (``filter_runs_usable_by_runner``) applies the
+    same ``deleted_at`` condition, so preflight and dispatch stay consistent.
 
     Transient status is **deliberately ignored** — OFFLINE / BUSY runners
     still count as "registered" because the owner can flip them back on and
@@ -407,6 +410,7 @@ def pod_has_runner_for_issue_principal(pod, issue, run_creator_id) -> bool:
     ignored here for the same reason as above — a closed laptop is not a
     structural failure, and the creation path (§8.5) decides whether to wait.
     """
+    from pi_dash.db.models.issue import IssueAssignee
     from pi_dash.runner.models import RunnerProvisioning
 
     if effective_executor_for_issue(issue) == AgentExecutorKind.MANAGED_RUNNER:
@@ -427,7 +431,9 @@ def pod_has_runner_for_issue_principal(pod, issue, run_creator_id) -> bool:
         eligible_owner_ids.add(run_creator_id)
     if issue.created_by_id is not None:
         eligible_owner_ids.add(issue.created_by_id)
-    eligible_owner_ids.update(issue.assignees.values_list("id", flat=True))
+    eligible_owner_ids.update(
+        IssueAssignee.objects.filter(issue=issue).values_list("assignee_id", flat=True)
+    )
     eligible_owner_ids.discard(None)
     if not eligible_owner_ids:
         return False

--- a/apps/api/pi_dash/runner/services/permissions.py
+++ b/apps/api/pi_dash/runner/services/permissions.py
@@ -86,13 +86,26 @@ def filter_runs_usable_by_runner(qs, runner):
     Private runners can process work initiated by their owner, work already
     billed to their owner, issue work involving their owner, or project
     scheduler work explicitly authored by their owner.
+
+    The assignee clause traverses the ``IssueAssignee`` through-model
+    explicitly rather than the ``Issue.assignees`` M2M. ``IssueAssignee`` is
+    a ``SoftDeleteModel`` and the un-assign path (issue serializer) only
+    stamps ``deleted_at``; a plain M2M join ignores that column, so going
+    through the M2M would keep granting execution rights to every user ever
+    assigned to the issue. ``deleted_at__isnull=True`` sits in the same
+    ``Q``/``filter()`` call as the owner match so both conditions bind to the
+    same joined row.
     """
     if runner.visibility == Visibility.PRIVATE:
         from pi_dash.db.models.issue import Issue
         from pi_dash.db.models.scheduler import SchedulerBinding
 
         visible_issue = Issue.objects.filter(pk=OuterRef("work_item_id")).filter(
-            Q(created_by_id=runner.owner_id) | Q(assignees__id=runner.owner_id)
+            Q(created_by_id=runner.owner_id)
+            | Q(
+                issue_assignee__assignee_id=runner.owner_id,
+                issue_assignee__deleted_at__isnull=True,
+            )
         )
         visible_scheduler = SchedulerBinding.objects.filter(
             pk=OuterRef("scheduler_binding_id"),

--- a/apps/api/pi_dash/runner/views/runs.py
+++ b/apps/api/pi_dash/runner/views/runs.py
@@ -107,7 +107,12 @@ def _can_view_run(user, run: AgentRun) -> bool:
     if run.work_item_id is not None:
         if run.work_item.created_by_id == user.id:
             return True
-        if run.work_item.assignees.filter(pk=user.id).exists():
+        # Through-model, not the ``assignees`` M2M: un-assignment soft-deletes
+        # the IssueAssignee row and a plain M2M join ignores ``deleted_at``,
+        # which would leave every past assignee able to view and cancel.
+        from pi_dash.db.models.issue import IssueAssignee
+
+        if IssueAssignee.objects.filter(issue_id=run.work_item_id, assignee_id=user.id).exists():
             return True
     return is_workspace_admin(user, run.workspace_id)
 
@@ -128,13 +133,16 @@ class AgentRunListEndpoint(APIView):
         # signals are surfaced:
         #   1. created_by == caller (free-form runs they kicked off)
         #   2. work_item.created_by == caller (their issues)
-        #   3. work_item.assignees contains caller (issues assigned to them)
+        #   3. work_item has a live IssueAssignee for the caller (issues
+        #      currently assigned to them — soft-deleted rows do not count,
+        #      so un-assignment actually withdraws the grant)
         # Tick-driven runs carry created_by = agent system bot per
         # ``orchestration/scheduling._resolve_creator_for_trigger``, so a
         # creator-only filter would hide them from the human owner of the
         # issue. The OR over (1)+(2)+(3) puts them back in view.
-        # ``distinct()`` guards against duplicates from the assignees join
-        # when the caller satisfies more than one clause.
+        # ``distinct()`` guards against duplicates from the assignee join
+        # when the caller satisfies more than one clause (and from repeat
+        # assign/un-assign cycles, which leave several through rows).
         #
         # Mandatory workspace-membership scope: clause (2) and (3) join
         # through ``work_item`` whose project lives in some workspace —
@@ -152,7 +160,10 @@ class AgentRunListEndpoint(APIView):
                 Q(created_by=request.user)
                 | Q(runner__owner=request.user)
                 | Q(work_item__created_by=request.user)
-                | Q(work_item__assignees=request.user)
+                | Q(
+                    work_item__issue_assignee__assignee=request.user,
+                    work_item__issue_assignee__deleted_at__isnull=True,
+                )
                 | Q(workspace_id__in=admin_workspaces)
             )
             # Private-runner gate, mirroring ``_can_view_run``: involvement or

--- a/apps/api/pi_dash/tests/unit/runner/test_matcher_issue_eligibility.py
+++ b/apps/api/pi_dash/tests/unit/runner/test_matcher_issue_eligibility.py
@@ -1,0 +1,293 @@
+# Copyright (c) 2023-present Pi Dash Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Matcher-level eligibility for *issue-backed* runs in a shared pod.
+
+``filter_runs_usable_by_runner`` accepts a run for a PRIVATE runner when
+``runner.owner`` is the run's ``created_by``/``owner``, the issue's
+``created_by``, or one of ``issue.assignees``. ``test_drain_pod`` covers
+only the free-form (no ``work_item``) case; this module pins the
+issue-backed clauses — in particular that assignment is what lets a
+second member's runner take work they did not create.
+
+Scenario throughout: one project, one default pod, two members (Alice
+and Luke) who each registered a private runner into that pod.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+from crum import impersonate
+from django.db import transaction
+from django.utils import timezone
+
+from pi_dash.db.models import Issue, State, User, WorkspaceMember
+from pi_dash.db.models.issue import IssueAssignee
+from pi_dash.runner.models import (
+    AgentRun,
+    AgentRunStatus,
+    Pod,
+    Runner,
+    RunnerStatus,
+)
+from pi_dash.runner.services import matcher
+
+
+@pytest.fixture
+def pod(project):
+    return Pod.default_for_project(project)
+
+
+@pytest.fixture
+def alice(create_user):
+    """Workspace owner from the conftest fixture; the issue creator."""
+    return create_user
+
+
+@pytest.fixture
+def luke(db, workspace):
+    suffix = uuid4().hex[:6]
+    user = User.objects.create(
+        email=f"luke-{suffix}@example.com",
+        username=f"luke_{suffix}",
+        first_name="Luke",
+    )
+    user.set_password("pw")
+    user.save()
+    WorkspaceMember.objects.create(workspace=workspace, member=user, role=15)
+    return user
+
+
+def _runner(owner, workspace, pod, name):
+    return Runner.objects.create(
+        owner=owner,
+        workspace=workspace,
+        pod=pod,
+        name=name,
+        status=RunnerStatus.ONLINE,
+        last_heartbeat_at=timezone.now(),
+    )
+
+
+@pytest.fixture
+def alice_runner(alice, workspace, pod):
+    return _runner(alice, workspace, pod, "alice-mbp")
+
+
+@pytest.fixture
+def luke_runner(luke, workspace, pod):
+    return _runner(luke, workspace, pod, "luke-desktop")
+
+
+@pytest.fixture
+def backlog(project, create_user):
+    with impersonate(create_user):
+        return State.objects.create(
+            name="Backlog", project=project, group="backlog", default=True, sequence=100
+        )
+
+
+@pytest.fixture(autouse=True)
+def _stub_send_to_runner():
+    with patch("pi_dash.runner.services.pubsub.send_to_runner") as mock:
+        yield mock
+
+
+@pytest.fixture(autouse=True)
+def _on_commit_immediate():
+    with patch("django.db.transaction.on_commit", side_effect=lambda fn, **kw: fn()):
+        yield
+
+
+def _issue(workspace, project, backlog, creator, assignees=()):
+    """Create an issue in Backlog (non-ticking, so no dispatch auto-fires)."""
+    with impersonate(creator):
+        issue = Issue.objects.create(
+            name="Task",
+            workspace=workspace,
+            project=project,
+            state=backlog,
+            created_by=creator,
+        )
+    for user in assignees:
+        IssueAssignee.objects.create(issue=issue, assignee=user, workspace=workspace, project=project)
+    return issue
+
+
+def _queued_run(workspace, pod, issue):
+    """Mirror the orchestration dispatch: created_by = issue.created_by,
+    owner unset until a runner is assigned."""
+    return AgentRun.objects.create(
+        workspace=workspace,
+        created_by=issue.created_by,
+        owner=None,
+        pod=pod,
+        work_item=issue,
+        status=AgentRunStatus.QUEUED,
+        prompt="do the thing",
+    )
+
+
+def _visible_to(runner, run):
+    """True if the matcher would hand ``run`` to ``runner``."""
+    with transaction.atomic():
+        picked = matcher.next_for_runner(runner)
+    return picked is not None and picked.pk == run.pk
+
+
+# ---------------------------------------------------------------------------
+# Row 1: created by Alice, assigned to Luke -> both runners eligible
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_assignee_runner_is_eligible_for_issue_it_did_not_create(
+    db, workspace, project, pod, backlog, alice, luke, alice_runner, luke_runner
+):
+    issue = _issue(workspace, project, backlog, creator=alice, assignees=[luke])
+    run = _queued_run(workspace, pod, issue)
+
+    assert _visible_to(alice_runner, run) is True, "creator's runner must be eligible"
+    assert _visible_to(luke_runner, run) is True, "assignee's runner must be eligible"
+
+
+@pytest.mark.unit
+def test_assigned_issue_is_actually_assigned_by_drain_pod(
+    db, workspace, project, pod, backlog, alice, luke, luke_runner
+):
+    """Luke's runner alone in the pod: assignment alone must be enough."""
+    issue = _issue(workspace, project, backlog, creator=alice, assignees=[luke])
+    run = _queued_run(workspace, pod, issue)
+
+    assert matcher.drain_pod(pod) == 1
+    run.refresh_from_db()
+    assert run.runner_id == luke_runner.id
+    assert run.status == AgentRunStatus.ASSIGNED
+    assert run.owner_id == luke.id, "billing follows the machine, not created_by"
+
+
+# ---------------------------------------------------------------------------
+# Row 2: created by Alice, unassigned -> only Alice's runner
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_unassigned_issue_is_invisible_to_other_members_runner(
+    db, workspace, project, pod, backlog, alice, luke, alice_runner, luke_runner
+):
+    issue = _issue(workspace, project, backlog, creator=alice, assignees=[])
+    run = _queued_run(workspace, pod, issue)
+
+    assert _visible_to(alice_runner, run) is True
+    assert _visible_to(luke_runner, run) is False, "co-member is not entitled without assignment"
+
+
+@pytest.mark.unit
+def test_drain_pod_leaves_unassigned_issue_queued_for_other_members_runner(
+    db, workspace, project, pod, backlog, alice, luke, luke_runner
+):
+    """Only Luke's runner is in the pod. The run must stay QUEUED, not leak."""
+    issue = _issue(workspace, project, backlog, creator=alice, assignees=[])
+    run = _queued_run(workspace, pod, issue)
+
+    assert matcher.drain_pod(pod) == 0
+    run.refresh_from_db()
+    assert run.status == AgentRunStatus.QUEUED
+    assert run.runner_id is None
+
+
+# ---------------------------------------------------------------------------
+# Row 3: created by Luke, assigned to Luke -> only Luke's runner
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_other_members_issue_is_invisible_to_alices_runner(
+    db, workspace, project, pod, backlog, alice, luke, alice_runner, luke_runner
+):
+    issue = _issue(workspace, project, backlog, creator=luke, assignees=[luke])
+    run = _queued_run(workspace, pod, issue)
+
+    assert _visible_to(luke_runner, run) is True
+    assert _visible_to(alice_runner, run) is False, (
+        "workspace admin standing must not let Alice's machine take Luke's work"
+    )
+
+
+@pytest.mark.unit
+def test_drain_pod_does_not_give_lukes_issue_to_alices_runner(
+    db, workspace, project, pod, backlog, alice, luke, alice_runner
+):
+    issue = _issue(workspace, project, backlog, creator=luke, assignees=[luke])
+    run = _queued_run(workspace, pod, issue)
+
+    assert matcher.drain_pod(pod) == 0
+    run.refresh_from_db()
+    assert run.status == AgentRunStatus.QUEUED
+    assert run.runner_id is None
+
+
+# ---------------------------------------------------------------------------
+# Un-assignment withdraws the grant
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_removing_assignee_revokes_eligibility_while_still_queued(
+    db, workspace, project, pod, backlog, alice, luke, luke_runner
+):
+    """Un-assignment must take Luke's runner back out of the eligible set.
+
+    ``IssueAssignee`` is a ``SoftDeleteModel`` and the un-assign path only
+    stamps ``deleted_at``; the eligibility reads therefore have to go through
+    the through-model's live manager, not the ``Issue.assignees`` M2M (whose
+    join ignores ``deleted_at`` and would grandfather every past assignee).
+    """
+    issue = _issue(workspace, project, backlog, creator=alice, assignees=[luke])
+    run = _queued_run(workspace, pod, issue)
+    assert _visible_to(luke_runner, run) is True
+
+    # Exactly what the issue serializer does when assignees are edited.
+    IssueAssignee.objects.filter(issue=issue).delete()
+    assert IssueAssignee.all_objects.filter(issue=issue, assignee=luke).exists(), (
+        "precondition: the row is soft-deleted, not removed"
+    )
+
+    assert _visible_to(luke_runner, run) is False
+    assert matcher.drain_pod(pod) == 0
+    run.refresh_from_db()
+    assert run.status == AgentRunStatus.QUEUED
+    assert run.runner_id is None
+
+
+@pytest.mark.unit
+def test_preflight_ignores_soft_deleted_assignee(
+    db, workspace, project, pod, backlog, alice, luke, luke_runner
+):
+    """The creation-time preflight must agree with the dispatch gate."""
+    issue = _issue(workspace, project, backlog, creator=alice, assignees=[luke])
+    assert matcher.pod_has_runner_for_issue_principal(pod, issue, alice.id) is True
+
+    IssueAssignee.objects.filter(issue=issue).delete()
+
+    assert matcher.pod_has_runner_for_issue_principal(pod, issue, alice.id) is False
+
+
+@pytest.mark.unit
+def test_reassignment_after_removal_restores_eligibility(
+    db, workspace, project, pod, backlog, alice, luke, luke_runner
+):
+    """Re-assigning leaves a soft-deleted row behind a live one; the live
+    row must still be found (and must not be double-counted)."""
+    issue = _issue(workspace, project, backlog, creator=alice, assignees=[luke])
+    run = _queued_run(workspace, pod, issue)
+    IssueAssignee.objects.filter(issue=issue).delete()
+    IssueAssignee.objects.create(issue=issue, assignee=luke, workspace=workspace, project=project)
+
+    assert IssueAssignee.all_objects.filter(issue=issue, assignee=luke).count() == 2
+    assert _visible_to(luke_runner, run) is True
+    assert matcher.drain_pod(pod) == 1


### PR DESCRIPTION
## Problem

`IssueAssignee` is a `SoftDeleteModel`. The un-assign path in `IssueSerializer.update` is:

```python
IssueAssignee.objects.filter(issue=instance).delete()   # api/serializers/issue.py:302
```

which resolves to `SoftDeletionQuerySet.delete()` → `update(deleted_at=now())`. The row survives.

`Issue.assignees` is a plain M2M over that through-model, and a Django M2M join does **not** apply the through-model's manager. So `issue.assignees` keeps reporting every user who was *ever* assigned.

Four eligibility reads traversed that M2M, so un-assignment withdrew nothing:

| Site | Consequence |
|---|---|
| `filter_runs_usable_by_runner` (`runner/services/permissions.py`) | A former assignee's private runner stayed eligible to **execute** the issue's runs, indefinitely |
| `pod_has_runner_for_issue_principal` (`runner/services/matcher.py`) | The creation-time preflight agreed, so the run was created rather than bounced |
| `_can_view_run` / `AgentRunListEndpoint.get` (`runner/views/runs.py`) | A former assignee kept **view and cancel** rights on those runs |
| `_resolve_creator_for_trigger` (`orchestration/scheduling.py`) | A former assignee could be picked as the **execution principal** (and LLM-config owner) for a cloud-agent run |

Because the serializer soft-deletes the whole set and re-creates it on every assignee edit, the grants **accumulate** — each pass through the assignee field leaves another permanent row behind.

Reproduced before the fix (Alice creates an issue, assigns Luke, then un-assigns him):

```
IssueAssignee row still present: True
  deleted_at set (soft-deleted): True
live manager sees it: False          <- IssueAssignee.objects correctly hides it
issue.assignees M2M still yields Luke: ['luke-...@e.com']   <- but the M2M does not
1. matcher hands run to ex-assignee's runner: True
2. filter_runs_usable_by_runner accepts:      True
3. preflight says pod is serviceable:         True
4. run.work_item.assignees grants Luke view:  True
5. drain_pod assigned to ex-assignee:         True
```

The `matcher` docstring asserted the opposite — "`issue.assignees` is the M2M live manager" — so this reads as unintended rather than a deliberate grandfather rule.

## Fix

Read assignees through `IssueAssignee.objects` (the soft-delete manager), or join with an explicit `deleted_at__isnull=True` in the same `filter()` call so both conditions bind to the same joined row. Docstring corrected.

## Behavior change

Un-assigning a user now actually withdraws:
- their runner's eligibility to execute that issue's runs
- their ability to view and cancel those runs
- their candidacy as cloud-agent execution principal

Users who are *currently* assigned are unaffected. Re-assignment after removal restores eligibility via the new live row (covered by a test; `distinct()` already guarded the duplicate join).

## Tests

New `apps/api/pi_dash/tests/unit/runner/test_matcher_issue_eligibility.py` (9 tests). It also pins the intended shared-pod matrix, which had **no matcher-level coverage** — the existing `test_drain_pod.py` only exercised free-form runs with no `work_item`. With two project members each running a private runner in one pod:

| Issue | Alice's runner | Luke's runner |
|---|---|---|
| Created by Alice, assigned to Luke | eligible | eligible |
| Created by Alice, unassigned | eligible | skips it |
| Created by Luke, assigned to Luke | skips it | eligible |

Each row is checked twice: at the gate (`next_for_runner`) and end-to-end (`drain_pod` actually assigns or leaves QUEUED). Row 3 also confirms workspace-admin standing does not pierce the gate.

## Verification

- New module: **9 passed**
- `tests/unit/runner` + `tests/unit/orchestration`: **565 passed, 3 failed**
- Those 3 failures **reproduce identically on clean `main`** (verified by stashing): 2x state-change dispatch in `test_runs_views.py`, 1x agent schema in `test_machine_commands.py`. Pre-existing, unrelated.
- `ruff check` clean on all changed files.

Note: the pre-commit hook was bypassed (`lint-staged` unavailable — node deps not installed in this worktree); `ruff` was run directly on the changed Python files instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5M5iP9cRnYaAUbRHT5nhb